### PR TITLE
fix: prevent chat scroll shake and ensure scroll-to-bottom after send

### DIFF
--- a/public/js/features/chat.ts
+++ b/public/js/features/chat.ts
@@ -12,6 +12,7 @@ import { ICONS } from '../icons.js';
 import { clearUnreadResponses } from './attention-badge.js';
 import { syncOrchestrateSnapshot } from '../ws.js';
 import { waitForSettingsSaveIdle } from './settings-core.js';
+import { isChatNearBottom, markFollowingBottom, reconcileChatBottomAfterLayout } from './chat-scroll.js';
 
 let activeObjectURLs: string[] = [];
 
@@ -182,14 +183,17 @@ export async function sendMessage(source: SendSource = 'enter'): Promise<void> {
                 // user-facing no-pending response through orchestrate_done.
                 addMessage('user', text);
                 upsertMessage({ role: 'user', content: text, timestamp: Date.now() });
+                reconcileChatBottomAfterLayout(true);
             } else if (data.continued) {
                 addMessage('user', text);
                 upsertMessage({ role: 'user', content: text, timestamp: Date.now() });
                 addSystemMsg(t('chat.continue'));
+                reconcileChatBottomAfterLayout(true);
             } else {
                 // started: backend already inserted the row; render now.
                 addMessage('user', text);
                 upsertMessage({ role: 'user', content: text, timestamp: Date.now() });
+                reconcileChatBottomAfterLayout(true);
             }
         }
     } finally {
@@ -283,10 +287,15 @@ export async function clearChat(): Promise<void> {
 let resizeRaf = 0;
 function autoResize(el: HTMLTextAreaElement): void {
     if (resizeRaf) return;
+    const shouldFollowBottom = isChatNearBottom();
     resizeRaf = requestAnimationFrame(() => {
         resizeRaf = 0;
         el.style.height = 'auto';
         el.style.height = el.scrollHeight + 'px';
+        if (shouldFollowBottom) {
+            const c = document.getElementById('chatMessages');
+            if (c) { c.scrollTop = c.scrollHeight; markFollowingBottom(); }
+        }
     });
 }
 
@@ -297,7 +306,12 @@ export function initAutoResize(): void {
 
 export function resetInputHeight(): void {
     const el = document.getElementById('chatInput') as HTMLTextAreaElement | null;
+    const shouldFollowBottom = isChatNearBottom();
     if (el) el.style.height = 'auto';
+    if (shouldFollowBottom) {
+        const c = document.getElementById('chatMessages');
+        if (c) { c.scrollTop = c.scrollHeight; markFollowingBottom(); }
+    }
 }
 
 export function initDragDrop(): void {


### PR DESCRIPTION
## Summary

- **Screen shake when typing multi-line**: Fixed by saving `isChatNearBottom()` before RAF and scrolling directly with `scrollTop = scrollHeight` + `markFollowingBottom()` in the same RAF callback — eliminates the 2-frame layout bounce caused by `scrollToBottom()`'s internal RAF
- **Scroll not following after sending message**: Fixed by calling `reconcileChatBottomAfterLayout(true)` (double-RAF) after each `addMessage('user', text)` to ensure scroll happens after the new message DOM layout is complete

## Changes

1 file changed, 14 insertions:
- `public/js/features/chat.ts`

## How to test

1. Open the web UI and type enough text to overflow to 2+ lines — no screen shake
2. Send a message — chat view scrolls to show your message without cutting off