### PR TITLE
[codex] Avoid misleading AGY binary quota percentages

### DIFF
--- a/public/js/features/settings-cli-status.ts
+++ b/public/js/features/settings-cli-status.ts
@@ -5,7 +5,7 @@ import { t } from './i18n.js';
 import { state } from '../state.js';
 import { ICONS } from '../icons.js';
 import { providerIcon, providerLabel } from '../provider-icons.js';
-import type { QuotaEntry } from './settings-types.js';
+import { resolveQuotaWindowDisplay, type QuotaEntry } from './settings-types.js';
 import {
     buildAccountParts,
     normalizeQuotaWindowLabel,
@@ -360,7 +360,8 @@ function renderCliStatus(data: { cliStatus: Record<string, { available: boolean 
             windowsHtml = renderQuotaSetupBox(name, q);
         } else if (q?.windows?.length) {
             windowsHtml = q.windows.map(w => {
-                const pct = Math.round(w.percent);
+                const display = resolveQuotaWindowDisplay(w);
+                const pct = display.percent ?? 0;
                 const barColor = pct > 80 ? 'var(--error)' : pct > 50 ? 'var(--warning)' : 'var(--info)';
                 const shortLabel = normalizeQuotaWindowLabel(name, w.label);
                 let resetStr = '';
@@ -373,13 +374,13 @@ function renderCliStatus(data: { cliStatus: Record<string, { available: boolean 
                         resetStr = `${d.getMonth() + 1}/${d.getDate()}`;
                     }
                 }
+                const usageDisplay = display.percent == null
+                    ? `<span style="flex:1"></span><span style="min-width:52px;text-align:right" title="Exact percentage unavailable">${escapeHtml(display.text)}</span>`
+                    : `<div style="flex:1;height:4px;background:var(--border);border-radius:2px;overflow:hidden"><div style="width:${pct}%;height:100%;background:${barColor};border-radius:2px"></div></div><span style="width:24px;text-align:right">${display.text}</span>`;
                 return `
                     <div style="display:flex;align-items:center;gap:4px;margin-left:16px;font-size:10px;color:var(--text-dim)">
                         <span style="min-width:18px;max-width:48px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${escapeHtml(shortLabel)}</span>
-                        <div style="flex:1;height:4px;background:var(--border);border-radius:2px;overflow:hidden">
-                            <div style="width:${pct}%;height:100%;background:${barColor};border-radius:2px"></div>
-                        </div>
-                        <span style="width:24px;text-align:right">${pct}%</span>
+                        ${usageDisplay}
                         ${resetStr ? `<span style="width:30px;text-align:right;opacity:0.6">${resetStr}</span>` : ''}
                     </div>
                 `;

--- a/public/js/features/settings-types.ts
+++ b/public/js/features/settings-types.ts
@@ -3,7 +3,24 @@
 export interface PerCliConfig { provider?: string; model?: string; effort?: string; fastMode?: boolean; contextWindow?: boolean; contextWindowSize?: number; contextCompactLimit?: number; }
 export interface TelegramConfig { enabled?: boolean; token?: string; allowedChatIds?: number[]; forwardAll?: boolean; mentionOnly?: boolean; }
 export interface DiscordConfig { enabled?: boolean; token?: string; guildId?: string; channelIds?: string[]; forwardAll?: boolean; allowBots?: boolean; mentionOnly?: boolean; }
-export interface QuotaWindow { label: string; percent: number; resetsAt?: string | number | null; modelId?: string; }
+export interface QuotaWindow {
+    label: string;
+    percent: number;
+    resetsAt?: string | number | null;
+    modelId?: string;
+    precision?: 'binary';
+    status?: 'available' | 'exhausted';
+}
+export function resolveQuotaWindowDisplay(window: QuotaWindow): { percent: number | null; text: string } {
+    if (window.precision === 'binary') {
+        return {
+            percent: null,
+            text: window.status === 'exhausted' ? 'Exhausted' : 'Available',
+        };
+    }
+    const percent = Math.max(0, Math.min(100, Math.round(window.percent)));
+    return { percent, text: `${percent}%` };
+}
 export interface QuotaEntry {
     account?: { email?: string; type?: string; plan?: string; tier?: string };
     windows?: QuotaWindow[];

--- a/src/routes/quota-agy-reverse.ts
+++ b/src/routes/quota-agy-reverse.ts
@@ -53,7 +53,23 @@ function classifyAgyQuotaFamily(model: AntigravityModelQuota): AgyQuotaFamily | 
 }
 
 export function collapseAgyQuotaWindows(models: AntigravityModelQuota[]) {
-    const buckets = new Map<AgyQuotaFamily, { label: string; percent: number; resetsAt: string | null; modelId?: string }>();
+    const quotaModels = models.filter((model) => (
+        !model.isAutocompleteOnly
+        && classifyAgyQuotaFamily(model) !== null
+        && model.remainingPercentage != null
+        && Number.isFinite(model.remainingPercentage)
+    ));
+    const binaryOnly = quotaModels.length > 0 && quotaModels.every((model) => (
+        model.remainingPercentage === 0 || model.remainingPercentage === 1
+    ));
+    const buckets = new Map<AgyQuotaFamily, {
+        label: string;
+        percent: number;
+        resetsAt: string | null;
+        modelId?: string;
+        precision?: 'binary';
+        status?: 'available' | 'exhausted';
+    }>();
     for (const model of models) {
         if (model.isAutocompleteOnly) continue;
         const family = classifyAgyQuotaFamily(model);
@@ -64,6 +80,10 @@ export function collapseAgyQuotaWindows(models: AntigravityModelQuota[]) {
             percent: usedPercentFromRemaining(model.remainingPercentage, model.isExhausted),
             resetsAt: model.resetTime ?? null,
             modelId: model.modelId,
+            precision: binaryOnly ? 'binary' : undefined,
+            status: binaryOnly
+                ? (model.isExhausted || model.remainingPercentage === 0 ? 'exhausted' : 'available')
+                : undefined,
         }));
     }
     return (['gem', 'cla'] as const).flatMap((family) => {

--- a/tests/unit/quota-reverse-agy.test.ts
+++ b/tests/unit/quota-reverse-agy.test.ts
@@ -86,10 +86,12 @@ test('normalizeAntigravityUsageSnapshot converts remaining percentage to used pe
     assert.deepEqual(result.windows?.map((window) => window.label), ['Gem', 'Cla']);
     assert.equal(result.windows?.[0]?.percent, 75);
     assert.equal(result.windows?.[1]?.percent, 0);
+    assert.equal(result.windows?.[0]?.precision, undefined);
+    assert.equal(result.windows?.[1]?.precision, undefined);
     assert.equal((result.account as { tier?: string })?.tier, 'Google AI Pro');
 });
 
-test('normalizeAntigravityUsageSnapshot degrades binary remaining values to 0/100 bars', () => {
+test('normalizeAntigravityUsageSnapshot marks binary remaining values as availability states', () => {
     const result = normalizeAntigravityUsageSnapshot({
         method: 'google',
         models: [
@@ -111,4 +113,8 @@ test('normalizeAntigravityUsageSnapshot degrades binary remaining values to 0/10
     assert.deepEqual(result.windows?.map((window) => window.label), ['Gem', 'Cla']);
     assert.equal(result.windows?.[0]?.percent, 100);
     assert.equal(result.windows?.[1]?.percent, 0);
+    assert.equal(result.windows?.[0]?.precision, 'binary');
+    assert.equal(result.windows?.[0]?.status, 'exhausted');
+    assert.equal(result.windows?.[1]?.precision, 'binary');
+    assert.equal(result.windows?.[1]?.status, 'available');
 });

--- a/tests/unit/quota-window-display.test.ts
+++ b/tests/unit/quota-window-display.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveQuotaWindowDisplay } from '../../public/js/features/settings-types.ts';
+
+test('resolveQuotaWindowDisplay keeps precise percentage bars', () => {
+    assert.deepEqual(
+        resolveQuotaWindowDisplay({ label: 'Gem', percent: 37.6 }),
+        { percent: 38, text: '38%' },
+    );
+});
+
+test('resolveQuotaWindowDisplay replaces binary values with availability text', () => {
+    assert.deepEqual(
+        resolveQuotaWindowDisplay({ label: 'Gem', percent: 0, precision: 'binary', status: 'available' }),
+        { percent: null, text: 'Available' },
+    );
+    assert.deepEqual(
+        resolveQuotaWindowDisplay({ label: 'Cla', percent: 100, precision: 'binary', status: 'exhausted' }),
+        { percent: null, text: 'Exhausted' },
+    );
+});


### PR DESCRIPTION
## What changed

- detect AGY snapshots where every relevant model exposes only binary
  `remainingPercentage` values (`0` or `1`)
- retain the existing numeric `percent` field for compatibility while adding
  `precision: binary` and an availability status
- render `Available` or `Exhausted` instead of a percentage bar for binary
  windows
- preserve reset-time display and precise percentage bars when fractional
  values are available

## Why

`antigravity-usage` can successfully authenticate through the Google Cloud
Code API while returning `remainingPercentage: 1` for every model. That value
only proves that quota is available, but cli-jaw currently renders it as
precise `0%` usage. This is misleading after the account has already been used.

The local quota method is not available in headless AGY deployments because it
requires an Antigravity IDE language server, so the UI needs to represent the
lower-precision Google response honestly.

Closes #247.

## Validation

- 35 focused quota, status, and UI tests pass
- `npx tsc --noEmit` passes
- `npm run build:frontend` passes
- `git diff --check` passes
