### PR TITLE
[codex] Bind interview answers to parent PABCD scope

### DIFF
--- a/src/orchestrator/pipeline.ts
+++ b/src/orchestrator/pipeline.ts
@@ -28,7 +28,7 @@ import { buildWorkerReplayNotice } from './worker-replay-notice.js';
 import { processQueue } from '../agent/spawn.js';
 import {
     getState, getPrefix, resetState, setState, getStatePrompt,
-    getCtx,
+    getCtx, buildScopeRebindGuard,
     type OrcStateName,
     type OrcContext,
     type DimensionAssessment,
@@ -286,7 +286,9 @@ export async function orchestrate(
                 ? `Project root: ${JSON.stringify(resolve(settings["workingDir"]))}`
                 : '';
         const wsBlock = wsInfo ? `\n## Workspace\n${wsInfo}\n` : '';
-        prompt = `${getStatePrompt('P')}${wsBlock}\nUser request:\n${planningTask}`;
+        const scopeRebindGuard = buildScopeRebindGuard(ctx);
+        const scopeRebindBlock = scopeRebindGuard ? `\n${scopeRebindGuard}\n` : '';
+        prompt = `${getStatePrompt('P')}${wsBlock}${scopeRebindBlock}\nUser request:\n${planningTask}`;
         skipPrefix = true;
 
         const nextCtx: OrcContext = {

--- a/src/orchestrator/state-machine.ts
+++ b/src/orchestrator/state-machine.ts
@@ -237,6 +237,25 @@ Do NOT paste the full employee output verbatim.
 Employee results:`,
 };
 
+function compactLine(value: unknown, max = 700): string {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export function buildScopeRebindGuard(ctx?: OrcContext | null): string {
+  const parentGoal = compactLine(ctx?.originalPrompt);
+  const interviewPurpose = compactLine(ctx?.interview?.request);
+  if (!parentGoal || !ctx?.interview) return '';
+  return [
+    '## Scope Rebind Guard',
+    `Parent Goal: ${parentGoal}`,
+    interviewPurpose && interviewPurpose !== parentGoal ? `Interview Purpose: ${interviewPurpose}` : '',
+    '- Bind interview answers only as parameters, constraints, success criteria, or wording choices for the Parent Goal.',
+    '- Do not reinterpret a clarification answer as a new parent task or feature.',
+    '- If an answer appears to request a new goal, stop and ask whether to split it into a separate IPABCD/PABCD flow.',
+  ].filter(Boolean).join('\n');
+}
+
 export function getPrefix(state: OrcStateName, source: 'user' | 'worker' = 'user', ctx?: OrcContext | null): string | null {
   if (state === 'I') {
     let prefix = PREFIXES["Ip"]!;
@@ -254,7 +273,10 @@ export function getPrefix(state: OrcStateName, source: 'user' | 'worker' = 'user
     }
     return prefix;
   }
-  if (state === 'P') return PREFIXES["Pb2"]!;
+  if (state === 'P') {
+    const guard = buildScopeRebindGuard(ctx);
+    return guard ? `${PREFIXES["Pb2"]!}\n\n${guard}` : PREFIXES["Pb2"]!;
+  }
   if (state === 'A') return source === 'worker' ? PREFIXES["Ab2"]! : PREFIXES["Ap"]!;
   if (state === 'B' && source === 'worker') return PREFIXES["Bb2"]!;
   return null;

--- a/tests/unit/state-machine.test.ts
+++ b/tests/unit/state-machine.test.ts
@@ -2,7 +2,7 @@ import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
     getState, setState, getCtx, resetState,
-    canTransition, getPrefix, getStatePrompt,
+    canTransition, getPrefix, getStatePrompt, buildScopeRebindGuard,
     type OrcStateName,
 } from '../../src/orchestrator/state-machine.ts';
 
@@ -117,5 +117,43 @@ describe('PABCD state-machine', () => {
         assert.equal(getState('default'), 'I');
         const saved = getCtx('default');
         assert.deepEqual(saved!.interview, ctx.interview);
+    });
+    test('26. scope rebind guard is empty without interview ctx', () => {
+        const ctx = { originalPrompt: 'build academy', workingDir: null, plan: null, workerResults: [], origin: 'web' };
+        assert.equal(buildScopeRebindGuard(ctx), '');
+    });
+    test('27. scope rebind guard binds interview answers to parent goal', () => {
+        const ctx = {
+            originalPrompt: 'Add a one-time study-session end notifier',
+            workingDir: null,
+            plan: null,
+            workerResults: [],
+            origin: 'web',
+            interview: {
+                request: 'Clarify praise phrase style and storage',
+                round: 2,
+                known: [],
+                unknown: [],
+            },
+        };
+        const guard = buildScopeRebindGuard(ctx);
+        assert.match(guard, /Scope Rebind Guard/);
+        assert.match(guard, /Parent Goal: Add a one-time study-session end notifier/);
+        assert.match(guard, /Interview Purpose: Clarify praise phrase style and storage/);
+        assert.match(guard, /Do not reinterpret a clarification answer as a new parent task/);
+    });
+    test('28. P prefix includes scope rebind guard when interview ctx exists', () => {
+        const ctx = {
+            originalPrompt: 'Add a session-end break notification',
+            workingDir: null,
+            plan: null,
+            workerResults: [],
+            origin: 'web',
+            interview: { request: 'Pick notification phrase style', round: 1, known: [], unknown: [] },
+        };
+        const prefix = getPrefix('P', 'user', ctx)!;
+        assert.match(prefix, /PLANNING MODE/);
+        assert.match(prefix, /Scope Rebind Guard/);
+        assert.match(prefix, /Bind interview answers only as parameters/);
     });
 });


### PR DESCRIPTION
## Summary

Adds a small prompt-level Scope Rebind Guard for I -> P / PABCD planning flows.

When an Interview step has collected clarification answers, the planning prompt now explicitly tells the model to bind those answers back to the original parent goal instead of treating the latest clarification as a new task.

## Why

This addresses #238 without adding semantic similarity checks or another validation model call. The orchestration state already carries the original prompt and interview context; this PR makes that relationship explicit in the prompt contract for lightweight backends that may otherwise over-focus on the latest interview answer.

## Changes

- Add `buildScopeRebindGuard(ctx)` in `state-machine.ts`.
- Include the guard in P prefixes when interview context exists.
- Include the same guard in initial planning prompts generated after Interview.
- Add unit coverage for guard generation and P-prefix injection.

## Validation

- `node --import tsx --test tests/unit/state-machine.test.ts`
- `npx tsc --noEmit`

Closes #238.
