### PR TITLE
fix(prompt): add bounded local search guard

### DIFF
--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -484,6 +484,17 @@ export function shouldIncludeVisionClickHint(activeCli?: string | null): boolean
     return activeCli === 'codex';
 }
 
+export function getBoundedLocalSearchContract(): string {
+    return [
+        '## Bounded Local Search Contract',
+        '- Native local search tools such as `grep_search`, Grep, Glob, or broad file listing must start from one known file or a narrow task-specific directory.',
+        '- Never run local search from `/`, a home directory, the whole runtime directory, dependency trees, caches, logs, backups, generated trees, or database files such as `*.db`.',
+        '- If a shell search is needed, prefer a bounded form such as `timeout 20s rg --glob \'!*.db\' --glob \'!*.log\' <query> <narrow-path>` and cap output.',
+        '- If a search times out, do not widen the search. Mark the item unresolved, ask for a narrower path when needed, or stop with a partial result.',
+        '- Use exact file checks (`test -e`, `test -s`, or a direct file read) when checking a known path; do not discover known files through repository-wide search.',
+    ].join('\n');
+}
+
 export function getSystemPrompt(opts: { currentPrompt?: string; forDisk?: boolean; memorySnapshot?: string; activeCli?: string } = {}) {
     // A-1: file takes priority (user-editable), rendered template fallback
     const a1 = fs.existsSync(A1_PATH) ? fs.readFileSync(A1_PATH, 'utf8') : getA1Content();
@@ -641,6 +652,8 @@ It defines phase contracts, dispatch pitfalls (delegation trap, context drift, p
             if (block) prompt += '\n\n---\n' + block;
         } catch { /* runtime-context not ready */ }
     }
+
+    prompt += '\n\n---\n' + getBoundedLocalSearchContract();
 
     // ─── Delegation rules: jaw employees vs CLI sub-agents ───
     // Always-injected guard block (survives user-edited A-1.md overrides).
@@ -869,6 +882,8 @@ export function getEmployeePromptV2(
     prompt += `\n- Your process cwd may be an isolated temporary directory. Do NOT treat process.cwd() as the repository root.`;
     prompt += `\n- Use the task's ## Workspace Context block as the source of truth for Project root and Devlog root.`;
     prompt += `\n- Resolve relative repository paths against Project root, and always use absolute paths in commands and reports.`;
+
+    prompt += `\n\n${getBoundedLocalSearchContract()}`;
 
     prompt += `\n\n## Delegation Rules`;
     prompt += `\n- Execute the assigned task directly in this employee session.`;

--- a/tests/unit/system-prompt.test.ts
+++ b/tests/unit/system-prompt.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { JAW_HOME, SKILLS_DIR, SKILLS_REF_DIR } from '../../src/core/config.ts';
-import { getSystemPrompt } from '../../src/prompt/builder.ts';
+import { getBoundedLocalSearchContract, getEmployeePromptV2, getSystemPrompt } from '../../src/prompt/builder.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..', '..');
@@ -173,6 +173,25 @@ test('rendered Boss prompt keeps skill matching guidance when only ref skills ex
         'ref-only Boss prompt should point to CLI command for browsing ref skills');
     assert.ok(prompt.includes(JAW_HOME),
         'rendered prompt should still use the configured test JAW_HOME');
+});
+
+test('rendered prompts include bounded local search contract', () => {
+    const contract = getBoundedLocalSearchContract();
+    const bossPrompt = getSystemPrompt({ forDisk: false });
+    const employeePrompt = getEmployeePromptV2(
+        { id: 1, name: 'Audit', role: 'reviewer', cli: 'agy' },
+        'backend',
+        2,
+    );
+
+    assert.ok(contract.includes('grep_search'),
+        'bounded local search contract should cover native grep_search tools');
+    assert.ok(contract.includes('timeout 20s rg'),
+        'bounded local search contract should recommend bounded shell search');
+    assert.ok(bossPrompt.includes(contract),
+        'Boss prompt should include the bounded local search contract');
+    assert.ok(employeePrompt.includes(contract),
+        'Employee prompt should include the bounded local search contract');
 });
 
 // ─── Active channel auto-selection ───────────────────


### PR DESCRIPTION
## Summary
- Add an always-injected Bounded Local Search Contract to the Boss prompt.
- Add the same contract to employee prompts so background/worker sessions avoid broad local searches too.
- Cover native search tools such as grep_search plus shell Grep/Glob/listing behavior.

## Why
Long-running agent sessions can time out when a model starts native grep_search or broad recursive search from a runtime root. In one observed heartbeat failure, the agent searched the whole runtime directory and hit a large SQLite database/log tree, then exceeded the watchdog window. This is especially risky for autonomous heartbeats and lightweight models that may over-broaden when unsure.

The contract does not remove search capability. It makes local search bounded by default: start from a known file or narrow directory, avoid runtime roots/caches/logs/databases, use bounded shell searches when needed, and stop rather than widening after timeout.

## Verification
- node --import tsx --test tests/unit/system-prompt.test.ts
- npx tsc --noEmit
- npm run build