### PR TITLE
[codex] Limit AGY default add-dir scope

### DIFF
--- a/src/agent/args.ts
+++ b/src/agent/args.ts
@@ -127,7 +127,8 @@ function geminiIncludeDirectoryArgs(options: BuildArgOptions): string[] {
 export function resolveAgyAddDirectories(options: BuildArgOptions = {}): string[] {
     const dirs = [
         options.workingDir,
-        options.homedir ?? os.homedir(),
+        // AGY's native tools can search every --add-dir root. Do not grant the
+        // whole home directory by default; callers may opt in via includeDirectories.
         ...(options.includeDirectories ?? []),
     ];
     const seen = new Set<string>();

--- a/tests/unit/agent-args.test.ts
+++ b/tests/unit/agent-args.test.ts
@@ -32,7 +32,6 @@ test('AG-000a: agy uses print p-mode with timeout, permissions, and add-dir root
         '--print-timeout', '10m',
         '--dangerously-skip-permissions',
         '--add-dir', '/repo',
-        '--add-dir', '/home/jun',
         '--add-dir', '/extra',
     ]);
 });
@@ -56,12 +55,12 @@ test('AG-000c: agy passes --model but never unsupported output/include-directory
     assert.ok(!args.includes('--include-directories'));
 });
 
-test('AG-000d: agy add-dir roots dedupe with working directory first', () => {
+test('AG-000d: agy add-dir roots dedupe without implicit home directory', () => {
     assert.deepEqual(resolveAgyAddDirectories({
         workingDir: '/repo/',
         homedir: '/home/jun',
         includeDirectories: ['/repo', '/extra', '/extra/'],
-    }), ['/repo', '/home/jun', '/extra']);
+    }), ['/repo', '/extra']);
 });
 
 test('AG-000e: agy resume uses exact native conversation id with print mode', () => {


### PR DESCRIPTION
## Summary
- Stop adding the user's home directory to AGY `--add-dir` by default.
- Keep the working directory and explicitly configured includeDirectories.
- Update AGY argument tests to reflect the narrower default scope.

## Why
AGY native tools can search every `--add-dir` root. When cli-jaw grants both the working directory and `os.homedir()`, AGY can choose broad roots such as `/home/test` for native `grep_search`, bypassing prompt-level bounded-search guidance and causing long timeouts or stuck runs.

This makes the default AGY tool surface match the current workspace instead of the whole home directory. Users who need extra roots can still opt in with configured include directories.

## Validation
- `npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test tests/unit/agent-args.test.ts`
- `npx tsc --noEmit`
