### PR TITLE
fix(memory): preserve curated profile during core sync

### DIFF
--- a/src/memory/bootstrap.ts
+++ b/src/memory/bootstrap.ts
@@ -68,6 +68,48 @@ function parseLegacyMemorySections(content: string) {
     return sections;
 }
 
+export function mergeCoreProfileContent(
+    existing: string,
+    coreContent: string,
+    sourceHash: string,
+    updatedAt = new Date().toISOString(),
+) {
+    const parsed = parseLegacyMemorySections(coreContent);
+    const managedBlock = `<!-- cli-jaw:core-memory:start -->
+## Core Memory Sync
+
+### User Preferences
+${parsed.userPreferences || ''}
+
+### Key Decisions
+${parsed.keyDecisions || ''}
+
+### Active Projects
+${parsed.activeProjects || ''}
+<!-- cli-jaw:core-memory:end -->`;
+    const startMarker = '<!-- cli-jaw:core-memory:start -->';
+    const endMarker = '<!-- cli-jaw:core-memory:end -->';
+    const start = existing.indexOf(startMarker);
+    const end = existing.indexOf(endMarker);
+    let content = start >= 0 && end >= start
+        ? existing.slice(0, start) + managedBlock + existing.slice(end + endMarker.length)
+        : `${existing.trimEnd()}\n\n${managedBlock}\n`;
+
+    const closingFrontmatter = content.startsWith('---\n') ? content.indexOf('\n---\n', 4) : -1;
+    if (closingFrontmatter >= 0) {
+        const header = content.slice(0, closingFrontmatter);
+        const body = content.slice(closingFrontmatter);
+        const withHash = /^source_hash:\s*.+$/m.test(header)
+            ? header.replace(/^source_hash:\s*.+$/m, `source_hash: ${sourceHash}`)
+            : `${header}\nsource_hash: ${sourceHash}`;
+        const withTimestamp = /^updated_at:\s*.+$/m.test(withHash)
+            ? withHash.replace(/^updated_at:\s*.+$/m, `updated_at: ${updatedAt}`)
+            : `${withHash}\nupdated_at: ${updatedAt}`;
+        content = withTimestamp + body;
+    }
+    return content;
+}
+
 function getLegacyClaudeMemoryDir() {
     const wd = expandHomePath(settings["workingDir"] || os.homedir(), os.homedir());
     const hash = wd.replace(/[\\/]/g, '-');
@@ -130,7 +172,17 @@ export function syncCoreProfile(root: string, opts: { force?: boolean } = {}) {
         }
     }
 
+    const existing = fs.existsSync(profilePath) ? safeReadFile(profilePath) : '';
     const parsed = parseLegacyMemorySections(coreContent);
+
+    if (existing.trim()) {
+        const content = mergeCoreProfileContent(existing, coreContent, sourceHash);
+        writeText(profilePath, content);
+        reindexSingleFile(root, profilePath);
+        updateImportedCount('core', 1);
+        return { updated: true, path: profilePath, sourceHash, preserved: true };
+    }
+
     const body = `# Profile
 
 ## User Preferences
@@ -143,7 +195,6 @@ ${parsed.keyDecisions || ''}
 ${parsed.activeProjects || ''}
 `;
 
-    const existing = fs.existsSync(profilePath) ? safeReadFile(profilePath) : '';
     const existingCreatedAt = /^created_at:\s+(.+)$/m.exec(existing)?.[1]?.trim() || '';
 
     const fm = frontmatter({

--- a/tests/unit/memory-core-profile-sync.test.ts
+++ b/tests/unit/memory-core-profile-sync.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeCoreProfileContent } from '../../src/memory/bootstrap.ts';
+
+const core = `# Memory
+
+## User Preferences
+- Recovery lighthouse preference
+
+## Key Decisions
+- Preserve curated profile
+
+## Active Projects
+- Memory repair
+`;
+
+test('core profile sync preserves curated profile sections', () => {
+    const original = `---\nsource_hash: old\nupdated_at: old\n---\n# Profile\n\n## Profile Summary\n- Ferrari fan\n\n## Personal Context\n- Seoul\n`;
+    const updated = mergeCoreProfileContent(original, core, 'new-hash', '2026-06-28T00:00:00.000Z');
+
+    assert.match(updated, /## Profile Summary\n- Ferrari fan/);
+    assert.match(updated, /## Personal Context\n- Seoul/);
+    assert.match(updated, /<!-- cli-jaw:core-memory:start -->/);
+    assert.match(updated, /Recovery lighthouse preference/);
+    assert.match(updated, /^source_hash: new-hash$/m);
+    assert.match(updated, /^updated_at: 2026-06-28T00:00:00.000Z$/m);
+});
+
+test('core profile sync replaces only its managed block on later sync', () => {
+    const original = `---\nsource_hash: old\n---\n# Profile\n\n## Profile Summary\n- Keep me\n\n<!-- cli-jaw:core-memory:start -->\nold managed data\n<!-- cli-jaw:core-memory:end -->\n`;
+    const updated = mergeCoreProfileContent(original, core, 'new-hash');
+
+    assert.match(updated, /## Profile Summary\n- Keep me/);
+    assert.doesNotMatch(updated, /old managed data/);
+    assert.equal((updated.match(/cli-jaw:core-memory:start/g) || []).length, 1);
+});


### PR DESCRIPTION
## Summary
- preserve existing structured profile content when `MEMORY.md` changes
- isolate legacy core-memory synchronization in a replaceable managed block
- keep `source_hash` and `updated_at` freshness metadata current
- add regression tests for first sync and repeated sync

## Problem
`syncCoreProfile()` rebuilt `memory/structured/profile.md` entirely from the small legacy `memory/MEMORY.md` file whenever its hash changed. Any independently curated profile sections were silently deleted. In a long-running instance this reduced a 21 KB user profile to a minimal 663-byte file after a memory flush.

## Verification
- `npx tsx --test tests/unit/memory-core-profile-sync.test.ts`
- `npx tsc --noEmit`
- `git diff upstream/main...HEAD --check`

All passed.
