### PR TITLE
[codex] make AGY bootstrap prompt order configurable

### DIFF
--- a/src/agent/agy-bootstrap.ts
+++ b/src/agent/agy-bootstrap.ts
@@ -4,6 +4,12 @@ import type { SpawnContext } from '../types/agent.js';
 export const AGY_BOOTSTRAP_VERSION = 1;
 export const AGY_BOOTSTRAP_PREFIX = 'CLI_JAW_BOOTSTRAP_SHA=';
 
+export type AgyPromptOrder = 'task-first' | 'context-first';
+
+export function resolveAgyPromptOrder(value: unknown): AgyPromptOrder {
+    return value === 'context-first' ? 'context-first' : 'task-first';
+}
+
 export type AgyPromptSegmentId =
     | 'bootstrap'
     | 'current-task'
@@ -81,18 +87,21 @@ export function buildAgyBootstrapEnvelope(input: {
     sessionId?: string | null;
     timestampMs?: number;
     maxChars?: number;
+    order?: AgyPromptOrder;
 }): AgyBootstrapEnvelope {
     const taskPrompt = normalizeText(input.taskPrompt);
     const operationalContext = normalizeText(input.operationalContext);
     const historyBlock = normalizeText(input.historyBlock);
     const workingDir = normalizeScalar(input.workingDir, 'unknown');
     const sessionId = normalizeScalar(input.sessionId, 'fresh');
+    const order = resolveAgyPromptOrder(input.order);
     const hash = shortSha256({
         version: AGY_BOOTSTRAP_VERSION,
         taskPrompt,
         operationalContext,
         workingDir,
         sessionId,
+        order,
     });
     const sentinel = `${AGY_BOOTSTRAP_PREFIX}${hash}`;
     const bootstrap = [
@@ -127,7 +136,10 @@ export function buildAgyBootstrapEnvelope(input: {
     ];
     const truncated: AgyPromptSegmentId[] = [];
     const omitted: AgyPromptSegmentId[] = [];
-    const joinPrompt = () => [...requiredSegments, ...optionalSegments]
+    const orderSegments = (optional: typeof optionalSegments) => order === 'context-first'
+        ? [requiredSegments[0], ...optional, requiredSegments[1]]
+        : [...requiredSegments, ...optional];
+    const joinPrompt = () => orderSegments(optionalSegments)
         .filter((segment) => segment.text)
         .map((segment) => segment.text)
         .join('\n\n---\n\n');
@@ -142,7 +154,7 @@ export function buildAgyBootstrapEnvelope(input: {
             const targetSegment = optionalSegments[idx];
             if (!targetSegment) continue;
             const withoutSegment = optionalSegments.filter((_, segmentIdx) => segmentIdx !== idx);
-            const promptWithoutSegment = [...requiredSegments, ...withoutSegment]
+            const promptWithoutSegment = orderSegments(withoutSegment)
                 .filter((segment) => segment.text)
                 .map((segment) => segment.text)
                 .join('\n\n---\n\n');

--- a/src/agent/agy-bootstrap.ts
+++ b/src/agent/agy-bootstrap.ts
@@ -121,10 +121,9 @@ export function buildAgyBootstrapEnvelope(input: {
         ].join('\n')
         : '';
     const historySection = historyBlock ? `[Recent context / history]\n${historyBlock}` : '';
-    const requiredSegments = [
-        { id: 'bootstrap' as const, text: bootstrap },
-        { id: 'current-task' as const, text: currentTask },
-    ];
+    const bootstrapSegment = { id: 'bootstrap' as const, text: bootstrap };
+    const currentTaskSegment = { id: 'current-task' as const, text: currentTask };
+    const requiredSegments = [bootstrapSegment, currentTaskSegment];
     let optionalSegments = [
         { id: 'operational-context' as const, text: operationalSection },
         { id: 'history' as const, text: historySection },
@@ -137,7 +136,7 @@ export function buildAgyBootstrapEnvelope(input: {
     const truncated: AgyPromptSegmentId[] = [];
     const omitted: AgyPromptSegmentId[] = [];
     const orderSegments = (optional: typeof optionalSegments) => order === 'context-first'
-        ? [requiredSegments[0], ...optional, requiredSegments[1]]
+        ? [bootstrapSegment, ...optional, currentTaskSegment]
         : [...requiredSegments, ...optional];
     const joinPrompt = () => orderSegments(optionalSegments)
         .filter((segment) => segment.text)

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -71,7 +71,11 @@ import {
     stripAgyResumeReplayPrefixes,
 } from './agy-runtime.js';
 import { detectAgyCapabilities } from './agy-capabilities.js';
-import { buildAgyBootstrapEnvelope, type AgyBootstrapEnvelope } from './agy-bootstrap.js';
+import {
+    buildAgyBootstrapEnvelope,
+    resolveAgyPromptOrder,
+    type AgyBootstrapEnvelope,
+} from './agy-bootstrap.js';
 import { startAgyTranscriptWatcher, type AgyTranscriptWatcherHandle } from './agy-transcript-watcher.js';
 import { appendAssistantTextSegment, normalizeAssistantDisplayText, pushTrace } from './events/helpers.js';
 import { listKiroConversationIdsForCwd } from './kiro-auth.js';
@@ -1142,6 +1146,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             historyBlock,
             workingDir: spawnCwd,
             sessionId: resumeSessionId,
+            order: resolveAgyPromptOrder(cfg.promptOrder),
             ...(sysPrompt ? { operationalContext: sysPrompt } : {}),
         });
         promptForArgs = agyBootstrap.prompt;

--- a/tests/unit/agy-bootstrap.test.ts
+++ b/tests/unit/agy-bootstrap.test.ts
@@ -65,6 +65,25 @@ test('AGY-BS-002: AGY envelope orders bootstrap, current task, operational conte
     assert.match(envelope.prompt, /session=fresh/);
 });
 
+test('AGY-BS-002b: context-first keeps bootstrap first and current task last', () => {
+    const envelope = buildAgyBootstrapEnvelope({
+        taskPrompt: 'current task',
+        operationalContext: 'operational rules',
+        historyBlock: 'old context',
+        workingDir: '/repo',
+        order: 'context-first',
+    });
+    const bootstrapIdx = envelope.prompt.indexOf('[CLI-JAW AGY BOOTSTRAP]');
+    const operationalIdx = envelope.prompt.indexOf('[Operational Context — cli-jaw Integration]');
+    const historyIdx = envelope.prompt.indexOf('[Recent context / history]');
+    const taskIdx = envelope.prompt.indexOf('[Current cli-jaw task]');
+
+    assert.ok(bootstrapIdx >= 0);
+    assert.ok(operationalIdx > bootstrapIdx);
+    assert.ok(historyIdx > operationalIdx);
+    assert.ok(taskIdx > historyIdx);
+});
+
 test('AGY-BS-003: AGY bootstrap hash changes when session id changes', () => {
     const base = {
         taskPrompt: 'task',

--- a/tests/unit/steer-flow.test.ts
+++ b/tests/unit/steer-flow.test.ts
@@ -141,7 +141,7 @@ test('SF-004b: resume argv CLIs keep enriched promptForArgs for agy and compact 
     );
 });
 
-test('SF-004c: agy front-loads current task before operational context', () => {
+test('SF-004c: agy passes configured prompt order to the bootstrap envelope', () => {
     const src = fs.readFileSync(join(__dirname, '../../src/agent/spawn.ts'), 'utf8');
     const agyBranchIdx = src.indexOf("if (cli === 'agy') {");
     const preflightIdx = src.indexOf('// ─── DIFF-A: Preflight', agyBranchIdx);
@@ -152,6 +152,7 @@ test('SF-004c: agy front-loads current task before operational context', () => {
     assert.ok(agyBranch.includes('buildAgyBootstrapEnvelope({'), 'agy branch should use the bootstrap envelope builder');
     assert.ok(agyBranch.includes('taskPrompt: prompt'), 'agy bootstrap should receive the current task prompt');
     assert.ok(agyBranch.includes('operationalContext: sysPrompt'), 'agy bootstrap should receive operational context separately');
+    assert.ok(agyBranch.includes('order: resolveAgyPromptOrder(cfg.promptOrder)'), 'agy bootstrap should receive the configured prompt order');
     assert.ok(agyBranch.includes('promptForArgs = agyBootstrap.prompt'), 'agy args prompt should be the ordered bootstrap prompt');
 });
 


### PR DESCRIPTION
## What changed

- adds `task-first` / `context-first` ordering to the AGY bootstrap envelope
- keeps the bootstrap sentinel first in both modes
- reads the existing per-CLI `promptOrder` setting when spawning AGY
- preserves the current `task-first` behavior as the default

## Why

AGY is invoked through a stateless print adapter, so some installations need the stable operational instructions before recent history and the current task to reduce provider-default behavior after compaction or session recreation. Other installations prefer the current task first. Making the ordering explicit avoids hard-coding one tradeoff for every AGY user.

Example:

```json
{
  "cli": {
    "agy": {
      "promptOrder": "context-first"
    }
  }
}
```

The bootstrap sentinel remains the first segment, and required task content remains protected by the existing spill budget logic.

## Validation

- `npx tsc --noEmit`
- `npx tsx --experimental-test-module-mocks --test tests/unit/agy-bootstrap.test.ts tests/unit/steer-flow.test.ts`
- 21 focused tests passed
- the equivalent `context-first` behavior has been operated in the fork for more than 72 hours without the previous repeated environment rediscovery pattern
