### PR TITLE
[codex] fix Telegram uploads and repeated progress edits

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,7 +1,7 @@
 // ─── Telegram Bot ────────────────────────────────────
 
 import https from 'node:https';
-import nodeFetch from 'node-fetch';
+import nodeFetch, { type RequestInit } from 'node-fetch';
 import { Bot, type Context } from 'grammy';
 import { sequentialize } from '@grammyjs/runner';
 import { addBroadcastListener, removeBroadcastListener } from '../core/bus.js';
@@ -370,7 +370,10 @@ async function _initTelegramInner() {
     const ipv4Fetch = (url: string, init: Record<string, unknown> = {}): Promise<unknown> => {
         const body = init["body"];
         if (requiresStreamingFetchBody(body)) {
-            return nodeFetch(url, { ...init, agent: ipv4Agent } as any) as Promise<unknown>;
+            return nodeFetch(url, {
+                ...(init as RequestInit),
+                agent: ipv4Agent,
+            });
         }
         return new Promise((resolve, reject) => {
             const u = new URL(url);

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,12 +1,15 @@
 // ─── Telegram Bot ────────────────────────────────────
 
 import https from 'node:https';
+import nodeFetch from 'node-fetch';
 import { Bot, type Context } from 'grammy';
 import { sequentialize } from '@grammyjs/runner';
 import { addBroadcastListener, removeBroadcastListener } from '../core/bus.js';
 import { settings } from '../core/config.js';
 import { stripUndefined } from '../core/strip-undefined.js';
 import { resolveHubCallback } from './hub-callback.js';
+import { requiresStreamingFetchBody } from './fetch-body.js';
+import { StatusUpdateBuffer } from './status-update-buffer.js';
 import { t, normalizeLocale } from '../core/i18n.js';
 import { isResetIntent } from '../orchestrator/pipeline.js';
 import { submitMessage } from '../orchestrator/gateway.js';
@@ -365,6 +368,10 @@ async function _initTelegramInner() {
 
     const ipv4Agent = new https.Agent({ family: 4 });
     const ipv4Fetch = (url: string, init: Record<string, unknown> = {}): Promise<unknown> => {
+        const body = init["body"];
+        if (requiresStreamingFetchBody(body)) {
+            return nodeFetch(url, { ...init, agent: ipv4Agent } as any) as Promise<unknown>;
+        }
         return new Promise((resolve, reject) => {
             const u = new URL(url);
             const headersInit = init["headers"];
@@ -386,7 +393,6 @@ async function _initTelegramInner() {
                 }));
             });
             req.on('error', reject);
-            const body = init["body"];
             if (body) req.write(typeof body === 'string' ? body : JSON.stringify(body));
             req.end();
         });
@@ -482,11 +488,11 @@ async function _initTelegramInner() {
         let statusMsgCreatePromise: Promise<number | null> | null = null;
         let statusUpdateTimer: ReturnType<typeof setTimeout> | null = null;
         let statusUpdateRunning = false;
-        let pendingStatusText = '';
+        const statusUpdateBuffer = new StatusUpdateBuffer();
         let toolLines: string[] = [];
 
         const flushStatusUpdate = async () => {
-            const display = pendingStatusText;
+            const display = statusUpdateBuffer.take();
             if (!display) return;
 
             if (!statusMsgId) {
@@ -520,7 +526,7 @@ async function _initTelegramInner() {
                 } finally {
                     statusUpdateRunning = false;
                     // If pending text changed while updating, flush once more.
-                    if (pendingStatusText && !statusUpdateTimer) scheduleStatusUpdate();
+                    if (statusUpdateBuffer.hasPending() && !statusUpdateTimer) scheduleStatusUpdate();
                 }
             }, 180);
         };
@@ -530,7 +536,7 @@ async function _initTelegramInner() {
             if (toolLines[toolLines.length - 1] === line) return;
             toolLines.push(line);
             if (toolLines.length > 24) toolLines = toolLines.slice(-24);
-            pendingStatusText = toolLines.slice(-5).join('\n');
+            statusUpdateBuffer.set(toolLines.slice(-5).join('\n'));
             scheduleStatusUpdate();
         };
 

--- a/src/telegram/fetch-body.ts
+++ b/src/telegram/fetch-body.ts
@@ -1,6 +1,8 @@
-const STREAMING_FETCH_BODY_TYPES = new Set(['FormData', 'Blob', 'Readable', 'ReadableStream']);
-
 export function requiresStreamingFetchBody(body: unknown): boolean {
     if (!body || typeof body !== 'object') return false;
-    return STREAMING_FETCH_BODY_TYPES.has(body.constructor?.name || '');
+    if (body instanceof FormData || body instanceof Blob) return true;
+    // grammY multipart uploads are Node streams. Duck-typing keeps custom
+    // Readable subclasses on the node-fetch path without routing WHATWG
+    // ReadableStream, which node-fetch v3 does not accept as RequestInit.body.
+    return typeof (body as { pipe?: unknown }).pipe === 'function';
 }

--- a/src/telegram/fetch-body.ts
+++ b/src/telegram/fetch-body.ts
@@ -1,0 +1,6 @@
+const STREAMING_FETCH_BODY_TYPES = new Set(['FormData', 'Blob', 'Readable', 'ReadableStream']);
+
+export function requiresStreamingFetchBody(body: unknown): boolean {
+    if (!body || typeof body !== 'object') return false;
+    return STREAMING_FETCH_BODY_TYPES.has(body.constructor?.name || '');
+}

--- a/src/telegram/status-update-buffer.ts
+++ b/src/telegram/status-update-buffer.ts
@@ -1,0 +1,17 @@
+export class StatusUpdateBuffer {
+    private pending = '';
+
+    set(text: string): void {
+        this.pending = text;
+    }
+
+    take(): string {
+        const text = this.pending;
+        this.pending = '';
+        return text;
+    }
+
+    hasPending(): boolean {
+        return this.pending.length > 0;
+    }
+}

--- a/tests/unit/telegram-fetch-body.test.ts
+++ b/tests/unit/telegram-fetch-body.test.ts
@@ -4,10 +4,19 @@ import { Readable } from 'node:stream';
 import { requiresStreamingFetchBody } from '../../src/telegram/fetch-body.js';
 
 test('multipart and streaming bodies bypass the JSON-only IPv4 adapter', () => {
+    class MultipartReadable extends Readable {
+        _read() {
+            this.push('image');
+            this.push(null);
+        }
+    }
+
     assert.equal(requiresStreamingFetchBody(new FormData()), true);
     assert.equal(requiresStreamingFetchBody(new Blob(['image'])), true);
     assert.equal(requiresStreamingFetchBody(Readable.from(['image'])), true);
-    assert.equal(requiresStreamingFetchBody(new ReadableStream()), true);
+    assert.equal(requiresStreamingFetchBody(new MultipartReadable()), true);
+    assert.equal(requiresStreamingFetchBody({ pipe() {} }), true);
+    assert.equal(requiresStreamingFetchBody(new ReadableStream()), false);
 });
 
 test('plain JSON-compatible bodies keep using the IPv4 adapter', () => {

--- a/tests/unit/telegram-fetch-body.test.ts
+++ b/tests/unit/telegram-fetch-body.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import { requiresStreamingFetchBody } from '../../src/telegram/fetch-body.js';
+
+test('multipart and streaming bodies bypass the JSON-only IPv4 adapter', () => {
+    assert.equal(requiresStreamingFetchBody(new FormData()), true);
+    assert.equal(requiresStreamingFetchBody(new Blob(['image'])), true);
+    assert.equal(requiresStreamingFetchBody(Readable.from(['image'])), true);
+    assert.equal(requiresStreamingFetchBody(new ReadableStream()), true);
+});
+
+test('plain JSON-compatible bodies keep using the IPv4 adapter', () => {
+    assert.equal(requiresStreamingFetchBody({ message: 'hello' }), false);
+    assert.equal(requiresStreamingFetchBody('text'), false);
+    assert.equal(requiresStreamingFetchBody(null), false);
+});

--- a/tests/unit/telegram-status-update-buffer.test.ts
+++ b/tests/unit/telegram-status-update-buffer.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { StatusUpdateBuffer } from '../../src/telegram/status-update-buffer.js';
+
+test('status update buffer consumes a snapshot exactly once', () => {
+    const buffer = new StatusUpdateBuffer();
+    buffer.set('first');
+    assert.equal(buffer.take(), 'first');
+    assert.equal(buffer.hasPending(), false);
+    assert.equal(buffer.take(), '');
+});
+
+test('status update buffer preserves an update that arrives after take', () => {
+    const buffer = new StatusUpdateBuffer();
+    buffer.set('first');
+    assert.equal(buffer.take(), 'first');
+    buffer.set('second');
+    assert.equal(buffer.hasPending(), true);
+    assert.equal(buffer.take(), 'second');
+});


### PR DESCRIPTION
## What changed

- routes Node streaming and multipart bodies through `node-fetch` instead of JSON-stringifying them in the IPv4 Telegram fetch adapter
- keeps the existing IPv4 HTTPS agent for file uploads
- consumes each pending Telegram tool-status snapshot exactly once
- adds focused tests for Node `Readable` uploads and status update coalescing

## Root cause

The custom IPv4 fetch adapter only handled strings and JSON-compatible bodies. grammY builds file uploads as a Node `Readable` multipart stream, so `sendPhoto` was serializing that stream as JSON and failing with a network-style error.

Separately, the Telegram tool-status updater never cleared `pendingStatusText` after a successful flush. Its `finally` block therefore scheduled the same `editMessageText` forever during long agent runs, generating unnecessary Telegram traffic and delaying real deliveries.

## Impact

- `sendPhoto`, `sendDocument`, and `sendVoice` can retain their multipart bodies
- long-running tasks no longer continuously resend an unchanged tool-status message
- ordinary JSON Telegram calls continue to use the existing IPv4 adapter

## Validation

- `npx tsc`
- 17 focused Telegram tests passed
- live `sendPhoto` through `/api/channel/send` succeeded with the generated dream image after restart
