### PR TITLE
ci: stabilize Tests / npm Publish / Postinstall on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,18 @@ jobs:
             esac
           fi
 
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$GITHUB_REF_NAME" = "main" ]; then
+            case "$version" in
+              *-*)
+                skip_publish="true"
+                skip_reason="main branch prerelease sync"
+                dry_run="true"
+                create_release="false"
+                echo "::notice::Skipping npm publish for main branch prerelease sync: $version"
+                ;;
+            esac
+          fi
+
           if [ "$tag" = "preview" ] && [ "$skip_publish" != "true" ]; then
             case "$version" in
               *-preview.*) ;;
@@ -147,7 +159,7 @@ jobs:
             esac
           fi
 
-          if [ "$tag" = "latest" ]; then
+          if [ "$tag" = "latest" ] && [ "$skip_publish" != "true" ]; then
             case "$version" in
               *-*)
                 echo "::error::latest publishes cannot use a prerelease version; got $version";

--- a/scripts/fresh-install-smoke.ts
+++ b/scripts/fresh-install-smoke.ts
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
         if (!cliRes.ok) throw new Error(`/api/cli-status HTTP ${cliRes.status}`);
         const cliJson = (await cliRes.json()) as Record<string, unknown> | null;
         const keys = Object.keys(cliJson ?? {});
-        const required: string[] = ['ai-e', 'claude', 'claude-e', 'codex', 'codex-app', 'copilot', 'cursor', 'kiro-code', 'gemini', 'grok', 'opencode'];
+        const required: string[] = ['ai-e', 'claude', 'claude-e', 'codex', 'codex-app', 'copilot', 'cursor', 'kiro-code', 'grok', 'opencode'];
         for (const k of required) {
             if (!keys.includes(k)) throw new Error(`missing cli key in status: ${k}`);
         }

--- a/src/routes/quota-agy-reverse.ts
+++ b/src/routes/quota-agy-reverse.ts
@@ -38,6 +38,7 @@ type AgyQuotaFamily = 'gem' | 'cla';
 
 function classifyAgyQuotaFamily(model: AntigravityModelQuota): AgyQuotaFamily | null {
     const haystack = `${model.label || ''} ${model.modelId || ''}`.toLowerCase();
+    if (haystack.includes('gemini')) return 'gem';
     if (
         haystack.includes('claude')
         || haystack.includes('opus')

--- a/tests/unit/grok-frontend-contract.test.ts
+++ b/tests/unit/grok-frontend-contract.test.ts
@@ -157,7 +157,7 @@ test('LEGACY-FE-002: fallback CLI surfaces include every canonical CLI', () => {
     const heartbeat = src('public/manager/src/settings/pages/components/heartbeat-helpers.ts');
     const status = src('public/js/features/settings-cli-status.ts');
     const freshInstallSmoke = src('scripts/fresh-install-smoke.ts');
-    for (const cli of ['ai-e', 'claude', 'claude-e', 'codex', 'codex-app', 'copilot', 'cursor', 'kiro-code', 'gemini', 'grok', 'opencode']) {
+    for (const cli of ['ai-e', 'claude', 'claude-e', 'codex', 'codex-app', 'copilot', 'cursor', 'kiro-code', 'grok', 'opencode']) {
         assert.match(employees, new RegExp(`'${cli}'`), `manager employee fallback must include ${cli}`);
         assert.match(heartbeat, new RegExp(`'${cli}'`), `manager heartbeat fallback must include ${cli}`);
         assert.match(status, new RegExp(`'${cli}'|${cli}:`), `legacy CLI status hints must include ${cli}`);

--- a/tests/unit/prompt-slim-contract.test.ts
+++ b/tests/unit/prompt-slim-contract.test.ts
@@ -65,5 +65,7 @@ test('PSC-005: ref skill catalog stays a lookup instruction, never a listing', (
 test('PSC-006: A-1 template stays under its size budget', () => {
     // 32,558 chars before the slim; regression guard so sections do not
     // silently regrow inline instead of pointing at skills.
-    assert.ok(a1Src.length <= 31000, `a1-system.md is ${a1Src.length} chars — over the 31,000 budget`);
+    // Budget raised 31,000 → 35,000 for the critical-stance block and
+    // exclusions-first dispatch constraint (4d8c54cc, 43c2a4f2).
+    assert.ok(a1Src.length <= 35000, `a1-system.md is ${a1Src.length} chars — over the 35,000 budget`);
 });

--- a/tests/unit/quota-status.test.ts
+++ b/tests/unit/quota-status.test.ts
@@ -187,7 +187,7 @@ test('QS-005b: /api/quota returns every top-level CLI runtime key', () => {
         settingsRouteSrc.includes('CLI_KEYS.map((key) => [key, quotaByCli[key]'),
         '/api/quota should be keyed by CLI_KEYS instead of a hand-maintained subset',
     );
-    for (const key of ['agy', "'ai-e'", 'claude', "'claude-e'", 'codex', "'codex-app'", 'cursor', "'kiro-code'", 'gemini', 'grok', 'opencode', 'copilot']) {
+    for (const key of ['agy', "'ai-e'", 'claude', "'claude-e'", 'codex', "'codex-app'", 'cursor', "'kiro-code'", 'grok', 'opencode', 'copilot']) {
         assert.ok(settingsRouteSrc.includes(`${key}:`), `/api/quota should define ${key}`);
     }
 });
@@ -203,10 +203,6 @@ test('QS-005c3: AGY quota uses reverse-engineered adapters', () => {
     assert.ok(
         agyQuotaSrc.includes('agy:antigravity-usage'),
         'AGY reverse quota should support antigravity-usage JSON adapter',
-    );
-    assert.ok(
-        agyQuotaSrc.includes('agy:google-cloud-code-api'),
-        'AGY reverse quota should fall back to Google Cloud Code API',
     );
 });
 
@@ -357,21 +353,6 @@ test('QS-010b: QuotaWindow type preserves source modelId for compact Gemini labe
     assert.ok(
         settingsSrc.includes('modelId?: string'),
         'QuotaWindow should allow preserving source modelId',
-    );
-});
-
-test('QS-010c: Gemini quota normalization exposes compact F/P policy', () => {
-    assert.ok(
-        quotaSrc.includes('normalizeGeminiQuotaBuckets'),
-        'should expose Gemini quota normalization helper',
-    );
-    assert.ok(
-        quotaSrc.includes("label: tier === 'pro' ? 'P' : 'F'"),
-        'Gemini quota labels should normalize to P/F',
-    );
-    assert.ok(
-        quotaSrc.includes("tier !== 'flash' && tier !== 'pro'"),
-        'Gemini quota normalization should exclude non-Pro/Flash tiers',
     );
 });
 

--- a/tests/unit/search-skill-policy.test.ts
+++ b/tests/unit/search-skill-policy.test.ts
@@ -158,9 +158,9 @@ test('SSP-012: common dev skill points external current evidence to search', { s
     const devSkill = fs.readFileSync(devSkillPath, 'utf8');
 
     assert.match(devSkill, /External\/current evidence/);
-    assert.match(devSkill, /current versions, release notes, CVEs, package\/source checks, provider\s+behavior/);
+    assert.match(devSkill, /current versions, release notes, CVEs, package\/source checks, or provider\s+behavior/);
     assert.match(devSkill, /read the active `search` skill/);
-    assert.match(devSkill, /query-rewrite, source-fetch, and evidence-status rules/);
+    assert.match(devSkill, /query-rewrite, source-fetch, and\s+evidence-status rules/);
     assert.doesNotMatch(devSkill, /\/Users\/jun\/\.cli-jaw-\d+/);
 });
 


### PR DESCRIPTION
## Summary
- **Tests** (12 failures): realign stale contracts after the gemini-cli runtime removal and recent prompt growth
  - restore the AGY `gemini→gem` family classification that f7edd104 removed alongside the Gemini CLI quota functions — the Antigravity snapshot's Gem pool has no dependency on the removed CLI functions, and the gem label/order plumbing was left behind (fixes 7 `quota-reverse-agy` tests)
  - QS-005b / QS-005c3 / QS-010c / LEGACY-FE-002 / fresh-install-smoke: drop the removed `gemini` runtime from required-key contracts
  - PSC-006: raise the A-1 template budget 31k→35k for the critical-stance block and exclusions-first dispatch constraint (4d8c54cc, 43c2a4f2)
  - SSP-012: match the reworded dev-skill external-evidence section
- **npm Publish**: pushes to main with a prerelease `package.json` version (currently `2.2.4-preview.*`) resolved `tag=latest` and hard-failed the prerelease guard on every push. Now skips with a notice, mirroring the existing preview-branch stable-sync skip. `workflow_dispatch` latest publishes still hard-fail on prerelease versions.
- **Postinstall Platform Checks**: fresh-install-smoke no longer requires the removed `gemini` cli-status key.

## Validation
- `npm test`: 5065 pass / 0 fail (on dev with these fixes)
- `npm run gate:all`: all 13 gates PASS
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)