### PR TITLE
fix(agy): preserve native sessions across high turns

### DIFF
--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -13,6 +13,7 @@ import { buildContinuationPrompt, type SmokeDetectionResult } from './smoke-dete
 import { shouldInvalidateResumeSession } from './resume-classifier.js';
 import { classifyExitError } from './error-classifier.js';
 import { backfillGrokTraceTools } from './grok-trace-backfill.js';
+import { shouldClearHighTurnSessionBucket, shouldUseTurnCountRefresh } from './spawn/resume.js';
 import { recordError, clearErrors } from './alert-escalation.js';
 import { stripInterviewTracker } from '../orchestrator/sanitize.js';
 import { clearLiveRun, getLiveRun } from './live-run-state.js';
@@ -390,11 +391,12 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
     }
 
     // ─── Phase 54-A: Proactive compact by turn count ───
-    // Non-Claude CLIs lack compact events. Suggest at 25 turns; force refresh at 35.
+    // CLIs without a reliable native compact/resume path get a conservative
+    // turn-count refresh. AGY owns its compaction and keeps its conversation.
     if (mainManaged && !opts.internal && code === 0 && !ctx.cliNativeCompactDetected) {
         const turns = ctx.turns ?? memoryFlushCounter;
-        const isNonClaude = runtimeCli !== 'claude' && runtimeCli !== 'claude-e';
-        if (isNonClaude && turns >= 35) {
+        const useTurnCountRefresh = shouldUseTurnCountRefresh(runtimeCli);
+        if (useTurnCountRefresh && turns >= 35) {
             console.log(`[jaw:compact] ${cli} reached ${turns} turns — forcing auto-refresh`);
             try {
                 const { autoCompactRefresh } = await import('../core/compact.js');
@@ -407,7 +409,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
             } catch (e) {
                 console.warn('[jaw:compact] turn-count auto-refresh failed:', (e as Error).message);
             }
-        } else if (isNonClaude && turns >= 25) {
+        } else if (useTurnCountRefresh && turns >= 25) {
             console.log(`[jaw:compact] ${cli} at ${turns} turns — suggesting compact`);
             broadcast('system_notice', {
                 code: 'compact_suggest',
@@ -416,12 +418,12 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         }
     }
 
-    // ─── Phase 54-C: Codex high-turn auto-compact coordination ───
-    // Codex may internally compact at high turn counts without notifying jaw.
-    // Force a fresh session on next spawn to avoid stale resume.
+    // ─── High-turn native-compaction coordination ───
+    // AGY keeps a native compacted conversation. Other CLIs still use the
+    // conservative fresh-session guard when their compaction is not observable.
     if (mainManaged && !opts.internal && code === 0 && !ctx.cliNativeCompactDetected) {
         const turns = ctx.turns ?? memoryFlushCounter;
-        if ((runtimeCli === 'codex' || runtimeCli === 'opencode' || runtimeCli === 'grok' || runtimeCli === 'agy') && turns > 15) {
+        if (shouldClearHighTurnSessionBucket(runtimeCli, turns)) {
             console.log(`[jaw:compact] ${cli} exited after ${turns} turns — clearing session bucket for fresh start`);
             try {
                 const bucket = resolveSessionBucket(cli, model, effectiveProvider);

--- a/src/agent/spawn/resume.ts
+++ b/src/agent/spawn/resume.ts
@@ -84,6 +84,21 @@ export function canGuardedAgyResume(input: GuardedAgyResumeInput): { ok: boolean
     return { ok: true, reason: 'guarded-resume' };
 }
 
+/**
+ * Generic high-turn bucket resets protect CLIs whose resumed session may become
+ * stale after internal compaction. AGY persists its own compacted conversation,
+ * so preserve that bucket until an explicit guarded-resume invalidation signal.
+ */
+export function shouldClearHighTurnSessionBucket(cli: string, turns: number): boolean {
+    if (turns <= 15) return false;
+    return cli === 'codex' || cli === 'opencode' || cli === 'grok';
+}
+
+/** AGY owns compaction for its native conversation and does not need refresh-by-turn. */
+export function shouldUseTurnCountRefresh(cli: string): boolean {
+    return cli !== 'claude' && cli !== 'claude-e' && cli !== 'agy';
+}
+
 
 function parseBucketUpdatedAt(value: string | number | null | undefined): number | null {
     if (typeof value === 'number' && Number.isFinite(value)) {

--- a/tests/unit/agy-native-resume.test.ts
+++ b/tests/unit/agy-native-resume.test.ts
@@ -6,6 +6,8 @@ import {
     AGY_RESUME_TTL_MS,
     canGuardedAgyResume,
     resolveAgyNativeResume,
+    shouldClearHighTurnSessionBucket,
+    shouldUseTurnCountRefresh,
     type GuardedAgyResumeInput,
 } from '../../src/agent/spawn/resume.js';
 
@@ -60,4 +62,18 @@ test('AGY-NR-004: guarded stale fallback is one-shot and replay stripping stays 
     assert.equal((source.match(/_agyStaleFreshRetry: true/g) || []).length, 1);
     assert.match(source, /if \(isResume && agyResumeReplayPrefixes\.length > 0\)/);
     assert.match(source, /stripAgyResumeReplayPrefixes\(ctx\.fullText, agyResumeReplayPrefixes\)/);
+});
+
+test('AGY-NR-005: generic high-turn policies preserve AGY native conversations', () => {
+    assert.equal(shouldClearHighTurnSessionBucket('agy', 16), false);
+    assert.equal(shouldClearHighTurnSessionBucket('agy', 80), false);
+    assert.equal(shouldUseTurnCountRefresh('agy'), false);
+
+    assert.equal(shouldClearHighTurnSessionBucket('codex', 16), true);
+    assert.equal(shouldClearHighTurnSessionBucket('opencode', 16), true);
+    assert.equal(shouldClearHighTurnSessionBucket('grok', 16), true);
+    assert.equal(shouldClearHighTurnSessionBucket('codex', 15), false);
+    assert.equal(shouldUseTurnCountRefresh('codex'), true);
+    assert.equal(shouldUseTurnCountRefresh('claude'), false);
+    assert.equal(shouldUseTurnCountRefresh('claude-e'), false);
 });


### PR DESCRIPTION
## Summary

- exclude AGY from the generic 25/35-turn compact-refresh policy
- preserve AGY session buckets past the generic 15-turn high-turn boundary
- retain the existing resets for stale conversations, failed guards, explicit refreshes, and identity mismatches

## Root cause

v2.2.6 added opt-in guarded native AGY resume, but the older generic high-turn policies still treated AGY like CLIs without a reliable native compacted conversation:

- the non-Claude branch suggested compaction at 25 turns and forced `autoCompactRefresh()` at 35;
- the high-turn branch cleared the AGY session bucket after 15 turns.

This made a healthy guarded AGY conversation fall back to a fresh DB-history bootstrap even though AGY persists and compacts its own native conversation.

## Behavior

AGY now keeps its native conversation across high turn counts. Existing invalidation boundaries remain unchanged: stale conversation output, watchdog/interruption failure, model or cwd mismatch, TTL expiry, checkpoint/planner-only guards, and explicit reset still select the fresh path.

## Verification

- `node --import tsx --test tests/unit/agy-native-resume.test.ts`
- `npx tsc --noEmit`
- `git diff --check`
