### PR TITLE
fix(agy): resolve checkpoint after final response

### DIFF
--- a/src/agent/agy-transcript-watcher.ts
+++ b/src/agent/agy-transcript-watcher.ts
@@ -69,7 +69,10 @@ export function updateFinalPlannerFlag(ctx: SpawnContext, line: string, minCreat
             ctx.agyFinalPlannerSeen = true;
             ctx.agyFinalPlannerText = rowContent;
             ctx.agyLastTranscriptError = undefined;
-            ctx.metadata = { ...ctx.metadata, agyPlannerOnly: false };
+            // A genuine final answer after CHECKPOINT resolves that compaction
+            // boundary. Keep checkpointSeen=true only when checkpoint is the
+            // last obligation-bearing row of the turn.
+            ctx.metadata = { ...ctx.metadata, agyCheckpointSeen: false, agyPlannerOnly: false };
         }
     } else if (kind === 'checkpoint') {
         ctx.agyFinalPlannerSeen = false;

--- a/tests/unit/agy-obligations.test.ts
+++ b/tests/unit/agy-obligations.test.ts
@@ -46,8 +46,17 @@ test('AGY-OB-002: checkpoint disarms stale final and a fresh later final re-arms
     updateFinalPlannerFlag(ctx, row('PLANNER_RESPONSE', 'fresh final', '2026-07-11T00:00:07.000Z'), start);
     assert.equal(ctx.agyFinalPlannerSeen, true);
     assert.equal(ctx.agyFinalPlannerText, 'fresh final');
-    assert.equal(ctx.metadata?.['agyCheckpointSeen'], true);
+    assert.equal(ctx.metadata?.['agyCheckpointSeen'], false);
     assert.equal(ctx.metadata?.['agyPlannerOnly'], false);
+});
+
+test('AGY-OB-002b: checkpoint after final remains unresolved', () => {
+    const ctx = context();
+    const start = Date.parse('2026-07-11T00:00:00.000Z');
+    updateFinalPlannerFlag(ctx, row('PLANNER_RESPONSE', 'final first', '2026-07-11T00:00:05.000Z'), start);
+    updateFinalPlannerFlag(ctx, row('CHECKPOINT', '{{ CHECKPOINT 1 }}', '2026-07-11T00:00:06.000Z'), start);
+    assert.equal(ctx.agyFinalPlannerSeen, false);
+    assert.equal(ctx.metadata?.['agyCheckpointSeen'], true);
 });
 
 test('AGY-OB-003: checkpoint tool evidence activates record_pending', () => {


### PR DESCRIPTION
## Summary

- clear `agyCheckpointSeen` when a genuine final planner response arrives after a checkpoint
- retain `agyCheckpointSeen=true` when the checkpoint is the final row of the turn
- add order-sensitive regression coverage for both cases

## Production reproduction

On v2.2.6 with `perCli.agy.nativeResume: "guarded"`, a normal AGY heartbeat produced:

1. `USER_INPUT`
2. tool execution
3. `CHECKPOINT`
4. a genuine final `PLANNER_RESPONSE`
5. exit 0 with a valid user-facing answer

`updateFinalPlannerFlag()` re-armed the final answer but left `agyCheckpointSeen=true`. The lifecycle therefore persisted `last_run_clean=0`, and the next turn selected `fresh reason=last-run-not-clean` instead of guarded resume.

The inverse order, final response followed by checkpoint, must remain unresolved and force fresh.

## Verification

- `node --import tsx --test tests/unit/agy-obligations.test.ts tests/unit/agy-native-resume.test.ts`
- `tsc --noEmit`
- reproduced from a live AGY transcript on the Telegram companion workload requested in #251
