### PR TITLE
ci: install ripgrep for Wiki provider tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,12 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Install system test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
## Summary

- install `ripgrep` explicitly in the `node-tests` GitHub Actions job
- print `rg --version` so the system test dependency is visible and reproducible

## Root cause

The Wiki provider tests exercise real note search, but the Ubuntu CI runner did not provide `rg`. Four tests therefore failed with `notes_search_unavailable` / `ripgrep (rg) is not installed`. The existing missing-`rg` behavior test remains in place.

## Verification

- `npx tsc --noEmit`
- four CI-failing Wiki provider tests: 4/4 passed
- manager notes search and release workflow contract tests: 20/20 passed
- workflow YAML parse
- `git diff --check`
- `bash structure/verify-counts.sh`

Other existing `node-tests` baseline failures remain tracked separately in #286–#289.

Closes #285