### PR TITLE
test: align source contract assertions with current implementation

### DIFF
--- a/tests/unit/assistant-text-segment.test.ts
+++ b/tests/unit/assistant-text-segment.test.ts
@@ -95,7 +95,6 @@ test('resolveSpawnOutputText prefers normalized display text over longer raw esc
 
 test('plain-text runtime display branches normalize escaped newlines before broadcast', () => {
     const spawnSrc = readFileSync('src/agent/spawn.ts', 'utf8');
-    assert.match(spawnSrc, /import \{ appendAssistantTextSegment, (?:emitAgentTool, )?normalizeAssistantDisplayText, pushTrace \} from '\.\/events\/helpers\.js';/);
     assert.match(spawnSrc, /const segment = normalizeAssistantDisplayText\(event\.text\)/);
     assert.match(spawnSrc, /const displayDelta = normalizeAssistantDisplayText\(delta\)/);
     assert.match(spawnSrc, /const newText = normalizeAssistantDisplayText\(/);

--- a/tests/unit/dual-insert-guard.test.ts
+++ b/tests/unit/dual-insert-guard.test.ts
@@ -4,13 +4,16 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { readSource } from './source-normalize.js';
+import { orchestrate } from '../../src/orchestrator/pipeline.ts';
+import { resetState } from '../../src/orchestrator/state-machine.ts';
+import { createQueueController } from '../../src/agent/spawn/queue.ts';
+import { SessionLanes } from '../../src/orchestrator/session-lanes.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const srcRoot = join(__dirname, '../../src');
 
 const gatewaySrc = readSource(join(srcRoot, 'orchestrator/gateway.ts'), 'utf8');
-const pipelineSrc = readSource(join(srcRoot, 'orchestrator/pipeline.ts'), 'utf8');
 const spawnSrc = readSource(join(srcRoot, 'agent/spawn.ts'), 'utf8');
 const queueSrc = readSource(join(srcRoot, 'agent/spawn/queue.ts'), 'utf8');
 const botSrc = readSource(join(srcRoot, 'telegram/bot.ts'), 'utf8');
@@ -54,33 +57,39 @@ test('DI-003: gateway reset path passes _skipInsert: true to orchestrateReset', 
 
 // ─── DI-004: pipeline PABCD spawnAgent propagates _skipInsert ───
 
-test('DI-004: pipeline PABCD path propagates _skipInsert to spawnAgent', () => {
-    // Locate the concrete main-agent invocation block.
-    // Research refactor may wrap spawnAgent behind runSpawnAgent for test injection.
-    const runSpawnIdx = pipelineSrc.indexOf('const { promise } = runSpawnAgent(prompt');
-    const directSpawnIdx = pipelineSrc.indexOf('const { promise } = spawnAgent(prompt');
-    const spawnStart = runSpawnIdx >= 0 ? runSpawnIdx : directSpawnIdx;
-    assert.ok(spawnStart > 0, 'main agent invocation must exist');
-    const pabcdBlock = pipelineSrc.slice(spawnStart, spawnStart + 300);
-    assert.ok(
-        pabcdBlock.includes('_skipInsert: !!meta._skipInsert'),
-        'pabcd main-agent invocation must propagate _skipInsert from meta',
-    );
+test('DI-004: pipeline PABCD path propagates _skipInsert to spawnAgent', async () => {
+    resetState('default');
+    let captured: Record<string, unknown> | undefined;
+    await orchestrate('dual-insert guard', {
+        origin: 'test',
+        _skipClear: true,
+        _skipReplayDrain: true,
+        _skipInsert: true,
+        _spawnAgent: (_prompt: string, opts: Record<string, unknown>) => {
+            captured = opts;
+            return { child: null, promise: Promise.resolve({ text: 'ok', code: 0 }) };
+        },
+    });
+    assert.equal(captured?._skipInsert, true);
+    resetState('default');
 });
 
 // ─── DI-005: pipeline PABCD has _skipInsert in spawn call ───
 
-test('DI-005: pipeline PABCD spawn includes _skipInsert', () => {
-    // Verify the main-agent invocation includes _skipInsert
-    const runSpawnIdx = pipelineSrc.indexOf('runSpawnAgent(prompt');
-    const directSpawnIdx = pipelineSrc.indexOf('spawnAgent(prompt');
-    const spawnIdx = runSpawnIdx >= 0 ? runSpawnIdx : directSpawnIdx;
-    assert.ok(spawnIdx > 0, 'main-agent invocation must exist');
-    const spawnBlock = pipelineSrc.slice(spawnIdx, spawnIdx + 200);
-    assert.ok(
-        spawnBlock.includes('_skipInsert'),
-        'main-agent invocation must include _skipInsert option',
-    );
+test('DI-005: pipeline PABCD spawn defaults _skipInsert to false', async () => {
+    resetState('default');
+    let captured: Record<string, unknown> | undefined;
+    await orchestrate('dual-insert default guard', {
+        origin: 'test',
+        _skipClear: true,
+        _skipReplayDrain: true,
+        _spawnAgent: (_prompt: string, opts: Record<string, unknown>) => {
+            captured = opts;
+            return { child: null, promise: Promise.resolve({ text: 'ok', code: 0 }) };
+        },
+    });
+    assert.equal(captured?._skipInsert, false);
+    resetState('default');
 });
 
 // ─── DI-006: bot.ts tgOrchestrate → orchestrateAndCollect with _skipInsert ───
@@ -96,14 +105,37 @@ test('DI-006: tgOrchestrate passes _skipInsert: true to orchestrateAndCollect', 
 
 // ─── DI-007: spawn.ts processQueue → orchestrate with _skipInsert ───
 
-test('DI-007: processQueue passes _skipInsert: true to orchestrate calls', () => {
-    const pqStart = queueSrc.indexOf('async function processQueue');
-    const pqEnd = queueSrc.indexOf('function purgeQueueOnStop', pqStart);
-    const pqBlock = queueSrc.slice(pqStart, pqEnd > 0 ? pqEnd : pqStart + 5000);
-    // All 3 orchestrate calls in processQueue must have _skipInsert
-    assert.ok(pqBlock.includes("orchestrateReset({ origin, target, chatId, requestId, overrides, replyViaTarget, _skipInsert: true })"), 'processQueue orchestrateReset');
-    assert.ok(pqBlock.includes("orchestrateContinue({ origin, target, chatId, requestId, overrides, replyViaTarget, _skipInsert: true })"), 'processQueue orchestrateContinue');
-    assert.ok(pqBlock.includes("orchestrate(combined, { origin, target, chatId, requestId, overrides, replyViaTarget, _skipInsert: true })"), 'processQueue orchestrate');
+test('DI-007: processQueue passes _skipInsert: true to every orchestrate path', async () => {
+    for (const intent of ['normal', 'continue', 'reset'] as const) {
+        let busy = true;
+        let captured: Record<string, unknown> | undefined;
+        const controller = createQueueController({
+            migrateQueuedMessagesV1ToV2() {},
+            isSpawnBusy: () => busy,
+            hasBlockingWorkers: () => false,
+            hasPendingWorkerReplays: () => false,
+            insertMessage: { run() {} },
+            getActiveChatSession: () => 'default',
+            insertQueuedMessage: { run() {} },
+            deleteQueuedMessage: { run() {} },
+            listQueuedMessages: { all: () => [] },
+            broadcast() {},
+            importPipeline: async () => ({
+                orchestrate: async (_prompt: string, meta: Record<string, unknown>) => { captured = meta; },
+                orchestrateContinue: async (meta: Record<string, unknown>) => { captured = meta; },
+                orchestrateReset: async (meta: Record<string, unknown>) => { captured = meta; },
+                isContinueIntent: () => intent === 'continue',
+                isResetIntent: () => intent === 'reset',
+                drainPendingReplays: async () => {},
+            }),
+            getWorkingDir: () => null,
+            isMultiSessionEnabled: () => false,
+        }, new SessionLanes(() => 1));
+        controller.enqueueMessage(`dual-insert ${intent}`, 'web');
+        busy = false;
+        await controller.processQueue('default');
+        assert.equal(captured?._skipInsert, true, `${intent} path`);
+    }
 });
 
 // ─── DI-008: spawn.ts steerAgent → orchestrate with _skipInsert ───
@@ -111,10 +143,12 @@ test('DI-007: processQueue passes _skipInsert: true to orchestrate calls', () =>
 test('DI-008: steerAgent passes _skipInsert: true to orchestrate calls', () => {
     const steerStart = spawnSrc.indexOf('export async function steerAgent');
     const steerEnd = spawnSrc.indexOf('// ─── Helpers', steerStart);
-    const steerBlock = spawnSrc.slice(steerStart, steerEnd > 0 ? steerEnd : steerStart + 800);
-    assert.ok(steerBlock.includes("orchestrateReset({ origin, _skipInsert: true })"), 'steerAgent orchestrateReset');
-    assert.ok(steerBlock.includes("orchestrateContinue({ origin, _skipInsert: true })"), 'steerAgent orchestrateContinue');
-    assert.ok(steerBlock.includes("orchestrate(newPrompt, { origin, _skipInsert: true })"), 'steerAgent orchestrate');
+    const steerBlock = spawnSrc.slice(steerStart, steerEnd > 0 ? steerEnd : steerStart + 5000);
+    assert.equal(
+        steerBlock.match(/_skipInsert:\s*true/g)?.length,
+        3,
+        'reset, continue, and normal steer paths must all suppress duplicate inserts',
+    );
 });
 
 // ─── DI-009: processQueue retains its own insertMessage (existing behavior) ───

--- a/tests/unit/enoent-guard.test.ts
+++ b/tests/unit/enoent-guard.test.ts
@@ -42,7 +42,7 @@ test('EG-001: spawnAgent calls detectCli() before any spawn', () => {
 test('EG-002: standard CLI branch has child.on(\'error\') listener', () => {
     const stdBranchIdx = spawnSrc.indexOf('// ─── Standard CLI branch');
     assert.ok(stdBranchIdx > 0, 'Standard CLI branch comment should exist');
-    const block = spawnSrc.slice(stdBranchIdx, stdBranchIdx + 2400);
+    const block = spawnSrc.slice(stdBranchIdx, stdBranchIdx + 7000);
 
     assert.ok(
         block.includes("child.on('error'"),
@@ -73,17 +73,17 @@ test('EG-003: ACP branch has acp.on(\'error\') listener', () => {
 
 // ─── EG-004: Windows shell:true for .cmd shim resolution ───
 
-test('EG-004: standard CLI spawn uses shell:true on win32', () => {
+test('EG-004: standard CLI spawn uses shell:true for Windows shims', () => {
     const stdBranchIdx = spawnSrc.indexOf('// ─── Standard CLI branch');
-    const block = spawnSrc.slice(stdBranchIdx, stdBranchIdx + 1200);
+    const block = spawnSrc.slice(stdBranchIdx, stdBranchIdx + 2500);
 
     assert.ok(
-        block.includes("process.platform === 'win32'"),
-        'should conditionally check for win32',
+        block.includes("process.platform === 'win32'") && block.includes("!spawnCommand.toLowerCase().endsWith('.exe')"),
+        'should use a shell only for non-executable Windows shims',
     );
     assert.ok(
-        block.includes('shell: true'),
-        'should set shell: true on Windows',
+        block.includes('windowsSpawnUsesShell ? { shell: true } : {}'),
+        'should apply shell:true only when the Windows shim guard passes',
     );
 });
 
@@ -220,7 +220,7 @@ test('EG-009: quota-copilot keychain lookup is darwin-only', () => {
 test('EG-010: preflight failure returns child: null', () => {
     const preflightIdx = spawnSrc.indexOf('formatCliUnavailableMessage(cli, detected)');
     assert.ok(preflightIdx > 0, 'preflight block should exist');
-    const pfBlock = spawnSrc.slice(preflightIdx, preflightIdx + 500);
+    const pfBlock = spawnSrc.slice(preflightIdx, preflightIdx + 1200);
     assert.ok(
         pfBlock.includes('child: null'),
         'preflight should return { child: null } to avoid caller crashes',

--- a/tests/unit/orchestrator-worker-reset.test.ts
+++ b/tests/unit/orchestrator-worker-reset.test.ts
@@ -13,7 +13,10 @@ test('reset: orchestrateReset does NOT kill the main agent (preserves conversati
     const resetBlock = pipelineSrc.slice(resetStart, resetStart + 900);
     assert.ok(!resetBlock.includes("killActiveAgent"), 'reset must NOT kill the main agent');
     assert.ok(!resetBlock.includes("messageQueue.length = 0"), 'reset must NOT empty the message queue');
-    assert.ok(resetBlock.includes('clearAllWorkers()'), 'reset should still clear worker registry');
+    assert.ok(
+        resetBlock.includes('clearWorkersForScope(scope)'),
+        'reset should clear only the worker registry entries owned by the reset scope',
+    );
 });
 
 test('reset: orchestrateReset terminates each live worker before cancel/clear', () => {

--- a/tests/unit/steer-interrupted.test.ts
+++ b/tests/unit/steer-interrupted.test.ts
@@ -23,7 +23,8 @@ test('SI-001: killActiveAgent sets killReason to the given reason', () => {
 
 test('SI-002: killActiveAgent defaults reason to "user"', () => {
     assert.ok(
-        /export function killActiveAgent\(reason\s*=\s*['"]user['"]\)/.test(spawnSrc),
+        /export function killActiveAgent\(scopeKeyOrReason\s*=\s*['"]user['"],\s*scopedReason\?:\s*string\)/.test(spawnSrc)
+            && spawnSrc.includes('const reason = scopedReason ?? scopeKeyOrReason'),
         'killActiveAgent default reason should be "user"',
     );
 });
@@ -138,8 +139,8 @@ test('steerAgent calls killActiveAgent with "steer" reason', () => {
     assert.ok(steerFnMatch, 'steerAgent function should exist');
     const steerBody = steerFnMatch[0];
     assert.ok(
-        steerBody.includes("killActiveAgent('steer')"),
-        'steerAgent should call killActiveAgent with "steer" reason',
+        steerBody.includes("killActiveAgent(scopeKey, 'steer')"),
+        'steerAgent should call killActiveAgent for its scope with "steer" reason',
     );
     assert.ok(
         steerBody.includes('waitForProcessEnd'),

--- a/tests/unit/verdict-retry.test.ts
+++ b/tests/unit/verdict-retry.test.ts
@@ -5,6 +5,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { createQueueController } from '../../src/agent/spawn/queue.ts';
+import { SessionLanes } from '../../src/orchestrator/session-lanes.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -72,15 +74,41 @@ test('QP-001: queue policy is documented as "fair"', () => {
     );
 });
 
-test('QP-002: batch tail goes after remaining (fair ordering)', () => {
-    const queueBlock = queueSrc.slice(
-        queueSrc.indexOf('if (batch.length > 1)'),
-        queueSrc.indexOf('const combined = batch[0]'),
-    );
-    assert.ok(
-        queueBlock.includes('...remaining, ...batch.slice(1)'),
-        'remaining should come before batch tail in push',
-    );
+test('QP-002: queued messages retain fair FIFO ordering', async () => {
+    let busy = true;
+    const runs: string[] = [];
+    const controller = createQueueController({
+        migrateQueuedMessagesV1ToV2() {},
+        isSpawnBusy: () => busy,
+        hasBlockingWorkers: () => false,
+        hasPendingWorkerReplays: () => false,
+        insertMessage: { run() {} },
+        getActiveChatSession: () => 'default',
+        insertQueuedMessage: { run() {} },
+        deleteQueuedMessage: { run() {} },
+        listQueuedMessages: { all: () => [] },
+        broadcast() {},
+        importPipeline: async () => ({
+            orchestrate: async (prompt: string) => { runs.push(prompt); },
+            orchestrateContinue: async () => {},
+            orchestrateReset: async () => {},
+            isContinueIntent: () => false,
+            isResetIntent: () => false,
+            drainPendingReplays: async () => {},
+        }),
+        getWorkingDir: () => null,
+        isMultiSessionEnabled: () => false,
+    }, new SessionLanes(() => 1));
+
+    controller.enqueueMessage('first', 'web');
+    controller.enqueueMessage('other-chat', 'telegram');
+    controller.enqueueMessage('same-chat-tail', 'web');
+    busy = false;
+    await controller.processQueue('default');
+    for (let i = 0; i < 20 && (controller.messageQueue.length > 0 || controller.isQueueBusy(null)); i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    assert.deepEqual(runs, ['first', 'other-chat', 'same-chat-tail']);
 });
 
 // ─── RC: orchestrateContinue PABCD-aware ─────────────

--- a/tests/unit/worker-result-classification.test.ts
+++ b/tests/unit/worker-result-classification.test.ts
@@ -21,16 +21,13 @@ test('worker classification: dispatch route marks non-done worker results as fai
 });
 
 test('worker classification: replay contract only runs for done workers', () => {
-    // In patch3, replay drain is separate from worker execution.
-    // The replay drain calls the scoped claim and list worker-result contracts.
-    // only returns done workers (checked in worker-registry).
     assert.ok(
-        pipelineSrc.includes('claimWorkerReplay(pr.agentId)'),
-        'replay should be gated behind claimWorkerReplay',
+        pipelineSrc.includes('claimWorkerReplay(pr.agentId, scopeKey)'),
+        'replay should claim the completed worker result within its owning scope',
     );
     assert.ok(
-        pipelineSrc.includes('listPendingWorkerResults'),
-        'replay drain should use listPendingWorkerResults which filters done workers',
+        pipelineSrc.includes('listPendingWorkerResults(scopeKey)'),
+        'replay drain should list only pending results from its owning scope',
     );
 });
 


### PR DESCRIPTION
## Summary

- align source-contract assertions with the current scoped and refactored implementation
- replace brittle source-text checks with behavioral coverage for `_skipInsert` propagation and queue FIFO ordering
- update Windows shim, reset, steer, preflight, and worker replay expectations without changing production code

## Root cause

The runtime contracts were still implemented, but several tests searched for source shapes that changed during refactors. The assertions therefore failed even though the corresponding behavior remained intact.

## Impact

This removes 13 baseline CI failures from issue #287 while preserving coverage of the intended runtime behavior.

## Verification

- focused test group: 64 passed, 0 failed
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- full `npm test` was attempted locally but exceeded the 10-minute limit in existing long-running asynchronous tests

Closes #287