### PR TITLE
test: stabilize unresolved asynchronous operation tests

### DIFF
--- a/tests/unit/codex-app-multiplex-spawn.test.ts
+++ b/tests/unit/codex-app-multiplex-spawn.test.ts
@@ -198,6 +198,18 @@ function createLaneLease(options: Record<string, unknown>): FakeLaneLease {
     };
 }
 
+// This fixture exercises only the Codex App routing layer. Make CLI detection
+// deterministic so CI does not require a real `codex` binary on PATH; otherwise
+// spawnAgent exits at its preflight guard before any of the mocked pool/client
+// behavior can run.
+const realConfig = await import('../../src/core/config.ts');
+test.mock.module('../../src/core/config.js', {
+    namedExports: {
+        ...realConfig,
+        detectCli: () => ({ available: true, path: null }),
+    },
+});
+
 test.mock.module('../../src/agent/codex-app-client.js', {
     namedExports: {
         CodexAppClient: FakeCodexAppClient,

--- a/tests/unit/codex-app-runtime.test.ts
+++ b/tests/unit/codex-app-runtime.test.ts
@@ -17,6 +17,18 @@ function injectRequest(client: CodexAppClient, handler: RequestHandler): void {
     Object.defineProperty(client, 'request', { value: handler });
 }
 
+async function settleWithin<T>(pending: Promise<T>, timeoutMs = 1_000): Promise<T> {
+    let timer!: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`test operation did not settle within ${timeoutMs}ms`)), timeoutMs);
+    });
+    try {
+        return await Promise.race([pending, timeout]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 test('validateModelEffort fails open without a catalog', () => {
     assert.deepEqual(
         validateModelEffort('gpt-5.5', 'high', new Map()),
@@ -662,7 +674,7 @@ test('non-terminal TTL expiry drops with diagnostics before replay', async () =>
         method: 'item/agentMessage/delta',
         params: { threadId: 'thread-a', turnId: 'turn-a', delta: 'expired' },
     }));
-    await expired;
+    await settleWithin(expired);
     resolveTurn({ turn: { id: 'turn-a' } });
     await starting;
     assert.deepEqual(seen, []);
@@ -685,7 +697,7 @@ test('terminal TTL expiry explicitly fails the pending turn operation', async ()
             error: { message: 'expires' },
         },
     }));
-    await assert.rejects(starting, /ttl-terminal-expired/);
+    await assert.rejects(settleWithin(starting), /ttl-terminal-expired/);
 });
 
 test('closeScope rejects active lanes and cleans idle state, latch, listener, and index', async () => {

--- a/tests/unit/slack-api-cancel.test.ts
+++ b/tests/unit/slack-api-cancel.test.ts
@@ -11,6 +11,18 @@ function abortAwareFetch(seen: RequestInit[]): typeof fetch {
     }) as typeof fetch;
 }
 
+async function settleWithin<T>(pending: Promise<T>, timeoutMs = 1_000): Promise<T> {
+    let timer!: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`test operation did not settle within ${timeoutMs}ms`)), timeoutMs);
+    });
+    try {
+        return await Promise.race([pending, timeout]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 test('slackApi forwards a caller cancellation signal', async () => {
     const seen: RequestInit[] = [];
     const controller = new AbortController();
@@ -38,9 +50,9 @@ test('slackApi composes timeout and caller cancellation', async () => {
 
 test('slackApi timeout alone aborts a stalled request', async () => {
     const seen: RequestInit[] = [];
-    const result = await slackApi('xoxb-test', 'files.info', { file: 'F1' }, {
+    const result = await settleWithin(slackApi('xoxb-test', 'files.info', { file: 'F1' }, {
         fetchImpl: abortAwareFetch(seen), timeoutMs: 5, form: true,
-    });
+    }));
     assert.equal(result.ok, false);
     assert.equal(seen[0]?.signal?.aborted, true);
 });


### PR DESCRIPTION
## Summary

- make the Codex App multiplex fixture independent of a real `codex` binary on CI
- bound unresolved Codex App runtime operations with an explicit settlement timeout
- bound the Slack API timeout test so a stalled request fails deterministically instead of leaving the test pending

## Root cause

The affected tests depended on environment availability or incidental event-loop timing. In CI, the multiplex fixture could stop at CLI detection before reaching its mocked routing behavior, while unresolved async operations could leave Node's test runner with pending promises and no live event-loop work.

## Impact

These changes make the affected tests fail with a clear timeout instead of hanging and allow the mocked Codex App routing tests to run consistently in environments without the real CLI installed.

## Validation

```text
npx tsx --experimental-test-module-mocks --test tests/unit/codex-app-multiplex-spawn.test.ts tests/unit/codex-app-runtime.test.ts tests/unit/slack-api-cancel.test.ts

tests 50
pass 50
fail 0
```

Related to #286.

> This PR targets `dev`. Issue #286 should remain open until CI confirms the fix and the change reaches the default branch.