### PR TITLE
fix(prompt): finish disk soul and instance context (#300)

### DIFF
--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -10,8 +10,7 @@ import { getActiveChatSession, listChatSessions } from '../core/chat-sessions.js
 import { currentSessionScope } from '../core/session-context.js';
 import { memoryFlushCounter } from '../agent/spawn.js';
 import { describeHeartbeatSchedule, normalizeHeartbeatSchedule } from '../memory/heartbeat-schedule.js';
-import { buildTaskSnapshot, loadProfileSummary } from '../memory/runtime.js';
-import { readSoul } from '../memory/identity.js';
+import { buildTaskSnapshot, hasSoulFile, loadProfileSummary, loadSoulSummary } from '../memory/runtime.js';
 import { buildMemoryInjection } from '../memory/injection.js';
 import { loadAndRender, loadTemplate, renderTemplate, parseWorkerContexts, clearTemplateCache } from './template-loader.js';
 import { findStaticEmployee } from '../core/employees.js';
@@ -28,13 +27,11 @@ const promptCache = new Map();
 /**
  * Character budget for soul.md inside generated AGENTS.md (#300).
  *
- * Sized between its neighbours in that block — profile 600, snapshot 1500 —
- * because identity is the part a session most needs to carry, but AGENTS.md is
- * read on every turn so an unbounded file would tax the context window forever.
- * readSoul() itself is unbounded; the bound belongs here, at the disk-prompt
- * boundary, not in the API surface that also serves it.
+ * Large enough to retain the reported 3.4 KB production soul, including safety
+ * rules near its tail, while still bounding a file that AGENTS.md injects on
+ * every turn. loadSoulSummary() adds an explicit marker when this is exceeded.
  */
-const SOUL_DISK_BUDGET = 1200;
+const SOUL_DISK_BUDGET = 6000;
 
 function getRepoBundledSkillPath(...parts: string[]): string {
     return join(process.cwd(), ...parts);
@@ -531,6 +528,41 @@ function promptIdentityValue(value: unknown, fallback: string): string {
     return (normalized || fallback).slice(0, 120);
 }
 
+function resolveDiskWorkingDir(): string {
+    return expandHomePath(settings["workingDir"] || JAW_HOME, os.homedir());
+}
+
+function diskPromptPath(value: string): string {
+    return `\`${value.replaceAll('`', '\\`')}\``;
+}
+
+function renderA2ForDisk(a2: string, workingDir: string): string {
+    return a2.replace(
+        /(## Working Directory\r?\n)- ~\/\.cli-jaw(?=\r?\n|$)/,
+        (_match, heading: string) => `${heading}- ${diskPromptPath(workingDir)}`,
+    );
+}
+
+function loadDiskSoul(): string {
+    try {
+        if (!hasSoulFile()) return '';
+        const soul = loadSoulSummary(SOUL_DISK_BUDGET);
+        if (!soul) {
+            log.warn('[memory] disk soul exists but has no injectable content');
+            return '';
+        }
+        if (soul.endsWith('\n...(truncated)')) {
+            log.warn(`[memory] disk soul truncated to ${SOUL_DISK_BUDGET} chars`);
+        } else {
+            log.info(`[memory] disk soul loaded: ${soul.length} chars`);
+        }
+        return soul;
+    } catch (error) {
+        log.warn('[memory] disk soul load failed:', (error as Error).message);
+        return '';
+    }
+}
+
 function getCurrentSessionIdentityLine(): string {
     const sessionId = currentSessionScope()?.chatSessionId ?? getActiveChatSession();
     const session = listChatSessions().find(row => row.id === sessionId);
@@ -541,13 +573,15 @@ function getCurrentSessionIdentityLine(): string {
 }
 
 export function getSystemPrompt(opts: { currentPrompt?: string; forDisk?: boolean; memorySnapshot?: string; activeCli?: string; freshSession?: boolean } = {}) {
+    const forDisk = opts.forDisk === true;
+    const diskWorkingDir = forDisk ? resolveDiskWorkingDir() : '';
     // A-1: file takes priority (user-editable), rendered template fallback
     const a1 = fs.existsSync(A1_PATH) ? fs.readFileSync(A1_PATH, 'utf8') : getA1Content();
-    const a2 = fs.existsSync(A2_PATH) ? fs.readFileSync(A2_PATH, 'utf8') : '';
+    const rawA2 = fs.existsSync(A2_PATH) ? fs.readFileSync(A2_PATH, 'utf8') : '';
+    const a2 = forDisk ? renderA2ForDisk(rawA2, diskWorkingDir) : rawA2;
     let prompt = `${a1}\n\n${a2}`;
     // Project root is now injected per-message in spawn.ts (user prompt wrapper)
     const currentPrompt = String(opts.currentPrompt || '').trim();
-    const forDisk = opts.forDisk === true;
 
     // Phase 15: Telegram guidance is now part of A1_CONTENT (hardcoded)
     // No dynamic injection needed — Bot-First policy with curl examples included
@@ -573,25 +607,24 @@ export function getSystemPrompt(opts: { currentPrompt?: string; forDisk?: boolea
         // Phase 54-B: forDisk (AGENTS.md) — include a minimal memory block
         // so Codex/OpenCode sessions have soul, profile, and snapshot context.
         prompt = appendLegacyMemoryContext(prompt);
+        prompt += '\n\n---\n## Resolved Instance Context\n';
+        prompt += `- JAW_HOME: ${diskPromptPath(JAW_HOME)}\n`;
+        prompt += `- Working directory: ${diskPromptPath(diskWorkingDir)}\n`;
+        prompt += '- These resolved instance paths override placeholder paths in older/custom prompt files.\n';
+        const soul = loadDiskSoul();
         try {
-            // #300: this block promised soul context and never read it, so a
-            // codex-app session ran on shipped defaults while the host had a
-            // configured identity on disk. readSoul() returns '' when the file
-            // is absent, so an unconfigured host is unchanged.
-            //
-            // Bounded like its neighbours: readSoul() is unbounded, and AGENTS.md
-            // is prepended to every turn, so an unbounded identity file would tax
-            // the context window on every request.
-            const soul = readSoul().trim().slice(0, SOUL_DISK_BUDGET);
             const profile = loadProfileSummary(600);
             const snapshot = buildTaskSnapshot('current session context', 1500);
             if (soul || profile || snapshot) {
-                prompt += '\n\n---\n## Core Memory\n';
-                if (soul) prompt += soul + '\n';
-                if (profile) prompt += profile + '\n';
+                prompt += '\n\n---\n## Disk Memory Context\n';
+                if (soul) prompt += `\n## Soul & Identity\n${soul}\n`;
+                if (profile) prompt += `\n## Profile Context\n${profile}\n`;
                 if (snapshot) prompt += '\n' + snapshot;
             }
-        } catch { /* memory not ready for disk generation */ }
+        } catch (error) {
+            log.warn('[memory] disk profile/snapshot load failed:', (error as Error).message);
+            if (soul) prompt += `\n\n---\n## Disk Memory Context\n\n## Soul & Identity\n${soul}\n`;
+        }
     }
 
     try {

--- a/structure/memory_architecture.md
+++ b/structure/memory_architecture.md
@@ -9,7 +9,7 @@ aliases: [CLI-JAW Memory Architecture, advanced memory runtime, memory architect
 # Memory Architecture — 통합 메모리 시스템
 
 > 최종 갱신: 2026-06-03
-> 소스: `src/memory/runtime.ts` 375L (사실상 facade), `src/memory/shared.ts` 265L, `src/memory/bootstrap.ts` 524L, `src/memory/indexing.ts` 569L, `src/memory/keyword-expand.ts` 98L, `src/memory/synonyms.ts` 60L, `src/memory/reflect.ts` 379L, `src/memory/identity.ts` 86L, `src/memory/injection.ts` 69L, `src/memory/memory.ts` 154L, `src/memory/worklog.ts` 200L, `src/memory/heartbeat.ts` 209L, `src/memory/heartbeat-schedule.ts` 410L, `src/memory/advanced.ts` 1L (re-export shim), `src/agent/memory-flush-controller.ts` 185L, `src/agent/spawn.ts` 2011L, `src/prompt/builder.ts` 806L, `src/orchestrator/pipeline.ts` 538L, `src/routes/memory.ts`, `src/routes/jaw-memory.ts`, `src/cli/command-context.ts`, `src/cli/handlers-runtime.ts`
+> 소스: `src/memory/runtime.ts` 375L (사실상 facade), `src/memory/shared.ts` 265L, `src/memory/bootstrap.ts` 524L, `src/memory/indexing.ts` 569L, `src/memory/keyword-expand.ts` 98L, `src/memory/synonyms.ts` 60L, `src/memory/reflect.ts` 379L, `src/memory/identity.ts` 86L, `src/memory/injection.ts` 69L, `src/memory/memory.ts` 154L, `src/memory/worklog.ts` 200L, `src/memory/heartbeat.ts` 209L, `src/memory/heartbeat-schedule.ts` 410L, `src/memory/advanced.ts` 1L (re-export shim), `src/agent/memory-flush-controller.ts` 185L, `src/agent/spawn.ts` 2011L, `src/prompt/builder.ts` 1040L, `src/orchestrator/pipeline.ts` 538L, `src/routes/memory.ts`, `src/routes/jaw-memory.ts`, `src/cli/command-context.ts`, `src/cli/handlers-runtime.ts`
 > 임베딩: `src/manager/memory/embedding/` — `provider.ts`, `vec-store.ts`, `sync.ts`, `state-machine.ts`, `hybrid-search.ts`, `index.ts` + `src/manager/routes/dashboard-memory.ts`
 
 ---
@@ -23,7 +23,7 @@ graph TD
     DB -->|"assistant 응답 저장 후"| FLUSH["🧠 Memory Flush"]
     FLUSH --> LIVE["📁 ~/.cli-jaw/memory/structured/episodes/live/YYYY-MM-DD.md"]
     INDEX["🔎 index.sqlite"] -->|"ready"| ADV["📄 Advanced Memory Prompt"]
-    ADV -->|"profile.md + task snapshot"| SYSPROMPT["📄 System Prompt"]
+    ADV -->|"profile.md + soul.md + task snapshot"| SYSPROMPT["📄 System Prompt"]
     LEGACY["📝 ~/.cli-jaw/memory/MEMORY.md"] -->|"fallback / forDisk"| LEGACYPROMPT["📄 Legacy Prompt Context"]
     HB --> PROMPT["📨 사용자 프롬프트 앞에 붙임"]
     LEGACYPROMPT --> SYSPROMPT
@@ -162,7 +162,7 @@ Prefers ES Module only, no CommonJS.
 - 각 섹션은 첫 줄만 bullet로 넣는다.
 - 파일 순서는 최신 파일 우선, 섹션도 역순이다.
 - 즉, raw conversation dump가 아니라 섹션 머리말 중심의 요약 주입이다.
-- `forDisk: true` 경로는 legacy fallback을 먼저 조립한 뒤, 준비된 경우 advanced `profile.md` 요약(600자)과 `buildTaskSnapshot('current session context', 1500)` 결과를 `## Core Memory` 아래에 추가한다. 즉 `B.md`/workspace `AGENTS.md`는 런타임 boss prompt와 동일하지는 않지만, 더 이상 legacy-only 스냅샷은 아니다.
+- `forDisk: true` 경로는 legacy fallback을 먼저 조립한 뒤, `shared/soul.md`를 인덱스 상태와 무관하게 최대 6000자로 읽고, 준비된 경우 advanced `profile.md` 요약(600자)과 `buildTaskSnapshot('current session context', 1500)` 결과를 `## Disk Memory Context` 아래에 추가한다. 6000자 초과, 빈 파일, 읽기 실패는 warning 로그로 드러난다. disk prompt에는 실제 `JAW_HOME`과 `settings.workingDir`도 함께 기록된다. 즉 `B.md`/workspace `AGENTS.md`는 런타임 boss prompt와 동일하지는 않지만, 더 이상 legacy-only 스냅샷은 아니다.
 
 ### 3-E: Core Memory
 
@@ -257,7 +257,7 @@ Prefers ES Module only, no CommonJS.
 |---|---|---|---|---|
 | **역할** | 최근 대화 원문 전달 | assistant 응답을 structured episode 로 요약 저장 | indexed memory + profile + task snapshot 주입 | legacy session memory + core fallback | 핵심 기억 상시 주입 |
 | **타이밍** | 새 세션만 | assistant 응답 저장 직후 | advanced index ready일 때 매번 | advanced 미준비 또는 forDisk base | 매번 |
-| **크기 제한** | 8000자 | 최근 메시지 4개 미만이면 스킵 | 800 / 2800 | 10000 / 1500 | 1500자 |
+| **크기 제한** | 8000자 | 최근 메시지 4개 미만이면 스킵 | runtime profile 800 / soul 1000 / snapshot 2800; disk soul 6000 / profile 600 / snapshot 1500 | 10000 / 1500 | 1500자 |
 | **저장소** | `messages` DB | `memory/structured/episodes/live` | `memory/structured` | `~/.claude/projects/{hash}/memory` + `~/.cli-jaw/memory/MEMORY.md` | `MEMORY.md` |
 | **코드** | `spawn.ts` | `memory-flush-controller.ts` + `spawn.ts` | `builder.ts` + `injection.ts` + `runtime.ts` | `builder.ts` | `builder.ts` |
 | **resume 시** | ❌ 스킵 | ✅ 정상 동작 | ✅ 정상 동작 | ✅ 정상 동작 | ✅ 정상 동작 |

--- a/structure/prompt_basic_B.md
+++ b/structure/prompt_basic_B.md
@@ -112,4 +112,4 @@ aliases: [B prompt cache, CLI-JAW B prompt, regenerated prompt]
 - 실행 규칙 + delegation 규칙: `cli-jaw dispatch`와 subtask JSON은 금지지만, CLI 자체 sub-agent(Task/Agent tool)는 내부 병렬 작업용으로 명시적으로 허용
 - PABCD A/B/C 중 Approved Plan이 주입될 때 `Project root`와 path guard가 함께 들어가므로, 직원은 `Workspace Context`와 Approved Plan의 root를 기준으로 파일을 읽고 검증한다.
 
-이 구조 때문에 B.md는 단순한 "완성본"이 아니라, 현재 시스템 프롬프트가 어떻게 합성되는지 보여주는 캐시 스냅샷이다. forDisk 경로가 advanced `## Memory Runtime` 블록 대신 legacy fallback + 축약 profile/snapshot 보강을 사용한다는 점은 같이 봐야 한다.
+이 구조 때문에 B.md는 단순한 "완성본"이 아니라, 현재 시스템 프롬프트가 어떻게 합성되는지 보여주는 캐시 스냅샷이다. forDisk 경로는 advanced `## Memory Runtime` 블록 대신 legacy fallback에 bounded `shared/soul.md`, 축약 profile/snapshot, 실제 `JAW_HOME`·working directory를 보강한다는 점을 같이 봐야 한다.

--- a/structure/prompt_flow.md
+++ b/structure/prompt_flow.md
@@ -8,7 +8,7 @@ aliases: [Prompt Injection Flow, CLI-JAW prompt flow, prompt pipeline]
 
 # 프롬프트 삽입 흐름 — Prompt Injection Flow
 
-> cli-jaw의 프롬프트 조립 + 주입 전체 흐름. 현재 기준 소스는 `src/prompt/builder.ts` 806L, `src/memory/injection.ts`, `src/agent/spawn.ts` 2011L, `src/prompt/templates/*` (a1-system 388L, a2-default 25L, orchestration 120L, employee 73L, control-system 56L, worker-context 11L, skills 24L, heartbeat-jobs 4L, heartbeat-default 4L, vision-click 3L).
+> cli-jaw의 프롬프트 조립 + 주입 전체 흐름. 현재 기준 소스는 `src/prompt/builder.ts` 1040L, `src/memory/injection.ts`, `src/agent/spawn.ts` 2011L, `src/prompt/templates/*` (a1-system 388L, a2-default 25L, orchestration 120L, employee 73L, control-system 56L, worker-context 11L, skills 24L, heartbeat-jobs 4L, heartbeat-default 4L, vision-click 3L).
 
 ---
 
@@ -98,7 +98,7 @@ graph TD
 메모리는 두 갈래다.
 
 - `forDisk: false`: `buildMemoryInjection()` 우선
-- `forDisk: true`: legacy fallback + 준비된 advanced profile/task snapshot의 축약 disk block
+- `forDisk: true`: legacy fallback + bounded soul(최대 6000자) + 준비된 advanced profile/task snapshot의 축약 disk block + resolved instance paths
 
 #### Advanced path
 
@@ -140,7 +140,9 @@ advanced index가 아직 준비되지 않았거나 `forDisk: true`인 경우 `ap
 - 코어 메모리 길이 제한: 1500자
 - 세션 메모리 길이 예산: 10000자
 
-`forDisk: true`는 그 뒤에 `loadProfileSummary(600)`과 `buildTaskSnapshot('current session context', 1500)` 결과를 `## Core Memory` 아래에 덧붙인다. 따라서 `B.md`와 workspace `AGENTS.md`는 "disk 캐시용 축약 memory snapshot"이며, 런타임 boss prompt의 advanced `profile + soul + task snapshot`과 완전히 동일하지 않다.
+`forDisk: true`는 그 뒤에 인덱스 준비 여부와 무관하게 `loadSoulSummary(6000)`을 읽고, `loadProfileSummary(600)`과 `buildTaskSnapshot('current session context', 1500)`을 `## Disk Memory Context` 아래에 덧붙인다. soul이 6000자를 넘으면 명시적 truncation marker와 warning 로그를 남기며, 파일이 있는데 읽거나 주입할 수 없는 경우도 warning으로 드러낸다. 따라서 `B.md`와 workspace `AGENTS.md`는 "disk 캐시용 축약 memory snapshot"이며, 런타임 boss prompt의 advanced `profile + soul + task snapshot`과 완전히 동일하지 않다.
+
+같은 disk 경로는 `## Resolved Instance Context`에 실제 `JAW_HOME`과 `settings.workingDir`을 기록한다. stock A2의 `## Working Directory\n- ~/.cli-jaw` placeholder는 실제 working directory로 바꾸되, 다른 custom A2 내용은 보존한다.
 
 ### Orchestration
 
@@ -266,6 +268,7 @@ delegation rules 블록은 prompt 끝에 항상 붙는다.
 
 - session invalidation은 더 이상 하지 않는다
 - AGENTS.md는 content hash가 바뀔 때만 fresh write 되며 resume continuity는 유지한다
+- AGENTS.md에는 bounded `Soul & Identity`와 resolved `JAW_HOME`/working directory가 포함된다. soul truncation/읽기 실패는 로그에 남아 silent omission이 되지 않는다
 - employee spawn은 별도 tmp cwd를 만들어 boss AGENTS.md와 격리한다
 
 ---

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -153,7 +153,7 @@ cli-jaw/
 │   │   ├── sanitize.ts       ← Interview tracker strip helper + stripPhaseAttestation re-export (79L)
 │   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> (tagged block + --attest object) + form-only checkAttestationGate (gates P→A/A→B/B→C/C→D; narrative did required, C→D needs checkOutput) + stripPhaseAttestation + warn-only no-state narration detector (217L)
 │   ├── prompt/               ← 프롬프트 조립 (4 files + templates/ 10 files)
-│   │   ├── builder.ts        ← A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1007L)
+│   │   ├── builder.ts        ← A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1040L)
 │   │   ├── runtime-context.ts ← 런타임 컨텍스트 주입 (RuntimeContextEntry, loadEntries, getActiveEntries, addEntry, removeEntry, clearAll, buildInjectionBlock) (80L)
 │   │   ├── soul-bootstrap-prompt.ts ← LLM 기반 soul.md 개인화 부트스트랩 프롬프트 빌더 (52L)
 │   │   ├── template-loader.ts ← 프롬프트 템플릿 로더 (50L)

--- a/tests/unit/agents-md-soul.test.ts
+++ b/tests/unit/agents-md-soul.test.ts
@@ -28,7 +28,8 @@ test('AGENTS.md carries soul.md, not just profile and snapshot', () => {
     writeSoul(SOUL_BODY);
     const prompt = getSystemPrompt({ forDisk: true });
 
-    assert.match(prompt, /## Core Memory/, 'the disk prompt should still emit the Core Memory block');
+    assert.match(prompt, /## Disk Memory Context/, 'the disk prompt should emit its bounded memory block');
+    assert.match(prompt, /## Soul & Identity/, 'soul content should be explicitly labelled');
     assert.ok(
         prompt.includes(SOUL_BODY),
         'soul.md content must reach the generated AGENTS.md — this is the whole of #300',
@@ -49,14 +50,14 @@ test('an oversized soul is bounded rather than pasted whole', () => {
     // AGENTS.md is read on every turn, so an unbounded identity file would tax
     // the context window forever. readSoul() itself is unbounded by design — the
     // API surface serves it in full — so the budget lives at this boundary.
-    const huge = 'X'.repeat(5000);
+    const huge = 'X'.repeat(7000);
     writeSoul(huge);
     const prompt = getSystemPrompt({ forDisk: true });
 
     const run = prompt.match(/X{50,}/)?.[0] ?? '';
     assert.ok(run.length > 0, 'the oversized soul should still appear');
     assert.ok(
-        run.length <= 1200,
+        run.length <= 6000,
         `soul must be truncated to the disk budget, saw ${run.length} chars`,
     );
 });

--- a/tests/unit/disk-prompt-memory.test.ts
+++ b/tests/unit/disk-prompt-memory.test.ts
@@ -1,0 +1,70 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JAW_HOME, PROMPTS_DIR, settings } from '../../src/core/config.ts';
+import { drainLogRing } from '../../src/core/logger.ts';
+import { getSystemPrompt, regenerateB } from '../../src/prompt/builder.ts';
+
+test('disk prompt carries soul safety rules and resolved instance paths', () => {
+    const workingDir = join(JAW_HOME, 'accounting-workspace');
+    const soulDir = join(JAW_HOME, 'memory', 'structured', 'shared');
+    mkdirSync(PROMPTS_DIR, { recursive: true });
+    mkdirSync(workingDir, { recursive: true });
+    mkdirSync(soulDir, { recursive: true });
+
+    settings.workingDir = workingDir;
+    writeFileSync(join(PROMPTS_DIR, 'A-1.md'), '# System\n', 'utf8');
+    writeFileSync(join(PROMPTS_DIR, 'A-2.md'), [
+        '# User Configuration',
+        '',
+        '## Working Directory',
+        '- ~/.cli-jaw',
+        '',
+    ].join('\n'), 'utf8');
+    writeFileSync(join(soulDir, 'soul.md'), [
+        '---',
+        'trust_level: high',
+        '---',
+        '# 회계봇 운영 원칙',
+        '',
+        '- 금액과 계정 코드를 임의로 바꾸지 않는다.',
+        '- 고객 자료를 외부로 전송하지 않는다.',
+        `- ${'안전규칙'.repeat(850)}`,
+        '- 장문 soul 끝까지 전달됨',
+    ].join('\n'), 'utf8');
+
+    regenerateB();
+    const prompt = readFileSync(join(workingDir, 'AGENTS.md'), 'utf8');
+
+    assert.match(prompt, /## Soul & Identity/);
+    assert.match(prompt, /회계봇 운영 원칙/);
+    assert.match(prompt, /금액과 계정 코드를 임의로 바꾸지 않는다/);
+    assert.match(prompt, /장문 soul 끝까지 전달됨/,
+        'a soul around the reported 3.4 KB size must not lose its trailing rules');
+    assert.ok(prompt.includes(JAW_HOME), 'disk prompt must expose the resolved JAW_HOME');
+    assert.ok(prompt.includes(workingDir), 'disk prompt must expose the resolved working directory');
+    assert.doesNotMatch(prompt, /## Working Directory\s*\n- ~\/\.cli-jaw/,
+        'the stock A2 working-directory placeholder must not survive disk generation');
+});
+
+test('oversized disk soul is bounded and truncation is visible in logs', () => {
+    const soulDir = join(JAW_HOME, 'memory', 'structured', 'shared');
+    mkdirSync(soulDir, { recursive: true });
+    writeFileSync(join(soulDir, 'soul.md'), [
+        '# Oversized Soul',
+        'A'.repeat(7000),
+        'TAIL_MUST_BE_TRUNCATED',
+    ].join('\n'), 'utf8');
+
+    drainLogRing();
+    const prompt = getSystemPrompt({ forDisk: true });
+    const logs = drainLogRing();
+
+    assert.match(prompt, /## Soul & Identity/);
+    assert.match(prompt, /\.\.\.\(truncated\)/);
+    assert.doesNotMatch(prompt, /TAIL_MUST_BE_TRUNCATED/);
+    assert.ok(logs.some(entry => entry.level === 'warn' && entry.text.includes('disk soul truncated')),
+        'truncation must be observable instead of silently dropping soul content');
+});


### PR DESCRIPTION
## What changed

- load `shared/soul.md` into disk-generated prompts independently of memory-index readiness
- preserve a production-sized 3.4 KB soul with a 6000-character boundary, explicit truncation marker, and warning logs
- emit resolved `JAW_HOME` and working-directory values, and replace the stock `~/.cli-jaw` A2 placeholder in disk prompts
- label disk soul/profile sections explicitly and add an end-to-end `AGENTS.md` regression test
- update the existing #300 regression expectations and architecture documentation

## Why

The first merged #300 patch connected `soul.md` to `getSystemPrompt({ forDisk: true })`, but it silently sliced the file at 1200 characters and did not address the issue's resolved-path requirement. The reported production soul is about 3.4 KB and carries safety rules near its tail, so the partial fix could still omit those rules without any signal.

This follow-up completes the issue contract while keeping disk context bounded.

## Validation

- `npm run build`
- `npm run build:frontend`
- `npm run typecheck`
- `npm run docs:check`
- `tsx --test` for disk soul, existing #300, system prompt, memory autoload, and session tagging: 45/45 passed
- `bash structure/verify-counts.sh`: 416/416 passed
- pre-rebase focused suite: 42/42 passed

## Windows baseline notes

- `npm test` reached existing long-running `code-workspace-pick-route-runtime` and `kill-escalation-liveness` cases and was stopped after 10 minutes.
- integration: 31 passed, 3 skipped, 8 existing Windows failures (`node_modules/.bin/tsx` ENOENT and shutdown cleanup EPERM).
- `gate:all` also reports existing Windows `status=null` child-spawn failures and a missing Electron `pty.node` bundle in this development checkout.

Closes #300
