### PR TITLE
fix(wiki): warn when enabled vault is unavailable

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -47,7 +47,11 @@ import { SearchCoordinator } from './src/search/coordinator.js';
 import { SearchProviderRegistry } from './src/search/provider.js';
 import { WikiSearchProvider } from './src/search/providers/wiki.js';
 import { registerWikiRoutes } from './src/routes/wiki.js';
-import { forbiddenWikiRoots, setForbiddenWikiRoots } from './src/wiki/config.js';
+import {
+    currentWikiStartupWarning,
+    forbiddenWikiRoots,
+    setForbiddenWikiRoots,
+} from './src/wiki/config.js';
 import { dashboardPath } from './src/manager/dashboard-home.js';
 import { ChatSearchProvider } from './src/search/providers/chat.js';
 import { MemorySearchProvider } from './src/search/providers/memory.js';
@@ -563,6 +567,9 @@ server.listen(PORT, bindHost, async () => {
     log.info(`  CLI:    ${settings["cli"]}`);
     log.info(`  Perms:  ${settings["permissions"]}`);
     log.info(`  CWD:    ${settings["workingDir"]}`);
+
+    const wikiWarning = currentWikiStartupWarning();
+    if (wikiWarning) log.warn(wikiWarning);
 
     // Stale PABCD cleanup already runs at module init (line ~195) with 24h filter
 

--- a/src/wiki/config.ts
+++ b/src/wiki/config.ts
@@ -147,10 +147,9 @@ export function storedWikiRoot(): string {
     return resolve(text.replace(/^~(?=$|\/)/, homedir()));
 }
 
-// The enable route validates the root before it scaffolds, but the generic settings API
-// and the settings-file watcher can both write this block without going near that route.
-// Enforcing the rule where the config is CONSUMED is what makes it hold whatever path
-// the setting arrived by.
+// The wiki routes own lifecycle writes and the live watcher strips attempts to bypass
+// them. This consume-side check still covers legacy settings and lifecycle fields loaded
+// directly from settings.json during boot, before the watcher begins enforcing the rule.
 export function readUsableWikiConfig(forbiddenRoots: readonly string[] = []): WikiConfig {
     const config = readWikiConfig();
     if (!config.enabled) return config;
@@ -209,6 +208,37 @@ export function wikiProviderHealth(
 
 export function wikiProviderStatus(config: WikiConfig): ProviderStatus {
     return wikiProviderHealth(config).status;
+}
+
+/**
+ * Produce a path-free startup diagnostic for a vault that was persisted as enabled
+ * but cannot serve searches. Lifecycle repair stays on the wiki routes; pointing at
+ * those routes keeps operators away from the generic settings back door.
+ */
+function formatWikiStartupWarning(reason: string): string {
+    return `[jaw:wiki] enabled but unavailable at startup (${reason}); `
+        + 'repair with POST /api/wiki/enable or disable with POST /api/wiki/configure';
+}
+
+export function wikiStartupWarning(
+    config: WikiConfig,
+    health: WikiProviderHealth = wikiProviderHealth(config),
+): string | null {
+    if (!config.enabled || health.status !== 'error') return null;
+    return formatWikiStartupWarning(health.safeFailureCode ?? 'wiki_provider_unavailable');
+}
+
+/** Read the persisted startup state without letting an invalid legacy root abort boot. */
+export function currentWikiStartupWarning(
+    readConfig: () => WikiConfig = readWikiConfig,
+    enabled: () => boolean = isWikiEnabled,
+): string | null {
+    if (!enabled()) return null;
+    try {
+        return wikiStartupWarning(readConfig());
+    } catch {
+        return formatWikiStartupWarning('wiki_configuration_invalid');
+    }
 }
 
 // The roots the vault must not occupy, registered once at composition. The registry

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -245,6 +245,12 @@ static → employees → heartbeat → skills → jaw-memory → orchestrate
 - `grok`은 `~/.grok/auth.json`의 OIDC `key`를 우선 읽고 `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig` gRPC-web 응답으로 SuperGrok weekly usage pool window를 만든다. 실패하면 legacy `cli-chat-proxy.grok.com/v1/billing` monthly credits window로 fallback한다.
 - `kiro-code`는 `src/routes/quota-kiro-reverse.ts`의 `fetchKiroUsage()`를 통해 CodeWhisperer `GetUsageLimits` API를 reverse-engineer 호출한다.
 
+### Wiki lifecycle ownership
+
+- `wiki.enabled` and `wiki.root` are owned by `POST /api/wiki/enable` and `POST /api/wiki/configure`. The enable route scaffolds the vault, verifies provider readiness, and only then persists the lifecycle configuration.
+- Generic `PUT /api/settings` rejects either lifecycle field with `409 wiki_configuration_requires_wiki_route`; `wiki.promptDigest` remains writable there. External `settings.json` reloads ignore the two lifecycle fields and emit a warning instead of bypassing the wiki routes.
+- At server startup, a persisted enabled vault whose provider is not ready emits `[jaw:wiki] enabled but unavailable at startup (...)` without logging the vault path. Repair it through `POST /api/wiki/enable`, or disable it through `POST /api/wiki/configure`.
+
 ### `/api/project/git-summary`
 
 - `GET /api/project/git-summary`는 Settings의 `projectDirs[0]`만 읽는 read-only header helper다.

--- a/tests/unit/wiki-config.test.ts
+++ b/tests/unit/wiki-config.test.ts
@@ -6,10 +6,12 @@ import { tmpdir, homedir } from 'node:os';
 import { join, parse } from 'node:path';
 import {
     DEFAULT_WIKI_CONFIG,
+    currentWikiStartupWarning,
     normalizeWikiConfig,
     readWikiConfig,
     wikiProviderHealth,
     wikiProviderStatus,
+    wikiStartupWarning,
     writeWikiConfig,
     WIKI_REQUIRED_DIRS,
     WIKI_REQUIRED_FILES,
@@ -88,6 +90,30 @@ test('an enabled complete vault reports the safe missing-engine reason', async (
     assert.deepEqual(
         wikiProviderHealth({ enabled: true, root, promptDigest: false }, () => false),
         { status: 'error', safeFailureCode: 'notes_search_unavailable' },
+    );
+});
+
+test('startup warning names the wiki lifecycle routes without exposing the vault path', () => {
+    const config = { enabled: true, root: 'C:\\private\\wiki', promptDigest: false };
+    const warning = wikiStartupWarning(config, {
+        status: 'error',
+        safeFailureCode: 'notes_search_unavailable',
+    });
+
+    assert.match(warning ?? '', /^\[jaw:wiki\] enabled but unavailable at startup/);
+    assert.match(warning ?? '', /notes_search_unavailable/);
+    assert.match(warning ?? '', /POST \/api\/wiki\/enable/);
+    assert.match(warning ?? '', /POST \/api\/wiki\/configure/);
+    assert.equal(warning?.includes(config.root), false);
+    assert.equal(wikiStartupWarning({ ...config, enabled: false }, { status: 'error' }), null);
+    assert.equal(wikiStartupWarning(config, { status: 'ready' }), null);
+    assert.match(
+        currentWikiStartupWarning(() => { throw new Error(`invalid root: ${config.root}`); }, () => true) ?? '',
+        /wiki_configuration_invalid/,
+    );
+    assert.equal(
+        currentWikiStartupWarning(() => { throw new Error('must not read'); }, () => false),
+        null,
     );
 });
 


### PR DESCRIPTION
## What changed

- emit a path-free startup warning when wiki is persisted as enabled but its provider is unavailable
- distinguish invalid legacy wiki configuration from an unavailable provider without letting boot fail
- direct operators to the wiki-owned enable/configure routes
- document that `wiki.enabled` and `wiki.root` cannot be changed through generic settings

## Why

The write-side bypass in #282 is already blocked on `dev`, but a legacy or boot-loaded `settings.json` can still contain an enabled vault that is not ready. Previously the server started silently while the wiki provider remained in `error`.

The warning intentionally omits the configured vault path.

## Validation

- 16 focused tests passed (startup warning, generic settings boundary, runtime boundary, settings watcher)
- compiled server live-started with an isolated enabled/missing vault and emitted the expected warning without exposing its path
- `npm run build` passed, including atomic `dist/` swap and dist asset verification
- `structure/verify-counts.sh` passed
- the broader wiki batch passed 47/51; the four failures are existing Windows `EPERM` failures while creating symlinks
- full `npm test` was stopped after reproducing the existing hang in `tests/unit/kill-escalation-liveness.test.ts`

Closes #282