### PR TITLE
fix(officecli): preflight Windows release assets

### DIFF
--- a/scripts/install-officecli.ps1
+++ b/scripts/install-officecli.ps1
@@ -40,9 +40,44 @@ function Normalize-Version([string]$version) {
   return $version.Trim().TrimStart('v')
 }
 
+function Get-LatestRelease([string]$repoName) {
+  return Invoke-RestMethod -Uri "https://api.github.com/repos/$repoName/releases/latest" -Headers @{ "User-Agent" = "cli-jaw-postinstall" }
+}
+
 function Get-LatestTag([string]$repoName) {
-  $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$repoName/releases/latest" -Headers @{ "User-Agent" = "cli-jaw-postinstall" }
+  $release = Get-LatestRelease $repoName
   return [string]$release.tag_name
+}
+
+function Assert-AssetPublished([string]$repoName, [string]$assetName) {
+  try {
+    $release = Get-LatestRelease $repoName
+  } catch {
+    # Match the shell installer's network fallback: if GitHub metadata itself is
+    # unavailable, let the download report the concrete transport failure.
+    Write-Warn "Could not inspect $repoName release assets; the download will verify availability"
+    return
+  }
+
+  $published = @($release.assets | ForEach-Object { [string]$_.name } | Where-Object { $_ })
+  if ($published -contains $assetName) { return }
+
+  $tag = if ($release.tag_name) { [string]$release.tag_name } else { "unknown" }
+  $publishedText = if ($published.Count -gt 0) { $published -join " " } else { "(none)" }
+  $lines = @(
+    "$repoName latest release ($tag) has no $assetName.",
+    "  published: $publishedText"
+  )
+  if ($repoName -eq "lidge-jun/OfficeCLI") {
+    $lines += @(
+      "",
+      "  The supported fork currently publishes only officecli-mac-arm64.",
+      "  For general XLSX/accessibility work use upstream, which builds every platform:",
+      "      powershell -ExecutionPolicy Bypass -File `"$PSCommandPath`" -Upstream",
+      "  The fork is required only for CJK font handling and HWP (rhwp sidecars)."
+    )
+  }
+  Fail ($lines -join [Environment]::NewLine)
 }
 
 Write-Info "Platform: win32/$arch -> $asset"
@@ -85,6 +120,7 @@ if ((Test-Path $targetBin) -and -not $Force -and $Update) {
   }
 }
 
+Assert-AssetPublished $Repo $asset
 New-Item -ItemType Directory -Force -Path $installDir | Out-Null
 $downloadUrl = "https://github.com/$Repo/releases/latest/download/$asset"
 

--- a/tests/unit/officecli-powershell-installer.test.ts
+++ b/tests/unit/officecli-powershell-installer.test.ts
@@ -6,6 +6,9 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const installer = resolve(import.meta.dirname, '../../scripts/install-officecli.ps1');
+const windowsOnly = {
+    skip: process.platform === 'win32' ? false : 'requires Windows PowerShell',
+};
 
 function encodedPowerShell(source: string): string {
     return Buffer.from(source, 'utf16le').toString('base64');
@@ -50,7 +53,7 @@ function runInstaller(release: { tag: string; assets: string[] }, repo?: string)
     }
 }
 
-test('#280: Windows fork install fails before download when the release omits its asset', () => {
+test('#280: Windows fork install fails before download when the release omits its asset', windowsOnly, () => {
     const result = runInstaller({ tag: 'v1.0.98', assets: ['officecli-mac-arm64'] });
 
     assert.equal(result.status, 1);
@@ -61,7 +64,7 @@ test('#280: Windows fork install fails before download when the release omits it
     assert.doesNotMatch(result.output, /DOWNLOAD_REACHED/);
 });
 
-test('#280: Windows upstream install proceeds when the release publishes its asset', () => {
+test('#280: Windows upstream install proceeds when the release publishes its asset', windowsOnly, () => {
     const result = runInstaller({
         tag: 'v1.0.143',
         assets: ['officecli-win-x64.exe', 'officecli-win-arm64.exe', 'SHA256SUMS'],

--- a/tests/unit/officecli-powershell-installer.test.ts
+++ b/tests/unit/officecli-powershell-installer.test.ts
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const installer = resolve(import.meta.dirname, '../../scripts/install-officecli.ps1');
+
+function encodedPowerShell(source: string): string {
+    return Buffer.from(source, 'utf16le').toString('base64');
+}
+
+function runInstaller(release: { tag: string; assets: string[] }, repo?: string) {
+    const localAppData = mkdtempSync(join(tmpdir(), 'jaw-officecli-ps-'));
+    const assetRows = release.assets
+        .map(name => `[pscustomobject]@{ name = '${name.replaceAll("'", "''")}' }`)
+        .join(', ');
+    const repoSetup = repo
+        ? `$env:OFFICECLI_REPO = '${repo.replaceAll("'", "''")}'`
+        : `Remove-Item Env:OFFICECLI_REPO -ErrorAction SilentlyContinue`;
+    const command = `
+        $env:LOCALAPPDATA = '${localAppData.replaceAll("'", "''")}'
+        ${repoSetup}
+        function Invoke-RestMethod {
+            [pscustomobject]@{
+                tag_name = '${release.tag.replaceAll("'", "''")}'
+                assets = @(${assetRows})
+            }
+        }
+        function Invoke-WebRequest { throw 'DOWNLOAD_REACHED' }
+        & '${installer.replaceAll("'", "''")}' -Force
+    `;
+    try {
+        const result = spawnSync('powershell.exe', [
+            '-NoProfile',
+            '-ExecutionPolicy', 'Bypass',
+            '-EncodedCommand', encodedPowerShell(command),
+        ], {
+            encoding: 'utf8',
+            windowsHide: true,
+            timeout: 20_000,
+        });
+        return {
+            status: result.status,
+            output: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+        };
+    } finally {
+        rmSync(localAppData, { recursive: true, force: true });
+    }
+}
+
+test('#280: Windows fork install fails before download when the release omits its asset', () => {
+    const result = runInstaller({ tag: 'v1.0.98', assets: ['officecli-mac-arm64'] });
+
+    assert.equal(result.status, 1);
+    assert.match(result.output, /lidge-jun\/OfficeCLI latest release \(v1\.0\.98\) has no officecli-win-(?:x64|arm64)\.exe/);
+    assert.match(result.output, /published: officecli-mac-arm64/);
+    assert.match(result.output, /-Upstream/);
+    assert.match(result.output, /fork is required only for CJK font handling and HWP/);
+    assert.doesNotMatch(result.output, /DOWNLOAD_REACHED/);
+});
+
+test('#280: Windows upstream install proceeds when the release publishes its asset', () => {
+    const result = runInstaller({
+        tag: 'v1.0.143',
+        assets: ['officecli-win-x64.exe', 'officecli-win-arm64.exe', 'SHA256SUMS'],
+    }, 'iOfficeAI/OfficeCLI');
+
+    assert.notEqual(result.status, 0, 'the download sentinel intentionally aborts the install');
+    assert.match(result.output, /DOWNLOAD_REACHED/);
+    assert.doesNotMatch(result.output, /latest release .* has no/);
+});


### PR DESCRIPTION
## What changed

- inspect the latest GitHub release metadata before the PowerShell installer downloads a Windows binary
- fail with the repository, release tag, missing asset, and published asset list instead of surfacing an opaque 404
- explain that `-Upstream` is suitable for general XLSX/accessibility work while the fork remains required for CJK font handling and HWP
- add behavior tests that exercise both the fork-missing and upstream-present paths without opening a visible shell window

## Why

The default `lidge-jun/OfficeCLI` release currently publishes only `officecli-mac-arm64` plus HWP sidecars, so a fresh Windows install requested an asset that does not exist. The shell installer already had a fail-closed preflight, but the PowerShell installer still attempted the download directly.

## Impact

Windows users now get an actionable message before any install directory or partial download is created. Upstream installs continue when the matching Windows asset is published.

## Validation

- `npx tsx --test tests/unit/officecli-powershell-installer.test.ts` (2 passed)
- `npx tsx --test --test-name-pattern="OFF-001|OFF-002|SAF-006c2" tests/unit/safe-install.test.ts` (4 passed)
- `npm run build`
- `structure/verify-counts.sh`
- broader focused installer run: 49 passed, 2 failed, 1 skipped; both failures (`SAF-004f1`, `SAF-004f2`) reproduce identically on clean `origin/dev`, so this branch adds zero failures

Closes #280