### PR TITLE
fix(manager): launch JS instances through Node on Windows

### DIFF
--- a/src/manager/lifecycle.ts
+++ b/src/manager/lifecycle.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { homedir } from 'node:os';
-import { getJawPath } from '../core/instance.js';
+import { getJawPath, getNodePath } from '../core/instance.js';
 import { stripUndefined } from '../core/strip-undefined.js';
 import type {
     DashboardInstance,
@@ -68,6 +68,7 @@ export type DashboardLifecycleManagerOptions = {
     from: number;
     count: number;
     jawPath?: string;
+    nodePath?: string;
     homeRoot?: string;
     dashboardHome?: string;
     storageRoot?: string;
@@ -81,6 +82,7 @@ export class DashboardLifecycleManager {
     private readonly from: number;
     private readonly to: number;
     private readonly jawPath: string;
+    private readonly nodePath: string | undefined;
     private readonly homeRoot: string;
     private readonly spawnImpl: typeof spawn;
     private readonly verify: ProcessVerifyImpl;
@@ -93,6 +95,7 @@ export class DashboardLifecycleManager {
         this.from = options.from;
         this.to = options.from + options.count - 1;
         this.jawPath = options.jawPath || getJawPath();
+        this.nodePath = options.nodePath;
         this.homeRoot = options.homeRoot || homedir();
         this.spawnImpl = options.spawnImpl || spawn;
         this.verify = { ...defaultProcessVerify, ...(options.processVerify || {}) };
@@ -109,7 +112,10 @@ export class DashboardLifecycleManager {
     }
 
     buildStartCommand(port: number, home = this.defaultHome(port)): string[] {
-        return [this.jawPath, '--home', home, 'serve', '--port', String(port), '--no-open'];
+        const jawCommand = /\.(?:c|m)?js$/i.test(this.jawPath)
+            ? [this.nodePath || getNodePath(), this.jawPath]
+            : [this.jawPath];
+        return [...jawCommand, '--home', home, 'serve', '--port', String(port), '--no-open'];
     }
 
     decorateScanResult(result: DashboardScanResult, serviceStates?: Map<number, DashboardServiceState>): DashboardScanResult {

--- a/tests/unit/manager-lifecycle.test.ts
+++ b/tests/unit/manager-lifecycle.test.ts
@@ -67,7 +67,7 @@ test('lifecycle builds start command with top-level home flag', () => {
     assert.deepEqual(manager.buildStartCommand(3457), [
         '/usr/local/bin/jaw',
         '--home',
-        '/Users/jun/.cli-jaw',
+        join('/Users/jun', '.cli-jaw'),
         'serve',
         '--port',
         '3457',
@@ -76,13 +76,60 @@ test('lifecycle builds start command with top-level home flag', () => {
     assert.deepEqual(manager.buildStartCommand(3458), [
         '/usr/local/bin/jaw',
         '--home',
-        '/Users/jun/.cli-jaw-3458',
+        join('/Users/jun', '.cli-jaw-3458'),
         'serve',
         '--port',
         '3458',
         '--no-open',
     ]);
     cleanup();
+});
+
+test('lifecycle runs JavaScript jaw entrypoints through Node', (t) => {
+    const { dir, cleanup } = setupTmpStorage();
+    t.after(cleanup);
+    const manager = new DashboardLifecycleManager({
+        managerPort: MANAGER_PORT,
+        from: 3457,
+        count: 50,
+        jawPath: 'C:\\Users\\user\\AppData\\Roaming\\npm\\node_modules\\cli-jaw\\dist\\bin\\cli-jaw.js',
+        nodePath: 'C:\\Program Files\\nodejs\\node.exe',
+        storageRoot: dir,
+    });
+
+    assert.deepEqual(manager.buildStartCommand(3458, 'C:\\Users\\user\\.cli-jaw-3458'), [
+        'C:\\Program Files\\nodejs\\node.exe',
+        'C:\\Users\\user\\AppData\\Roaming\\npm\\node_modules\\cli-jaw\\dist\\bin\\cli-jaw.js',
+        '--home',
+        'C:\\Users\\user\\.cli-jaw-3458',
+        'serve',
+        '--port',
+        '3458',
+        '--no-open',
+    ]);
+});
+
+test('lifecycle keeps executable jaw entrypoints in command position', (t) => {
+    const { dir, cleanup } = setupTmpStorage();
+    t.after(cleanup);
+    const manager = new DashboardLifecycleManager({
+        managerPort: MANAGER_PORT,
+        from: 3457,
+        count: 50,
+        jawPath: 'C:\\Users\\user\\AppData\\Roaming\\npm\\jaw.cmd',
+        nodePath: 'C:\\Program Files\\nodejs\\node.exe',
+        storageRoot: dir,
+    });
+
+    assert.deepEqual(manager.buildStartCommand(3458, 'C:\\Users\\user\\.cli-jaw-3458'), [
+        'C:\\Users\\user\\AppData\\Roaming\\npm\\jaw.cmd',
+        '--home',
+        'C:\\Users\\user\\.cli-jaw-3458',
+        'serve',
+        '--port',
+        '3458',
+        '--no-open',
+    ]);
 });
 
 test('lifecycle rejects ports outside scan range', async (t) => {
@@ -157,10 +204,10 @@ test('lifecycle marks offline ports as startable with default home policy', (t) 
     const defaultRow = manager.decorateInstance(makeOffline(3457));
     const row = manager.decorateInstance(makeOffline(3460));
 
-    assert.equal(defaultRow.lifecycle?.defaultHome, '/Users/jun/.cli-jaw');
+    assert.equal(defaultRow.lifecycle?.defaultHome, join('/Users/jun', '.cli-jaw'));
     assert.equal(row.lifecycle?.owner, 'none');
     assert.equal(row.lifecycle?.canStart, true);
-    assert.equal(row.lifecycle?.defaultHome, '/Users/jun/.cli-jaw-3460');
+    assert.equal(row.lifecycle?.defaultHome, join('/Users/jun', '.cli-jaw-3460'));
 });
 
 test('lifecycle stop can terminate external core listener PID but restart remains owner-limited', async (t) => {


### PR DESCRIPTION
## Summary

- run JavaScript cli-jaw entrypoints through the resolved Node executable
- keep executable entrypoints such as `jaw` and `jaw.cmd` unchanged
- add cross-platform lifecycle command tests for both entrypoint forms
- make the existing home-path assertions portable on Windows

## Root cause

The Dashboard passes its `dist/bin/cli-jaw.js` path through `CLI_JAW_BIN`. The lifecycle manager then used that path as the executable in `child_process.spawn()`.

Unix can execute the JavaScript entrypoint through its shebang, but Windows `CreateProcess` rejects the direct `.js` spawn with `EFTYPE`. The instance never came online, and the Dashboard subsequently showed an offline/proxy error.

## User impact

The Dashboard Start, Restart, and Stop lifecycle now works for Windows-native instances launched from an npm/source JavaScript entrypoint.

Closes #311

## Validation

- `npx tsx --experimental-test-module-mocks --test tests/unit/manager-lifecycle.test.ts` — 15/15 passed
- `npm run typecheck` — passed
- `npm run build` — passed; atomic `dist/` swap and asset verification succeeded
- Windows-native smoke on isolated ports 24577/3505:
  - Dashboard Start — passed
  - instance `/api/health` — passed
  - Dashboard Restart — passed
  - Dashboard Stop — passed
  - generated command began with `node.exe .../dist/bin/cli-jaw.js`
- `bash structure/verify-counts.sh` — 365 entries matched

## Full-suite note

`npm test` produced no assertion failure before the local 10-minute command limit, but did not complete. At timeout, unrelated tests including `code-workspace-pick-route-runtime`, `kill-escalation-liveness`, and `pi-persistent-runtime` were still running. The target tests and direct Windows lifecycle smoke passed independently.