### PR TITLE
docs: document native Windows log ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ $port = 3458
 $logDir = Join-Path $jawHome 'logs'
 $outLog = Join-Path $logDir 'serve.out.log'
 $errLog = Join-Path $logDir 'serve.err.log'
-New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+New-Item -ItemType Directory -Force -Path $logDir -ErrorAction Stop | Out-Null
+foreach ($path in @($outLog, $errLog)) {
+    # OpenOrCreate preserves existing content while proving that the child can append.
+    $probe = [IO.File]::Open($path, 'OpenOrCreate', 'Write', 'ReadWrite')
+    $probe.Dispose()
+}
 
 $jaw = (Get-Command jaw.cmd -ErrorAction Stop).Source
 $childCommand = "& '$jaw' --home '$jawHome' serve --port $port --no-open 1>> '$outLog' 2>> '$errLog'"
@@ -134,11 +139,16 @@ $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childCom
 Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile', '-EncodedCommand', $encoded -WindowStyle Hidden | Out-Null
 ```
 
-Read each stream from a PowerShell terminal:
+Read each stream from a separate PowerShell terminal (`Get-Content -Wait`
+occupies its terminal). These commands use explicit paths because variables
+from the launch terminal are not available in a new PowerShell session:
 
 ```powershell
-Get-Content -LiteralPath $outLog -Tail 100 -Wait
-Get-Content -LiteralPath $errLog -Tail 100 -Wait
+# Terminal 1
+Get-Content -LiteralPath 'C:\jaw\worker-a\logs\serve.out.log' -Tail 100 -Wait
+
+# Terminal 2
+Get-Content -LiteralPath 'C:\jaw\worker-a\logs\serve.err.log' -Tail 100 -Wait
 ```
 
 Lifecycle commands are home-scoped and verify `<JAW_HOME>\jaw.pid.json`
@@ -154,11 +164,31 @@ cannot recreate the operator's file redirection. To preserve file capture,
 `stop`, optionally rotate the closed logs, and run the launch block again:
 
 ```powershell
+$pidFile = Join-Path $jawHome 'jaw.pid.json'
+$serverProcess = $null
+if (Test-Path -LiteralPath $pidFile -PathType Leaf) {
+    $record = Get-Content -LiteralPath $pidFile -Raw -ErrorAction Stop | ConvertFrom-Json
+    $serverProcess = Get-Process -Id ([int]$record.pid) -ErrorAction SilentlyContinue
+}
+
 & $jaw --home $jawHome service stop --port $port
+if ($LASTEXITCODE -ne 0) {
+    throw "jaw service stop failed with exit code $LASTEXITCODE"
+}
+if ($serverProcess) {
+    try {
+        if (-not $serverProcess.WaitForExit(5000)) {
+            throw "jaw serve pid $($serverProcess.Id) did not exit within 5000ms"
+        }
+    } finally {
+        $serverProcess.Dispose()
+    }
+}
+
 $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 foreach ($path in @($outLog, $errLog)) {
     if (Test-Path -LiteralPath $path) {
-        Move-Item -LiteralPath $path -Destination "$path.$stamp"
+        Move-Item -LiteralPath $path -Destination "$path.$stamp" -ErrorAction Stop
     }
 }
 # Run the Start-Process launch block above again.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,67 @@ wsl.exe -d Ubuntu -- bash -lc "jaw dashboard"
 </details>
 
 <details>
+<summary><b>Native Windows (PowerShell beta)</b> — detached server logs</summary>
+
+`jaw serve` writes to the stdout and stderr streams it inherits. It does not
+create or open `serve.out.log`, and native Windows does not have a registered
+`jaw service` logging backend. PowerShell's
+`Start-Process -RedirectStandardOutput/-RedirectStandardError` creates or
+truncates its target files on every launch.
+
+Run the redirection inside a child PowerShell process instead. This example
+appends operator-owned logs under `<JAW_HOME>\logs`:
+
+```powershell
+$jawHome = 'C:\jaw\worker-a'
+$port = 3458
+$logDir = Join-Path $jawHome 'logs'
+$outLog = Join-Path $logDir 'serve.out.log'
+$errLog = Join-Path $logDir 'serve.err.log'
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+$jaw = (Get-Command jaw.cmd -ErrorAction Stop).Source
+$childCommand = "& '$jaw' --home '$jawHome' serve --port $port --no-open 1>> '$outLog' 2>> '$errLog'"
+$encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childCommand))
+Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile', '-EncodedCommand', $encoded -WindowStyle Hidden | Out-Null
+```
+
+Read each stream from a PowerShell terminal:
+
+```powershell
+Get-Content -LiteralPath $outLog -Tail 100 -Wait
+Get-Content -LiteralPath $errLog -Tail 100 -Wait
+```
+
+Lifecycle commands are home-scoped and verify `<JAW_HOME>\jaw.pid.json`
+before signalling:
+
+```powershell
+& $jaw --home $jawHome service stop --port $port
+& $jaw --home $jawHome service restart --port $port
+```
+
+A standalone `service restart` safely relaunches the instance detached, but
+cannot recreate the operator's file redirection. To preserve file capture,
+`stop`, optionally rotate the closed logs, and run the launch block again:
+
+```powershell
+& $jaw --home $jawHome service stop --port $port
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+foreach ($path in @($outLog, $errLog)) {
+    if (Test-Path -LiteralPath $path) {
+        Move-Item -LiteralPath $path -Destination "$path.$stamp"
+    }
+}
+# Run the Start-Process launch block above again.
+```
+
+Do not use `Get-Process node | Stop-Process`; it can terminate unrelated
+cli-jaw instances and AI runtime processes.
+
+</details>
+
+<details>
 <summary><b>Fresh-machine evidence</b> — maintainer release check</summary>
 
 Run this on a clean VM before publishing installer changes. It writes environment snapshots, installer logs, the exact collector/installer/verifier scripts that ran, their SHA-256 hashes, verifier logs, and new-shell PATH probes into `~/cli-jaw-fresh-install-evidence-*`.


### PR DESCRIPTION
## What changed

- document that `jaw serve` inherits stdout/stderr and never opens `serve.out.log`
- warn that PowerShell `Start-Process -RedirectStandardOutput/-RedirectStandardError` truncates its targets
- provide a tested native-Windows append launcher, explicit stdout/stderr paths, tail commands, and stop/rotation guidance
- distinguish the safe home-scoped `service stop|restart` surface from operator-owned logging

## Why

The status/capability reports attached to #284 are already handled by #277, #281, and #312, and safe instance lifecycle is handled by #283. The remaining repository-owned gap is documentation: native Windows has no service logging backend, while the common PowerShell launcher pattern destroys earlier log evidence on restart.

This is documentation-only. It does not add a Windows service backend or touch TUI/dispatch auth (#276).

## Validation

- PowerShell 5.1 reproduced truncation: a second `Start-Process -RedirectStandardOutput` launch left only the second run
- live native-Windows launch test: two `jaw serve` runs on a temporary home/port grew `serve.out.log` from 5,262 to 7,842 bytes; home-scoped `service stop` stopped each instance
- `npm run build` — passed
- `npm run docs:check` — passed
- `npm run typecheck` — passed
- issue-relevant unit batch — 92 passed, 1 skipped; 3 wiki symlink setup cases could not create symlinks on this non-elevated Windows host (`EPERM`)
- `npm run gate:all` — 13/21 passed; 8 aggregate runner steps returned empty output/`status=null`; their direct typecheck/docs checks passed

Related to #284.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the Native Windows PowerShell beta.
  * Documented detached `jaw serve` logging, log monitoring, lifecycle commands, safe log rotation, and relaunch procedures.
  * Added a warning about avoiding termination of all Node processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->