### PR TITLE
ci(tests): make ci-aggregate the one required check every PR produces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,35 +12,110 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This workflow carries no `paths-ignore` on purpose. A required status check
+  # that is never produced for docs-only pull requests leaves them stuck on
+  # "Expected — Waiting for status" forever, so the workflow always starts and
+  # the cost is controlled by skipping the expensive job below instead.
   changes:
+    name: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.scope.outputs.code }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # Full history: the push range and the pull-request merge base below
+          # both need commits that a shallow clone does not have.
           fetch-depth: 0
 
       - name: Determine code changes
         id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        # `-e` is off so every fallback below can be reached; each git call that
+        # is allowed to fail is checked explicitly.
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            base="${{ github.event.pull_request.base.sha }}"
-            head="${{ github.event.pull_request.head.sha }}"
+          set -uo pipefail
+
+          # Fail CLOSED. Every path that cannot *prove* the change is docs-only
+          # reports code=true and runs the full suite. A wrong "docs-only"
+          # verdict silently skips every release gate; a wrong "code" verdict
+          # only costs runner minutes.
+          emit() { echo "code=$1" >> "$GITHUB_OUTPUT"; echo "resolved code=$1"; }
+
+          range_base=""
+          range_head=""
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            range_head="$PR_HEAD_SHA"
+            # Diff against the merge base rather than the base branch tip, so
+            # commits that landed on the base after this PR opened are not
+            # attributed to this PR.
+            if [ -n "$PR_BASE_SHA" ] && git rev-parse --verify --quiet "$PR_BASE_SHA^{commit}" >/dev/null; then
+              range_base="$(git merge-base "$PR_BASE_SHA" "$range_head" 2>/dev/null || true)"
+            fi
+            if [ -z "$range_base" ] && [ -n "$PR_BASE_REF" ]; then
+              git fetch --no-tags origin "+refs/heads/$PR_BASE_REF:refs/remotes/origin/$PR_BASE_REF" || true
+              range_base="$(git merge-base "refs/remotes/origin/$PR_BASE_REF" "$range_head" 2>/dev/null || true)"
+            fi
           else
-            base="${{ github.event.before }}"
-            head="${{ github.sha }}"
+            range_head="$HEAD_SHA"
+            # github.event.before is the all-zeros SHA for the first push to a
+            # ref (branch creation), where there is no previous commit to diff.
+            case "$PUSH_BEFORE" in
+              ''|0000000000000000000000000000000000000000)
+                range_base=""
+                ;;
+              *)
+                if git rev-parse --verify --quiet "$PUSH_BEFORE^{commit}" >/dev/null; then
+                  range_base="$PUSH_BEFORE"
+                fi
+                ;;
+            esac
           fi
-          changed=$(git diff --name-only "$base".."$head" || true)
-          non_doc=$(echo "$changed" | grep -vE '^README.*\.md$|^docs/' || true)
-          if [ -z "$non_doc" ]; then
-            echo "code=false" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$range_base" ] || [ -z "$range_head" ]; then
+            echo "::notice::no usable diff range (base='$range_base' head='$range_head') — running the full suite"
+            emit true
+            exit 0
+          fi
+
+          if ! changed="$(git diff --name-only "$range_base" "$range_head")"; then
+            echo "::notice::git diff $range_base..$range_head failed — running the full suite"
+            emit true
+            exit 0
+          fi
+
+          echo "changed files ($range_base..$range_head):"
+          echo "$changed"
+
+          if [ -z "$changed" ]; then
+            # An empty diff is not evidence of a docs-only change; it usually
+            # means the range was wrong. Run the suite.
+            echo "::notice::empty diff for a real range — running the full suite"
+            emit true
+            exit 0
+          fi
+
+          # Same set the old `paths-ignore` carried: top-level README*.md and
+          # everything under docs/. Anything else — including this workflow —
+          # counts as code.
+          non_doc="$(echo "$changed" | grep -vE '^README[^/]*\.md$|^docs/' || true)"
+          if [ -n "$non_doc" ]; then
+            emit true
           else
-            echo "code=true" >> "$GITHUB_OUTPUT"
+            emit false
           fi
 
   node-tests:
+    name: node-tests
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -190,17 +265,64 @@ jobs:
         env:
           NODE_ENV: test
 
-  tests:
+  # The single required status check for the `main` ruleset.
+  #
+  # The check name is the job `name:` below and is load-bearing: the branch
+  # ruleset and the publish gate both match on the literal string
+  # `ci-aggregate`. Renaming this job silently detaches both of them, so the
+  # name is pinned explicitly instead of being inherited from the job id.
+  #
+  # It runs on every event this workflow accepts — including docs-only pull
+  # requests, where `node-tests` is legitimately skipped — so a required check
+  # always has a run to wait for.
+  ci-aggregate:
+    name: ci-aggregate
     needs: [changes, node-tests]
+    # `always()` rather than the default success() semantics: the point of this
+    # job is to report on upstream failures, so it must still run after one.
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Verify producers
         env:
-          RESULTS: ${{ toJSON(needs) }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          NODE_TESTS_RESULT: ${{ needs.node-tests.result }}
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
         run: |
-          count=$(echo "$RESULTS" | jq '[.[] | select(.result != "success" and .result != "skipped")] | length')
-          if [ "$count" -ne 0 ]; then
-            echo "$RESULTS" | jq '.'
+          set -uo pipefail
+          failed=0
+
+          # `success` and `skipped` pass; `failure`, `cancelled`, an empty
+          # result, and anything unrecognised fail. Skipped and failed are
+          # deliberately NOT collapsed together: a docs-only change skips
+          # node-tests on purpose, a broken one does not.
+          check() {
+            job="$1"
+            result="$2"
+            case "$result" in
+              success)  echo "PASS  $job: success" ;;
+              skipped)  echo "PASS  $job: skipped (not required for this change)" ;;
+              failure)  echo "FAIL  $job: failure"; failed=1 ;;
+              cancelled) echo "FAIL  $job: cancelled"; failed=1 ;;
+              '')       echo "FAIL  $job: no result reported"; failed=1 ;;
+              *)        echo "FAIL  $job: unexpected result '$result'"; failed=1 ;;
+            esac
+          }
+
+          check changes "$CHANGES_RESULT"
+          check node-tests "$NODE_TESTS_RESULT"
+
+          # A skip is only legitimate when change detection actually said the
+          # change was docs-only. If it said "code" and the suite still did not
+          # run, something dropped the job and the check must not go green.
+          if [ "$CHANGES_RESULT" = "success" ] && [ "$CODE_CHANGED" = "true" ] && [ "$NODE_TESTS_RESULT" = "skipped" ]; then
+            echo "FAIL  node-tests was skipped even though change detection reported code changes"
+            failed=1
+          fi
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::ci-aggregate failed — see the per-job results above"
             exit 1
           fi
+          echo "ci-aggregate: all required jobs succeeded or were legitimately skipped"


### PR DESCRIPTION
Refs #333 (P1 — CI lane cleanup so docs-only PRs still produce the required check).

## ⚠️ Merge order

**This PR must merge before the `main` ruleset's required check is enabled.**

Enabling a required check first would leave every docs-only PR permanently stuck on *"Expected — Waiting for status"*, because nothing would ever produce a run for it. This PR is what guarantees the check always exists.

**The check name is exactly `ci-aggregate`.** P2's publish gate matches on that literal string, so it is pinned with an explicit job `name:` rather than being inherited from the job id. Renaming the job would silently detach both the ruleset and the publish gate.

## What changed

Only `.github/workflows/test.yml`.

`.github/workflows/postinstall-platform.yml` keeps its own `paths:` filters and is untouched — cross-workflow `needs:` is impossible, so `ci-aggregate` aggregates only the jobs in its own file. P2's publish gate checks the platform workflow separately.

### 1. `tests` → `ci-aggregate`

The aggregate job existed but was named `tests`, which is not the name the ruleset will require.

### 2. Explicit `needs.*.result` inspection

The old body ran a `jq` scan over `toJSON(needs)`. It is now an explicit per-job case:

| upstream result | verdict |
| --- | --- |
| `success` | pass |
| `skipped` | pass — a docs-only change skips `node-tests` on purpose |
| `failure` | **fail** |
| `cancelled` | **fail** |
| empty / unrecognised | **fail** |

`skipped` and `failure` are deliberately not collapsed together. There is also a contradiction guard: if change detection reported `code=true` and `node-tests` was still skipped, the check fails rather than going green on a dropped job.

### 3. Change detection now fails **closed**

Previously `git diff ... || true` meant *any* failure produced an empty diff, which read as "docs-only" and skipped every release gate. Now every range that cannot be resolved runs the full suite:

- all-zeros `github.event.before` (first push to a ref)
- empty or unresolvable `github.event.before`
- a `git diff` that exits non-zero
- an empty diff over a real range (an empty diff is evidence of a bad range, not of a docs-only change)

### 4. Pull requests diff against the merge base

`github.event.pull_request.base.sha` is the base branch tip, so commits landing on the base after the PR opened were attributed to the PR. It now uses `git merge-base`, with an `origin/<base ref>` fetch as fallback. The `changes` job keeps `fetch-depth: 0` so both endpoints resolve.

### 5. Docs pattern anchored

`^README.*\.md$` → `^README[^/]*\.md$`, so a nested `pkg/README.md` correctly counts as code. `docs/` is unchanged.

`node-tests` is otherwise untouched: `timeout-minutes: 8`, the elapsed-time warning logic, and their load-bearing comments are all preserved.

## Four-case reasoning

| case | `changes` | `node-tests` | `ci-aggregate` conclusion |
| --- | --- | --- | --- |
| **(a) docs-only PR** | `success` (`code=false`) | `skipped` | ✅ **success** — the required check exists and is green without running the suite |
| **(b) code PR, all green** | `success` (`code=true`) | `success` | ✅ **success** |
| **(c) code PR, failing tests** | `success` (`code=true`) | `failure` | ❌ **failure** — `if: always()` runs the job, and `failure` is explicitly rejected |
| **(d) cancelled run** | any | `cancelled` | ❌ **failure** (or the whole run is cancelled and the check reports `cancelled`) — never `success` |

Additional non-green paths: if the `changes` job itself fails, `node-tests` is skipped and `ci-aggregate` still fails on `changes: failure`; if `code=true` but `node-tests` was skipped anyway, the contradiction guard fails the check.

## Verification

YAML parsed with `yaml.safe_load` — three jobs (`changes`, `node-tests`, `ci-aggregate`), triggers are `push: [preview, main]` + unfiltered `pull_request`, no `paths-ignore` anywhere, `node-tests` still has 23 steps and `timeout-minutes: 8` on the test step.

Both `run:` bodies were extracted and executed locally against a throwaway git repo:

- aggregate logic: 8/8 cases behave as tabled above, including empty and unrecognised results.
- change detection: 12/12 cases, covering docs-only and code ranges on push, the all-zeros SHA, an empty `before`, an unknown `before`, an empty diff, a nested `README.md`, PR merge-base resolution, a base branch that moved on after the PR opened, an unresolvable base with no usable ref fallback, and an entirely empty event payload.

`tests/unit/release-scripts-contract.test.ts` still passes (7/7).

## Deviation from the P1 brief — `push:` branches

The brief asked for `push` on `dev`/`preview`/`main`. This PR leaves the trigger at `preview`/`main` and **does not add `- dev`**, because `tests/unit/release-scripts-contract.test.ts:176` already asserts `!workflow.includes('- dev')` — *"CI workflows must not run on dev after M0"* — landed by the earlier M0 commit `b029c67d` under this same issue, which also plans to remove remote `dev` entirely.

Adding `- dev` would fail the very suite `ci-aggregate` gates on. It also is not needed for the stated goal: the `pull_request` trigger carries **no branch filter**, so every PR targeting `dev` (including this one) still produces a `ci-aggregate` run. Only direct pushes to `dev` would go unchecked, and `dev` is slated for removal.

Flagging it rather than silently deviating — say the word if `- dev` should be added and the contract test relaxed alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
