### PR TITLE
fix(release): derive the installer-sensitive path set from postinstall-platform.yml (#333 G1)

### DIFF
--- a/.github/workflows/postinstall-platform.yml
+++ b/.github/workflows/postinstall-platform.yml
@@ -49,6 +49,7 @@ on:
       - 'structure/infra.md'
       - 'tests/unit/install-integrity.test.ts'
       - 'tests/unit/scriptless-install-contract.test.ts'
+      - 'tests/unit/installer-sensitive-path-parity.test.ts'
       - 'package.json'
       - 'package-lock.json'
   pull_request:
@@ -96,6 +97,7 @@ on:
       - 'structure/infra.md'
       - 'tests/unit/install-integrity.test.ts'
       - 'tests/unit/scriptless-install-contract.test.ts'
+      - 'tests/unit/installer-sensitive-path-parity.test.ts'
       - 'package.json'
       - 'package-lock.json'
   workflow_dispatch:

--- a/scripts/require-release-evidence.mjs
+++ b/scripts/require-release-evidence.mjs
@@ -8,38 +8,166 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
-const installerSensitivePaths = [
-  '.github/workflows/postinstall-platform.yml',
+// ---------------------------------------------------------------------------
+// Installer-sensitive path set (issue #333 gap G1)
+//
+// This list used to be hand-maintained here, in parallel with the trigger list
+// in .github/workflows/postinstall-platform.yml. The two drifted: 21 paths the
+// platform workflow considers installer-sensitive were missing here, including
+// scripts/install.ps1, src/core/install-integrity.ts, scripts/postinstall-guard.cjs
+// and bin/cli-jaw.ts. A change touching only scripts/install.ps1 therefore
+// reached the npm `latest` dist-tag with zero platform CI evidence behind it.
+//
+// The workflow is now the single source of truth: its trigger paths are parsed
+// at runtime and unioned with a short, explicitly justified extras list below.
+// ---------------------------------------------------------------------------
+
+const PLATFORM_WORKFLOW_PATH = '.github/workflows/postinstall-platform.yml';
+
+// The platform workflow's trigger paths answer "does Postinstall Platform
+// Checks need to run?". These extra entries answer the wider release question
+// "does this change need fresh-machine install evidence?", and are deliberately
+// NOT in that workflow because none of them changes what the platform matrix
+// would execute.
+const EXTRA_SENSITIVE_PATHS = [
+  // The four READMEs carry the copy-pasteable install instructions users
+  // actually run. Editing them cannot change platform CI behaviour, but it can
+  // absolutely break a fresh install, so release evidence is still required.
   'README.md',
   'README.ko.md',
   'README.ja.md',
   'README.zh-CN.md',
-  'bin/postinstall.ts',
-  'src/core/claude-install.ts',
-  'src/core/cli-detect.ts',
-  'src/core/runtime-path.ts',
-  'scripts/install-risk-gate.mjs',
-  'scripts/install.sh',
-  'scripts/install-wsl.sh',
-  'scripts/fresh-install-smoke.ts',
-  'scripts/verify-fresh-install.sh',
-  'scripts/collect-fresh-install-evidence.sh',
-  'scripts/audit-fresh-install-evidence.mjs',
-  'scripts/verify-release-evidence.mjs',
-  'scripts/require-release-evidence.mjs',
+  // The release drivers themselves: they build, gate, tag, push and publish the
+  // artifact users install. They are not part of the installed surface the
+  // platform matrix exercises, so they do not belong in the workflow triggers,
+  // but a change to either one changes how a release is produced.
   'scripts/promote-to-main.sh',
   'scripts/release-preview.sh',
-  'tests/unit/cli-detect.test.ts',
-  'tests/unit/install-sh-exec.test.ts',
-  'tests/unit/fresh-evidence-audit.test.ts',
-  'tests/unit/safe-install.test.ts',
-  'tests/unit/service.test.ts',
-  'tests/unit/postinstall-strict-tools.test.ts',
-  'tests/unit/wsl-installer-doctor.test.ts',
-  'tests/unit/wsl-installer-exec.test.ts',
-  'package.json',
-  'package-lock.json',
 ];
+
+/**
+ * Minimal, deliberately strict reader for a GitHub Actions trigger `paths:`
+ * block.
+ *
+ * This script runs in .github/workflows/publish.yml BEFORE `npm ci`, so no
+ * dependency (including the `yaml` package already in package.json) is
+ * importable here. Hence a hand-rolled reader.
+ *
+ * It is strict on purpose: every unexpected shape throws. A detector that
+ * silently degrades to a short or empty path list fails OPEN, which is strictly
+ * worse than the drift bug it replaces.
+ */
+function parseWorkflowTriggerPaths(source, eventName) {
+  const fail = (message) => {
+    throw new Error(`${PLATFORM_WORKFLOW_PATH}: ${message} (on.${eventName}.paths)`);
+  };
+  const lines = source.split(/\r?\n/);
+  const ignorable = (line) => line.trim() === '' || line.trim().startsWith('#');
+  const indentOf = (line) => /^ */.exec(line)[0].length;
+
+  // Locate the top-level `on:` mapping. Note YAML 1.1 would fold a bare `on`
+  // key to the boolean `true`; GitHub keeps it literal, and so do we.
+  const onIndex = lines.findIndex((line) => line === 'on:');
+  if (onIndex === -1) fail('no top-level `on:` block found');
+
+  const blockEnd = (startIndex, parentIndent) => {
+    for (let i = startIndex; i < lines.length; i += 1) {
+      if (ignorable(lines[i])) continue;
+      if (lines[i].startsWith('\t')) fail(`tab indentation on line ${i + 1}`);
+      if (indentOf(lines[i]) <= parentIndent) return i;
+    }
+    return lines.length;
+  };
+
+  const findSoleKey = (from, to, key, minIndent) => {
+    const hits = [];
+    for (let i = from; i < to; i += 1) {
+      if (ignorable(lines[i])) continue;
+      if (lines[i].trim() !== `${key}:`) continue;
+      if (indentOf(lines[i]) <= minIndent) continue;
+      hits.push(i);
+    }
+    if (hits.length === 0) fail(`no \`${key}:\` key found`);
+    if (hits.length > 1) fail(`expected exactly one \`${key}:\` key, found ${hits.length}`);
+    return hits[0];
+  };
+
+  const onEnd = blockEnd(onIndex + 1, 0);
+  const eventIndex = findSoleKey(onIndex + 1, onEnd, eventName, 0);
+  const eventIndent = indentOf(lines[eventIndex]);
+  const eventEnd = blockEnd(eventIndex + 1, eventIndent);
+  const pathsIndex = findSoleKey(eventIndex + 1, eventEnd, 'paths', eventIndent);
+  const pathsIndent = indentOf(lines[pathsIndex]);
+
+  const collected = [];
+  for (let i = pathsIndex + 1; i < eventEnd; i += 1) {
+    const line = lines[i];
+    if (ignorable(line)) continue;
+    if (line.startsWith('\t')) fail(`tab indentation on line ${i + 1}`);
+    const indent = indentOf(line);
+    if (indent <= pathsIndent) break;
+    const item = /^ *- (.+?) *$/.exec(line);
+    if (!item) fail(`unexpected non-list line ${i + 1}: ${JSON.stringify(line)}`);
+    let value = item[1];
+    const quote = value[0];
+    if (quote === "'" || quote === '"') {
+      if (value.length < 2 || value[value.length - 1] !== quote) {
+        fail(`unterminated quoted entry on line ${i + 1}`);
+      }
+      value = value.slice(1, -1);
+      if (quote === "'") value = value.replace(/''/g, "'");
+    } else if (/[#'"]/.test(value)) {
+      // Bare scalars with quotes or trailing comments need real YAML rules.
+      fail(`entry on line ${i + 1} needs quoting: ${JSON.stringify(item[1])}`);
+    }
+    if (value === '') fail(`empty entry on line ${i + 1}`);
+    // Path matching here is exact string equality (stdin mode) and per-file git
+    // comparison (base-ref mode); neither can express a glob. Today no entry
+    // uses one. If that changes, refuse loudly instead of quietly under-matching.
+    if (/[*?[\]!]/.test(value)) {
+      fail(
+        `entry on line ${i + 1} uses a glob or negation (${JSON.stringify(value)}); `
+        + 'this detector only supports literal paths — teach it globs before adding one',
+      );
+    }
+    collected.push(value);
+  }
+
+  if (collected.length === 0) fail('trigger path list is empty');
+  return collected;
+}
+
+function deriveInstallerSensitivePaths() {
+  const workflowFile = path.join(repoRoot, PLATFORM_WORKFLOW_PATH);
+  let source;
+  try {
+    source = fs.readFileSync(workflowFile, 'utf8');
+  } catch (error) {
+    // Fail closed: an unreadable source of truth must never become an empty
+    // sensitive set.
+    throw new Error(`cannot read ${PLATFORM_WORKFLOW_PATH}: ${error.message}`);
+  }
+  // `push` is what actually determines whether platform evidence can exist:
+  // publish.yml looks for a successful `--event push` run of this workflow. The
+  // union of both trigger lists is used so a divergence errs toward requiring
+  // evidence rather than skipping it; a unit test asserts they stay identical.
+  const pushPaths = parseWorkflowTriggerPaths(source, 'push');
+  const pullRequestPaths = parseWorkflowTriggerPaths(source, 'pull_request');
+  return [...new Set([...pushPaths, ...pullRequestPaths, ...EXTRA_SENSITIVE_PATHS])];
+}
+
+let installerSensitivePaths;
+try {
+  installerSensitivePaths = deriveInstallerSensitivePaths();
+} catch (error) {
+  console.error('[release-evidence-required] FAIL cannot derive installer-sensitive paths');
+  console.error(`- ${error.message}`);
+  console.error(`- Fix ${PLATFORM_WORKFLOW_PATH} (or this reader) before releasing; refusing to guess.`);
+  // Exit 2, not 1: publish.yml treats 1 as "sensitive, require platform run"
+  // and anything else as a hard detector failure. A broken source of truth must
+  // stop the release outright rather than masquerade as a normal gate hit.
+  process.exit(2);
+}
 
 function usage() {
   console.log(`Usage: require-release-evidence.mjs [options]
@@ -49,7 +177,12 @@ Options:
   --changed-files-stdin
                     Read changed file paths from stdin and check whether any are installer-sensitive.
                     Cannot be combined with --base-ref.
+  --print-paths     Print the derived installer-sensitive path set as JSON and exit.
   -h, --help        Show this help.
+
+The installer-sensitive path set is derived from the trigger paths of
+${PLATFORM_WORKFLOW_PATH}, unioned with EXTRA_SENSITIVE_PATHS in this file.
+It is never hand-maintained here.
 
 If installer-sensitive files changed, this script requires:
   CLI_JAW_MACOS_EVIDENCE_DIR=/path/to/macos-evidence
@@ -61,12 +194,17 @@ Then it runs scripts/verify-release-evidence.mjs before publish/release can cont
 
 let baseRef = '';
 let changedFilesStdin = false;
+let printPaths = false;
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i += 1) {
   const arg = args[i];
   if (arg === '-h' || arg === '--help') {
     usage();
     process.exit(0);
+  }
+  if (arg === '--print-paths') {
+    printPaths = true;
+    continue;
   }
   if (arg === '--changed-files-stdin') {
     changedFilesStdin = true;
@@ -82,6 +220,11 @@ for (let i = 0; i < args.length; i += 1) {
 
 if (baseRef && changedFilesStdin) {
   throw new Error('--changed-files-stdin cannot be combined with --base-ref');
+}
+
+if (printPaths) {
+  console.log(JSON.stringify(installerSensitivePaths, null, 2));
+  process.exit(0);
 }
 
 function readChangedFilesFromStdin() {

--- a/tests/unit/installer-sensitive-path-parity.test.ts
+++ b/tests/unit/installer-sensitive-path-parity.test.ts
@@ -1,0 +1,192 @@
+// Regression guard for issue #333 gap G1.
+//
+// scripts/require-release-evidence.mjs decides whether a release needs
+// fresh-machine install evidence, and .github/workflows/publish.yml uses the
+// same decision to decide whether a successful Postinstall Platform Checks run
+// is required before publishing. For a long time the detector carried its OWN
+// hand-written copy of the installer-sensitive path list. It drifted from the
+// authoritative list in .github/workflows/postinstall-platform.yml by 21 paths,
+// so a change touching only scripts/install.ps1 could reach the npm `latest`
+// dist-tag with zero platform CI evidence behind it.
+//
+// The detector now derives its set from the workflow. These tests are the thing
+// that stops the drift coming back.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../..');
+const detectorPath = join(repoRoot, 'scripts/require-release-evidence.mjs');
+const workflowPath = join(repoRoot, '.github/workflows/postinstall-platform.yml');
+
+const detectorSrc = fs.readFileSync(detectorPath, 'utf8');
+const workflowSrc = fs.readFileSync(workflowPath, 'utf8');
+
+/**
+ * Independent reader for the workflow's trigger paths.
+ *
+ * Deliberately NOT the detector's own parser: if the test reused it, a parser
+ * bug would agree with itself and the parity assertion would prove nothing.
+ */
+function workflowTriggerPaths(event: 'push' | 'pull_request'): string[] {
+    const lines = workflowSrc.split(/\r?\n/);
+    const eventIndex = lines.findIndex(line => line.trim() === `${event}:` && /^\s+\S/.test(line));
+    assert.notEqual(eventIndex, -1, `workflow should declare an on.${event} trigger`);
+    const eventIndent = /^ */.exec(lines[eventIndex]!)![0].length;
+
+    let inPaths = false;
+    const out: string[] = [];
+    for (let i = eventIndex + 1; i < lines.length; i += 1) {
+        const line = lines[i]!;
+        if (line.trim() === '') continue;
+        const indent = /^ */.exec(line)![0].length;
+        if (indent <= eventIndent) break;
+        if (line.trim() === 'paths:') { inPaths = true; continue; }
+        if (!inPaths) continue;
+        const item = /^\s+- '(.+)'$/.exec(line);
+        if (!item) { inPaths = false; continue; }
+        out.push(item[1]!);
+    }
+    assert.ok(out.length > 0, `should have read on.${event}.paths entries`);
+    return out;
+}
+
+/** Runs the real detector and returns the set it actually uses. */
+function derivedSensitivePaths(): string[] {
+    const result = spawnSync(process.execPath, [detectorPath, '--print-paths'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `--print-paths should succeed:\n${result.stderr}`);
+    return JSON.parse(result.stdout) as string[];
+}
+
+function runDetectorOnChangedFiles(files: string[], cwd = repoRoot) {
+    return spawnSync(process.execPath, [detectorPath, '--changed-files-stdin'], {
+        cwd,
+        input: `${files.join('\n')}\n`,
+        encoding: 'utf8',
+    });
+}
+
+/**
+ * Copies the detector into a throwaway tree next to a caller-supplied workflow
+ * file, so fail-closed behaviour can be exercised without touching the repo.
+ */
+function detectorWithWorkflow(workflowContent: string | null): string {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'jaw-path-parity-'));
+    fs.mkdirSync(join(dir, 'scripts'), { recursive: true });
+    fs.copyFileSync(detectorPath, join(dir, 'scripts/require-release-evidence.mjs'));
+    if (workflowContent !== null) {
+        fs.mkdirSync(join(dir, '.github/workflows'), { recursive: true });
+        fs.writeFileSync(join(dir, '.github/workflows/postinstall-platform.yml'), workflowContent);
+    }
+    return dir;
+}
+
+function runIsolatedDetector(workflowContent: string | null) {
+    const dir = detectorWithWorkflow(workflowContent);
+    try {
+        return spawnSync(process.execPath, [join(dir, 'scripts/require-release-evidence.mjs'), '--print-paths'], {
+            cwd: dir,
+            encoding: 'utf8',
+        });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+test('G1-parity: every postinstall-platform trigger path is installer-sensitive to the release gate', () => {
+    const derived = new Set(derivedSensitivePaths());
+    const pullRequestPaths = workflowTriggerPaths('pull_request');
+    const missing = pullRequestPaths.filter(path => !derived.has(path));
+    assert.deepEqual(
+        missing,
+        [],
+        'paths that trigger Postinstall Platform Checks but would NOT require release evidence — '
+        + 'these can reach npm with no platform CI behind them',
+    );
+
+    const pushMissing = workflowTriggerPaths('push').filter(path => !derived.has(path));
+    assert.deepEqual(pushMissing, [], 'on.push.paths must also be fully covered by the release gate');
+});
+
+test('G1-parity: push and pull_request trigger lists stay identical', () => {
+    // publish.yml requires a successful `--event push` run of the platform
+    // workflow, so on.push.paths is what decides whether platform evidence can
+    // exist at all. The detector unions both lists so a divergence errs toward
+    // requiring evidence; this assertion makes the divergence itself visible in
+    // CI instead of surfacing as a mysterious publish block.
+    assert.deepEqual(workflowTriggerPaths('push'), workflowTriggerPaths('pull_request'));
+});
+
+test('G1-parity: the detector does not keep a second hand-written path list', () => {
+    assert.ok(
+        detectorSrc.includes('parseWorkflowTriggerPaths'),
+        'detector must derive its path set from the platform workflow',
+    );
+    assert.equal(
+        /const installerSensitivePaths = \[/.test(detectorSrc),
+        false,
+        'a literal installerSensitivePaths array is the exact drift bug #333 G1 describes',
+    );
+    // The extras are allowed, but they must stay a short, justified list rather
+    // than a place the workflow list gets re-copied into.
+    const extras = /const EXTRA_SENSITIVE_PATHS = \[([\s\S]*?)\n\];/.exec(detectorSrc);
+    assert.ok(extras, 'detector should declare EXTRA_SENSITIVE_PATHS');
+    const extraEntries = [...extras![1]!.matchAll(/'([^']+)'/g)].map(match => match[1]!);
+    assert.deepEqual(extraEntries.sort(), [
+        'README.ja.md',
+        'README.ko.md',
+        'README.md',
+        'README.zh-CN.md',
+        'scripts/promote-to-main.sh',
+        'scripts/release-preview.sh',
+    ], 'extras beyond the platform workflow must stay deliberate and reviewed');
+    assert.ok(extras![1]!.includes('//'), 'each extras entry group must carry a comment explaining why it is here');
+});
+
+test('G1-parity: a diff touching only scripts/install.ps1 requires platform evidence', () => {
+    // The concrete regression. Before the fix this exited 0 ("SKIP"), which let
+    // publish.yml proceed to the npm `latest` dist-tag without a platform run.
+    const result = runDetectorOnChangedFiles(['scripts/install.ps1']);
+    assert.equal(result.status, 1, `install.ps1 must be installer-sensitive\n${result.stdout}${result.stderr}`);
+    assert.ok(result.stderr.includes('scripts/install.ps1'));
+});
+
+test('G1-parity: unrelated changes still skip the evidence requirement', () => {
+    const result = runDetectorOnChangedFiles(['src/manager/design/store.ts', 'public/js/app.ts']);
+    assert.equal(result.status, 0, `unrelated paths must not demand evidence\n${result.stdout}${result.stderr}`);
+    assert.ok(result.stdout.includes('SKIP'));
+});
+
+test('G1-parity: trigger paths contain no globs the detector cannot match', () => {
+    // Detection is exact string equality (stdin mode) and per-file git
+    // comparison (base-ref mode). Neither can express a glob, so the detector
+    // refuses to parse one rather than quietly under-matching.
+    const globbed = workflowTriggerPaths('pull_request').filter(path => /[*?[\]!]/.test(path));
+    assert.deepEqual(globbed, [], 'add glob support to the detector before adding a glob trigger path');
+});
+
+test('G1-parity: an unreadable source of truth fails closed, never to an empty set', () => {
+    const missingWorkflow = runIsolatedDetector(null);
+    assert.notEqual(missingWorkflow.status, 0, 'a missing platform workflow must not yield a path set');
+    assert.equal(missingWorkflow.status, 2, 'detector errors use exit 2; publish.yml treats 1 as "sensitive"');
+    assert.ok(missingWorkflow.stderr.includes('cannot derive installer-sensitive paths'));
+
+    const emptied = runIsolatedDetector(workflowSrc.replace(/^ +- '.+'$/gm, ''));
+    assert.equal(emptied.status, 2, 'an empty trigger list must be an error, not zero sensitive paths');
+
+    const globbed = runIsolatedDetector(workflowSrc.replace("- 'Dockerfile'", "- 'src/core/**'"));
+    assert.equal(globbed.status, 2, 'a glob trigger path must be rejected loudly');
+    assert.ok(globbed.stderr.includes('glob'), `expected a glob complaint, got:\n${globbed.stderr}`);
+
+    const truncated = runIsolatedDetector(workflowSrc.replace(/^on:$/m, 'triggers:'));
+    assert.equal(truncated.status, 2, 'a workflow with no `on:` block must fail closed');
+});

--- a/tests/unit/safe-install.test.ts
+++ b/tests/unit/safe-install.test.ts
@@ -591,14 +591,30 @@ test('SAF-004j2: fresh-machine evidence collector documents supported release ev
 });
 
 test('SAF-004j3: publish scripts enforce fresh-machine evidence before push or publish', () => {
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/install.sh'), 'release evidence trigger paths should include macOS installer changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/install-wsl.sh'), 'release evidence trigger paths should include WSL installer changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/verify-fresh-install.sh'), 'release evidence trigger paths should include verifier changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/audit-fresh-install-evidence.mjs'), 'release evidence trigger paths should include auditor changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/verify-release-evidence.mjs'), 'release evidence trigger paths should include release-gate changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/require-release-evidence.mjs'), 'release evidence trigger paths should include this publish guard');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/promote-to-main.sh'), 'release evidence trigger paths should include stable release script changes');
-    assert.ok(requireReleaseEvidenceSrc.includes('scripts/release-preview.sh'), 'release evidence trigger paths should include preview release script changes');
+    // These used to be substring checks against the guard's source, back when it
+    // carried its own hand-written path list. That list drifted from the platform
+    // workflow by 21 paths (#333 G1), so the guard now derives the set instead —
+    // and the assertions have to look at the DERIVED set, not the source text.
+    // Full parity coverage lives in tests/unit/installer-sensitive-path-parity.test.ts.
+    const printed = spawnSync(process.execPath, [join(repoRoot, 'scripts/require-release-evidence.mjs'), '--print-paths'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+    assert.equal(printed.status, 0, `release evidence guard should print its derived path set:\n${printed.stderr}`);
+    const sensitivePaths: string[] = JSON.parse(printed.stdout);
+    const requiresEvidence = (path: string) => assert.ok(
+        sensitivePaths.includes(path),
+        `release evidence trigger paths should include ${path}`,
+    );
+    requiresEvidence('scripts/install.sh');
+    requiresEvidence('scripts/install-wsl.sh');
+    requiresEvidence('scripts/install.ps1');
+    requiresEvidence('scripts/verify-fresh-install.sh');
+    requiresEvidence('scripts/audit-fresh-install-evidence.mjs');
+    requiresEvidence('scripts/verify-release-evidence.mjs');
+    requiresEvidence('scripts/require-release-evidence.mjs');
+    requiresEvidence('scripts/promote-to-main.sh');
+    requiresEvidence('scripts/release-preview.sh');
     assert.ok(readmeSrc.includes('CLI_JAW_MACOS_EVIDENCE_DIR=/path/to/macos-evidence'), 'README should document release-script evidence env');
     assert.ok(readmeSrc.includes('bash scripts/promote-to-main.sh'), 'README should show stable promotion script with evidence directories');
 


### PR DESCRIPTION
Refs #333 (gap **G1**).

## The defect

`.github/workflows/publish.yml` gates publishes on installer-sensitive changes by calling `scripts/require-release-evidence.mjs`. That script hardcoded its own `installerSensitivePaths` array in parallel with the authoritative list — `.github/workflows/postinstall-platform.yml`'s trigger paths. They drifted.

**Measured on `origin/dev` @ `0e93a0ae`:**

| | count |
|---|---|
| `postinstall-platform.yml` `on.pull_request.paths` | 45 |
| `postinstall-platform.yml` `on.push.paths` | 45 (byte-identical to the PR list) |
| detector's hardcoded array | 30 |
| in the workflow, **missing** from the detector | **21** |
| in the detector, **not** in the workflow | 6 |
| detector set after this PR | 52 (45 workflow + 6 extras + 1 new test file added to the workflow) |

The 21 missing paths: `.gitattributes`, `src/core/platform-kind.ts`, `scripts/install-officecli.ps1`, `tests/unit/platform-kind.test.ts`, `tests/unit/platform-kind-runtime.test.ts`, `tests/unit/platform-kind-delegation.test.ts`, `tests/unit/windows-native-cli-detect.test.ts`, `tests/unit/doctor-platform-lanes.test.ts`, `src/core/install-integrity.ts`, `scripts/install.ps1`, `scripts/postinstall-guard.cjs`, `scripts/ensure-native-modules.cjs`, `scripts/bundle-sidecar.sh`, `bin/cli-jaw.ts`, `bin/commands/init.ts`, `bin/commands/doctor.ts`, `Dockerfile`, `Dockerfile.dev`, `structure/infra.md`, `tests/unit/install-integrity.test.ts`, `tests/unit/scriptless-install-contract.test.ts`.

The 6 detector-only paths are **deliberate**, not accidental, and are preserved: the four READMEs carry the copy-pasteable install instructions users actually run, and `scripts/promote-to-main.sh` / `scripts/release-preview.sh` are the release drivers. None of them changes what the platform matrix executes, so they correctly do not belong in the workflow triggers.

## Proof: `scripts/install.ps1` alone

```
$ printf 'scripts/install.ps1\n' | node <origin/dev detector> --changed-files-stdin
[release-evidence-required] SKIP no installer-sensitive paths in stdin
exit=0        # publish.yml proceeds straight to npm latest, no platform CI

$ printf 'scripts/install.ps1\n' | node scripts/require-release-evidence.mjs --changed-files-stdin
[release-evidence-required] CHANGED installer-sensitive files (1, 49e87bd475b9)
- scripts/install.ps1
exit=1        # publish.yml now requires a successful Postinstall Platform Checks run
```

## The fix

`installerSensitivePaths = parse(postinstall-platform.yml → on.push.paths ∪ on.pull_request.paths) ∪ EXTRA_SENSITIVE_PATHS`

- **No new dependency, and not the existing `yaml` one either.** publish.yml runs this script at L96, *before* `npm ci` at L133 — nothing in `node_modules` is importable at that point. Hence a hand-rolled reader for just the `paths:` block.
- **Strict, fails closed.** Missing/unreadable workflow, no `on:` block, an empty trigger list, a duplicate or absent `paths:` key, tab indentation, an unquoted scalar with a trailing comment, or a glob/negation entry all **throw** and exit **2**. Exit 2 rather than 1 is deliberate: publish.yml treats 1 as "sensitive, require a platform run" and anything else as a hard detector failure, so a broken source of truth stops the release outright instead of masquerading as a normal gate hit. A detector that silently degrades to a short or empty list fails *open* — worse than the drift it replaces.
- **Globs:** no current entry uses one (asserted by a test). Detection is exact string equality (stdin mode) and per-file git comparison (base-ref mode), neither of which can express a glob, so the parser rejects one loudly with a remediation message rather than quietly under-matching.
- **`on.push.paths` vs `on.pull_request.paths`:** currently byte-identical. `push` is the authoritative one for evidence purposes — publish.yml requires a successful `--event push` run of the platform workflow, so `on.push.paths` decides whether evidence can exist at all. The detector unions both so a future divergence errs toward *requiring* evidence, and a test asserts the two stay identical so the divergence surfaces in CI rather than as a mysterious publish block.
- `--print-paths` added so the derived set is introspectable (and testable) without importing the script.

## Regression guard

`tests/unit/installer-sensitive-path-parity.test.ts` — 7 tests. It reads the workflow with its **own independent** reader, not the detector's parser, so a parser bug cannot agree with itself.

`tests/unit/safe-install.test.ts` SAF-004j3's eight substring-against-source assertions were rewritten to assert against the **derived set** (they would otherwise pass vacuously or fail spuriously now that the list is not source text), and `scripts/install.ps1` was added to them.

`tests/unit/installer-sensitive-path-parity.test.ts` is itself added to both trigger blocks in the workflow, so changing the guard re-runs platform CI.

## Quantified impact of gap 1-b — **deliberately out of scope, needs an owner decision**

There is a second, opposite defect in the same gate: the gate's diff window is `previous stable v* tag .. GITHUB_SHA` (publish.yml L85/L93) while the trigger's window is the push diff. On `preview` these diverge, because many merges accumulate between stable tags. A head can be gate-sensitive while its own push never triggered the platform workflow — so publish.yml demands evidence for `$GITHUB_SHA` that could never have been produced.

**Adding 21 paths makes this measurably worse.** Measured over push-triggered `test.yml` runs on `preview`, comparing the `origin/dev` list against this PR's derived list. A head counts as false-blocked when `previous-stable-tag..SHA` contains a sensitive path but the push diff that produced that SHA does not:

| sample | evaluated green heads | old detector | this PR | delta |
|---|---|---|---|---|
| last 40 push runs (27 green) | 26 | 6 (23.1%) | **7 (26.9%)** | **+1 head, +3.8pp** |
| last 25 push runs (17 green) | 15 | 1 (6.7%) | 1 (6.7%) | 0 |

The single newly false-blocked head is `31e290ab69`, via `structure/infra.md` becoming sensitive. The 25-run window happens to sample a quiet recent stretch; the 40-run window is the more representative figure and lands close to the ~20% cited in #333.

Worth noting for the design decision: the residual false-blocks are **not** caused by list drift. The most common driver is `package.json` / `package-lock.json` appearing in the tag-to-SHA window (e.g. `146064cbea`), and `--changed-files-stdin` — the mode publish.yml uses — does not apply the version-bump normalization that `normalizeForEvidence` gives `--base-ref`. A pure version bump therefore reads as installer-sensitive on the publish path. Both belong to the window/normalization design question, not to this parity fix.

**Not fixed here.** Narrowing or realigning the diff window changes what "certified" means for a publish and needs a call from the repo owner.

## Test output

New parity suite — all green:

```
$ npx tsx --experimental-test-module-mocks tests/run.mts tests/unit/installer-sensitive-path-parity.test.ts
✔ G1-parity: every postinstall-platform trigger path is installer-sensitive to the release gate (60.5943ms)
✔ G1-parity: push and pull_request trigger lists stay identical (0.3534ms)
✔ G1-parity: the detector does not keep a second hand-written path list (0.2608ms)
✔ G1-parity: a diff touching only scripts/install.ps1 requires platform evidence (56.7119ms)
✔ G1-parity: unrelated changes still skip the evidence requirement (55.0119ms)
✔ G1-parity: trigger paths contain no globs the detector cannot match (0.3187ms)
✔ G1-parity: an unreadable source of truth fails closed, never to an empty set (248.1398ms)
ℹ tests 7
ℹ pass 7
ℹ fail 0
```

Combined with the suites that touch this script:

```
$ npx tsx --experimental-test-module-mocks tests/run.mts \
    tests/unit/installer-sensitive-path-parity.test.ts \
    tests/unit/safe-install.test.ts \
    tests/unit/release-scripts-contract.test.ts
✔ SAF-004j3: publish scripts enforce fresh-machine evidence before push or publish (61.8247ms)
✖ SAF-004f1: runnable lookup skips a broken first PATH candidate (55.1053ms)
✖ SAF-004f2: non-Claude all-tools dry-run skips repair when later PATH candidate works (1548.7523ms)
✖ SAF-006d: `jaw init` honours the skill-dep and MCP skip switches (55.1218ms)
ℹ tests 64
ℹ pass 60
ℹ fail 3
ℹ skipped 1
```

**Those 3 failures are pre-existing and environmental, not from this change.** Verified by stashing the change and re-running on unmodified `origin/dev` in the same checkout — identical 3 failures, no `node_modules` present in the agent worktree (`SAF-006d` fails with `ERR_MODULE_NOT_FOUND`). `SAF-004j3` fails on `origin/dev` + this change without the test update and passes with it, which is the intended migration from source-text to derived-set assertions.

Also run:

- `node scripts/install-risk-gate.mjs` → `[install-risk] PASS node syntax: scripts/require-release-evidence.mjs`. Other steps in that gate fail with "exit signal" in this environment for the same missing-`node_modules` reason (`npm pack`, ripgrep unavailable).
- `tests/unit/release-gates.test.ts`, `tests/unit/integrated-release-audit-contract.test.ts`, `tests/unit/release-gate-skip-semantics.test.ts` → 4 failures, all confirmed pre-existing on unmodified `origin/dev`.
- `tsc --noEmit` was **not** run: this worktree has no `node_modules`, and `tests/**` is excluded from `tsconfig.json` anyway, so the tsx run above is the real check for the new test file.

Both invocation modes exercised end-to-end:

```
$ node scripts/require-release-evidence.mjs --base-ref v2.2.17
[release-evidence-required] installer-sensitive changes detected since v2.2.17 (21, ae722e4fcb62)
- .github/workflows/postinstall-platform.yml
- bin/postinstall.ts
- src/core/cli-detect.ts
- scripts/install-officecli.ps1
- src/core/install-integrity.ts
- scripts/install.ps1
- scripts/postinstall-guard.cjs
...
```

## Files changed

- `scripts/require-release-evidence.mjs` — derive instead of hardcode; strict reader; `--print-paths`
- `tests/unit/installer-sensitive-path-parity.test.ts` — new, 7 tests
- `tests/unit/safe-install.test.ts` — SAF-004j3 asserts the derived set
- `.github/workflows/postinstall-platform.yml` — the new parity test added to both trigger blocks

Left as **draft**. Nothing published, no workflow dispatched, nothing pushed to `main` or `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
