### PR TITLE
test(redact): guard the fold's cost with a work counter, not a stopwatch

### DIFF
--- a/src/messaging/fold.ts
+++ b/src/messaging/fold.ts
@@ -31,6 +31,37 @@
 const INVISIBLE_CHARS = /[\p{Cc}\p{Cf}\u034F\u17B4\u17B5\u180B-\u180E\uFE00-\uFE0F]/gu;
 
 /**
+ * Characters the fold has walked, across every round, since the last reset.
+ *
+ * The twin of `redactionCopyWork` in redact.ts, and it exists for the same
+ * reason: the test that guards this cost cannot use wall-clock time. A 300 ms
+ * budget on a 43 KB fixture failed CI at 307 ms and then passed on re-run with
+ * identical code, on a runner whose own job time moved between 4m50s and 7m28s.
+ * Milliseconds measure the runner; this counts the work the algorithm actually
+ * does, so it reads the same on every machine and under any load.
+ *
+ * It is charged exactly where the budget is charged, because the budget IS the
+ * bound being asserted: `decodeBudgetFor` caps total work at 8x the input, so
+ * folding is linear by construction. Bounding ROUNDS instead — the shape this
+ * module was fixed away from — leaves each round rescanning the whole string,
+ * which is quadratic in nesting depth and is what the guard has to catch.
+ *
+ * Incrementing one integer per round costs nothing measurable and is never
+ * read in production.
+ */
+let charsFolded = 0;
+
+/** Read the fold-work counter; test-only introspection. */
+export function foldWork(): number {
+    return charsFolded;
+}
+
+/** Reset the fold-work counter; test-only introspection. */
+export function resetFoldWork(): void {
+    charsFolded = 0;
+}
+
+/**
  * A folded string plus, for each of its characters, the offset in the ORIGINAL
  * that produced it.
  *
@@ -70,6 +101,7 @@ export function canonicalize(input: string): FoldedText {
         origin: Array.from({ length: input.length }, (_, i) => i),
         end: Array.from({ length: input.length }, (_, i) => i + 1),
     };
+    charsFolded += input.length; // the initial strip walks the whole input
     current = stripInvisible(current);
     // Fold to a FIXED POINT. Decoding strictly shrinks — an escape is always
     // longer than the character it denotes — so this terminates on its own,
@@ -82,6 +114,7 @@ export function canonicalize(input: string): FoldedText {
     for (;;) {
         if (budget <= 0) return { ...current, exhausted: true };
         budget -= current.text.length;
+        charsFolded += current.text.length; // every round rescans the whole string
         const next = stripInvisible(decodeOnce(current));
         if (next.text === current.text) break;
         current = next;

--- a/tests/unit/channel-redaction.test.ts
+++ b/tests/unit/channel-redaction.test.ts
@@ -9,6 +9,7 @@ import {
     redactChannelSecrets, userErrorText, logErrorText,
     redactionCopyWork, resetRedactionCopyWork,
 } from '../../src/messaging/redact.js';
+import { foldWork, resetFoldWork } from '../../src/messaging/fold.js';
 
 // A realistic Telegram secret: 35 chars after the numeric bot id.
 const TG_SECRET = 'AAHfoobarbazquxquux12345678901234567';
@@ -54,6 +55,40 @@ function assertLinearCopyWork(build: (n: number) => string, n: number, label: st
     assert.ok(ratio < 1.5, `${label}: copy work per character grew ${ratio.toFixed(2)}x `
         + `(${small.toFixed(2)} → ${large.toFixed(2)} between ${n} and ${n * 2}); `
         + 'expected assembly to stay proportional to input length');
+}
+
+/** Characters the FOLD walked while masking `input`, per input character. */
+function foldWorkPerChar(input: string): number {
+    resetFoldWork();
+    redactChannelSecrets(input);
+    return foldWork() / input.length;
+}
+
+/**
+ * Assert that fold work stays proportional to input length as the input grows.
+ *
+ * The twin of `assertLinearCopyWork`, for the other half of the cost. The two
+ * are not interchangeable, and the deep-nesting test proves it: its fixture
+ * nests escapes until the fold gives up, so `stripSecretsFoundInCanonicalForm`
+ * returns down the `exhausted` branch and never reaches the apply loop at all.
+ * Copy work on that fixture is exactly 0 — measured 0 at every size and on both
+ * axes — so a copy-work ratio there is 0/0, and the assertion it produces can
+ * neither pass nor mean anything. Fold work is what that fixture actually
+ * spends, so fold work is what guards it.
+ *
+ * Budgeted folding holds this flat at 9.93 per character for every depth.
+ * Bounding rounds instead — each one rescanning the whole string — moves it to
+ * 140.7, 269.2 and 525.5 for depth 256/512/1024: it doubles with the depth,
+ * which is the signature of the quadratic. The 1.5x bound sits far outside the
+ * flat case and far below the regression, matching `assertLinearCopyWork`.
+ */
+function assertLinearFoldWork(build: (n: number) => string, n: number, label: string): void {
+    const small = foldWorkPerChar(build(n));
+    const large = foldWorkPerChar(build(n * 2));
+    const ratio = large / small;
+    assert.ok(ratio < 1.5, `${label}: fold work per character grew ${ratio.toFixed(2)}x `
+        + `(${small.toFixed(2)} → ${large.toFixed(2)} between ${n} and ${n * 2}); `
+        + 'expected folding to stay proportional to input length');
 }
 
 // ─── Telegram: the token lives in the URL path ───────
@@ -378,17 +413,32 @@ test('the repeat sweep covers every proven credential, not the first few', () =>
 test('deep nesting across many runs does not stall the sink', () => {
     // 40 runs nested 512 deep is 43 KB, and rebuilding the fold per round took
     // three quarters of a second — enough to matter in a logging path.
-    let input = '';
-    for (let run = 0; run < 40; run += 1) {
-        let piece = `bot123456789:${'A'.repeat(35)}`;
-        for (let round = 0; round < 512; round += 1) {
-            piece = piece.replace(/%/g, '%25').replace(/^bot/, '%62ot');
+    //
+    // NESTING DEPTH is the axis, not the number of runs, and the two are not
+    // interchangeable. The fold rescans the whole string once per decode round,
+    // so its cost is (rounds x length). Only depth drives the round count:
+    // doubling the runs doubles the length but leaves the rounds alone, which
+    // is linear growth even when the bound is broken. Measured against a
+    // round-capped fold, per-character work went 140.7 -> 269.2 -> 525.5 along
+    // depth (it doubles — the quadratic signature) while the runs axis sat at
+    // 269.2 -> 269.2, a ratio of 1.00. A guard on the runs axis cannot fail.
+    //
+    // What holds it flat is `decodeBudgetFor`: charging every round against one
+    // character budget caps total work at 8x the input, so the healthy fold
+    // reads 9.93 per character at every depth.
+    const build = (depth: number) => {
+        let input = '';
+        for (let run = 0; run < 40; run += 1) {
+            let piece = `bot123456789:${'A'.repeat(35)}`;
+            for (let round = 0; round < depth; round += 1) {
+                piece = piece.replace(/%/g, '%25').replace(/^bot/, '%62ot');
+            }
+            input += `${piece} `;
         }
-        input += `${piece} `;
-    }
-    const started = Date.now();
-    redactChannelSecrets(input);
-    assert.ok(Date.now() - started < 300, `took ${Date.now() - started}ms on ${input.length} chars`);
+        return input;
+    };
+
+    assertLinearFoldWork(build, 512, 'nesting depth');
 });
 
 test('keyboard button labels and urls are masked', async () => {


### PR DESCRIPTION
## The flake

`tests/unit/channel-redaction.test.ts` → `deep nesting across many runs does not stall the sink` ended with a 300 ms wall-clock budget on a 43 KB fixture.

It failed on the **Tests** run for #346 ([run 31785145222](https://github.com/lidge-jun/cli-jaw/actions/runs/31785145222)):

```
not ok 1229 - deep nesting across many runs does not stall the sink
  location: '.../tests/unit/channel-redaction.test.ts:1:9743'
  error: 'took 307ms on 42920 chars'
```

307 ms against a 300 ms budget — **2.3% over**. Both attempts ran the identical commit `222b83a1`:

| attempt | conclusion | `node-tests` duration |
|---|---|---|
| 1 | **failure** (307 ms) | 08:44:38 → 08:49:28 = **4m50s** |
| 2 | **success** | 08:55:09 → 09:02:37 = **7m28s** |

Same code, opposite results, and the job's own wall time moved by 55% between attempts. The runner's throughput varies by far more than the 2.3% margin the assertion left itself, so the budget was measuring the runner, not the algorithm.

`fd54099c` already made exactly this argument and acted on it — it added `redactionCopyWork()` **"because the tests that guard this cannot use wall-clock time"**, and three tests in this file assert copy work instead of milliseconds. This test was never migrated.

## Why the obvious migration is wrong

Pointing the existing `assertLinearCopyWork` at this fixture does not work, and why is the substance of this PR.

The fixture nests escapes 512 deep, which **exhausts the fold**. `stripSecretsFoundInCanonicalForm` therefore returns down its `if (folded.exhausted)` branch and never reaches the apply loop that the copy-work counter instruments. Measured on the exact fixture:

```
original (40 runs x 512 depth)  len=42920  exhausted=true  copyWork=0  perChar=0.000
runs=20/40/80/160  (depth=512)                exhausted=true  copyWork=0  perChar=0.000
depth=128/256/512/1024 (runs=40)              exhausted=true  copyWork=0  perChar=0.000
```

Copy work is **0 at every size on both axes**, so `assertLinearCopyWork` would compute `0/0 = NaN` and `NaN < 1.5` is false. Confirmed from the other side by reverting `fd54099c`'s apply loop to the per-range full-string rebuild: this test **passes at 83 ms against the pathology**, while the three genuine copy-work tests fail. Migrating it would have swapped a flaky guard for one that cannot fail.

## Chosen axis: nesting depth

What this fixture actually spends is **fold work** — which is what the test's own comment blames ("rebuilding the fold per round"). So this adds the twin counter `foldWork()` / `resetFoldWork()` in `src/messaging/fold.ts`, charged exactly where `decodeBudgetFor`'s budget is charged, because that budget *is* the bound being asserted: capping total work at 8x the input is what makes folding linear by construction.

**The axis is nesting depth, not the number of runs.** The fold rescans the whole string once per decode round, so cost is `rounds × length`, and only depth drives the round count. Doubling the runs doubles the length but leaves the rounds alone — linear growth even when the bound is broken. Measured against a round-capped fold:

| axis | healthy (budget) | round-cap pathology | ratio |
|---|---|---|---|
| **depth** 256 → 512 → 1024 | 9.93 flat | 140.7 → 269.2 → 525.5 | **1.91 / 1.95** ✅ catches |
| **runs** 20 → 40 → 80 | 9.93 flat | 269.2 → 269.2 | **1.00** ❌ blind |

A guard on the runs axis could not fail, so only depth is asserted. The `40 runs` dimension is kept fixed in the builder so the fixture stays the realistic 43 KB shape it always was.

Note this is a **narrower, sharper property than the original**: the old assertion covered total end-to-end milliseconds; the new one covers the fold-cost growth that the fixture was built to exercise and that its comment names. The credential-count axis `fd54099c` identified remains guarded by the three existing `assertLinearCopyWork` tests, which are untouched.

## Revert-proof

**1. Budget swapped for a round cap** (`rounds >= 100_000` instead of charging `budget -= current.text.length`) — the migrated test is the **only one of the 56 that fails**:

```
✖ deep nesting across many runs does not stall the sink (8376.9677ms)
  AssertionError: nesting depth: fold work per character grew 1.95x
  (269.21 → 525.48 between 512 and 1024); expected folding to stay
  proportional to input length

ℹ tests 56   ℹ pass 55   ℹ fail 1
```

**2. Budget restored** — 56/56 pass:

```
✔ deep nesting across many runs does not stall the sink (227.8941ms)
ℹ tests 56   ℹ suites 0   ℹ pass 56   ℹ fail 0
ℹ cancelled 0   ℹ skipped 0   ℹ todo 0   ℹ duration_ms 3164.8847
```

Also verified that reverting `fd54099c`'s **apply loop** leaves this test passing (83 ms) while `secrets of many different lengths`, `secrets sharing a prefix` and `many distinct credentials` all fail — which is what proves the copy-work counter is the wrong instrument here and the fold counter is the right one.

## The other two wall-clock assertions — left alone, deliberately

`folding stays linear on hostile escape sequences` and `redaction stays linear on pathological input` both assert `< 1_000`. They are **not** a clean extension, so per scope they stay:

| fixture family | fold work / char | ratio under round-cap pathology |
|---|---|---|
| `%41`, `&#98;`, `b`, `%25`, `%E2%80%8B` | 2.0 – 2.3 | **1.00** (flat) |
| `https://aaa…`, `1…:A…`, `bot×n`, `%3A×n`, query fixtures | 2.0 – 2.3 | **1.00** (flat) |

Those inputs are long but *flat* — they decode in about two rounds, so the round count never grows with `n` and both counters read linear no matter how broken the fold is. What they actually guard is **catastrophic regex backtracking in the passes after the fold**, a third property neither counter observes. Migrating them would trade a flaky guard for a vacuous one. Making them load-independent needs a different instrument and is worth its own change.

## Scope / risk

- `src/messaging/redact.ts` is **untouched**.
- `src/messaging/fold.ts` gains only the counter declaration and two `charsFolded +=` lines, charged alongside the existing budget arithmetic — no behavior change. The test-only export is genuinely required: there is no other load-independent way to observe fold work, and it mirrors the `redactionCopyWork` precedent set by `fd54099c` in the same subsystem.
- `npm run build` clean. `npm run gate:all` produces the **same 10/22 pre-existing failures before and after** this change (verified by stashing); `gate:redaction-sinks` passes in both.

Not part of #333. Worth landing before required status checks are enabled on `main`, though — once they are, this flake blocks promotions on a coin toss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
