### PR TITLE
docs(release): stop explaining the preview script by a deleted one

### DIFF
--- a/scripts/release-preview.sh
+++ b/scripts/release-preview.sh
@@ -7,7 +7,7 @@
 #   ./release-preview.sh --major         → major bump (1.6.9 → 2.0.0-preview.*)
 #   ./release-preview.sh 1.8.0           → explicit base version
 #   ./release-preview.sh --require-evidence  → fail if fresh-machine evidence is missing
-#                                              (default: warn and continue, same as release.sh)
+#                                              (default: warn and continue)
 # npm publish is handled by .github/workflows/publish.yml through npm Trusted
 # Publishing (OIDC). Desktop artifacts are built and attached by GitHub Actions
 # after the GitHub prerelease is published.
@@ -159,8 +159,10 @@ npm version "$PREVIEW_VERSION" --no-git-tag-version
 VERSION=$(node -p "require('./package.json').version")
 echo "📌 package.json version: $VERSION"
 
-# Same reason as release.sh: the committed Electron version names the desktop
-# artifacts. This also has to run BEFORE gate:all below -- the electron-version
+# The committed Electron version names the desktop artifacts, and
+# desktop-release.yml builds from a tag checkout, so the sync has to happen here
+# rather than at build time. promote-to-main.sh does the same, for the same
+# reason. This also has to run BEFORE gate:all below -- the electron-version
 # gate compares the two manifests, and the bump above has just moved the root
 # one, so skipping this would fail the preview release outright.
 echo "🖥️  Syncing Electron version to $VERSION..."
@@ -180,11 +182,15 @@ run_electron_release_checks
 echo "🛡️  Running release gates (gate:all)..."
 npm run gate:all
 
-# Matches release.sh: the fresh-machine evidence gate is advisory by default and
-# enforced with --require-evidence. A preview build is the channel you reach for
-# precisely when installer changes still need real-machine coverage, so making
-# preview stricter than stable had it backwards — it blocked the release that
-# exists to be tested.
+# The fresh-machine evidence gate is advisory here and enforced with
+# --require-evidence. A preview build is the channel you reach for precisely
+# when installer changes still need real-machine coverage, so making preview
+# stricter had it backwards — it blocked the release that exists to be tested.
+#
+# The stable path is the strict one: promote-to-main.sh runs the same gate
+# unconditionally, so missing evidence fails the promotion rather than the
+# preview. Loosening this without tightening that would leave nothing enforcing
+# it.
 if [ "$REQUIRE_EVIDENCE" = true ]; then
   node scripts/require-release-evidence.mjs
 else


### PR DESCRIPTION
Closes the last loose end of #333's **"기존 `release.sh` 제거 및 문서·호출부 정리"** scope item.

`release.sh` was deleted in `b029c67d`, and every code path, test, and doc reference was correctly retargeted at the time. Three comments in `scripts/release-preview.sh` were not — they still justified the script's behavior by pointing at a file a reader cannot open.

## One of them had become wrong, not just stale

```
# Matches release.sh: the fresh-machine evidence gate is advisory by default and
# enforced with --require-evidence.
```

Under `release.sh` this was true — both paths ran `require-release-evidence.mjs` with a `|| echo` fallback. The stable path is now `promote-to-main.sh`, which runs the same gate **unconditionally**:

```sh
npm run gate:all
node scripts/require-release-evidence.mjs   # no `|| echo` — missing evidence fails the promotion
```

So preview is not "matching" stable. It is deliberately **looser** than stable, and the enforcement lives in the promotion. That distinction matters: a reader trusting the old comment would conclude that loosening this line further costs nothing, when in fact the promotion gate is the only thing enforcing evidence at all.

The replacement states the real relationship and says what breaks if both are loosened.

## The other two

| line | before | after |
|---|---|---|
| 10 | `(default: warn and continue, same as release.sh)` | dropped the dead comparison |
| 162 | `Same reason as release.sh: the committed Electron version names the desktop artifacts` | self-contained, names `promote-to-main.sh` as the live sibling, and absorbs the rationale the deleted file used to carry (`desktop-release.yml` builds from a tag checkout, so the sync cannot wait for build time) |

## Verification

- `bash -n scripts/release-preview.sh` — OK
- `git grep 'release\.sh'` over `scripts/ README.md structure/ tests/` — **no matches remain** (`CHANGELOG.md` history intentionally untouched)
- Diff is comment-only: filtering the diff for changed non-comment lines returns nothing
- `tests/unit/release-scripts-contract.test.ts` asserts on code constructs (`run_electron_release_checks`, `npm --prefix electron …`, `ELECTRON_RELEASE_NOTES`, …), none of which are touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
