### PR TITLE
docs(readme): let the release badge read the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Your personal AI agent. 2 lines to install. 13 AI runtime surfaces in one dashboard.
 
 [![npm](https://img.shields.io/npm/v/cli-jaw)](https://npmjs.com/package/cli-jaw)
-[![Version](https://img.shields.io/badge/v2.2.3-GA-brightgreen)](https://github.com/lidge-jun/cli-jaw/releases)
+[![Release](https://img.shields.io/github/v/release/lidge-jun/cli-jaw)](https://github.com/lidge-jun/cli-jaw/releases)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue)](https://typescriptlang.org)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.4-blue)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)


### PR DESCRIPTION
## The fix

README's version badge was hardcoded to `v2.2.3`. npm `latest` is `2.3.0` and the newest GitHub release is `v2.3.0`, so the first thing a visitor saw was a version several releases stale.

Nothing keeps it current: `release-preview.sh` and `promote-to-main.sh` bump `package.json` and `electron/package.json`, never this line. It moves only when someone notices.

```diff
-[![Version](https://img.shields.io/badge/v2.2.3-GA-brightgreen)](https://github.com/lidge-jun/cli-jaw/releases)
+[![Release](https://img.shields.io/github/v/release/lidge-jun/cli-jaw)](https://github.com/lidge-jun/cli-jaw/releases)
```

shields.io reads the latest GitHub release directly — which is what the badge already linked to. It stays correct with no maintenance, and it stops duplicating the npm badge on the line above it.

## Second purpose: this PR is the docs-only CI proof

#333's scope item *"docs-only PR에도 aggregate check가 생성되도록 CI lane 정리"* was closed by #344, but **the docs-only path has never actually run.** #345 looked like a docs PR yet touched `structure/infra.md` and `CLAUDE.md`, which are not excluded, so it took the `code=true` path and ran the full suite (7m32s). #344's skip branch was verified only by local simulation.

This PR touches **`README.md` and nothing else**, which is the one shape that matches the exclusion `^README[^/]*\.md$`. So it is the first real exercise of the intended behaviour:

| job | expected |
|---|---|
| `changes` | success, `code=false` |
| `node-tests` | **skipped** |
| `ci-aggregate` | **success** |

If `ci-aggregate` comes back anything other than green, the required-status-check rollout on `main` must not proceed — a docs-only PR would be permanently blocked on a check that never reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
