### PR TITLE
docs(readme): let the release badge read the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Your personal AI agent. 2 lines to install. 13 AI runtime surfaces in one dashboard.
 
 [![npm](https://img.shields.io/npm/v/cli-jaw)](https://npmjs.com/package/cli-jaw)
-[![Version](https://img.shields.io/badge/v2.2.3-GA-brightgreen)](https://github.com/lidge-jun/cli-jaw/releases)
+[![Release](https://img.shields.io/github/v/release/lidge-jun/cli-jaw)](https://github.com/lidge-jun/cli-jaw/releases)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue)](https://typescriptlang.org)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.4-blue)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)


### PR DESCRIPTION
#333의 마지막 미실증 완료조건을 닫습니다:

> - [ ] docs-only PR required checks가 성공함

## 왜 별도 PR인가

#349가 같은 변경을 담고 있지만 **base가 `dev`입니다.** 방금 브랜치 보호를
`main`에 걸었으므로(`ci-aggregate` required), `dev`로 머지되는 PR은 그 규칙을
지나가지 않습니다. required check가 강제된 상태에서 docs-only PR이 통과한다는
증거가 되려면 **base가 `main`이어야** 합니다.

## 변경

`README.md` 한 줄. 버전 배지가 `v2.2.3`에 고정돼 있어 npm `latest`(2.3.0)와
최신 릴리스(v2.3.0)보다 몇 단계 뒤처져 있었습니다.

```diff
-[![Version](https://img.shields.io/badge/v2.2.3-GA-brightgreen)](...)
+[![Release](https://img.shields.io/github/v/release/lidge-jun/cli-jaw)](...)
```

shields.io가 최신 GitHub release를 직접 읽으므로 유지보수 없이 정확해집니다.
(이 아이디어는 #349에서 가져왔습니다.)

## 이 PR이 증명하는 것

`README.md` **하나만** 건드립니다. `test.yml:110`의 제외 패턴
`^README[^/]*\.md$|^docs/`에 정확히 걸리는 모양입니다.

| job | 기대 |
|---|---|
| `changes` | success, `code=false` |
| `node-tests` | **skipped** |
| `ci-aggregate` | **success** |

`ci-aggregate`가 초록이 아니면 방금 건 required check 설정을 되돌려야 합니다 —
docs-only PR이 영원히 보고되지 않는 check를 기다리게 되기 때문입니다.

관련: #333, #349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README release badge to display the current GitHub release version dynamically instead of a fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->