### PR TITLE
fix(release): the preview release waits for the CI its publish gate reads

### DIFF
--- a/scripts/release-preview.sh
+++ b/scripts/release-preview.sh
@@ -214,12 +214,148 @@ else
   git push origin HEAD:preview
 fi
 
-# ─── Dispatch publish workflow ─────────────────────────
+# ─── Wait for release CI, then dispatch publish ────────
 RELEASE_SHA="$(git rev-parse HEAD)"
 LIVE_SHA="$(git ls-remote origin refs/heads/preview | cut -f1)"
 
 if [ -z "$LIVE_SHA" ] || [ "$LIVE_SHA" != "$RELEASE_SHA" ]; then
   echo "❌ origin/preview moved after push (expected $RELEASE_SHA, got ${LIVE_SHA:-'(empty)'}). Aborting."
+  exit 1
+fi
+
+# Printed on every path that gives up before dispatching, so the operator can
+# resume the release without reconstructing the command from the workflow file.
+publish_dispatch_hint() {
+  echo ""
+  echo "Resume once the required runs are green:"
+  echo "  gh workflow run publish.yml --ref preview \\"
+  echo "    -f version=\"$VERSION\" -f tag=preview -f expected-sha=\"$RELEASE_SHA\" -f dry-run=false"
+}
+
+# publish.yml refuses to publish without a SUCCESSFUL PUSH run of test.yml for
+# this exact SHA -- and, when the installer surface changed, of
+# postinstall-platform.yml too. The push above is seconds old, so dispatching
+# immediately made the first attempt of every preview release fail by
+# construction: v2.4.0-preview (18e6337) needed three dispatches, 10:29:13
+# (Tests still running), 10:37:23 (Postinstall still running), 10:38:29 (green).
+# So wait for the evidence first, exactly as promote-to-main.sh already does for
+# the merged main SHA on the stable path.
+
+# publish.yml derives its range on a fetch-depth: 0 checkout and therefore sees
+# every tag. Match that view before deciding below, or a checkout missing the
+# newest stable tag answers a different question than the gate will.
+git fetch origin --tags --quiet || echo "⚠️  Could not refresh tags; using the local tag list."
+
+# postinstall-platform.yml carries `paths:` filters, so for a SHA that touches
+# no installer-sensitive path it never runs at all and waiting for it would burn
+# the whole deadline on a run that will never exist. publish.yml decides with
+# `require-release-evidence.mjs --changed-files-stdin` over the diff since the
+# last stable tag merged into the release SHA, so ask the same detector the same
+# question over the same range rather than guessing.
+PLATFORM_REQUIRED=false
+PREVIOUS_STABLE_TAG="$(git tag --merged "$RELEASE_SHA" --sort=-v:refname \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
+if [ -z "$PREVIOUS_STABLE_TAG" ]; then
+  echo "ℹ️  No previous stable v* tag; publish.yml treats this as a first release and skips the platform gate."
+else
+  CHANGED_FILES="$(mktemp)"
+  git diff --name-only "$PREVIOUS_STABLE_TAG..$RELEASE_SHA" > "$CHANGED_FILES"
+  DETECTOR_STATUS=0
+  node scripts/require-release-evidence.mjs --changed-files-stdin < "$CHANGED_FILES" || DETECTOR_STATUS=$?
+  rm -f "$CHANGED_FILES"
+  case "$DETECTOR_STATUS" in
+    0)
+      echo "ℹ️  No installer-sensitive changes since $PREVIOUS_STABLE_TAG; platform checks are not required."
+      ;;
+    1)
+      PLATFORM_REQUIRED=true
+      ;;
+    *)
+      echo "ERROR: installer-sensitive path detector failed with status $DETECTOR_STATUS" >&2
+      publish_dispatch_hint
+      exit "$DETECTOR_STATUS"
+      ;;
+  esac
+fi
+
+echo "⏳ Waiting for preview Tests on $RELEASE_SHA..."
+deadline=$((SECONDS + 1200))
+PREVIEW_TESTS_URL=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  PREVIEW_TESTS_URL="$(gh run list \
+    --workflow test.yml \
+    --branch preview \
+    --commit "$RELEASE_SHA" \
+    --event push \
+    --status success \
+    --limit 1 --json url --jq '.[0].url // ""')"
+  [ -n "$PREVIEW_TESTS_URL" ] && break
+  # An empty result also covers "GitHub has not materialised the run yet", which
+  # is the normal state for the first seconds after a push, so keep polling.
+  failed="$(gh run list \
+    --workflow test.yml \
+    --branch preview \
+    --commit "$RELEASE_SHA" \
+    --event push \
+    --status completed \
+    --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
+  case "$failed" in
+    failure|cancelled|timed_out|startup_failure|action_required)
+      echo "ERROR: preview Tests completed with $failed" >&2
+      publish_dispatch_hint
+      exit 1
+      ;;
+  esac
+  sleep 10
+done
+if [ -z "$PREVIEW_TESTS_URL" ]; then
+  echo "ERROR: timed out waiting for successful preview Tests" >&2
+  publish_dispatch_hint
+  exit 1
+fi
+echo "✅ Tests: $PREVIEW_TESTS_URL"
+
+if [ "$PLATFORM_REQUIRED" = true ]; then
+  echo "⏳ Waiting for preview Postinstall Platform Checks on $RELEASE_SHA..."
+  deadline=$((SECONDS + 1200))
+  PREVIEW_PLATFORM_URL=""
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    PREVIEW_PLATFORM_URL="$(gh run list \
+      --workflow postinstall-platform.yml \
+      --branch preview \
+      --commit "$RELEASE_SHA" \
+      --event push \
+      --status success \
+      --limit 1 --json url --jq '.[0].url // ""')"
+    [ -n "$PREVIEW_PLATFORM_URL" ] && break
+    failed="$(gh run list \
+      --workflow postinstall-platform.yml \
+      --branch preview \
+      --commit "$RELEASE_SHA" \
+      --event push \
+      --status completed \
+      --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
+    case "$failed" in
+      failure|cancelled|timed_out|startup_failure|action_required)
+        echo "ERROR: preview Postinstall Platform Checks completed with $failed" >&2
+        publish_dispatch_hint
+        exit 1
+        ;;
+    esac
+    sleep 10
+  done
+  if [ -z "$PREVIEW_PLATFORM_URL" ]; then
+    echo "ERROR: timed out waiting for successful preview Postinstall Platform Checks" >&2
+    publish_dispatch_hint
+    exit 1
+  fi
+  echo "✅ Postinstall Platform Checks: $PREVIEW_PLATFORM_URL"
+fi
+
+LIVE_SHA="$(git ls-remote origin refs/heads/preview | cut -f1)"
+if [ "$LIVE_SHA" != "$RELEASE_SHA" ]; then
+  echo "ERROR: origin/preview moved while waiting for release CI" >&2
+  publish_dispatch_hint
   exit 1
 fi
 
@@ -239,7 +375,7 @@ RELEASE_BODY="## Preview Release v$VERSION
 $CHANGELOG
 
 ### Publish
-- npm preview publish runs from \`.github/workflows/publish.yml\` on the \`preview\` branch.
+- npm preview publish is dispatched by \`scripts/release-preview.sh\` into \`.github/workflows/publish.yml\` (\`workflow_dispatch\`), pinned to this commit, after preview CI is green.
 - npm dist-tag: \`preview\`
 - Install after the workflow succeeds: \`npm install -g cli-jaw@preview\`
 
@@ -270,4 +406,4 @@ echo "✅ Preview release queued: cli-jaw@$VERSION"
 echo "   Install: npm install -g cli-jaw@preview"
 echo "   Exact:   npm install -g cli-jaw@$VERSION"
 echo "   Release: https://github.com/lidge-jun/cli-jaw/releases/tag/v$VERSION"
-echo "   Workflow: https://github.com/lidge-jun/cli-jaw/actions/workflows/publish.yml?query=branch%3Apreview"
+echo "   Workflow: https://github.com/lidge-jun/cli-jaw/actions/workflows/publish.yml?query=event%3Aworkflow_dispatch"

--- a/tests/unit/release-scripts-contract.test.ts
+++ b/tests/unit/release-scripts-contract.test.ts
@@ -82,6 +82,93 @@ for (const scriptPath of ['scripts/release-preview.sh']) {
             'release script must invoke gh release create',
         );
     });
+
+    test(`${scriptPath} waits for the runs publish.yml gates on before dispatching publish`, () => {
+        // publish.yml refuses to publish without a SUCCESSFUL PUSH run of
+        // test.yml for the exact release SHA, plus postinstall-platform.yml when
+        // the installer surface changed. This script pushes and then dispatches,
+        // so without a wait the FIRST dispatch of every preview release fails by
+        // construction. v2.4.0-preview (18e6337) needed three: 10:29:13 died on
+        // "Require successful Tests for this commit" (Tests still running),
+        // 10:37:23 died on "Require platform checks when installer surface
+        // changed" (Postinstall still running), 10:38:29 finally published.
+        const script = read(scriptPath);
+        // Collapse backslash-continuations so the multi-line gh invocations can
+        // be matched as the single commands they are.
+        const flat = script.replace(/\\\r?\n\s*/g, ' ').replace(/[ \t]+/g, ' ');
+
+        assert.ok(
+            flat.includes('gh run list --workflow test.yml --branch preview --commit "$RELEASE_SHA" --event push --status success'),
+            'release script must wait for a successful PUSH run of test.yml on the exact release SHA',
+        );
+        assert.ok(
+            flat.includes('gh run list --workflow postinstall-platform.yml --branch preview --commit "$RELEASE_SHA" --event push --status success'),
+            'release script must wait for a successful PUSH run of postinstall-platform.yml on the exact release SHA',
+        );
+
+        const waitIndex = script.indexOf('Waiting for preview Tests');
+        // The real dispatch sits at column 0; the resume hint echoes an indented
+        // copy of the same command, which must not be mistaken for it.
+        const dispatchIndex = script.indexOf('\ngh workflow run publish.yml --ref preview');
+        assert.ok(waitIndex !== -1, 'release script must announce the CI wait');
+        assert.ok(dispatchIndex !== -1, 'release script must dispatch publish.yml');
+        assert.ok(
+            waitIndex < dispatchIndex,
+            'release script must wait for release CI BEFORE dispatching publish.yml',
+        );
+
+        // Mirrors the two wait loops in scripts/promote-to-main.sh.
+        assert.ok(script.includes('deadline=$((SECONDS + 1200))'), 'CI wait must be bounded by the same 1200s deadline as promote-to-main.sh');
+        assert.ok(script.includes('while [ "$SECONDS" -lt "$deadline" ]'), 'CI wait must poll against the deadline');
+        assert.ok(script.includes('sleep 10'), 'CI wait must poll on the promote-to-main.sh interval');
+        assert.ok(
+            script.includes('failure|cancelled|timed_out|startup_failure|action_required'),
+            'CI wait must abort on a failed conclusion instead of polling to the deadline',
+        );
+        assert.ok(
+            script.includes('[ -n "$PREVIEW_TESTS_URL" ] && break'),
+            'CI wait must treat an empty result as "run not created yet" and keep polling',
+        );
+        assert.ok(
+            script.includes('ERROR: origin/preview moved while waiting for release CI'),
+            'release script must re-check that preview did not move while waiting',
+        );
+
+        // postinstall-platform.yml carries `paths:` filters, so it never runs at
+        // all for a SHA that touches no installer-sensitive path. Waiting
+        // unconditionally would burn the full deadline on a run that will never
+        // exist, so the wait is gated on the same detector publish.yml uses.
+        assert.ok(
+            flat.includes('node scripts/require-release-evidence.mjs --changed-files-stdin'),
+            'platform wait must be decided by the shared installer-sensitive path detector',
+        );
+        assert.ok(
+            script.includes('if [ "$PLATFORM_REQUIRED" = true ]'),
+            'platform wait must be conditional, not unconditional',
+        );
+
+        assert.ok(
+            script.includes('publish_dispatch_hint'),
+            'every give-up path must print the exact resume dispatch command',
+        );
+    });
+
+    test(`${scriptPath} describes the dispatch-triggered publish, not the removed push trigger`, () => {
+        const script = read(scriptPath);
+
+        assert.ok(
+            !script.includes('runs from \\`.github/workflows/publish.yml\\` on the \\`preview\\` branch'),
+            'prerelease body must not claim publish is triggered by the preview branch push',
+        );
+        assert.ok(
+            !script.includes('publish.yml?query=branch%3Apreview'),
+            'publish.yml has no push trigger, so a branch-filtered actions URL lists nothing',
+        );
+        assert.ok(
+            script.includes('publish.yml?query=event%3Aworkflow_dispatch'),
+            'the workflow link must filter on the dispatch event that actually publishes',
+        );
+    });
 }
 
 test('desktop release workflow uploads OS matrix artifacts only after GitHub release publication', () => {


### PR DESCRIPTION
## The race

`scripts/release-preview.sh` pushed the release commit, verified `origin/preview` still equalled the release SHA, and then — in the very next statement — ran:

```sh
gh workflow run publish.yml --ref preview \
  -f version="$VERSION" -f tag=preview -f expected-sha="$RELEASE_SHA" -f dry-run=false
```

`publish.yml` opens with two gates:

- **`Require successful Tests for this commit`** — `gh run list --workflow test.yml --branch "$branch" --commit "$GITHUB_SHA" --event push --status success`
- **`Require platform checks when installer surface changed`** — the same lookup against `postinstall-platform.yml`, run only when `scripts/require-release-evidence.mjs --changed-files-stdin` reports installer-sensitive files in `git diff --name-only "$previous_tag..$GITHUB_SHA"`

A commit pushed one second earlier cannot have a *successful* push run of either. **The first publish attempt of every preview release failed by construction**, and a human sat re-dispatching until each gate happened to turn green.

## Evidence — v2.4.0-preview, SHA `18e6337786466b0fe988ca2542d431541397417b`

`gh run list --repo lidge-jun/cli-jaw --commit 18e6337786466b0fe988ca2542d431541397417b`:

| run | created | outcome |
|---|---|---|
| Tests (push) | 10:29:12 | success at **10:37:04** |
| Postinstall Platform Checks (push) | 10:29:12 | success at **10:38:05** |
| [31792404416](https://github.com/lidge-jun/cli-jaw/actions/runs/31792404416) | 10:29:13 | failure — `Require successful Tests for this commit` (Tests still in progress) |
| [31792947032](https://github.com/lidge-jun/cli-jaw/actions/runs/31792947032) | 10:37:23 | failure — `Require platform checks when installer surface changed` (Postinstall still in progress) |
| [31793019302](https://github.com/lidge-jun/cli-jaw/actions/runs/31793019302) | 10:38:29 | success → published 10:40:10 |

Failed step names read back from `gh run view <id> --json jobs`. Three dispatches for one release.

## What was mirrored from `promote-to-main.sh`

The stable path already solves this. `scripts/promote-to-main.sh` waits on the merged `main` SHA with two loops before dispatching publish, and this change mirrors them rather than inventing a second design:

- `deadline=$((SECONDS + 1200))` / `while [ "$SECONDS" -lt "$deadline" ]` / `sleep 10`
- the same `gh run list … --event push --status success --limit 1 --json url --jq '.[0].url // ""'` success probe
- the same `--status completed --json conclusion` failure probe with the same abort set: `failure|cancelled|timed_out|startup_failure|action_required`
- the same `ERROR: … completed with $failed` / `ERROR: timed out waiting for successful …` message shape
- the same post-wait re-check that the branch did not move (`ERROR: origin/preview moved while waiting for release CI`)

Added on top, because the brief for preview asks for it: every give-up path calls `publish_dispatch_hint`, which prints the exact `gh workflow run publish.yml …` command with the real version and SHA filled in, so the operator resumes by hand instead of reconstructing it.

## The `postinstall-platform.yml` paths-filter decision

`promote-to-main.sh` waits for it **unconditionally**. Preview cannot copy that: `postinstall-platform.yml` carries `paths:` filters, so for a SHA touching no installer-sensitive path it never produces a run at all, and an unconditional wait would burn the full 20 minutes on a run that will never exist.

**Decision: gate the wait on the same detector, over the same range, that `publish.yml` itself uses.**

```sh
PREVIOUS_STABLE_TAG="$(git tag --merged "$RELEASE_SHA" --sort=-v:refname \
  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
…
git diff --name-only "$PREVIOUS_STABLE_TAG..$RELEASE_SHA" > "$CHANGED_FILES"
node scripts/require-release-evidence.mjs --changed-files-stdin < "$CHANGED_FILES" || DETECTOR_STATUS=$?
```

Exit `0` skips the wait, `1` requires it, anything else aborts — the same three case arms as the gate. Rationale:

- **It cannot disagree with the gate.** Any other rule (hardcoding paths, timing out quietly, probing whether a run exists) answers a *different* question than the one that will actually be enforced, which is the exact drift class #346 removed by making `require-release-evidence.mjs` the single source of truth.
- **When the tag lookup is empty, it skips** — mirroring `publish.yml`, which treats a missing previous stable tag as a first release and exits the gate step early.
- **Tags are refreshed first** (`git fetch origin --tags --quiet`, non-fatal). `publish.yml` computes that range on a `fetch-depth: 0` checkout, so a local checkout missing the newest stable tag would answer a different question than the gate.

Worth noting for reviewers: in practice this branch is currently always taken, because `release-preview.sh` commits `package.json` + `package-lock.json` on every release and both are in `postinstall-platform.yml`'s `paths:` list — confirmed by the Postinstall push run that *did* exist for `18e6337`. The conditional is therefore not load-bearing today; it is there so the script stays correct if that ever stops being true, without ever hanging.

Also handled per the brief: an empty `gh run list` result means "GitHub has not materialised the run yet" and keeps polling; a *completed* run with a failure conclusion aborts immediately rather than waiting out the deadline.

## Also in scope

Two output strings still described the pre-hardening world; both verified stale against `origin/dev` and fixed:

- the prerelease body said npm publish "runs from `.github/workflows/publish.yml` on the `preview` branch" — true only under the push trigger, which `publish.yml` no longer has (`on: workflow_dispatch:` only).
- the trailing `Workflow:` link used `?query=branch%3Apreview`, push-trigger-era phrasing that lists nothing for a dispatch-only workflow. Now `?query=event%3Aworkflow_dispatch`.

## Real test output

**`bash -n` and `shellcheck` (v0.11.0):**

```
$ bash -n scripts/release-preview.sh && echo "bash -n OK"
bash -n OK
$ npx --yes shellcheck@latest scripts/release-preview.sh && echo "shellcheck OK (exit 0)"
shellcheck OK (exit 0)
```

(`shellcheck scripts/promote-to-main.sh` exits 1 on three pre-existing SC1083 warnings; the file changed here is clean.)

**Contract test — `tests/unit/release-scripts-contract.test.ts`,** now carrying two new blocks that read `scripts/release-preview.sh`:

```
$ npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test tests/unit/release-scripts-contract.test.ts
✔ scripts/release-preview.sh pushes the tree it just built, not a same-named local branch (1.3236ms)
✔ scripts/release-preview.sh validates Electron shell before publishing (0.2744ms)
✔ scripts/release-preview.sh delegates desktop distribution to release-triggered GitHub Actions (0.285ms)
✔ scripts/release-preview.sh waits for the runs publish.yml gates on before dispatching publish (1.5733ms)
✔ scripts/release-preview.sh describes the dispatch-triggered publish, not the removed push trigger (0.2696ms)
✔ desktop release workflow uploads OS matrix artifacts only after GitHub release publication (0.2712ms)
✔ npm publish workflow uses dev/preview/main branch policy without release retargeting existing versions (0.2865ms)
✔ release branch policy is reflected in CI workflows, release script, installers, and public docs (5.7034ms)
✔ electron-builder scripts stay free of POSIX command substitution (0.3453ms)
ℹ tests 9
ℹ pass 9
ℹ fail 0
```

The new assertions are a real regression guard, not vacuous — checked against `git show origin/dev:scripts/release-preview.sh`:

```
YES  stale prerelease body line present in OLD
YES  push-trigger-era workflow URL present in OLD
NO   dispatch-event workflow URL present in OLD
NO   CI wait present in OLD
NO   detector reuse present in OLD
NO   resume hint present in OLD
```

**Parity suite still green** (the detector is shared, so this is the neighbouring risk):

```
$ npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test tests/unit/installer-sensitive-path-parity.test.ts
ℹ tests 7
ℹ pass 7
ℹ fail 0
```

**Polling logic against real GitHub data**, no dispatch, no publish:

```
$ gh run list --repo lidge-jun/cli-jaw --workflow test.yml --branch preview \
    --commit 18e6337786466b0fe988ca2542d431541397417b --event push --status success \
    --limit 1 --json url --jq '.[0].url // ""'
https://github.com/lidge-jun/cli-jaw/actions/runs/31792403157

$ gh run list --repo lidge-jun/cli-jaw --workflow test.yml --branch preview \
    --commit 0000000000000000000000000000000000000000 --event push --status success \
    --limit 1 --json url --jq '.[0].url // ""'
                    # empty, exit=0 -- "not found" is not an error, so the loop keeps waiting
```

**Detector, real release range** — reproducing exactly what `publish.yml` computed for the failing run:

```
$ git tag --merged 18e6337786466b0fe988ca2542d431541397417b --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1
v2.3.0
$ git diff --name-only v2.3.0..18e6337786466b0fe988ca2542d431541397417b | node scripts/require-release-evidence.mjs --changed-files-stdin; echo "exit=$?"
[release-evidence-required] CHANGED installer-sensitive files (9, 5606150f7d71)
- .github/workflows/postinstall-platform.yml
- README.md
- bin/commands/doctor.ts
- package-lock.json
- package.json
- scripts/require-release-evidence.mjs
- structure/infra.md
- tests/unit/installer-sensitive-path-parity.test.ts
- tests/unit/safe-install.test.ts
exit=1
```

**The wait block executed end-to-end against stubbed `gh`/`git`/`node`/`sleep`.** The harness `sed -n '217,365p'`-extracts the real bytes from `scripts/release-preview.sh` and sources them, so this exercises the shipped code, not a copy. No network, no push, no dispatch, no npm.

| scenario | result |
|---|---|
| sensitive; test run absent on polls 1–2, present on 3 | keeps polling, `✅ Tests`, `✅ Postinstall`, dispatch — exit 0 |
| detector exit 0 (not sensitive) | `platform checks are not required`, platform wait skipped entirely, dispatch — exit 0 |
| no previous stable tag | `treats this as a first release and skips the platform gate`, dispatch — exit 0 |
| Tests conclude `failure` | aborts on the **first** poll with `ERROR: preview Tests completed with failure` + resume hint — exit 1 |
| Tests never appear until deadline | `ERROR: timed out waiting for successful preview Tests` + resume hint — exit 1 |
| detector exits 2 | `ERROR: installer-sensitive path detector failed with status 2` + resume hint — exit 2 |
| `origin/preview` moves during the wait | `ERROR: origin/preview moved while waiting for release CI` + resume hint — exit 1 |

Failure-path output, verbatim:

```
⏳ Waiting for preview Tests on aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
ERROR: preview Tests completed with failure

Resume once the required runs are green:
  gh workflow run publish.yml --ref preview \
    -f version="9.9.9-preview.20260814000000" -f tag=preview -f expected-sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" -f dry-run=false
```

## Not verified

The end-to-end behaviour of a real preview release. Per the task constraints, nothing here ran the release script, pushed to `preview` or `main`, dispatched a workflow, published to npm, or touched a dist-tag. The wait block was exercised only through the stub harness and against read-only `gh run list` queries.

## Relationship to #333

Issue **#333 is closed**. Its work (#344 `ci-aggregate`, #345 rollback docs, #346 the shared installer-sensitive path detector) hardened the *publish gates*. This is **follow-up**, not part of it: it fixes the preview *driver* that dispatches into those gates blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
