### PR TITLE
chore: promote v2.4.1

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.0",
+  "version": "2.4.1-preview.20260814205008",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.4.0",
+      "version": "2.4.1-preview.20260814205008",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.1-preview.20260814205008",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.4.1-preview.20260814205008",
+      "version": "2.4.1",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.0",
+  "version": "2.4.1-preview.20260814205008",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.1-preview.20260814205008",
+  "version": "2.4.1",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.1-preview.20260814205008",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.4.1-preview.20260814205008",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.0",
+  "version": "2.4.1-preview.20260814205008",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.4.0",
+      "version": "2.4.1-preview.20260814205008",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.0",
+  "version": "2.4.1-preview.20260814205008",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.1-preview.20260814205008",
+  "version": "2.4.1",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/scripts/release-preview.sh
+++ b/scripts/release-preview.sh
@@ -7,7 +7,7 @@
 #   ./release-preview.sh --major         → major bump (1.6.9 → 2.0.0-preview.*)
 #   ./release-preview.sh 1.8.0           → explicit base version
 #   ./release-preview.sh --require-evidence  → fail if fresh-machine evidence is missing
-#                                              (default: warn and continue, same as release.sh)
+#                                              (default: warn and continue)
 # npm publish is handled by .github/workflows/publish.yml through npm Trusted
 # Publishing (OIDC). Desktop artifacts are built and attached by GitHub Actions
 # after the GitHub prerelease is published.
@@ -159,8 +159,10 @@ npm version "$PREVIEW_VERSION" --no-git-tag-version
 VERSION=$(node -p "require('./package.json').version")
 echo "📌 package.json version: $VERSION"
 
-# Same reason as release.sh: the committed Electron version names the desktop
-# artifacts. This also has to run BEFORE gate:all below -- the electron-version
+# The committed Electron version names the desktop artifacts, and
+# desktop-release.yml builds from a tag checkout, so the sync has to happen here
+# rather than at build time. promote-to-main.sh does the same, for the same
+# reason. This also has to run BEFORE gate:all below -- the electron-version
 # gate compares the two manifests, and the bump above has just moved the root
 # one, so skipping this would fail the preview release outright.
 echo "🖥️  Syncing Electron version to $VERSION..."
@@ -180,11 +182,15 @@ run_electron_release_checks
 echo "🛡️  Running release gates (gate:all)..."
 npm run gate:all
 
-# Matches release.sh: the fresh-machine evidence gate is advisory by default and
-# enforced with --require-evidence. A preview build is the channel you reach for
-# precisely when installer changes still need real-machine coverage, so making
-# preview stricter than stable had it backwards — it blocked the release that
-# exists to be tested.
+# The fresh-machine evidence gate is advisory here and enforced with
+# --require-evidence. A preview build is the channel you reach for precisely
+# when installer changes still need real-machine coverage, so making preview
+# stricter had it backwards — it blocked the release that exists to be tested.
+#
+# The stable path is the strict one: promote-to-main.sh runs the same gate
+# unconditionally, so missing evidence fails the promotion rather than the
+# preview. Loosening this without tightening that would leave nothing enforcing
+# it.
 if [ "$REQUIRE_EVIDENCE" = true ]; then
   node scripts/require-release-evidence.mjs
 else

--- a/server.ts
+++ b/server.ts
@@ -642,16 +642,23 @@ server.listen(PORT, bindHost, async () => {
     } catch (e: unknown) { console.error('[mcp-init]', (e as Error).message); }
 
     hydrateTargetsFromSettings(settings);
+    // Children first, journal second. The journal's constructor asserts that every
+    // table with a foreign key into it has registered a retention predicate, and a
+    // predicate is only registered by its owning store's constructor. On a FRESH
+    // database the old order survived by accident — the child tables did not exist
+    // yet, so the assert found nothing to complain about. On any host that has
+    // already run this version once, the tables are on disk while the registry is
+    // empty at process start, so the assert threw and took the whole boot with it:
+    // messaging never initialized and every channel silently went dark.
+    //
+    // Creating the stores first is also the honest order — the guard is meant to
+    // prove the children announced themselves, which it cannot do before they exist.
+    initEffectClaimStore(db);
+    initOutboundOutbox(db);
     // Before any transport starts: the journal must exist for the first inbound event,
     // and the connection is handed in rather than imported so the module stays testable
     // against a temporary database.
     initIngressJournal(db);
-    // Right after the journal, before any transport: the retention guard only learns
-    // about a child table when its owner registers a predicate, so a claim store
-    // created lazily on first use would leave a window in which the sweeper is
-    // allowed to delete the parent of a live claim.
-    initEffectClaimStore(db);
-    initOutboundOutbox(db);
     const messagingBoot = await initEnabledMessagingRuntimes();
     // Only `failed` is an incident. An outbound-only Slack install and a deliberate
     // non-attach instance are operator choices; shouting `init failed` at them on

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -19,7 +19,7 @@ aliases: [CLI-JAW Source Structure, str_func, source structure reference]
 
 ```text
 cli-jaw/
-├── server.ts                 ← Express 라우트 base + auth/CORS/rate-limit + WS bootstrap + `register*Routes()` glue + startup stale orc_state guard + graceful shutdown(closeDb) + employee migration + seed defaults + registerAvatarRoutes + async listen bootstrap (await initActiveMessagingRuntime) + orphaned jaw-emp-* cleanup + clearAllEmployeeSessions startup + no-store Vite index serving (715L)
+├── server.ts                 ← Express 라우트 base + auth/CORS/rate-limit + WS bootstrap + `register*Routes()` glue + startup stale orc_state guard + graceful shutdown(closeDb) + employee migration + seed defaults + registerAvatarRoutes + async listen bootstrap (await initActiveMessagingRuntime) + orphaned jaw-emp-* cleanup + clearAllEmployeeSessions startup + no-store Vite index serving (722L)
 ├── lib/                      ← 외부 통합/공용 헬퍼 (5 root files + mcp/ 8 files)
 │   ├── mcp-sync.ts           ← MCP 통합 + 스킬 복사 + softResetSkills + runSkillReset + trusted repair gate + clone cooldown (76L)
 │   ├── mcp/                  ← MCP 모듈 분리 (8 files)

--- a/tests/unit/messaging-boot-order.test.ts
+++ b/tests/unit/messaging-boot-order.test.ts
@@ -1,0 +1,57 @@
+// A cli-jaw upgrade went dark on a real Windows host: 2.4.0 booted, reported
+// ok:true, and answered nothing on Slack. The journal's retention guard threw
+// during startup and killed boot before any transport initialized.
+//
+// The guard asserts that every table with a foreign key into ingress_events has
+// registered a retention predicate, and a predicate is only registered by its
+// owning store's CONSTRUCTOR. server.ts built the journal first, so:
+//
+//   fresh database  -> child tables do not exist yet -> assert finds nothing -> passes
+//   second boot     -> child tables are on disk, registry is empty -> THROWS
+//
+// So the bug could only appear on a host that had already run once. Every test
+// and every fresh install passed. This pins the restart shape specifically.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+
+import {
+    initIngressJournal,
+    __resetChildRetentionPredicatesForTests,
+} from '../../src/messaging/durable-ingress.ts';
+import { initEffectClaimStore } from '../../src/messaging/effect-once.ts';
+import { initOutboundOutbox } from '../../src/messaging/outbound-outbox.ts';
+
+/** The order server.ts boots these in. Children first, journal last. */
+function bootMessagingStores(db: Database.Database): void {
+    initEffectClaimStore(db);
+    initOutboundOutbox(db);
+    initIngressJournal(db);
+}
+
+test('a second boot against an existing database does not throw', () => {
+    const db = new Database(':memory:');
+    bootMessagingStores(db);
+
+    // A new process starts with an empty predicate registry but inherits the
+    // tables from the previous run. This is the exact state of every upgraded
+    // host, and it used to abort startup.
+    __resetChildRetentionPredicatesForTests();
+    assert.doesNotThrow(() => bootMessagingStores(db), 'restart boot must survive');
+});
+
+test('the guard still fires when a child really did not announce itself', () => {
+    const db = new Database(':memory:');
+    bootMessagingStores(db);
+    __resetChildRetentionPredicatesForTests();
+
+    // Only the outbox registers. effect_claims exists on disk with a foreign key
+    // into the journal and no predicate — precisely what the guard is for.
+    initOutboundOutbox(db);
+    assert.throws(
+        () => initIngressJournal(db),
+        /effect_claims.*without a registered retention predicate/s,
+        'the guard must not be weakened into silence',
+    );
+});
+


### PR DESCRIPTION
Promotes the certified preview `2.4.1-preview.20260814205008` at `81e10561`.

## 왜 이 릴리스가 필요한가

**v2.4.0을 이미 설치한 호스트는 재시작하면 모든 채널이 조용히 죽습니다.**

`desktop-c795oh4`(Windows 11)를 2.4.0으로 올리고 재시작하면서 발견했습니다.
서버는 정상 기동하고 `/api/health`가 `ok:true`를 반환하는데 Slack이 아무
반응을 하지 않았습니다.

```
[server] unhandledRejection: Error: ingress retention: effect_claims, outbound_attempts
reference ingress_events without a registered retention predicate.
    at assertChildRetentionPredicatesRegistered (dist/src/messaging/durable-ingress.js:75:15)
    at initIngressJournal (dist/src/messaging/durable-ingress.js:448:5)
    at Server.<anonymous> (dist/server.js:582:5)
```

부팅이 여기서 끊겨 `initEnabledMessagingRuntimes()`가 실행되지 않습니다.
포트는 열리고 health는 초록인데 게이트웨이만 없는 상태가 됩니다.

## 왜 지금까지 안 잡혔나

가드는 "ingress_events를 참조하는 테이블은 retention predicate를 등록해야
한다"고 단언하는데, predicate는 소유 store의 **생성자**에서만 등록됩니다.
`server.ts`가 journal을 먼저 만들었습니다.

| | 자식 테이블 | registry | 결과 |
|---|---|---|---|
| 새 DB 첫 부팅 | 아직 없음 | 비어 있음 | 검사할 FK가 없어 **통과** |
| 두 번째 부팅 | 디스크에 있음 | 비어 있음 | **throw** |

즉 **한 번이라도 돌린 적 있는 호스트에서만** 발생합니다. 새 설치와 CI는
전부 통과했고, 그래서 릴리스 게이트 22/22도 통과했습니다.

## 수정

자식 store를 먼저 만들고 journal을 나중에 만듭니다. 이게 정직한 순서이기도
합니다 — 가드의 목적이 "자식들이 스스로를 등록했는지 증명"하는 것인데,
자식이 존재하기 전에는 그걸 증명할 수 없습니다.

## 회귀 테스트

`tests/unit/messaging-boot-order.test.ts`는 하나의 DB에 대해 registry를
리셋하고 두 번 부팅합니다. 그게 재시작의 실제 모양입니다. 가드가 침묵으로
퇴화하지 않도록 **여전히 throw해야 하는 케이스**도 함께 고정했습니다.

옛 순서로 돌리면 이 테스트는 실패합니다(직접 확인).

## 검증

```
npm test          → 7580 tests, 7559 pass, 0 fail
npm run gate:all  → 22/22 PASS
tsc --noEmit      → clean
```

preview SHA `81e10561` CI: Tests=success, Postinstall Platform Checks=success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging startup and restart reliability when using an existing database.
  * Prevented database initialization errors by ensuring required messaging stores are ready before journal validation.

* **Release**
  * Updated the application and Electron package versions to 2.4.1.

* **Tests**
  * Added coverage for messaging boot order, restart behavior, and invalid child-table configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->