### PR TITLE
chore: promote v2.4.2

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.1",
+  "version": "2.4.2-preview.20260814213712",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.4.1",
+      "version": "2.4.2-preview.20260814213712",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.2-preview.20260814213712",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.4.2-preview.20260814213712",
+      "version": "2.4.2",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.1",
+  "version": "2.4.2-preview.20260814213712",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.4.2-preview.20260814213712",
+  "version": "2.4.2",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.1",
+  "version": "2.4.2-preview.20260814213712",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.4.1",
+      "version": "2.4.2-preview.20260814213712",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.2-preview.20260814213712",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.4.2-preview.20260814213712",
+      "version": "2.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.1",
+  "version": "2.4.2-preview.20260814213712",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.4.2-preview.20260814213712",
+  "version": "2.4.2",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1057,6 +1057,15 @@ export function loadSettings() {
                 user: { ...defaults.avatar.user, ...(raw.avatar?.user || {}) },
             },
            messaging: {
+               // Spread the stored block FIRST. This object is rebuilt field by field,
+               // so anything not named here is dropped — and `enabledChannels` /
+               // `homeChannel` were not named. A v4 document therefore lost its gateway
+               // on every load, and migrateSettings then refilled it from the legacy
+               // `channel` key, which v4 had already deleted, so the fallback landed on
+               // telegram. The result was silent and self-inflicted: a Slack install
+               // read as telegram, no transport started, and the rewritten file made
+               // the corruption permanent on the next boot.
+               ...(raw.messaging || {}),
                latestSeen: { ...defaults.messaging.latestSeen, ...(raw.messaging?.latestSeen || {}) },
                lastActive: { ...defaults.messaging.lastActive, ...(raw.messaging?.lastActive || {}) },
            },

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -38,7 +38,7 @@ cli-jaw/
 │   └── mime-detect.ts        ← MIME 타입 감지 헬퍼 (67L)
 ├── src/
 │   ├── core/                 ← 의존 0 인프라 계층 (31 files, 3847L)
-│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1305L)
+│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1314L)
 │   │   ├── cli-detection.ts  ← CLI 탐지 + `pi` npm-exec fallback + `kiro-code`(`kiro-cli` binary)/`claude-e`/`ai-e` helper `--idle-timeout-ms` compatibility probe + local package release/debug candidates (288L)
 │   │   ├── compact.ts        ← compact 헬퍼 (COMPACT_MARKER_CONTENT, managed summary builder, cutoff logic, harvestGitGrep + harvestChatGrep 1KB/1KB budget split) (772L)
 │   │   ├── instance.ts       ← 인스턴스 ID, node/jaw 경로, 유닛명 sanitize (61L)

--- a/tests/unit/settings-messaging-gateway-load.test.ts
+++ b/tests/unit/settings-messaging-gateway-load.test.ts
@@ -1,0 +1,79 @@
+// A v4 settings document lost its gateway every time it was read.
+//
+// loadSettings() rebuilds the messaging block field by field, and the rebuild
+// named only latestSeen and lastActive. enabledChannels and homeChannel were
+// dropped, migrateSettings then refilled them from the legacy `channel` key —
+// which the v4 migration had already deleted — so the fallback landed on
+// telegram.
+//
+// It was silent and it was permanent: the load path rewrites the file when it
+// migrates, so a Slack install came up as telegram, started no transport, and
+// stayed that way. Seen on a real Windows host where /api/health reported
+// ok:true while Slack answered nothing.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function v4Document(enabled: string[], home: string): Record<string, any> {
+    return {
+        settingsSchemaVersion: 4,
+        runtimeDefaultMigration: null,
+        multiSessionDefaultMigration: null,
+        cli: 'codex-app',
+        multiSession: {
+            enabled: true, maxConcurrent: 2, midRunPolicy: 'steer',
+            channels: { telegram: false, discord: false, slack: true },
+        },
+        slack: { enabled: true, botToken: 'xoxb-test', appToken: 'xapp-test', teamId: 'T1' },
+        messaging: {
+            enabledChannels: enabled,
+            homeChannel: home,
+            latestSeen: { telegram: null, discord: null, slack: null },
+            lastActive: { telegram: null, discord: null, slack: null },
+        },
+    };
+}
+
+async function loadInHome(doc: unknown): Promise<{ settings: any; onDisk: any }> {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-jaw-settings-'));
+    const file = path.join(home, 'settings.json');
+    fs.writeFileSync(file, JSON.stringify(doc, null, 2));
+    process.env['CLI_JAW_HOME'] = home;
+    // Fresh module per home: config.ts resolves its paths at import time.
+    const mod = await import('../../src/core/config.ts?home=' + encodeURIComponent(home));
+    mod.loadSettings();
+    return { settings: mod.settings, onDisk: JSON.parse(fs.readFileSync(file, 'utf8')) };
+}
+
+test('a v4 slack gateway survives being loaded', async () => {
+    const { settings, onDisk } = await loadInHome(v4Document(['slack'], 'slack'));
+
+    assert.deepEqual(settings.messaging.enabledChannels, ['slack'],
+        'the stored gateway must not be replaced by the legacy-channel fallback');
+    assert.equal(settings.messaging.homeChannel, 'slack');
+
+    // A load that corrupts the block in memory makes the corruption permanent,
+    // because the same load path writes the file back. Pin the disk too.
+    assert.deepEqual(onDisk.messaging.enabledChannels, ['slack'],
+        'loading must not rewrite the file with a different gateway');
+    assert.equal(onDisk.messaging.homeChannel, 'slack');
+});
+
+test('the reply-target bookkeeping still merges against defaults', async () => {
+    // The named-field rebuild existed to fill in missing per-channel slots. That
+    // has to keep working, or a document written before a channel existed would
+    // read back without its slot.
+    const doc = v4Document(['slack'], 'slack');
+    doc['messaging'].latestSeen = { telegram: null };
+    doc['messaging'].lastActive = { telegram: null };
+
+    const { settings } = await loadInHome(doc);
+    for (const key of ['telegram', 'discord', 'slack']) {
+        assert.ok(key in settings.messaging.latestSeen, 'latestSeen.' + key + ' must exist');
+        assert.ok(key in settings.messaging.lastActive, 'lastActive.' + key + ' must exist');
+    }
+    assert.deepEqual(settings.messaging.enabledChannels, ['slack']);
+});
+


### PR DESCRIPTION
Promotes the certified preview `2.4.2-preview.20260814213712`.

## 왜 필요한가

**v4 설정 문서는 읽을 때마다 게이트웨이를 잃습니다.**

`loadSettings()`가 `messaging` 블록을 필드 단위로 재조립하는데, 그 목록에
`latestSeen`과 `lastActive`만 있습니다. `enabledChannels`와 `homeChannel`이
통째로 사라진 뒤 `migrateSettings`가 legacy `channel` 키에서 복구를 시도하는데,
v4 마이그레이션이 이미 그 키를 지웠기 때문에 fallback인 **telegram**으로 갑니다.

```
디스크: {"enabledChannels":["slack"],"homeChannel":"slack"}
메모리: {"enabledChannels":["telegram"],"homeChannel":"telegram"}
```

그리고 load 경로가 마이그레이션 시 파일을 다시 쓰므로 **잘못된 값이 디스크에
영구 기록**됩니다. 다음 부팅은 그걸 진실로 읽습니다.

## 왜 눈에 안 띄었나

아무것도 설정을 가리키지 않았습니다. 서버는 포트를 열고, `/api/health`는
`ok:true`, `slack.configured`도 토큰이 남아 있어 `true`였습니다. 유일한 신호는
파일이 명백히 `["slack"]`인데 `activeInboundChannels`가 비어 있다는 것뿐이었습니다.

Windows 호스트를 2.4.0으로 올리는 중 발견했습니다. Slack이 설정돼 있고
스코프도 완전한데 아무 반응이 없었습니다.

## 수정

저장된 블록을 먼저 spread합니다. 명시 필드가 하던 per-channel 기본값 병합은
그대로 유지되고, 재조립이 어떤 키의 존재를 임의로 결정하지 않게 됩니다.

## 회귀 테스트

`tests/unit/settings-messaging-gateway-load.test.ts`는 실제 v4 문서를 임시 home에
쓰고 로드한 뒤 **메모리와 디스크 양쪽**을 확인합니다. 디스크까지 보는 이유는
이 버그의 진짜 피해가 영속화이기 때문입니다. 수정 없이 돌리면 2건 모두
실패합니다(직접 확인).

두 번째 테스트는 명시 필드가 원래 하던 일(누락된 채널 슬롯 채우기)이 여전히
동작하는지 고정합니다.

## 검증

```
npm test          → 7582 tests, 7560 pass, 1 fail (FC-007, 환경 의존 기존 실패)
npm run gate:all  → 22/22 PASS
tsc --noEmit      → clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved saved messaging channel and home-channel settings when loading configurations.
  * Prevented valid gateway settings from being replaced by default fallback values.
  * Ensured missing activity-tracking fields continue to receive appropriate defaults.

* **Tests**
  * Added coverage verifying messaging settings survive loading and rewriting.

* **Chores**
  * Updated the application version to 2.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->