### PR TITLE
chore: promote v2.17.3

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3-preview.20260816002955",
+  "version": "2.17.2-preview.20260816010039",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.3-preview.20260816002955",
+      "version": "2.17.2-preview.20260816010039",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3-preview.20260816011125",
+  "version": "2.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.3-preview.20260816011125",
+      "version": "2.17.3",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.2-preview.20260816010039",
+  "version": "2.17.3-preview.20260816011125",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.2-preview.20260816010039",
+      "version": "2.17.3-preview.20260816011125",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3-preview.20260816011125",
+  "version": "2.17.3",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3-preview.20260816002955",
+  "version": "2.17.2-preview.20260816010039",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.2-preview.20260816010039",
+  "version": "2.17.3-preview.20260816011125",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/sidecar/jawcode/packages/jwc/scripts/bootstrap-cli-jaw-home.cjs
+++ b/electron/sidecar/jawcode/packages/jwc/scripts/bootstrap-cli-jaw-home.cjs
@@ -274,30 +274,38 @@ function resolveLinkTarget(linkPath) {
 }
 
 /**
- * True when the symlink at `p` is one of ours: it resolves inside `ownerDir`.
- * A user may point skills/jaw-browser at their own checkout; that is theirs.
+ * True when the symlink at `p` is one WE created: it already aims at
+ * `expectedTarget`. "Inside the tree" is not ownership — a user can point
+ * skills/jaw-browser at their own skills/my-browser, and that link is theirs.
  */
-function isOwnedCompatLink(p, ownerDir) {
+function isOwnedCompatLink(p, expectedTarget) {
+	try { if (!fs.lstatSync(p).isSymbolicLink()) return false; } catch { return false; }
+	if (linkPointsAt(p, expectedTarget)) return true;
 	try {
-		if (!fs.lstatSync(p).isSymbolicLink()) return false;
-		const resolved = resolveLinkTarget(p);
-		const root = path.resolve(ownerDir);
-		return resolved === root || resolved.startsWith(root + path.sep);
+		return !fs.existsSync(p) && path.basename(fs.readlinkSync(p)) === path.basename(expectedTarget);
 	} catch { return false; }
 }
 
-/** True when the canonical path is an immovable collision. */
-function canonicalIsBlocked(canonicalPath, ownerDir) {
+/**
+ * True when the canonical path is an immovable collision. `legacyId` is passed
+ * because a link aimed at the directory we are migrating (jaw-browser ->
+ * browser) is ours too — leaving it strands a link whose target is moving.
+ */
+function canonicalIsBlocked(canonicalPath, canonicalId, legacyId) {
 	let stat = null;
 	// lstat, not existsSync: a dangling link still occupies the path.
 	try { stat = fs.lstatSync(canonicalPath); } catch { return false; }
 	if (!stat.isSymbolicLink()) return true;
-	return !isOwnedCompatLink(canonicalPath, ownerDir);
+	if (isOwnedCompatLink(canonicalPath, canonicalId)) return false;
+	if (legacyId && linkPointsAt(canonicalPath, legacyId)) return false;
+	return true;
 }
 
 /** Remove a compat link we own so a rename can land on its path. */
-function clearOwnedLink(p, ownerDir) {
-	try { if (isOwnedCompatLink(p, ownerDir)) fs.unlinkSync(p); } catch { /* nothing there */ }
+function clearOwnedLink(p, canonicalId, legacyId) {
+	try {
+		if (isOwnedCompatLink(p, canonicalId) || (legacyId && linkPointsAt(p, legacyId))) fs.unlinkSync(p);
+	} catch { /* nothing there */ }
 }
 
 /** True when the link at `p` already resolves to its sibling `target`. */
@@ -324,10 +332,16 @@ function migrateRefNamespace() {
 		const legacyPath = path.join(refDir, legacyId);
 		let stat = null;
 		try { stat = fs.lstatSync(legacyPath); } catch { continue; }
-		if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+		if (stat.isSymbolicLink()) {
+			// The reference tree carries no compat links; a stray one is noise
+			// the detector would otherwise report pending on every run.
+			try { fs.unlinkSync(legacyPath); } catch { /* leave it */ }
+			continue;
+		}
+		if (!stat.isDirectory()) continue;
 		try {
-			if (!canonicalIsBlocked(path.join(refDir, canonicalId), refDir)) {
-				clearOwnedLink(path.join(refDir, canonicalId), refDir);
+			if (!canonicalIsBlocked(path.join(refDir, canonicalId), canonicalId, legacyId)) {
+				clearOwnedLink(path.join(refDir, canonicalId), canonicalId, legacyId);
 				fs.renameSync(legacyPath, path.join(refDir, canonicalId));
 			} else {
 				if (!backupRoot) {
@@ -361,10 +375,10 @@ function normalizeSkillNamespace() {
 			try { fs.unlinkSync(legacyPath); } catch { /* leave it alone */ }
 		} else if (stat && stat.isDirectory()) {
 			try {
-				if (!canonicalIsBlocked(path.join(activeDir, canonicalId), activeDir)) {
+				if (!canonicalIsBlocked(path.join(activeDir, canonicalId), canonicalId, legacyId)) {
 					// Free canonical name: rename, so an in-place user edit is
 					// carried forward instead of stranded in a backup.
-					clearOwnedLink(path.join(activeDir, canonicalId), activeDir);
+					clearOwnedLink(path.join(activeDir, canonicalId), canonicalId, legacyId);
 					fs.renameSync(legacyPath, path.join(activeDir, canonicalId));
 					console.log(`[skills] legacy skill migrated: ${legacyId} -> ${canonicalId}`);
 				} else {

--- a/lib/mcp/skills-migration.ts
+++ b/lib/mcp/skills-migration.ts
@@ -23,7 +23,7 @@
  */
 import fs from 'fs';
 import os from 'os';
-import { basename, dirname, isAbsolute, join, resolve, sep } from 'path';
+import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import { LEGACY_SKILL_ALIASES } from './skills-aliases.js';
 import { createBackupContext, movePathToBackup } from './skills-symlinks.js';
 
@@ -64,20 +64,26 @@ function pointsAt(p: string, expectedTarget: string): boolean {
 }
 
 /**
- * True when the symlink at `p` is one of OURS: a compat link that resolves
- * somewhere inside `ownerDir`.
+ * True when the symlink at `p` is one WE created: a compat link that resolves
+ * to `expectedTarget`, or a dangling link that was aiming there.
  *
- * A user may point `skills/jaw-browser` at a checkout of their own. Clearing
- * that to make room for a rename would destroy their setup, so only links that
- * stay inside the skill tree are ever removed.
+ * "Somewhere inside the skill tree" is not ownership — a user can point
+ * `skills/jaw-browser` at their own `skills/my-browser`, and that link is
+ * theirs. Only a link already aimed at the exact id we are about to write may
+ * be cleared, because replacing it changes nothing the user chose.
  */
-function isOwnedCompatLink(p: string, ownerDir: string): boolean {
+function isOwnedCompatLink(p: string, expectedTarget: string): boolean {
     try {
         if (!fs.lstatSync(p).isSymbolicLink()) return false;
+    } catch {
+        return false;
+    }
+    if (pointsAt(p, expectedTarget)) return true;
+    // A link we wrote whose target has since gone missing still points at the
+    // id we own; anything else belongs to the user.
+    try {
         const raw = fs.readlinkSync(p);
-        const resolved = isAbsolute(raw) ? resolve(raw) : resolve(dirname(p), raw);
-        const root = resolve(ownerDir);
-        return resolved === root || resolved.startsWith(root + sep);
+        return !fs.existsSync(p) && basename(raw) === basename(expectedTarget);
     } catch {
         return false;
     }
@@ -96,24 +102,34 @@ function pathIsOccupied(p: string): boolean {
 }
 
 /** Move `legacyPath` onto `canonicalPath`, clearing OUR stale link first. */
-function renameOntoCanonical(legacyPath: string, canonicalPath: string, ownerDir: string): void {
-    // Only a link we own may be cleared: a real directory is a genuine
-    // collision (the caller backs the legacy copy up), and a link pointing
-    // outside the tree belongs to the user.
+function renameOntoCanonical(legacyPath: string, canonicalPath: string, canonicalId: string, legacyId?: string): void {
+    // Only a link we wrote may be cleared: a real directory is a genuine
+    // collision (the caller backs the legacy copy up), and a link the user
+    // aimed somewhere else is theirs.
     try {
-        if (isOwnedCompatLink(canonicalPath, ownerDir)) fs.unlinkSync(canonicalPath);
+        if (isOwnedCompatLink(canonicalPath, canonicalId)
+            || (legacyId && pointsAt(canonicalPath, legacyId))) fs.unlinkSync(canonicalPath);
     } catch { /* nothing there */ }
     fs.renameSync(legacyPath, canonicalPath);
 }
 
-/** True when the canonical path must be treated as an immovable collision. */
-function canonicalIsBlocked(canonicalPath: string, ownerDir: string): boolean {
+/**
+ * True when the canonical path must be treated as an immovable collision.
+ *
+ * `legacyId` is passed because a link aimed at the very directory we are
+ * migrating (`jaw-browser -> browser`) is ours too: leaving it would strand a
+ * link whose target is about to move, and the skill would stop resolving.
+ */
+function canonicalIsBlocked(canonicalPath: string, canonicalId: string, legacyId?: string): boolean {
     if (!pathIsOccupied(canonicalPath)) return false;
     try {
         if (!fs.lstatSync(canonicalPath).isSymbolicLink()) return true;
     } catch { return false; }
-    // A symlink is only ours to clear when it resolves inside the skill tree.
-    return !isOwnedCompatLink(canonicalPath, ownerDir);
+    // A symlink is only ours to clear when we are the one who aimed it —
+    // either at the canonical id, or back at the legacy directory itself.
+    if (isOwnedCompatLink(canonicalPath, canonicalId)) return false;
+    if (legacyId && pointsAt(canonicalPath, legacyId)) return false;
+    return true;
 }
 
 /**
@@ -157,12 +173,12 @@ export function migrateLegacySkillDirs(activeDir: string, jawHome: string): Lega
         try {
             const canonicalPath = join(activeDir, canonicalId);
             // lstat, not existsSync: a dangling compat link occupies the path.
-            if (canonicalIsBlocked(canonicalPath, activeDir)) {
+            if (canonicalIsBlocked(canonicalPath, canonicalId, legacyId)) {
                 backup ??= createBackupContext(jawHome);
                 const moved = movePathToBackup(legacyPath, backup);
                 result.backedUp.push(`${legacyId} -> ${moved}`);
             } else {
-                renameOntoCanonical(legacyPath, canonicalPath, activeDir);
+                renameOntoCanonical(legacyPath, canonicalPath, canonicalId, legacyId);
                 result.renamed.push(`${legacyId} -> ${canonicalId}`);
             }
         } catch (e) {
@@ -260,12 +276,12 @@ export function migrateLegacyRefDirs(refDir: string, jawHome: string): LegacyMig
         if (!stat.isDirectory()) continue;
 
         try {
-            if (canonicalIsBlocked(canonicalPath, refDir)) {
+            if (canonicalIsBlocked(canonicalPath, canonicalId, legacyId)) {
                 backup ??= createBackupContext(jawHome);
                 const moved = movePathToBackup(legacyPath, backup);
                 result.backedUp.push(`skills_ref/${legacyId} -> ${moved}`);
             } else {
-                renameOntoCanonical(legacyPath, canonicalPath, refDir);
+                renameOntoCanonical(legacyPath, canonicalPath, canonicalId, legacyId);
                 result.renamed.push(`skills_ref/${legacyId} -> ${canonicalId}`);
             }
         } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.1-preview.20260816001738",
+  "version": "2.17.2-preview.20260816010039",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.1-preview.20260816001738",
+      "version": "2.17.2-preview.20260816010039",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.2-preview.20260816010039",
+  "version": "2.17.3-preview.20260816011125",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.2-preview.20260816010039",
+      "version": "2.17.3-preview.20260816011125",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.3-preview.20260816011125",
+  "version": "2.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.3-preview.20260816011125",
+      "version": "2.17.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.1-preview.20260816001738",
+  "version": "2.17.2-preview.20260816010039",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.3-preview.20260816011125",
+  "version": "2.17.3",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.2-preview.20260816010039",
+  "version": "2.17.3-preview.20260816011125",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/tests/unit/skill-namespace-migration.test.ts
+++ b/tests/unit/skill-namespace-migration.test.ts
@@ -320,3 +320,29 @@ test('SNM-019: the Electron default set matches the runtime active set', () => {
     const expected = [...CODEX_ACTIVE, ...OPENCLAW_ACTIVE].sort();
     assert.deepEqual(ids, expected);
 });
+
+test('SNM-020: a user link aimed at another IN-TREE skill is still theirs', () => {
+    // 'somewhere inside the skill tree' is not ownership. Someone can point
+    // skills/jaw-browser at their own skills/my-browser; only a link already
+    // aimed at the id we are about to write is ours to clear.
+    withBox(root => {
+        const home = makeHome(root, '.cli-jaw');
+        const active = join(home, 'skills');
+        makeSkill(active, 'my-browser', 'MY OWN SKILL\n');
+        fs.symlinkSync('my-browser', join(active, 'jaw-browser'), 'junction');
+        makeSkill(active, 'browser', 'LEGACY\n');
+
+        migrateAllJawHomes(home);
+
+        assert.equal(fs.readFileSync(join(active, 'jaw-browser', 'SKILL.md'), 'utf8'), 'MY OWN SKILL\n');
+        assert.equal(fs.existsSync(join(active, 'my-browser', 'SKILL.md')), true);
+    });
+});
+
+test('SNM-021: the Electron migrator clears a stray reference link', () => {
+    // TS removes it; CJS used to skip it, so the detector reported the same
+    // home pending forever.
+    assert.doesNotMatch(CJS, /if \(stat\.isSymbolicLink\(\) \|\| !stat\.isDirectory\(\)\) continue;/,
+        'a stray reference link must be removed, not skipped');
+});
+


### PR DESCRIPTION
Promotes certified preview 2.17.3-preview.20260816011125 at 6f9165a680d5728557831985798330ad1d151a33. Tests: https://github.com/lidge-jun/cli-jaw/actions/runs/31894853257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill migration handling for canonical and legacy links.
  * Preserved user-owned symlinks during migrations.
  * Removed stray reference links when appropriate.
  * Improved collision detection, including for dangling links, to prevent incorrect link replacement or migration failures.

* **Tests**
  * Added coverage for user-owned links and cleanup of stray migration links.

* **Chores**
  * Updated the application version to 2.17.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->