### PR TITLE
chore: promote v2.17.4

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.4-preview.20260818181009",
+  "version": "2.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.4-preview.20260818181009",
+      "version": "2.17.4",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3",
+  "version": "2.17.4-preview.20260818181009",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.3",
+      "version": "2.17.4-preview.20260818181009",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.3",
+  "version": "2.17.4-preview.20260818181009",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.4-preview.20260818181009",
+  "version": "2.17.4",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/src/main/lib/install-cli.ts
+++ b/electron/src/main/lib/install-cli.ts
@@ -1,10 +1,40 @@
-import { existsSync, symlinkSync, unlinkSync, mkdirSync, lstatSync, realpathSync } from 'node:fs';
+import { existsSync, symlinkSync, unlinkSync, mkdirSync, lstatSync, realpathSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { execSync } from 'node:child_process';
 import { app, dialog } from 'electron';
 
 const CLI_BINS = ['jaw'] as const;
+
+// The launch prompt must ask at most once. Previously every app start re-asked
+// users who had already chosen Skip, which read as a nagging install alarm.
+// The tray menu keeps a manual install entry, so a declined prompt loses
+// nothing.
+const INSTALL_PROMPT_PREFS_FILENAME = 'cli-install-prompt.json';
+
+function installPromptPrefsPath(): string {
+  return join(app.getPath('userData'), INSTALL_PROMPT_PREFS_FILENAME);
+}
+
+function hasDeclinedInstallPrompt(): boolean {
+  try {
+    const parsed = JSON.parse(readFileSync(installPromptPrefsPath(), 'utf8')) as { declined?: unknown };
+    return parsed.declined === true;
+  } catch {
+    return false;
+  }
+}
+
+function rememberDeclinedInstallPrompt(): void {
+  try {
+    writeFileSync(
+      installPromptPrefsPath(),
+      JSON.stringify({ declined: true, declinedAt: new Date().toISOString() }, null, 2),
+    );
+  } catch {
+    // Best-effort: failing to persist only means the prompt may appear again.
+  }
+}
 
 const SYMLINK_DIR: Record<string, string> = {
   darwin: '/usr/local/bin',
@@ -126,6 +156,7 @@ export async function promptInstallCli(): Promise<void> {
   if (!app.isPackaged) return;
   if (isCliInstalled()) return;
   if (!getSidecarBinPath('jaw')) return;
+  if (hasDeclinedInstallPrompt()) return;
 
   const { response } = await dialog.showMessageBox({
     type: 'question',
@@ -143,5 +174,8 @@ export async function promptInstallCli(): Promise<void> {
       message: result.ok ? 'CLI Installed' : 'Installation Failed',
       detail: result.message,
     });
+    return;
   }
+
+  rememberDeclinedInstallPrompt();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.4-preview.20260818181009",
+  "version": "2.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.4-preview.20260818181009",
+      "version": "2.17.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.3",
+  "version": "2.17.4-preview.20260818181009",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.3",
+      "version": "2.17.4-preview.20260818181009",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.3",
+  "version": "2.17.4-preview.20260818181009",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.4-preview.20260818181009",
+  "version": "2.17.4",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/tests/unit/manager-electron-desktop-contract.test.ts
+++ b/tests/unit/manager-electron-desktop-contract.test.ts
@@ -95,6 +95,8 @@ test('Electron CLI installer rejects incomplete or partially installed sidecar c
     assert.ok(installCli.includes("buttons: ['Skip', 'Install']"), 'install prompt must make the non-invasive option first');
     assert.ok(installCli.includes('Existing terminal commands are not overwritten'), 'install prompt must disclose that existing commands are protected');
     assert.ok(installCli.includes("if (response === 1)"), 'install prompt must only install after the explicit Install choice');
+    assert.ok(installCli.includes('if (hasDeclinedInstallPrompt()) return'), 'install prompt must not re-ask after the user declined once');
+    assert.ok(installCli.includes('rememberDeclinedInstallPrompt()'), 'a Skip choice must be persisted so launches stop prompting');
     assert.ok(installCli.includes('Windows installer PATH entry'), 'Windows packaged installs must explain that NSIS owns PATH setup instead of symlinking');
     assert.equal(installCli.includes('Partial failures:'), false, 'installCli must not append partial failures to an ok:true success message');
 });


### PR DESCRIPTION
Promotes certified preview 2.17.4-preview.20260818181009 at 3f0897fd49788fb8337b3c83b873e690395d2a93. Tests: https://github.com/lidge-jun/cli-jaw/actions/runs/32120208079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent preference for declining the CLI installation prompt.
  * The prompt is no longer shown after a user declines it.

* **Bug Fixes**
  * Improved handling of CLI installation preferences across app launches.

* **Chores**
  * Updated the application version to 2.17.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->