### PR TITLE
fix(release): delete the promotion branch when the promotion never merges

### DIFF
--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -47,10 +47,35 @@ REMOTE_URL="$(git remote get-url origin)"
 PROMOTION_TMP_ROOT="$(promotion_tmp_root)"
 WORKTREE="$(mktemp -d "$PROMOTION_TMP_ROOT/cli-jaw-promote.XXXXXX")"
 PROMOTION_BRANCH="codex/promote-${STABLE_VERSION}-${PREVIEW_SHA:0:12}"
+# Guards for the remote-branch cleanup below. PROMOTION_BRANCH_PUSHED is proof
+# that THIS run created the remote ref: a re-run computes the same branch name
+# from the same version and preview SHA, so deleting by name alone could destroy
+# a branch another promotion is still using. PROMOTION_PR_MERGED hands the
+# success path back to the repo's delete_branch_on_merge setting.
+PROMOTION_BRANCH_PUSHED=0
+PROMOTION_PR_MERGED=0
 cleanup() {
+  local status=$?
   if ! cleanup_promotion_checkout "$WORKTREE"; then
     echo "WARNING: failed to clean promotion checkout: $WORKTREE" >&2
   fi
+  # Anything that aborts between the push and the merge would otherwise leave
+  # the promotion branch on origin forever; that is how codex/promote-2.3.0,
+  # -2.4.0, -2.4.1, -2.4.2 and -2.17.3-6f9165a680d5 accumulated. Delete first
+  # and classify afterwards, so a probe that cannot reach origin warns loudly
+  # instead of silently deciding the branch was already gone.
+  if [ "$PROMOTION_BRANCH_PUSHED" -eq 1 ] && [ "$PROMOTION_PR_MERGED" -eq 0 ]; then
+    if git push origin --delete "$PROMOTION_BRANCH" >/dev/null 2>&1; then
+      echo "cleaned up remote promotion branch after unfinished promotion: $PROMOTION_BRANCH"
+    elif ! git ls-remote --exit-code --heads origin "$PROMOTION_BRANCH" >/dev/null 2>&1; then
+      echo "remote promotion branch already absent: $PROMOTION_BRANCH"
+    else
+      echo "WARNING: failed to delete remote promotion branch: $PROMOTION_BRANCH (delete it manually)" >&2
+    fi
+  fi
+  # The trap runs on every exit, including the failure it is cleaning up after.
+  # Re-raise the original status so cleanup never rewrites the script's result.
+  exit "$status"
 }
 trap cleanup EXIT
 prepare_promotion_checkout "$REMOTE_URL" "$PREVIEW_SHA" "$PROMOTION_BRANCH" "$WORKTREE"
@@ -67,6 +92,10 @@ prepare_promotion_checkout "$REMOTE_URL" "$PREVIEW_SHA" "$PROMOTION_BRANCH" "$WO
   assert_promotion_checkout_ready_to_push "$WORKTREE" "$PREVIEW_SHA" "$PROMOTION_BRANCH"
   git push --set-upstream origin "$PROMOTION_BRANCH"
 )
+# A flag set inside the subshell cannot reach the trap, so it is set here. That
+# is equivalent to "immediately after the push" only while the push stays the
+# LAST command in the block above; keep it last (pinned by the contract test).
+PROMOTION_BRANCH_PUSHED=1
 
 PROMOTION_COMMIT="$(git -C "$WORKTREE" rev-parse HEAD)"
 PR_URL="$(gh pr create \
@@ -77,6 +106,10 @@ PR_URL="$(gh pr create \
 
 gh pr checks "$PR_URL" --required --watch --fail-fast
 gh pr merge "$PR_URL" --squash --match-head-commit "$PROMOTION_COMMIT"
+# From here the branch belongs to GitHub's delete_branch_on_merge. Racing that
+# auto-delete only produces confusing errors, and a later verification failure
+# is not a reason to remove a branch whose merge already landed.
+PROMOTION_PR_MERGED=1
 
 MERGED_AT="$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt // ""')"
 if [ -z "$MERGED_AT" ]; then

--- a/tests/unit/release-scripts-contract.test.ts
+++ b/tests/unit/release-scripts-contract.test.ts
@@ -182,6 +182,122 @@ test('stable promotion delegates checkout isolation and never auto-rewrites docs
     assert.ok(!script.includes('verify-counts.sh --fix'));
 });
 
+test('stable promotion deletes the remote promotion branch it pushed when the promotion never merges', () => {
+    // The script mints codex/promote-<version>-<sha12>, pushes it to origin,
+    // opens a PR and squash-merges it, but its EXIT trap only removed the LOCAL
+    // checkout. Every abort between the push and the merge therefore leaked the
+    // branch on origin: codex/promote-2.3.0, -2.4.0, -2.4.1, -2.4.2 and
+    // -2.17.3-6f9165a680d5 all had to be deleted by hand, the last one after a
+    // promotion whose publish dispatch failed three times.
+    //
+    // The SUCCESS path is deliberately not this script's job: the repository has
+    // delete_branch_on_merge enabled, so GitHub removes the branch as the PR
+    // merges. Deleting it here too would only race that and print confusing
+    // errors. This pins the failure path, and only the failure path.
+    const script = read('scripts/promote-to-main.sh');
+    const cleanup = script.slice(script.indexOf('cleanup() {'), script.indexOf('trap cleanup EXIT'));
+
+    assert.ok(cleanup.includes('cleanup() {'), 'promotion script must still install a cleanup trap body');
+
+    // The pre-existing local checkout cleanup must survive untouched.
+    assert.ok(
+        cleanup.includes('if ! cleanup_promotion_checkout "$WORKTREE"; then'),
+        'cleanup must keep removing the local promotion checkout',
+    );
+    assert.ok(
+        cleanup.includes('WARNING: failed to clean promotion checkout'),
+        'cleanup must keep warning when the local checkout cannot be removed',
+    );
+
+    // cleanup() runs under `set -u`. Both flags must exist before the trap is
+    // installed, or a failure before the assignments would surface as an
+    // unbound-variable error instead of the real one.
+    const trapIndex = script.indexOf('trap cleanup EXIT');
+    const pushedInit = script.indexOf('PROMOTION_BRANCH_PUSHED=0');
+    const mergedInit = script.indexOf('PROMOTION_PR_MERGED=0');
+    assert.ok(pushedInit !== -1 && pushedInit < trapIndex, 'PROMOTION_BRANCH_PUSHED must be initialised before the trap is installed');
+    assert.ok(mergedInit !== -1 && mergedInit < trapIndex, 'PROMOTION_PR_MERGED must be initialised before the trap is installed');
+
+    // Deleting on the branch NAME alone would be worse than leaking: a re-run
+    // computes the same name from the same version and preview SHA, so the
+    // delete has to be gated on this run having actually created the ref.
+    assert.ok(
+        cleanup.includes('[ "$PROMOTION_BRANCH_PUSHED" -eq 1 ] && [ "$PROMOTION_PR_MERGED" -eq 0 ]'),
+        'the remote delete must require both "this run pushed it" and "the merge did not complete"',
+    );
+    assert.ok(
+        cleanup.includes('git push origin --delete "$PROMOTION_BRANCH"'),
+        'cleanup must delete the tracked promotion branch from origin',
+    );
+    assert.ok(
+        !/--delete\s+["']?codex\/promote/.test(cleanup),
+        'cleanup must never delete a literal or globbed promotion branch name',
+    );
+
+    // The push lives in a subshell, whose assignments cannot reach the trap, so
+    // the flag is set just outside it. That is only equivalent to "set right
+    // after a successful push" while the push stays the LAST command of the
+    // block -- anything appended after it would make the flag mean something else.
+    const pushIndex = script.indexOf('git push --set-upstream origin "$PROMOTION_BRANCH"');
+    assert.ok(pushIndex !== -1, 'promotion script must push the promotion branch');
+    assert.ok(
+        script.includes('  git push --set-upstream origin "$PROMOTION_BRANCH"\n)\n'),
+        'the push must remain the last command of the push subshell, or PROMOTION_BRANCH_PUSHED no longer tracks the push',
+    );
+    const pushedFlag = script.indexOf('PROMOTION_BRANCH_PUSHED=1');
+    const prCreateIndex = script.indexOf('gh pr create');
+    assert.ok(pushedFlag > pushIndex, 'PROMOTION_BRANCH_PUSHED must be set after the push succeeds');
+    assert.ok(pushedFlag < prCreateIndex, 'PROMOTION_BRANCH_PUSHED must be set before the PR exists, so a failed gh pr create still cleans up');
+
+    // Once the merge lands, GitHub owns the branch. Every later verification in
+    // this script can still exit 1, and none of those is a reason to delete a
+    // branch whose merge already happened.
+    const mergeIndex = script.indexOf('gh pr merge "$PR_URL"');
+    const mergedFlag = script.indexOf('PROMOTION_PR_MERGED=1');
+    assert.ok(mergeIndex !== -1, 'promotion script must squash-merge the promotion PR');
+    assert.ok(mergedFlag > mergeIndex, 'PROMOTION_PR_MERGED must be set once gh pr merge succeeds');
+    assert.ok(
+        mergedFlag < script.indexOf('MERGED_AT='),
+        'PROMOTION_PR_MERGED must be set before the post-merge verification that can still exit 1',
+    );
+
+    // The trap fires on the very failure it is cleaning up after, so it must not
+    // become the thing that decides the exit code.
+    assert.ok(
+        /cleanup\(\) \{\n  local status=\$\?\n/.test(script),
+        'cleanup must capture the original exit status before running anything else',
+    );
+    assert.ok(cleanup.includes('exit "$status"'), 'cleanup must re-raise the original exit status');
+
+    // Under `set -e` a bare failing command inside the trap aborts the trap and
+    // replaces the real exit code, so every fallible cleanup command has to sit
+    // in a condition.
+    for (const line of cleanup.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#') || !/\bgit /.test(trimmed)) continue;
+        assert.ok(
+            /^(if|elif) /.test(trimmed),
+            `cleanup runs "${trimmed}" outside a condition: under set -e that aborts the trap and rewrites the exit code`,
+        );
+    }
+
+    // A failed delete is a warning naming the branch, never a hard error, and a
+    // successful delete says so -- a failed promotion must not mutate remote
+    // state silently.
+    assert.ok(
+        cleanup.includes('WARNING: failed to delete remote promotion branch: $PROMOTION_BRANCH (delete it manually)'),
+        'a failed delete must warn with the branch name so an operator can remove it by hand',
+    );
+    assert.ok(
+        /echo "cleaned up remote promotion branch[^"]*\$PROMOTION_BRANCH"/.test(cleanup),
+        'cleanup must announce the branch it deleted',
+    );
+    assert.ok(
+        cleanup.includes('git ls-remote --exit-code --heads origin "$PROMOTION_BRANCH"'),
+        'a failed delete must be classified against origin so an already-deleted branch is not reported as a failure',
+    );
+});
+
 test('desktop release workflow uploads OS matrix artifacts only after GitHub release publication', () => {
     const workflow = read('.github/workflows/desktop-release.yml');
 


### PR DESCRIPTION
## The gap

`scripts/promote-to-main.sh` mints a promotion branch, pushes it to origin, opens a PR against `main` and squash-merges it:

```
PROMOTION_BRANCH="codex/promote-${STABLE_VERSION}-${PREVIEW_SHA:0:12}"   # line 49
git push --set-upstream origin "$PROMOTION_BRANCH"                        # line 68 (in a subshell)
PR_URL="$(gh pr create ...)"                                              # line 72
gh pr merge "$PR_URL" --squash --match-head-commit "$PROMOTION_COMMIT"    # line 79
```

Its `trap cleanup EXIT` (line 55) removed only the **local** promotion checkout. The pushed remote ref was nobody's job on any path that did not reach a merge.

**Evidence — five leaked branches, deleted by hand:**

| branch | PR |
| --- | --- |
| `codex/promote-2.3.0` | #343 |
| `codex/promote-2.4.0` | #353 |
| `codex/promote-2.4.1` | #356 |
| `codex/promote-2.4.2` | #357 |
| `codex/promote-2.17.3-6f9165a680d5` | #376 |

## Why the success path is out of scope

`delete_branch_on_merge` is now enabled on the repository (verified: `gh api repos/lidge-jun/cli-jaw --jq .delete_branch_on_merge` → `true`). GitHub deletes the promotion branch as the PR merges. Adding a delete here for that path would only race the auto-delete and turn a clean promotion into one that prints an error about a ref that is already gone.

The hole that remains is the **failure** path, and that is the one that actually leaked.

> **Correction to the framing this was scoped from.** There are **zero** explicit `exit 1` statements between the push and `gh pr merge` — verified by inspection; all **14** of them sit *after* the merge, where `PROMOTION_PR_MERGED` deliberately suppresses cleanup. The leaking window is governed by `set -e` on four commands:
>
> ```
> PROMOTION_COMMIT="$(git -C "$WORKTREE" rev-parse HEAD)"
> PR_URL="$(gh pr create ...)"
> gh pr checks "$PR_URL" --required --watch --fail-fast
> gh pr merge  "$PR_URL" --squash --match-head-commit "$PROMOTION_COMMIT"
> ```
>
> plus an operator interrupt during the `--watch`, which can be a long wait. A red required check tripping `--fail-fast`, or Ctrl-C during that watch, is the realistic leak.

## Flag design

Two flags, because both of the mistakes they prevent are worse than the leak itself.

**`PROMOTION_BRANCH_PUSHED`** — proof that *this run* created the remote ref. The branch name is a pure function of the stable version and the preview SHA, so a re-run computes the **same** name. Deleting on the name alone could destroy a branch a concurrent promotion is still using; leaking one is the lesser failure.

It is set just **outside** the push subshell, not inside it — a subshell assignment cannot reach the parent's trap. That is only equivalent to "immediately after a successful push" while the push remains the **last** command of that block, so a contract assertion pins it there:

```ts
assert.ok(
    script.includes('  git push --set-upstream origin "$PROMOTION_BRANCH"\n)\n'),
    'the push must remain the last command of the push subshell, ...',
);
```

**`PROMOTION_PR_MERGED`** — set the instant `gh pr merge` returns, *before* the post-merge verification block. A SHA-mismatch or version-mismatch failure after a merge that already landed is not a reason to delete a merged branch; from that point the branch belongs to `delete_branch_on_merge`.

**Not masking the failure.** The trap fires on the very failure it is cleaning up after. It captures `$?` as its first statement and re-raises it, and every fallible command sits in an `if`/`elif` condition — under `set -e`, a bare failing command inside a trap aborts the trap and replaces the real exit code with its own.

Measured rather than assumed: with the `exit "$status"` line stripped, the exit code was still preserved (7), because bash uses the pre-trap status when an EXIT trap does not call `exit`. So the re-raise is a guard that makes the contract explicit and shell-independent; the `if`-condition discipline is what actually does the work. Conversely, injecting a bare `false` into the trap produces exit **1** with *or* without the re-raise — errexit fires before the re-raise is reached, which is exactly why the condition rule is asserted per-line.

**Tolerant, and loud.** The delete is attempted first and only classified against origin afterwards. Probing first would mean a `ls-remote` that cannot reach the remote silently concludes "already gone" and leaks the branch; delete-first makes an unreachable remote fall through to the warning. A failed delete names the branch so an operator can remove it manually — never a hard error. A successful delete prints a line, so a failed promotion does not silently mutate remote state.

## Trap scenario matrix — real results

The `cleanup()` body was extracted from the shipped script (`awk`, never hand-copied) and driven against stubbed `git`/`gh`.

| # | scenario | flags | delete attempted | exit code | output |
| --- | --- | --- | --- | --- | --- |
| a | fail after push, before `gh pr create` | 1/0 | yes | **1** | `cleaned up remote promotion branch after unfinished promotion: codex/promote-9.9.9-deadbeefcafe` |
| b | fail after PR create, before merge | 1/0 | yes | **1** | same delete line |
| c | success after merge | 1/1 | **no** | **0** | `stable publish dispatched: ...` |
| c2 | fail *after* merge (publish dispatch) | 1/1 | **no** | **1** | no delete line |
| d | delete command fails, branch still on origin | 1/0 | yes (rc=1) | **7** | `WARNING: failed to delete remote promotion branch: ... (delete it manually)` |
| d2 | delete fails, branch already gone | 1/0 | yes (rc=1) | **7** | `remote promotion branch already absent: ...` |
| e | fail before any push | 0/0 | **no** | **1** | no delete line |
| f | non-standard exit code | 1/0 | yes | **42** | code preserved through the trap |
| g | local checkout cleanup ALSO fails | 1/0 | yes | **7** | both `WARNING: failed to clean promotion checkout` and the delete line |

Stubbed calls confirm ordering — the pre-existing local cleanup still runs first:

```
CALL cleanup_promotion_checkout /tmp/cli-jaw-promote.harness
CALL git push origin --delete codex/promote-9.9.9-deadbeefcafe
CALL git ls-remote --exit-code --heads origin codex/promote-9.9.9-deadbeefcafe   # only on delete failure
```

## Verification

- `bash -n scripts/promote-to-main.sh` — clean.
- `shellcheck 0.11.0` — **identical before and after**: one pre-existing `SC1091` (info) about the sourced `promotion-checkout.sh`, exit 1. No new findings. (The task brief described three pre-existing `SC1083` warnings; that is not what this file produces.)
- `tsc --noEmit` — clean.
- `npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test tests/unit/release-scripts-contract.test.ts` — **11/11 pass** (10 before, 1 added).

**Non-vacuity.** The new test run against `git show origin/dev:scripts/promote-to-main.sh` fails:

```
✖ stable promotion deletes the remote promotion branch it pushed when the promotion never merges
  AssertionError: PROMOTION_BRANCH_PUSHED must be initialised before the trap is installed
ℹ pass 10 / fail 1
```

Node bails at the first assertion, so each predicate was also evaluated individually against both versions. Eleven flip `false → true`. Three are regression guards that `origin/dev` satisfies vacuously (it has no delete at all), so those were proven by **mutation** against the new script instead:

| mutant | assertion that rejected it |
| --- | --- |
| delete a literal `codex/promote-2.4.0` instead of `"$PROMOTION_BRANCH"` | `cleanup must delete the tracked promotion branch from origin` |
| add `git tag ...` after the push inside the subshell | `the push must remain the last command of the push subshell, or PROMOTION_BRANCH_PUSHED no longer tracks the push` |
| run the delete bare instead of inside a condition | `cleanup runs "git push origin --delete "$PROMOTION_BRANCH"" outside a condition: under set -e that aborts the trap and rewrites the exit code` |

Two assertions confirm the pre-existing local-checkout cleanup is byte-identical (`true` on both versions, by design).

## Not verified

The promotion script itself was **not executed**. Nothing was pushed to `main` or `preview`, no workflow was dispatched, nothing was published, no dist-tag was touched, and no remote branch was deleted during testing — all branch deletion was exercised through stubs. The end-to-end behaviour against real GitHub is therefore UNVERIFIED-ON-HOST; the trap logic is verified in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
