### PR TITLE
perf(release): drop the redundant main-CI wait via tree identity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,11 @@ on:
         description: "SHA that must match the checked-out HEAD"
         required: true
         type: string
+      certified-sha:
+        description: "Promotion PR head whose tree equals HEAD; its PR checks certify this publish (260819 release-speed)"
+        required: false
+        default: ""
+        type: string
       dry-run:
         description: "Dry run: build, pack, and validate without publishing"
         required: false
@@ -64,11 +69,56 @@ jobs:
           fi
           echo "Dispatched SHA matches checked-out HEAD."
 
+      - name: Resolve certified SHA (tree-identity fast path)
+        id: certified
+        env:
+          CERTIFIED_SHA: ${{ inputs.certified-sha }}
+        run: |
+          set -euo pipefail
+          # Order matters (audit r8): fetch -> tree-verify -> run-lookup, so an
+          # unreachable or mismatched certified SHA fails on the cheap
+          # deterministic check instead of a confusing empty run list.
+          if [ -z "$CERTIFIED_SHA" ]; then
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "No certified-sha supplied; gates will require main push runs."
+            exit 0
+          fi
+          # The promotion branch auto-deletes on merge, so the PR head may only
+          # be reachable through the pull refs. Fetch them explicitly.
+          git fetch --quiet origin "+refs/pull/*/head:refs/remotes/certified/*" || true
+          if ! git cat-file -e "$CERTIFIED_SHA^{commit}" 2>/dev/null; then
+            echo "::error::certified-sha $CERTIFIED_SHA is not reachable even via pull refs"
+            exit 1
+          fi
+          certified_tree="$(git rev-parse "$CERTIFIED_SHA^{tree}")"
+          head_tree="$(git rev-parse "$GITHUB_SHA^{tree}")"
+          if [ "$certified_tree" != "$head_tree" ]; then
+            echo "::error::certified-sha tree $certified_tree does not equal HEAD tree $head_tree — the squash was re-applied onto a moved base; re-dispatch without certified-sha"
+            exit 1
+          fi
+          echo "sha=$CERTIFIED_SHA" >> "$GITHUB_OUTPUT"
+          echo "Tree identity verified: $CERTIFIED_SHA certifies $GITHUB_SHA"
+
       - name: Require successful Tests for this commit
         env:
           GH_TOKEN: ${{ github.token }}
+          CERTIFIED_SHA: ${{ steps.certified.outputs.sha }}
         run: |
           set -euo pipefail
+          if [ -n "$CERTIFIED_SHA" ]; then
+            # The certified run rode the promotion PR, so its head_branch is
+            # the promotion branch — a --branch filter would always miss it.
+            # Assert the returned run really is for the certified commit, and
+            # accept only pull_request events so a stray run cannot launder in.
+            row="$(gh run list --workflow test.yml --commit "$CERTIFIED_SHA" --event pull_request --status success --limit 1 --json databaseId,headSha --jq '.[0] // empty')"
+            run_id="$(printf '%s' "$row" | jq -r --arg sha "$CERTIFIED_SHA" 'select(.headSha == $sha) | .databaseId // empty')"
+            if [ -z "$run_id" ]; then
+              echo "::error::No successful pull_request run of test.yml found for certified $CERTIFIED_SHA"
+              exit 1
+            fi
+            echo "Found successful certified test run: $run_id"
+            exit 0
+          fi
           branch="${GITHUB_REF#refs/heads/}"
           run_id="$(gh run list --workflow test.yml --branch "$branch" --commit "$GITHUB_SHA" --event push --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
           if [ -z "$run_id" ]; then
@@ -80,6 +130,7 @@ jobs:
       - name: Require platform checks when installer surface changed
         env:
           GH_TOKEN: ${{ github.token }}
+          CERTIFIED_SHA: ${{ steps.certified.outputs.sha }}
         run: |
           set -euo pipefail
           previous_tag="$(git tag --merged "$GITHUB_SHA" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)"
@@ -99,6 +150,23 @@ jobs:
               echo "No installer-sensitive changes since $previous_tag"
               ;;
             1)
+              if [ -n "$CERTIFIED_SHA" ]; then
+                # Tree identity (verified above) also guarantees the diff file
+                # set matches, so the certified PR run covers the same
+                # installer surface. No --event filter, matching bc7c19ba.
+                row="$(gh run list \
+                  --workflow postinstall-platform.yml \
+                  --commit "$CERTIFIED_SHA" \
+                  --status success \
+                  --limit 1 --json url,headSha --jq '.[0] // empty')"
+                platform_url="$(printf '%s' "$row" | jq -r --arg sha "$CERTIFIED_SHA" 'select(.headSha == $sha) | .url // empty')"
+                if [ -z "$platform_url" ]; then
+                  echo "::error::No successful Postinstall Platform Checks run found for certified $CERTIFIED_SHA"
+                  exit 1
+                fi
+                echo "platform certified by (PR run): $platform_url"
+                exit 0
+              fi
               branch="${GITHUB_REF#refs/heads/}"
               platform_url="$(gh run list \
                 --workflow postinstall-platform.yml \

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -157,66 +157,55 @@ if [ "$MERGED_VERSION" != "$STABLE_VERSION" ]; then
   exit 1
 fi
 
-deadline=$((SECONDS + 1200))
-MAIN_TESTS_URL=""
-while [ "$SECONDS" -lt "$deadline" ]; do
-  MAIN_TESTS_URL="$(gh run list \
-    --workflow test.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status success \
-    --limit 1 --json url --jq '.[0].url // ""')"
-  [ -n "$MAIN_TESTS_URL" ] && break
-  failed="$(gh run list \
-    --workflow test.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status completed \
-    --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
-  case "$failed" in
-    failure|cancelled|timed_out|startup_failure|action_required)
-      echo "ERROR: main Tests completed with $failed" >&2
-      exit 1
-      ;;
-  esac
-  sleep 10
-done
-if [ -z "$MAIN_TESTS_URL" ]; then
-  echo "ERROR: timed out waiting for successful main Tests" >&2
-  exit 1
-fi
-
-deadline=$((SECONDS + 1200))
-MAIN_PLATFORM_URL=""
-while [ "$SECONDS" -lt "$deadline" ]; do
-  MAIN_PLATFORM_URL="$(gh run list \
-    --workflow postinstall-platform.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status success \
-    --limit 1 --json url --jq '.[0].url // ""')"
-  [ -n "$MAIN_PLATFORM_URL" ] && break
-  failed="$(gh run list \
-    --workflow postinstall-platform.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status completed \
-    --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
-  case "$failed" in
-    failure|cancelled|timed_out|startup_failure|action_required)
-      echo "ERROR: main Postinstall Platform Checks completed with $failed" >&2
-      exit 1
-      ;;
-  esac
-  sleep 10
-done
-if [ -z "$MAIN_PLATFORM_URL" ]; then
-  echo "ERROR: timed out waiting for successful main Postinstall Platform Checks" >&2
-  exit 1
+# ─── Tree-identity fast path (260819 release-speed) ─────────────────────────
+# A squash merge onto an unmoved main produces a commit whose TREE equals the
+# promotion PR head's tree — the exact tree the PR's required checks already
+# certified (branch protection accepts PR-head evidence; strict=false). When
+# the trees match, the main push CI re-run carries no new information, so the
+# release does not wait for it. When they differ (main advanced between PR
+# creation and merge, so the squash re-applied onto a new base), that is a
+# tree nobody tested: fail closed into the original wait loops.
+git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*" 2>/dev/null || true
+MERGED_TREE="$(git rev-parse "$MERGED_MAIN_SHA^{tree}")"
+CERTIFIED_TREE="$(git rev-parse "$PROMOTION_COMMIT^{tree}" 2>/dev/null || echo "")"
+CERTIFIED_SHA=""
+if [ -n "$CERTIFIED_TREE" ] && [ "$MERGED_TREE" = "$CERTIFIED_TREE" ]; then
+  CERTIFIED_SHA="$PROMOTION_COMMIT"
+  echo "tree-identity: merge $MERGED_MAIN_SHA tree matches certified PR head $PROMOTION_COMMIT; skipping the main CI wait"
+else
+  echo "tree-identity: MISMATCH (main advanced during promotion?) — falling back to the main CI wait"
+  wait_for_main_run() {
+    local workflow="$1" label="$2" url="" failed=""
+    local deadline=$((SECONDS + 1200))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+      url="$(gh run list \
+        --workflow "$workflow" \
+        --branch main \
+        --commit "$MERGED_MAIN_SHA" \
+        --event push \
+        --status success \
+        --limit 1 --json url --jq '.[0].url // ""')"
+      [ -n "$url" ] && { echo "$label certified by: $url" >&2; return 0; }
+      failed="$(gh run list \
+        --workflow "$workflow" \
+        --branch main \
+        --commit "$MERGED_MAIN_SHA" \
+        --event push \
+        --status completed \
+        --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
+      case "$failed" in
+        failure|cancelled|timed_out|startup_failure|action_required)
+          echo "ERROR: main $label completed with $failed" >&2
+          return 1
+          ;;
+      esac
+      sleep 10
+    done
+    echo "ERROR: timed out waiting for successful main $label" >&2
+    return 1
+  }
+  wait_for_main_run test.yml "Tests"
+  wait_for_main_run postinstall-platform.yml "Postinstall Platform Checks"
 fi
 
 LIVE_MAIN_SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
@@ -230,6 +219,7 @@ gh workflow run publish.yml \
   -f version="$STABLE_VERSION" \
   -f tag=latest \
   -f expected-sha="$MERGED_MAIN_SHA" \
+  ${CERTIFIED_SHA:+-f certified-sha="$CERTIFIED_SHA"} \
   -f dry-run=false \
   -f create-github-release=true
 


### PR DESCRIPTION
## 문제

v2.17.5 stable 승격 실측: promotion PR 생성 → npm까지 20.2분, 그중 **9.2분이 main push CI 대기** — promotion PR의 required checks가 이미 인증한 것과 바이트 단위로 동일한 트리를 재검증하는 시간입니다.

## 변경

- **promote-to-main.sh**: merge 후 `merge^{tree} == pr-head^{tree}` 검증. 일치하면 main CI를 기다리지 않고 즉시 publish를 `certified-sha`와 함께 dispatch. 불일치(승격 중 main이 움직여 squash가 새 베이스에 재적용된 경우 — 아무도 검증 안 한 트리)는 **기존 대기 루프로 fail-closed 폴백**. merge 후 LIVE_MAIN_SHA 재확인은 유지.
- **publish.yml**: 선택적 `certified-sha` 입력. 제공 시 pull refs를 명시 fetch(승격 브랜치는 merge 시 자동 삭제) → 트리 동일성 자체 검증 → certified PR-head의 Tests(`--event pull_request` + headSha 단언)/platform run 수용. 미제공 시 기존 경로 그대로.

## 근거

- branch protection이 strict=false로 PR-head 증거만으로 merge를 이미 허용 — publish 게이트를 보호 규칙과 일관되게 만드는 변경.
- opus-5 적대 감사 2라운드 (NEAR-PASS→PASS). 감사가 promote 재시도(#386-388) 원인도 정정: preview 이동이 아니라 이미 수정된 gh pr checks 조기 종료 버그. 새 중단 경로는 추가하지 않음.
- 계획·감사 기록: devlog `_plan/260819_release_speed/000_plan.md`

## 검증

- shellcheck / actionlint 통과, release-scripts-contract 10/10
- 예상 효과: promotion PR 생성→npm ~20분 → **~11분**
- ima2-gen에서 같은 원칙(검증된 SHA 재검증 금지)으로 stable 레인 806s→252s 실측한 동형 변경