### PR TITLE
release: merge dev into preview (release-speed tree identity #390)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,11 @@ on:
         description: "SHA that must match the checked-out HEAD"
         required: true
         type: string
+      certified-sha:
+        description: "Promotion PR head whose tree equals HEAD; its PR checks certify this publish (260819 release-speed)"
+        required: false
+        default: ""
+        type: string
       dry-run:
         description: "Dry run: build, pack, and validate without publishing"
         required: false
@@ -64,11 +69,56 @@ jobs:
           fi
           echo "Dispatched SHA matches checked-out HEAD."
 
+      - name: Resolve certified SHA (tree-identity fast path)
+        id: certified
+        env:
+          CERTIFIED_SHA: ${{ inputs.certified-sha }}
+        run: |
+          set -euo pipefail
+          # Order matters (audit r8): fetch -> tree-verify -> run-lookup, so an
+          # unreachable or mismatched certified SHA fails on the cheap
+          # deterministic check instead of a confusing empty run list.
+          if [ -z "$CERTIFIED_SHA" ]; then
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "No certified-sha supplied; gates will require main push runs."
+            exit 0
+          fi
+          # The promotion branch auto-deletes on merge, so the PR head may only
+          # be reachable through the pull refs. Fetch them explicitly.
+          git fetch --quiet origin "+refs/pull/*/head:refs/remotes/certified/*" || true
+          if ! git cat-file -e "$CERTIFIED_SHA^{commit}" 2>/dev/null; then
+            echo "::error::certified-sha $CERTIFIED_SHA is not reachable even via pull refs"
+            exit 1
+          fi
+          certified_tree="$(git rev-parse "$CERTIFIED_SHA^{tree}")"
+          head_tree="$(git rev-parse "$GITHUB_SHA^{tree}")"
+          if [ "$certified_tree" != "$head_tree" ]; then
+            echo "::error::certified-sha tree $certified_tree does not equal HEAD tree $head_tree — the squash was re-applied onto a moved base; re-dispatch without certified-sha"
+            exit 1
+          fi
+          echo "sha=$CERTIFIED_SHA" >> "$GITHUB_OUTPUT"
+          echo "Tree identity verified: $CERTIFIED_SHA certifies $GITHUB_SHA"
+
       - name: Require successful Tests for this commit
         env:
           GH_TOKEN: ${{ github.token }}
+          CERTIFIED_SHA: ${{ steps.certified.outputs.sha }}
         run: |
           set -euo pipefail
+          if [ -n "$CERTIFIED_SHA" ]; then
+            # The certified run rode the promotion PR, so its head_branch is
+            # the promotion branch — a --branch filter would always miss it.
+            # Assert the returned run really is for the certified commit, and
+            # accept only pull_request events so a stray run cannot launder in.
+            row="$(gh run list --workflow test.yml --commit "$CERTIFIED_SHA" --event pull_request --status success --limit 1 --json databaseId,headSha --jq '.[0] // empty')"
+            run_id="$(printf '%s' "$row" | jq -r --arg sha "$CERTIFIED_SHA" 'select(.headSha == $sha) | .databaseId // empty')"
+            if [ -z "$run_id" ]; then
+              echo "::error::No successful pull_request run of test.yml found for certified $CERTIFIED_SHA"
+              exit 1
+            fi
+            echo "Found successful certified test run: $run_id"
+            exit 0
+          fi
           branch="${GITHUB_REF#refs/heads/}"
           run_id="$(gh run list --workflow test.yml --branch "$branch" --commit "$GITHUB_SHA" --event push --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
           if [ -z "$run_id" ]; then
@@ -80,6 +130,7 @@ jobs:
       - name: Require platform checks when installer surface changed
         env:
           GH_TOKEN: ${{ github.token }}
+          CERTIFIED_SHA: ${{ steps.certified.outputs.sha }}
         run: |
           set -euo pipefail
           previous_tag="$(git tag --merged "$GITHUB_SHA" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)"
@@ -99,6 +150,23 @@ jobs:
               echo "No installer-sensitive changes since $previous_tag"
               ;;
             1)
+              if [ -n "$CERTIFIED_SHA" ]; then
+                # Tree identity (verified above) also guarantees the diff file
+                # set matches, so the certified PR run covers the same
+                # installer surface. No --event filter, matching bc7c19ba.
+                row="$(gh run list \
+                  --workflow postinstall-platform.yml \
+                  --commit "$CERTIFIED_SHA" \
+                  --status success \
+                  --limit 1 --json url,headSha --jq '.[0] // empty')"
+                platform_url="$(printf '%s' "$row" | jq -r --arg sha "$CERTIFIED_SHA" 'select(.headSha == $sha) | .url // empty')"
+                if [ -z "$platform_url" ]; then
+                  echo "::error::No successful Postinstall Platform Checks run found for certified $CERTIFIED_SHA"
+                  exit 1
+                fi
+                echo "platform certified by (PR run): $platform_url"
+                exit 0
+              fi
               branch="${GITHUB_REF#refs/heads/}"
               platform_url="$(gh run list \
                 --workflow postinstall-platform.yml \

--- a/scripts/check-native-load.cjs
+++ b/scripts/check-native-load.cjs
@@ -65,9 +65,27 @@ if (!ptyRoot) {
     process.exit(EXIT_SKIPPED);
   }
 } else {
-  const binary = join(ptyRoot, 'build', 'Release', 'pty.node');
-  if (!existsSync(binary)) {
-    fail(`missing native binary: ${binary}`);
+  // Resolve the binary the way node-pty's own loadNativeModule does:
+  // build/Release, then build/Debug, then prebuilds/<platform>-<arch>.
+  // node-pty >= 1.1 ships prebuilds and skips the source build entirely when
+  // they match, so on Windows build/Release legitimately never contains
+  // pty.node -- hardcoding it failed the gate on every prebuild-only install.
+  const binaryName = process.platform === 'win32' ? 'conpty.node' : 'pty.node';
+  const candidates = [
+    join(ptyRoot, 'build', 'Release', binaryName),
+    join(ptyRoot, 'build', 'Debug', binaryName),
+    join(ptyRoot, 'prebuilds', `${process.platform}-${process.arch}`, binaryName),
+  ];
+  if (process.platform === 'win32') {
+    // winpty fallback binary: probe it too if conpty is somehow absent.
+    candidates.push(
+      join(ptyRoot, 'build', 'Release', 'pty.node'),
+      join(ptyRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'pty.node'),
+    );
+  }
+  const binary = candidates.find((candidate) => existsSync(candidate));
+  if (!binary) {
+    fail(`missing native binary: none of\n   ${candidates.join('\n   ')}`);
   } else {
     // 1. The binary must actually dlopen under this runtime.
     try {

--- a/scripts/generate-channel-capability-table.mts
+++ b/scripts/generate-channel-capability-table.mts
@@ -127,7 +127,12 @@ function main(): number {
     const check = process.argv.includes('--check');
     const abs = path.join(repoRoot, TABLE_REL);
     const original = fs.readFileSync(abs, 'utf8');
-    const located = locate(original);
+    // The repo stores this file with LF, but a core.autocrlf=true checkout
+    // (the git-for-windows default) hands us CRLF -- and the byte-for-byte
+    // comparison below then reported drift on line 1 ("\r" vs "") for a table
+    // that was in fact in sync. Normalize for comparison; writes still go
+    // through the normalized text, and git renormalizes on commit either way.
+    const located = locate(original.replace(/\r\n/g, '\n'));
     const expected = `\n${buildBlock()}\n`;
 
     if (check) {
@@ -147,7 +152,9 @@ function main(): number {
         console.log(`[unchanged] ${TABLE_REL}`);
         return 0;
     }
-    const next = original.slice(0, located.startIdx + START.length) + expected + original.slice(located.endIdx);
+    // Slice the same normalized text the indices came from; slicing the raw
+    // CRLF original with normalized indices would splice at shifted offsets.
+    const next = located.text.slice(0, located.startIdx + START.length) + expected + located.text.slice(located.endIdx);
     fs.writeFileSync(abs, next);
     console.log(`[written] ${TABLE_REL} messaging capability matrix regenerated from ${SOURCE_REL}`);
     return 0;

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -106,10 +106,13 @@ PR_URL="$(gh pr create \
 
 # GitHub materializes required checks on a fresh PR asynchronously; when
 # `--watch` lands in that window it exits immediately with "no checks
-# reported" and the whole promotion dies (observed: PR #386, killed seconds
-# after creation while its checks were still queueing). Retry the watch while
-# that specific startup condition holds; real check failures still fail fast.
-CHECKS_DEADLINE=$((SECONDS + 300))
+# reported" / "no required checks reported" and the whole promotion dies
+# (observed: PRs #386-#388, killed while checks were queueing). The required
+# context here is ci-aggregate, which is REPORTED ONLY AFTER node-tests
+# finishes (~7-8 min), so the deadline must comfortably exceed a full test.yml
+# run, not just the registration lag. Retry the watch while that startup
+# condition holds; real check failures still fail fast.
+CHECKS_DEADLINE=$((SECONDS + 1800))
 while true; do
   CHECKS_STATUS=0
   CHECKS_OUTPUT="$(gh pr checks "$PR_URL" --required --watch --fail-fast 2>&1)" || CHECKS_STATUS=$?

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -157,66 +157,55 @@ if [ "$MERGED_VERSION" != "$STABLE_VERSION" ]; then
   exit 1
 fi
 
-deadline=$((SECONDS + 1200))
-MAIN_TESTS_URL=""
-while [ "$SECONDS" -lt "$deadline" ]; do
-  MAIN_TESTS_URL="$(gh run list \
-    --workflow test.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status success \
-    --limit 1 --json url --jq '.[0].url // ""')"
-  [ -n "$MAIN_TESTS_URL" ] && break
-  failed="$(gh run list \
-    --workflow test.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status completed \
-    --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
-  case "$failed" in
-    failure|cancelled|timed_out|startup_failure|action_required)
-      echo "ERROR: main Tests completed with $failed" >&2
-      exit 1
-      ;;
-  esac
-  sleep 10
-done
-if [ -z "$MAIN_TESTS_URL" ]; then
-  echo "ERROR: timed out waiting for successful main Tests" >&2
-  exit 1
-fi
-
-deadline=$((SECONDS + 1200))
-MAIN_PLATFORM_URL=""
-while [ "$SECONDS" -lt "$deadline" ]; do
-  MAIN_PLATFORM_URL="$(gh run list \
-    --workflow postinstall-platform.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status success \
-    --limit 1 --json url --jq '.[0].url // ""')"
-  [ -n "$MAIN_PLATFORM_URL" ] && break
-  failed="$(gh run list \
-    --workflow postinstall-platform.yml \
-    --branch main \
-    --commit "$MERGED_MAIN_SHA" \
-    --event push \
-    --status completed \
-    --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
-  case "$failed" in
-    failure|cancelled|timed_out|startup_failure|action_required)
-      echo "ERROR: main Postinstall Platform Checks completed with $failed" >&2
-      exit 1
-      ;;
-  esac
-  sleep 10
-done
-if [ -z "$MAIN_PLATFORM_URL" ]; then
-  echo "ERROR: timed out waiting for successful main Postinstall Platform Checks" >&2
-  exit 1
+# ─── Tree-identity fast path (260819 release-speed) ─────────────────────────
+# A squash merge onto an unmoved main produces a commit whose TREE equals the
+# promotion PR head's tree — the exact tree the PR's required checks already
+# certified (branch protection accepts PR-head evidence; strict=false). When
+# the trees match, the main push CI re-run carries no new information, so the
+# release does not wait for it. When they differ (main advanced between PR
+# creation and merge, so the squash re-applied onto a new base), that is a
+# tree nobody tested: fail closed into the original wait loops.
+git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*" 2>/dev/null || true
+MERGED_TREE="$(git rev-parse "$MERGED_MAIN_SHA^{tree}")"
+CERTIFIED_TREE="$(git rev-parse "$PROMOTION_COMMIT^{tree}" 2>/dev/null || echo "")"
+CERTIFIED_SHA=""
+if [ -n "$CERTIFIED_TREE" ] && [ "$MERGED_TREE" = "$CERTIFIED_TREE" ]; then
+  CERTIFIED_SHA="$PROMOTION_COMMIT"
+  echo "tree-identity: merge $MERGED_MAIN_SHA tree matches certified PR head $PROMOTION_COMMIT; skipping the main CI wait"
+else
+  echo "tree-identity: MISMATCH (main advanced during promotion?) — falling back to the main CI wait"
+  wait_for_main_run() {
+    local workflow="$1" label="$2" url="" failed=""
+    local deadline=$((SECONDS + 1200))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+      url="$(gh run list \
+        --workflow "$workflow" \
+        --branch main \
+        --commit "$MERGED_MAIN_SHA" \
+        --event push \
+        --status success \
+        --limit 1 --json url --jq '.[0].url // ""')"
+      [ -n "$url" ] && { echo "$label certified by: $url" >&2; return 0; }
+      failed="$(gh run list \
+        --workflow "$workflow" \
+        --branch main \
+        --commit "$MERGED_MAIN_SHA" \
+        --event push \
+        --status completed \
+        --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
+      case "$failed" in
+        failure|cancelled|timed_out|startup_failure|action_required)
+          echo "ERROR: main $label completed with $failed" >&2
+          return 1
+          ;;
+      esac
+      sleep 10
+    done
+    echo "ERROR: timed out waiting for successful main $label" >&2
+    return 1
+  }
+  wait_for_main_run test.yml "Tests"
+  wait_for_main_run postinstall-platform.yml "Postinstall Platform Checks"
 fi
 
 LIVE_MAIN_SHA="$(git ls-remote origin refs/heads/main | cut -f1)"
@@ -230,6 +219,7 @@ gh workflow run publish.yml \
   -f version="$STABLE_VERSION" \
   -f tag=latest \
   -f expected-sha="$MERGED_MAIN_SHA" \
+  ${CERTIFIED_SHA:+-f certified-sha="$CERTIFIED_SHA"} \
   -f dry-run=false \
   -f create-github-release=true
 

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -104,7 +104,24 @@ PR_URL="$(gh pr create \
   --title "chore: promote v$STABLE_VERSION" \
   --body "Promotes certified preview $PREVIEW_VERSION at $PREVIEW_SHA. Tests: $TESTS_URL")"
 
-gh pr checks "$PR_URL" --required --watch --fail-fast
+# GitHub materializes required checks on a fresh PR asynchronously; when
+# `--watch` lands in that window it exits immediately with "no checks
+# reported" and the whole promotion dies (observed: PR #386, killed seconds
+# after creation while its checks were still queueing). Retry the watch while
+# that specific startup condition holds; real check failures still fail fast.
+CHECKS_DEADLINE=$((SECONDS + 300))
+while true; do
+  CHECKS_STATUS=0
+  CHECKS_OUTPUT="$(gh pr checks "$PR_URL" --required --watch --fail-fast 2>&1)" || CHECKS_STATUS=$?
+  printf '%s\n' "$CHECKS_OUTPUT"
+  [ "$CHECKS_STATUS" -eq 0 ] && break
+  if printf '%s' "$CHECKS_OUTPUT" | grep -qi 'no checks reported' \
+    && [ "$SECONDS" -lt "$CHECKS_DEADLINE" ]; then
+    sleep 15
+    continue
+  fi
+  exit "$CHECKS_STATUS"
+done
 gh pr merge "$PR_URL" --squash --match-head-commit "$PROMOTION_COMMIT"
 # From here the branch belongs to GitHub's delete_branch_on_merge. Racing that
 # auto-delete only produces confusing errors, and a later verification failure

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -115,7 +115,7 @@ while true; do
   CHECKS_OUTPUT="$(gh pr checks "$PR_URL" --required --watch --fail-fast 2>&1)" || CHECKS_STATUS=$?
   printf '%s\n' "$CHECKS_OUTPUT"
   [ "$CHECKS_STATUS" -eq 0 ] && break
-  if printf '%s' "$CHECKS_OUTPUT" | grep -qi 'no checks reported' \
+  if printf '%s' "$CHECKS_OUTPUT" | grep -qiE 'no (required )?checks reported' \
     && [ "$SECONDS" -lt "$CHECKS_DEADLINE" ]; then
     sleep 15
     continue

--- a/scripts/release-gates.mjs
+++ b/scripts/release-gates.mjs
@@ -17,14 +17,52 @@ import { auditClaims, formatClaimAuditReport } from './claim-audit.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+/**
+ * Windows-safe command resolution for spawnSync.
+ * Bare 'npm'/'npx' resolve to .cmd shims on Windows, which Node refuses to
+ * spawn without shell:true (EINVAL since the CVE-2024-27980 hardening), so
+ * every gate that shelled out reported status=null with empty output on a
+ * native-Windows checkout. Run the CLI js entrypoints under the current node
+ * binary instead; POSIX resolution is unchanged.
+ */
+function resolveCliJs(name) {
+    const nodeBinDir = path.dirname(process.execPath);
+    const candidates = [
+        name === 'npm' ? process.env.npm_execpath : null,
+        path.join(nodeBinDir, 'node_modules', 'npm', 'bin', `${name}-cli.js`),
+        path.join(nodeBinDir, 'lib', 'node_modules', 'npm', 'bin', `${name}-cli.js`),
+        path.join(path.dirname(nodeBinDir), 'lib', 'node_modules', 'npm', 'bin', `${name}-cli.js`),
+    ].filter(Boolean);
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) return candidate;
+    }
+    return null;
+}
+
+function windowsSafeCommand(cmd, args) {
+    if (cmd === 'npm' || cmd === 'npx') {
+        const cliJs = resolveCliJs(cmd);
+        if (cliJs) return [process.execPath, [cliJs, ...args]];
+        if (process.platform === 'win32') return [`${cmd}.cmd`, args, { shell: true }];
+        return [cmd, args];
+    }
+    return [cmd, args];
+}
+
 function run(cmd, args, opts = {}) {
-    return spawnSync(cmd, args, {
+    const [bin, finalArgs, extra] = windowsSafeCommand(cmd, args);
+    return spawnSync(bin, finalArgs, {
         cwd: repoRoot,
         stdio: opts.stdio || 'pipe',
         encoding: 'utf8',
+        ...(extra || {}),
         ...opts,
     });
 }
+
+// tsx's dist/cli.mjs run under node works identically on every platform;
+// node_modules/.bin/tsx is a bash script that Windows cannot execute.
+const tsxCli = path.resolve(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
 
 function readFile(rel) {
     return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
@@ -98,7 +136,7 @@ const GATES = {
             // The generated messaging block first: a stale matrix is a wrong claim
             // regardless of the file's mtime, so freshness must not excuse it.
             // node_modules/.bin/tsx directly — npx resolution is not a gate dependency.
-            const generated = run(path.join('node_modules', '.bin', 'tsx'), [
+            const generated = run(process.execPath, [tsxCli, 
                 'scripts/generate-channel-capability-table.mts', '--check',
             ], { timeout: 60_000 });
             if (generated.status !== 0) {
@@ -189,9 +227,9 @@ const GATES = {
             try {
                 const { spawnSync } = await import('node:child_process');
                 const path = await import('node:path');
-                const tsxBin = path.resolve(repoRoot, 'node_modules/.bin/tsx');
-                const fixtureScript = `import { buildObserveActions, formatObserveActions } from '${path.resolve(repoRoot, 'src/browser/web-ai/observe-actions.ts').replace(/\\\\/g, '/')}';\nconst r = buildObserveActions({ snapshotId: 'gate-fixture', url: null, refs: { '@e1': { role: 'button', name: 'Sign in' }, '@e2': { role: 'textbox', name: 'Email' }, '@e3': { role: 'link', name: 'Forgot password?' } } }, 'click sign in');\nif (!r || !Array.isArray(r.candidates) || r.candidates.length < 3) { console.error('candidates<3'); process.exit(2); }\nif (r.candidates[0].ref !== '@e1' || r.candidates[0].action !== 'click') { console.error('rank-fail'); process.exit(3); }\nif (!r.candidates.every(c => c.args.snapshotId === 'gate-fixture')) { console.error('snapId-missing'); process.exit(4); }\nconst t = formatObserveActions(r); if (!t || typeof t !== 'string') { console.error('format-fail'); process.exit(5); }\nconsole.log('OK ' + r.candidates.length);`;
-                const res = spawnSync(tsxBin, ['--eval', fixtureScript], { encoding: 'utf8' });
+                const tsxBin = tsxCli;
+                const fixtureScript = `import { buildObserveActions, formatObserveActions } from '${path.resolve(repoRoot, 'src/browser/web-ai/observe-actions.ts').split(path.sep).join('/')}';\nconst r = buildObserveActions({ snapshotId: 'gate-fixture', url: null, refs: { '@e1': { role: 'button', name: 'Sign in' }, '@e2': { role: 'textbox', name: 'Email' }, '@e3': { role: 'link', name: 'Forgot password?' } } }, 'click sign in');\nif (!r || !Array.isArray(r.candidates) || r.candidates.length < 3) { console.error('candidates<3'); process.exit(2); }\nif (r.candidates[0].ref !== '@e1' || r.candidates[0].action !== 'click') { console.error('rank-fail'); process.exit(3); }\nif (!r.candidates.every(c => c.args.snapshotId === 'gate-fixture')) { console.error('snapId-missing'); process.exit(4); }\nconst t = formatObserveActions(r); if (!t || typeof t !== 'string') { console.error('format-fail'); process.exit(5); }\nconsole.log('OK ' + r.candidates.length);`;
+                const res = spawnSync(process.execPath, [tsxBin, '--eval', fixtureScript], { encoding: 'utf8' });
                 if (res.status !== 0) {
                     return { ok: false, detail: `observe-actions fixture failed: status=${res.status} stderr=${(res.stderr || '').trim()} stdout=${(res.stdout || '').trim()}` };
                 }
@@ -207,10 +245,10 @@ const GATES = {
             try {
                 const { spawnSync } = await import('node:child_process');
                 const path = await import('node:path');
-                const tsxBin = path.resolve(repoRoot, 'node_modules/.bin/tsx');
-                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/observation-bundle.ts').replace(/\\\\/g, '/');
+                const tsxBin = tsxCli;
+                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/observation-bundle.ts').split(path.sep).join('/');
                 const fixtureScript = `import { buildObservationBundle, OBSERVATION_BUNDLE_SCHEMA_VERSION } from '${modPath}';\nconst b = buildObservationBundle({ url: 'https://x.test/', viewport: { width: 800, height: 600 }, snapshotNodes: [{ ref: '@e1', role: 'button', name: 'Go' }, { ref: '...', role: 'note', name: 't' }], boxes: { '@e1': { x: 1, y: 2, width: 10, height: 20 } }, textSummary: 'hello' });\nif (b.schemaVersion !== OBSERVATION_BUNDLE_SCHEMA_VERSION) { console.error('schema-mismatch'); process.exit(2); }\nif (b.refs.length !== 1) { console.error('ref-filter-fail'); process.exit(3); }\nif (!b.refs[0].box || b.refs[0].box.width !== 10) { console.error('box-attach-fail'); process.exit(4); }\nif (b.stats.refCount !== 1 || b.stats.boxCount !== 1 || b.stats.textChars !== 5) { console.error('stats-fail'); process.exit(5); }\nconsole.log('OK refs=' + b.stats.refCount + ' boxes=' + b.stats.boxCount + ' text=' + b.stats.textChars + 'ch');`;
-                const res = spawnSync(tsxBin, ['--eval', fixtureScript], { encoding: 'utf8' });
+                const res = spawnSync(process.execPath, [tsxBin, '--eval', fixtureScript], { encoding: 'utf8' });
                 if (res.status !== 0) {
                     return { ok: false, detail: `observation-bundle fixture failed: status=${res.status} stderr=${(res.stderr || '').trim()} stdout=${(res.stdout || '').trim()}` };
                 }
@@ -226,10 +264,10 @@ const GATES = {
             try {
                 const { spawnSync } = await import('node:child_process');
                 const path = await import('node:path');
-                const tsxBin = path.resolve(repoRoot, 'node_modules/.bin/tsx');
-                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/action-breadth.ts').replace(/\\\\/g, '/');
+                const tsxBin = tsxCli;
+                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/action-breadth.ts').split(path.sep).join('/');
                 const fixtureScript = `import { BROWSER_PRIMITIVES, listPrimitiveCommands, BROWSER_PRIMITIVE_SCHEMA_VERSION, auditPrimitiveCoverage } from '${modPath}';\nif (BROWSER_PRIMITIVE_SCHEMA_VERSION !== 'browser-primitives-v1') { console.error('schema-mismatch'); process.exit(2); }\nif (BROWSER_PRIMITIVES.length < 18) { console.error('too-few'); process.exit(3); }\nconst cmds = new Set(listPrimitiveCommands());\nfor (const c of ['select','check','uncheck','upload','drag','scroll','wait-for']) { if (!cmds.has(c)) { console.error('missing:'+c); process.exit(4); } }\nconst fake = [...BROWSER_PRIMITIVES].map(p => 'case ' + JSON.stringify(p.command) + ':').join('\\n');\nconst r = auditPrimitiveCoverage(fake);\nif (!r.ok || r.missing.length !== 0) { console.error('audit-fail'); process.exit(5); }\nconsole.log('OK ' + BROWSER_PRIMITIVES.length + ' primitives');`;
-                const res = spawnSync(tsxBin, ['--eval', fixtureScript], { encoding: 'utf8' });
+                const res = spawnSync(process.execPath, [tsxBin, '--eval', fixtureScript], { encoding: 'utf8' });
                 if (res.status !== 0) {
                     return { ok: false, detail: `action-breadth fixture failed: status=${res.status} stderr=${(res.stderr || '').trim()} stdout=${(res.stdout || '').trim()}` };
                 }
@@ -245,10 +283,10 @@ const GATES = {
             try {
                 const { spawnSync } = await import('node:child_process');
                 const path = await import('node:path');
-                const tsxBin = path.resolve(repoRoot, 'node_modules/.bin/tsx');
-                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/action-memory.ts').replace(/\\\\/g, '/');
+                const tsxBin = tsxCli;
+                const modPath = path.resolve(repoRoot, 'src/browser/web-ai/action-memory.ts').split(path.sep).join('/');
                 const fixtureScript = `import { createActionMemory, validateMemoryHit, ACTION_MEMORY_SCHEMA_VERSION } from '${modPath}';\nif (ACTION_MEMORY_SCHEMA_VERSION !== 'action-memory-v1') { console.error('schema-mismatch'); process.exit(2); }\nconst m = createActionMemory();\nm.put({ origin: 'https://x.test', intentId: 'i', signature: 'sig-A', ref: '@e1', hits: 0, validations: { ok: 0, fail: 0 }, lastGoodAt: '' });\nconst hit = m.get('https://x.test', 'i', 'sig-A');\nif (!hit || hit.ref !== '@e1') { console.error('miss-on-match'); process.exit(3); }\nif (m.get('https://x.test', 'i', 'sig-B') !== null) { console.error('hit-on-drift'); process.exit(4); }\nif (validateMemoryHit(hit, 'sig-B') !== null) { console.error('validate-allowed-drift'); process.exit(5); }\nm.clear();\nif (m.size() !== 0) { console.error('clear-failed'); process.exit(6); }\nconsole.log('OK hit-on-match miss-on-drift clear');`;
-                const res = spawnSync(tsxBin, ['--eval', fixtureScript], { encoding: 'utf8' });
+                const res = spawnSync(process.execPath, [tsxBin, '--eval', fixtureScript], { encoding: 'utf8' });
                 if (res.status !== 0) {
                     return { ok: false, detail: `action-memory fixture failed: status=${res.status} stderr=${(res.stderr || '').trim()} stdout=${(res.stdout || '').trim()}` };
                 }
@@ -519,11 +557,11 @@ const GATES = {
             if (tests.status !== 0) {
                 return { ok: false, detail: [tests.stdout, tests.stderr].filter(Boolean).join('\n').trim().slice(-800) };
             }
-            const written = run(path.join('node_modules', '.bin', 'tsx'), ['scripts/write-messaging-certification.mts'], { timeout: 30_000 });
+            const written = run(process.execPath, [tsxCli, 'scripts/write-messaging-certification.mts'], { timeout: 30_000 });
             if (written.status !== 0) {
                 return { ok: false, detail: [written.stdout, written.stderr].filter(Boolean).join('\n').trim().slice(-800) };
             }
-            const validated = run(path.join('node_modules', '.bin', 'tsx'), ['scripts/validate-messaging-certification.mts'], { timeout: 30_000 });
+            const validated = run(process.execPath, [tsxCli, 'scripts/validate-messaging-certification.mts'], { timeout: 30_000 });
             if (validated.status !== 0) {
                 return { ok: false, detail: [validated.stdout, validated.stderr].filter(Boolean).join('\n').trim().slice(-800) };
             }

--- a/scripts/require-release-evidence.mjs
+++ b/scripts/require-release-evidence.mjs
@@ -412,12 +412,18 @@ if (!macosEvidence || !wslEvidence) {
       'run', 'list',
       '--workflow', 'postinstall-platform.yml',
       '--commit', headSha,
-      '--event', 'push',
       '--status', 'success',
       '--limit', '1',
       '--json', 'url',
       '--jq', '.[0].url // ""',
     ], { cwd: repoRoot, encoding: 'utf8', shell: false });
+    // No --event filter, mirroring bc7c19ba which already made publish.yml
+    // accept any-event Postinstall Platform Checks. A merge commit whose diff
+    // is empty (e.g. main merged back into preview after a promotion) never
+    // produces a push run for its own SHA, so requiring the push event made
+    // this gate unpassable for exactly the SHA a promotion certifies. Any
+    // successful run of the pinned workflow on this commit is the same
+    // evidence regardless of the event that started it.
     const ciUrl = (ciCheck.stdout || '').trim();
     if (ciUrl) {
       console.log(`[release-evidence-required] PASS CI postinstall-platform evidence: ${ciUrl}`);

--- a/scripts/sync-electron-version.cjs
+++ b/scripts/sync-electron-version.cjs
@@ -19,7 +19,9 @@
  * wrote something else.
  */
 const { readFileSync } = require('node:fs');
+const { existsSync } = require('node:fs');
 const { join } = require('node:path');
+const { dirname } = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const repoRoot = join(__dirname, '..');
@@ -39,6 +41,28 @@ function readVersion(dir) {
     } catch (error) {
         throw new Error(`${file} is not valid JSON: ${error.message}`);
     }
+}
+
+/**
+ * Resolve npm as [bin, ...baseArgs] runnable via spawnSync WITHOUT a shell.
+ * On Windows the bare name 'npm' is npm.cmd, and Node's spawnSync refuses to
+ * run .cmd/.bat files without shell:true (EINVAL since the CVE-2024-27980
+ * hardening) -- so the sync silently failed on every native-Windows release.
+ * Running npm-cli.js under the current node binary sidesteps both the shim
+ * and the shell. Same resolution ladder as scripts/ensure-native-modules.cjs.
+ */
+function resolveNpmCommand() {
+    const nodeBinDir = dirname(process.execPath);
+    const candidates = [
+        process.env.npm_execpath,
+        join(nodeBinDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        join(nodeBinDir, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        join(dirname(nodeBinDir), 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    ].filter(Boolean);
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) return [process.execPath, candidate];
+    }
+    return [process.platform === 'win32' ? 'npm.cmd' : 'npm'];
 }
 
 function main() {
@@ -75,13 +99,20 @@ function main() {
     // both files directly means reimplementing the lockfile's shape, and
     // getting it subtly wrong surfaces later as unexplained churn in someone
     // else's dependency diff.
+    const [npmBin, ...npmBaseArgs] = resolveNpmCommand();
     const result = spawnSync(
-        'npm',
-        ['version', rootVersion, '--no-git-tag-version', '--allow-same-version'],
-        { cwd: electronDir, encoding: 'utf8', timeout: 60_000 },
+        npmBin,
+        [...npmBaseArgs, 'version', rootVersion, '--no-git-tag-version', '--allow-same-version'],
+        {
+            cwd: electronDir,
+            encoding: 'utf8',
+            timeout: 60_000,
+            // .cmd shims need a shell; the npm-cli.js path never takes this branch.
+            shell: npmBin.endsWith('.cmd'),
+        },
     );
     if (result.status !== 0) {
-        const detail = (result.stderr || result.stdout || '').trim();
+        const detail = (result.stderr || result.stdout || (result.error && result.error.message) || '').trim();
         console.error(`ERROR: npm version failed in electron/: ${detail}`);
         return 1;
     }

--- a/tests/integration/promotion-checkout.test.ts
+++ b/tests/integration/promotion-checkout.test.ts
@@ -139,16 +139,31 @@ test('promotion checkout stays isolated when invoked from a submodule and fails 
         mkdirSync(symlinkTarget);
         writeFileSync(join(symlinkTarget, 'keep.txt'), 'keep\n');
         const symlinkCheckout = join(root, 'cli-jaw-promote.symlink');
-        symlinkSync(symlinkTarget, symlinkCheckout);
-        const symlinkRejected = bashHelper(
-            child,
-            root,
-            'cleanup_promotion_checkout "$2"',
-            [symlinkCheckout],
-            1,
-        );
-        assert.match(symlinkRejected.stderr, /refusing symlink promotion checkout path/);
-        assert.equal(existsSync(join(symlinkTarget, 'keep.txt')), true, 'symlink target must remain intact');
+        // Windows only grants CreateSymbolicLink to admins or Developer Mode;
+        // a junction would not trip bash's -L guard, so it cannot stand in.
+        // Skip just this scenario when the OS refuses the fixture -- the guard
+        // itself is POSIX bash either way.
+        let symlinkSupported = true;
+        try {
+            symlinkSync(symlinkTarget, symlinkCheckout);
+        } catch (error) {
+            if (process.platform === 'win32' && (error as NodeJS.ErrnoException).code === 'EPERM') {
+                symlinkSupported = false;
+            } else {
+                throw error;
+            }
+        }
+        if (symlinkSupported) {
+            const symlinkRejected = bashHelper(
+                child,
+                root,
+                'cleanup_promotion_checkout "$2"',
+                [symlinkCheckout],
+                1,
+            );
+            assert.match(symlinkRejected.stderr, /refusing symlink promotion checkout path/);
+            assert.equal(existsSync(join(symlinkTarget, 'keep.txt')), true, 'symlink target must remain intact');
+        }
     } finally {
         rmSync(root, { recursive: true, force: true });
     }

--- a/tests/unit/gyp-python-pick.test.ts
+++ b/tests/unit/gyp-python-pick.test.ts
@@ -18,6 +18,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..', '..');
 const picker = join(projectRoot, 'scripts', 'pick-gyp-python.sh');
 
+// The picker is a POSIX bash script consumed only by the electron-builder
+// launcher, which routes it through bash on every platform that packages
+// desktop builds. The execution-shaped tests below need chmod +x shims,
+// PATH=dir:/usr/bin:/bin colon-lists, and shell shebangs -- none of which
+// exist on native Windows (bash.exe here is a MinGW shim that resolves
+// Windows Store aliases like WindowsApps/python3 that cannot spawn). The
+// source-shaped assertions still run everywhere.
+const posixOnly = process.platform === 'win32' ? test.skip : test;
+
 const run = (env: NodeJS.ProcessEnv = {}) =>
     spawnSync('bash', [picker], {
         cwd: projectRoot,
@@ -36,7 +45,7 @@ function fakePython(dir: string, name: string, hasDistutils: boolean): string {
     return path;
 }
 
-test('picks an interpreter that can actually import distutils', () => {
+posixOnly('picks an interpreter that can actually import distutils', () => {
     const result = run();
     assert.equal(result.status, 0, result.stderr);
     const picked = result.stdout.trim();
@@ -58,7 +67,7 @@ test('an explicit PYTHON wins', () => {
     assert.equal(result.stdout.trim(), '/opt/deliberate/python3');
 });
 
-test('skips a python3 that lacks distutils and keeps looking', () => {
+posixOnly('skips a python3 that lacks distutils and keeps looking', () => {
     // This is the real-world shape: Homebrew python3 first on PATH at 3.14,
     // a usable interpreter further down. Verified against a machine where
     // `python3 --version` said 3.14.6 and the picker returned /usr/bin/python3.
@@ -80,7 +89,7 @@ test('skips a python3 that lacks distutils and keeps looking', () => {
     }
 });
 
-test('warns instead of failing silently when nothing has distutils', () => {
+posixOnly('warns instead of failing silently when nothing has distutils', () => {
     // Failing closed here would block a build node-gyp might still manage;
     // failing silently would produce a confusing gyp traceback. It prints the
     // fallback and explains the likely failure.

--- a/tests/unit/release-gates.test.ts
+++ b/tests/unit/release-gates.test.ts
@@ -21,9 +21,12 @@ function runGate(name: string): { status: number; stdout: string; stderr: string
 }
 
 function runGenerator(...args: string[]): { status: number; stdout: string; stderr: string } {
-    // node_modules/.bin/tsx, not npx: the gate resolves it the same way, and a
-    // test that used npx would pass while the gate failed offline.
-    const r = spawnSync(path.join(repoRoot, 'node_modules/.bin/tsx'), [
+    // tsx's dist/cli.mjs under the current node, not npx and not the .bin
+    // shim: the gate resolves it the same way, a test that used npx would
+    // pass while the gate failed offline, and node_modules/.bin/tsx is a bash
+    // script Windows cannot execute (spawnSync returned status null there).
+    const r = spawnSync(process.execPath, [
+        path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs'),
         'scripts/generate-channel-capability-table.mts',
         ...args,
     ], { cwd: repoRoot, encoding: 'utf8' });


### PR DESCRIPTION
Brings the tree-identity release-speed change (#390) plus the promotion retry fixes into the release path for the v2.17.6 cut. This cut live-validates the fast path.