### PR TITLE
fix: close the nine open issues (#393-#401)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,61 @@ gh pr checks <n>
 gh run view <run-id> --json headSha,conclusion
 ```
 
+
+### 릴리스 절차 (dev → preview → main → npm)
+
+개발은 `dev` 에서만 한다. `preview` 와 `main` 은 이 절차를 통해서만 움직인다.
+
+```bash
+git checkout dev && git fetch origin
+git rebase origin/main                      # ff-able 유지
+bash scripts/release-preview.sh             # 버전 범프 + gate:all + preview 푸시 + preview publish
+git push origin dev                         # dev 를 preview head 와 같게 맞춘다  ★
+bash scripts/promote-to-main.sh             # preview CI 인증 확인 → main 승격 → stable publish
+```
+
+**★ 를 빼먹으면 다음 사이클이 어긋난다.** `release-preview.sh` 는 버전 범프를
+현재 브랜치에 커밋하고 `HEAD:preview` 로 푸시한다. 그 커밋을 `dev` 에도 올리지
+않으면 origin/dev 만 뒤처진 채 남는다.
+
+승격이 끝나면 `main` 에 승격 커밋이 하나 더 생기므로 `dev`/`preview` 를 그 위로
+다시 맞춘다. 내용은 같고 버전 장부만 다르므로 리셋이 안전하다:
+
+```bash
+git fetch origin
+git branch -f backup/dev-pre-align-$(date +%y%m%d) dev
+git reset --hard origin/main
+git push --force-with-lease origin dev
+git push --force-with-lease origin HEAD:preview
+```
+
+#### 게이트가 막을 때
+
+- **`origin/main is not an ancestor of the certified preview SHA`** — preview 를
+  force-push 해서 main 이 조상에서 빠졌거나, **승격이 이미 끝난 뒤 스크립트를 다시
+  돌린** 경우다. `git log --oneline origin/preview..origin/main` 으로 main 이 이미
+  그 버전을 갖고 있는지부터 볼 것. 갖고 있으면 승격은 성공한 것이고 재실행할 일이
+  아니다 — `promote-to-main.sh` 는 승격 후 재실행을 지원하지 않는다.
+- **`No successful Postinstall Platform Checks run found for certified <sha>`** —
+  승격 직후 stable publish 가 main 의 push CI 보다 먼저 dispatch 되면 난다. main
+  push 런이 끝나기를 기다렸다가 publish 만 다시 dispatch 하면 된다. 승격을 되돌릴
+  필요는 없다.
+
+#### 배포 확인은 npm 버전만으로 부족하다
+
+설치 호스트에서 **실행 중인 프로세스가 새 `dist/` 를 로드했는지**까지 본다.
+`npm i -g` 는 파일만 교체하고 서비스는 옛 코드를 계속 돌린다:
+
+```bash
+ssh <host> 'export PATH=~/.local/bin:$PATH; jaw --version'
+ssh <host> 'grep -c <new-symbol> ~/.local/lib/node_modules/cli-jaw/dist/src/<path>.js'
+ssh <host> 'export PATH=~/.local/bin:$PATH; jaw service restart'
+ssh <host> 'ps -o lstart= -p $(sed -n "s/.*pid.: *\\([0-9]*\\).*/\\1/p" ~/.cli-jaw/jaw.pid.json|head -1)'
+```
+
+프로세스 시작 시각이 `dist/` mtime 보다 이르면 아직 옛 코드가 돌고 있다는 뜻이다.
+비대화형 `ssh` 는 `.zshrc` 를 읽지 않으므로 PATH 를 직접 줘야 `jaw` 를 찾는다.
+
 ### Clone
 
 ```bash


### PR DESCRIPTION
Closes #393, #394, #395, #396, #397, #398, #399, #400, #401.

Nine open issues, worked in dependency order. Plan and evidence live in
`devlog/_plan/260820_open_issue_closeout/`.

## What each commit does

| Issue | Commit | Change |
|---|---|---|
| #401 | c485d3ed | `isEstablishedHome` no longer counts `skills/`, `uploads/` and `heartbeat.json` — postinstall creates all three, so every new install read as established and got the pre-v3 session defaults |
| #395 | b1b22b58 | init distinguishes a channel the caller named from the untouched `telegram` seed before enabling it |
| #399 | f156c4a7 | a queued message recovers its conversation from `remoteKey` instead of falling back to the globally active session |
| #400 | aaecd48d | a thread the bot started is told apart from one it was pulled into midway; only the former keeps flowing without a mention |
| #398 | 9350fdab | `agent_tool` carries its run identity, and the Slack progress listener filters on it instead of `origin !== 'slack'` |
| #397 | c7467623 | an explicitly addressed, bound conversation is authorized, so an agent can name the channel it is working in |
| #394 | 74688b3d | Grok resolves through the account's `cursor-` prefixed ids; 92 missing ids added from a live catalogue |
| #393 | 32e1186d | the launchd plist carries `AGENT_CLI_CREDENTIAL_STORE`, which a login shell would otherwise have supplied |
| #396 | 9ba3ebda | `jaw slack manifest --url`, and setup rejects a truncated app-level token |

## Three issue bodies were wrong

Read-only investigation of all nine before any code was written turned up three
factual errors in the reports themselves:

- **#401** named two artifacts to remove; `heartbeat.json` is also seeded by
  postinstall (`bin/postinstall.ts:1038-1042`), so it is three.
- **#397** blamed `createSlackForwarder`. Both `relaySlackImages` call sites use
  the closure target and the forwarder skips Slack-origin runs. The live path is
  `/api/channel/send` with the prompt recommending target omission.
- **#398** pointed at the jwc mapper. The cursor runtime emits through
  `src/agent/events/helpers.ts`, so both emit sites needed the field.

## Implementation reversed the plan twice

- **#399**: loosening `scopeForChatSession` broke `SSD-001a`, which pins a
  deliberate contract — the default session is shared, and giving it a
  conversation-specific scope binds it to one conversation. The defect was the
  queue inventing `default`, not the rule about what `default` means.
- **#395**: dropping the `unshift` outright broke environment-managed Slack init,
  which relies on it. The real defect was that one line could not tell a named
  channel from an untouched default.

## Verification

- `npm run gate:all` — 22/22 pass
- `bash structure/verify-counts.sh` — 437/437 entries match
- Full suite compared against a baseline taken by stashing only the owned files:
  `comm -13` gives **0 new failures**
- Each fix has a red-green regression test; #394 was checked against a live
  `cursor-agent models` run rather than release notes

Pre-existing failures present on both sides: `FC-007` (flush-command) and two
`getArgumentCompletionItems` cases. `widget-watcher` fails identically with the
changes stashed — environment-dependent, not introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the embedded development log component to its latest version.
  * No user-facing functionality or public interfaces changed.

* **Documentation**
  * Added guidance for release promotion, deployment verification, and handling release gate failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->