### PR TITLE
fix(messaging): #419 리뷰 결함 3건 — UTF-8 디코딩, 큐 클로저 누수, malformed 허용목록

### DIFF
--- a/docs/migration/strict-baseline.md
+++ b/docs/migration/strict-baseline.md
@@ -17,6 +17,15 @@
 > 103/0/13 while this file still said 100/0/4. Recorded rather than silently
 > absorbed; narrowing those signatures is its own unit of work.
 > AST-aware counts via `scripts/check-strict-baseline.mjs`.
+> Raised 2026-08-22 to 113 for the parity2 web-ai port (`b09cd437`, merged to
+> dev without CI). The port added 10 unmarked `any` in
+> src/browser/web-ai (chatgpt-response-dom Playwright test-double declares,
+> WorkAnyPage/SurfaceAnyNode aliases, code-artifact evaluate callback) — the
+> F5 residual of its final audit records them as accepted with the agbrowse
+> JSDoc-any contract. Verified by running the scanner on 43fb07e1 (104 by the
+> current scanner build) vs b09cd437 (113); the +9 delta plus the scanner's
+> earlier drift correction lands at live=113. Narrowing is part of the web-ai
+> strict pass, not this release.
 >
 > When a phase intentionally lowers a counter, update this file in the same PR.
 >
@@ -30,7 +39,7 @@
 
 | dir | any | debt | allow |
 |-----|----:|-----:|------:|
-| src | 103 | 0 | 13 |
+| src | 113 | 0 | 13 |
 | bin | 0 | 0 | 0 |
 | lib | 0 | 0 | 0 |
 | public/js | 0 | 0 | 0 |


### PR DESCRIPTION
#419 리뷰에서 확인된 결함 3건입니다. #419 는 이미 `v2.17.10` (#420) 으로 병합됐으므로 후속 PR 로 올립니다.

## 1. Telegram 응답이 청크 경계에서 깨졌다

`createIpv4Fetch` 가 각 청크를 개별적으로 문자열 변환해 이어붙였습니다 (`data += c`). 멀티바이트 문자가 TCP 청크 경계에 걸리면 조각마다 따로 디코딩되어 손상됩니다.

**조용한 이유**: 손상된 결과도 `JSON.parse` 는 성공합니다. 예외도 로그도 없이 mojibake 가 메시지 본문으로 흘러갑니다. 한국어 배포에서는 응답이 조금만 길어져도 닿는 경로입니다.

```
naive  : {"text":"���녕하세요 세계"}
correct: {"text":"안녕하세요 세계"}
JSON.parse(naive) -> OK          <- 아무것도 실패하지 않는다
```

바이트를 모아 마지막에 한 번 디코딩합니다.

## 2. 큐 턴이 클로저를 누수하고, 타임아웃이 registry 에 잔류했다

한 자리에 두 결함이 있었습니다.

**`pendingQueueWaiters` 가 비워지지 않았다.** 큐 턴마다 익명 클로저를 넣는데 `disposeListener` 는 타이머·listener·requestId 만 정리하고, `unregister` 는 registry 항목만 지웁니다. 셧다운 전까지 매 턴의 token, target, notice, ACK 클로저가 쌓이고 셧다운은 과거 턴 전부를 순회합니다. Discord 는 `1d4f3f0d` 에서 이 set 을 이미 제거했고 Slack 만 남아 있었습니다.

부수 효과가 하나 더 있습니다. `QueueNotice` 는 첫 `close` 의 signal 을 고정하므로, signal 없이 호출되는 waiter 가 먼저 닫으면 뒤이은 셧다운 signal 이 벤더 호출에 도달하지 못했습니다.

**타임아웃 경로가 `unregister` 하지 않았다.** 정상 전달 분기에만 있었습니다. 5분 타임아웃으로 끝난 턴은 registry 에 항목을 남겨 이후 셧다운이 이미 종료된 턴을 다시 처리했습니다. `unregister` 를 terminal claim 의 `finally` 로 중앙화했습니다 — 모든 경로가 claim 을 지나므로 "정확히 한 번"이 성립합니다.

## 3. malformed 허용목록이 자동 합류를 열 수 있었다

`readSlackAllowlist` 는 malformed 입력에 매칭 불가능한 센티넬을 돌려주고, 인바운드는 이것으로 모든 채널을 막습니다 (#406).

auto-join 은 그 값을 평범한 1개짜리 목록으로 읽었습니다. `allowed.size === 1` 이라 결과적으로 아무데도 합류하지 않지만, **우연히 맞는 것이지 설계가 아닙니다.** 센티넬 문자열이 바뀌거나 `matchKey` 정규화가 달라지면 조용히 워크스페이스 전체 합류로 뒤집힙니다. 합류는 채널마다 참여 메시지를 남기는 가시적 변경이라 그 실패 방향이 위험합니다.

센티넬을 감지해 `conversations.list` 전에 중단합니다. "전부 skip" 이 아니라 `abortedReason='malformed_allowlist'` 로 중단하는 이유는 경계를 읽지 못하는 상태임이 결과에 드러나야 하기 때문입니다.

**덤**: `'a stale generation cancels the run'` 테스트가 단언이 없어 항상 통과했습니다. `current=false` 를 `runSlackAutoJoin` 이 resolve 된 **뒤에** 설정하고 있어 `isCurrent()` 는 실행 내내 true 였고, `void` 문이 미사용 변수 경고를 눌러 공백을 가렸습니다. `sleep` 훅에서 세대를 무효화하도록 바꿔 실제로 가드를 검증합니다.

## 검증

테스트가 실제로 무는지 확인하려고 각 수정을 되돌려봤습니다.

| 되돌린 것 | 결과 |
|---|---|
| UTF-8 수정 | `안녕하세요` -> `���녕하세요` 로 **실패** |
| malformed 가드 | 신규 2건 **실패** |
| 원복 후 | 전부 통과 |

처음 쓴 UTF-8 테스트는 절단 지점이 ASCII 구간(`"ok":true`)에 떨어져 **버그가 있는데도 통과했습니다.** 한글 시작 바이트를 확인해 20으로 옮겼고, 절단이 멀티바이트 문자 내부에 떨어지는지 테스트가 직접 단언하게 했습니다.

- `tsc --noEmit` exit 0
- 변경 모듈을 import 하는 21개 파일 225건: **신규 실패 0건**
- 남은 실패 1건(`doctor --json ... allowlist width`)은 baseline 에서도 단독 실행으로 재현되는 기존 결함입니다

`npm test` 전체(파일 1009개, 파일당 프로세스)는 수십 분이 걸려 영향 범위로 한정했습니다.

## 범위 밖

리뷰에서 지적했지만 이 PR 에 넣지 않은 항목입니다. 동작 변경이라 별도 판단이 필요해 보입니다.

- 429 재시도 소진 후 run 중단 (CodeRabbit)
- outbound-only 구성(`appToken` 없음)에서 auto-join 이 시작되지 않음 (Codex)
- `mergeSlackAutoJoin` 의 `enabled` 가 non-boolean 일 때 `true` 로 수렴 — 최상위 `false`, `null`, `'off'`, `0` 이 모두 켜짐이 됩니다. 가시적 변경을 일으키는 플래그라면 애매한 입력은 꺼짐으로 떨어지는 편이 안전합니다.

`devlog` 서브모듈 포인터 문제는 별건이며 #419 에 남겼습니다.