### PR TITLE
feat(web-ai): mirror agbrowse parity into cli-jaw

### DIFF
--- a/src/browser/web-ai/active-command-store.ts
+++ b/src/browser/web-ai/active-command-store.ts
@@ -60,11 +60,16 @@ function readStore(): ActiveCommandStore {
     try {
         const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<ActiveCommandStore>;
         if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.commands)) {
-            return { version: STORE_VERSION, commands: [] };
+            throw new Error(`active-command store schema-invalid at ${path}`);
         }
         return { version: STORE_VERSION, commands: parsed.commands as ActiveCommandRow[] };
-    } catch {
-        return { version: STORE_VERSION, commands: [] };
+    } catch (err) {
+        // parity2 110 fix (final-audit F2): a corrupt store must be OBSERVED —
+        // silently returning empty unprotects every running command's tab
+        // (agbrowse throws active-command.store-unavailable here).
+        const error = new Error(`active-command store unavailable: ${(err as Error)?.message || err}`) as Error & { code?: string };
+        error.code = 'active-command.store-unavailable';
+        throw error;
     }
 }
 
@@ -251,4 +256,3 @@ export async function withActiveCommand<T>(input: ActiveCommandInput, fn: (comma
         if (heartbeatTimer) clearInterval(heartbeatTimer);
     }
 }
-

--- a/src/browser/web-ai/active-command-store.ts
+++ b/src/browser/web-ai/active-command-store.ts
@@ -1,0 +1,254 @@
+// Cross-process active-command registry (parity2 100, catalog B8).
+//
+// Ported subset of agbrowse web-ai/active-command-store.mjs: a file-backed
+// registry of in-flight commands (heartbeat + TTL, atomic lock) so tab cleanup
+// and the session doctor can see active commands from OTHER processes.
+// `activeCommandTargetIds` protects their tabs from lease reclamation.
+
+import { existsSync, mkdirSync, openSync, closeSync, readFileSync, writeFileSync, renameSync, unlinkSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { JAW_HOME } from '../../core/config.js';
+
+export interface ActiveCommandRow {
+    commandId: string;
+    status: 'running' | 'completed' | 'failed' | 'expired' | 'stale';
+    command?: string;
+    owner?: string;
+    targetId?: string;
+    sessionId?: string;
+    browserProfileKey?: string;
+    pid?: number;
+    startedAt: string;
+    heartbeatAt: string;
+    expiresAt: string;
+    completedAt?: string;
+}
+
+export interface ActiveCommandInput {
+    commandId?: string;
+    command?: string;
+    owner?: string;
+    targetId?: string;
+    sessionId?: string;
+    browserProfileKey?: string | number;
+    ttlMs?: number;
+    heartbeatIntervalMs?: number;
+    startedAt?: string;
+    heartbeatAt?: string;
+    expiresAt?: string;
+}
+
+interface ActiveCommandStore { version: number; commands: ActiveCommandRow[] }
+
+const STORE_VERSION = 1;
+const DEFAULT_TTL_MS = 120_000;
+const LOCK_RETRY_MS = 25;
+const LOCK_RETRY_LIMIT = 200;
+const STALE_LOCK_MS = 30_000;
+
+function storePath(): string {
+    return join(JAW_HOME, 'web-ai-active-commands.json');
+}
+function lockPath(): string {
+    return `${storePath()}.lock`;
+}
+
+function readStore(): ActiveCommandStore {
+    const path = storePath();
+    if (!existsSync(path)) return { version: STORE_VERSION, commands: [] };
+    try {
+        const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<ActiveCommandStore>;
+        if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.commands)) {
+            return { version: STORE_VERSION, commands: [] };
+        }
+        return { version: STORE_VERSION, commands: parsed.commands as ActiveCommandRow[] };
+    } catch {
+        return { version: STORE_VERSION, commands: [] };
+    }
+}
+
+function writeStore(store: ActiveCommandStore): void {
+    const path = storePath();
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+    writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+    renameSync(tmp, path);
+}
+
+function isStaleLock(path: string): boolean {
+    try {
+        const acquired = statSync(path).mtimeMs;
+        return !Number.isFinite(acquired) || Date.now() - acquired > STALE_LOCK_MS;
+    } catch {
+        return true;
+    }
+}
+
+async function withActiveCommandLock<T>(fn: () => Promise<T> | T): Promise<T> {
+    const path = lockPath();
+    mkdirSync(dirname(path), { recursive: true });
+    let attempts = 0;
+    while (attempts < LOCK_RETRY_LIMIT) {
+        try {
+            const fd = openSync(path, 'wx');
+            closeSync(fd);
+            try {
+                return await fn();
+            } finally {
+                try { unlinkSync(path); } catch { /* already gone */ }
+            }
+        } catch (err) {
+            if ((err as { code?: string })?.code !== 'EEXIST') throw err;
+            attempts += 1;
+            if (isStaleLock(path)) {
+                try { unlinkSync(path); } catch { /* races resolve naturally */ }
+                continue;
+            }
+            await new Promise(resolve => setTimeout(resolve, LOCK_RETRY_MS));
+        }
+    }
+    throw new Error(`active-command store: failed to acquire lock at ${path} after ${LOCK_RETRY_LIMIT} attempts`);
+}
+
+function normalizeActiveCommand(input: ActiveCommandInput & { commandId: string; startedAt: string; heartbeatAt: string; expiresAt: string; status: ActiveCommandRow['status'] }): ActiveCommandRow {
+    return {
+        commandId: input.commandId,
+        status: input.status,
+        ...(input.command ? { command: input.command } : {}),
+        ...(input.owner ? { owner: input.owner } : {}),
+        ...(input.targetId ? { targetId: input.targetId } : {}),
+        ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+        ...(input.browserProfileKey !== undefined ? { browserProfileKey: String(input.browserProfileKey) } : {}),
+        pid: process.pid,
+        startedAt: input.startedAt,
+        heartbeatAt: input.heartbeatAt,
+        expiresAt: input.expiresAt,
+    };
+}
+
+export class ActiveCommandTargetOwnedError extends Error {
+    code = 'active-command.target-owned';
+    command: ActiveCommandRow;
+    constructor(conflict: ActiveCommandRow) {
+        super(`target already owned by active command: ${conflict.commandId}`);
+        this.command = conflict;
+    }
+}
+
+export async function registerActiveCommand(input: ActiveCommandInput = {}): Promise<ActiveCommandRow> {
+    const now = new Date();
+    const command = normalizeActiveCommand({
+        ...input,
+        commandId: input.commandId || randomUUID(),
+        startedAt: input.startedAt || now.toISOString(),
+        heartbeatAt: input.heartbeatAt || now.toISOString(),
+        expiresAt: input.expiresAt || new Date(now.getTime() + (input.ttlMs || DEFAULT_TTL_MS)).toISOString(),
+        status: 'running',
+    });
+    return withActiveCommandLock(() => {
+        const store = readStore();
+        const nowMs = Date.now();
+        let changed = false;
+        store.commands = store.commands.map(row => {
+            if (row.status !== 'running') return row;
+            const expiresMs = Date.parse(row.expiresAt || '');
+            if (!Number.isFinite(expiresMs) || expiresMs <= nowMs) {
+                changed = true;
+                return { ...row, status: 'expired' as const, completedAt: new Date(nowMs).toISOString() };
+            }
+            return row;
+        });
+        if (changed) writeStore(store);
+        const targetConflict = command.targetId
+            ? store.commands.find(row =>
+                row.status === 'running' &&
+                row.targetId === command.targetId &&
+                row.commandId !== command.commandId)
+            : null;
+        if (targetConflict) throw new ActiveCommandTargetOwnedError(targetConflict);
+        store.commands = store.commands.filter(row => row.commandId !== command.commandId);
+        store.commands.push(command);
+        writeStore(store);
+        return command;
+    });
+}
+
+export async function heartbeatActiveCommand(commandId: string, { ttlMs = DEFAULT_TTL_MS }: { ttlMs?: number } = {}): Promise<ActiveCommandRow | null> {
+    const now = new Date();
+    return withActiveCommandLock(() => {
+        const store = readStore();
+        const idx = store.commands.findIndex(row => row.commandId === commandId);
+        if (idx < 0) return null;
+        store.commands[idx] = {
+            ...store.commands[idx]!,
+            heartbeatAt: now.toISOString(),
+            expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+        };
+        writeStore(store);
+        return store.commands[idx]!;
+    });
+}
+
+export async function releaseActiveCommand(commandId: string, status: ActiveCommandRow['status'] = 'completed'): Promise<ActiveCommandRow | null> {
+    return withActiveCommandLock(() => {
+        const store = readStore();
+        const idx = store.commands.findIndex(row => row.commandId === commandId);
+        if (idx < 0) return null;
+        const updated: ActiveCommandRow = { ...store.commands[idx]!, status, completedAt: new Date().toISOString() };
+        store.commands[idx] = updated;
+        writeStore(store);
+        return updated;
+    });
+}
+
+export async function listActiveCommands(filter: { active?: boolean; targetId?: string; browserProfileKey?: string | number; owner?: string } = {}): Promise<ActiveCommandRow[]> {
+    return withActiveCommandLock(() => {
+        const now = Date.now();
+        const store = readStore();
+        let changed = false;
+        let commands = store.commands.map(row => {
+            if (row.status === 'running' && Date.parse(row.expiresAt || '') <= now) {
+                changed = true;
+                return { ...row, status: 'stale' as const };
+            }
+            return row;
+        });
+        if (changed) writeStore({ ...store, commands });
+        if (filter.active === true) commands = commands.filter(row => row.status === 'running');
+        if (filter.targetId) commands = commands.filter(row => row.targetId === filter.targetId);
+        if (filter.browserProfileKey !== undefined) commands = commands.filter(row => row.browserProfileKey === String(filter.browserProfileKey));
+        if (filter.owner) commands = commands.filter(row => row.owner === filter.owner);
+        return commands;
+    });
+}
+
+/** Target ids owned by RUNNING commands — lease cleanup must not reclaim these tabs. */
+export async function activeCommandTargetIds(filter: { targetId?: string; browserProfileKey?: string | number; owner?: string } = {}): Promise<Set<string>> {
+    const commands = await listActiveCommands({ ...filter, active: true });
+    return new Set(commands.map(row => row.targetId).filter((id): id is string => Boolean(id)));
+}
+
+/** Run `fn` under a registered command with periodic heartbeats; always released. */
+export async function withActiveCommand<T>(input: ActiveCommandInput, fn: (command: ActiveCommandRow) => Promise<T>): Promise<T> {
+    const command = await registerActiveCommand(input);
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    if (input.heartbeatIntervalMs !== 0) {
+        const interval = Math.max(1000, input.heartbeatIntervalMs || 15_000);
+        heartbeatTimer = setInterval(() => {
+            void heartbeatActiveCommand(command.commandId, { ttlMs: input.ttlMs ?? DEFAULT_TTL_MS }).catch(() => undefined);
+        }, interval);
+        heartbeatTimer.unref?.();
+    }
+    try {
+        const result = await fn(command);
+        await releaseActiveCommand(command.commandId, 'completed').catch(() => undefined);
+        return result;
+    } catch (err) {
+        await releaseActiveCommand(command.commandId, 'failed').catch(() => undefined);
+        throw err;
+    } finally {
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+    }
+}
+

--- a/src/browser/web-ai/cdp-liveness.ts
+++ b/src/browser/web-ai/cdp-liveness.ts
@@ -1,0 +1,73 @@
+// Independent CDP liveness probe.
+//
+// Ported from agbrowse `web-ai/cdp-liveness.mjs` (parity2 020 slice 2.2,
+// catalog B6). After a Playwright/CDP client disconnect, probe Chrome's HTTP
+// DevTools endpoint OUT-OF-BAND to classify the disconnect: Chrome alive with
+// the target present means the disconnect is recoverable by reattaching;
+// anything else is fatal for that tab.
+
+export interface CdpLiveness {
+    endpointReachable: boolean;
+    targetFound: boolean | null;
+    matchedUrl?: string;
+    error?: string;
+}
+
+export interface ProbeCdpLivenessOptions {
+    port: number;
+    targetId?: string | null;
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+}
+
+/** Probe Chrome independently from the CDP client that disconnected. */
+export async function probeCdpLiveness(options: ProbeCdpLivenessOptions): Promise<CdpLiveness> {
+    const port = Number(options.port);
+    const targetId = options.targetId?.trim() || '';
+    if (!Number.isFinite(port) || port <= 0) {
+        return { endpointReachable: false, targetFound: null, error: 'missing debug port' };
+    }
+    if (!targetId) {
+        return { endpointReachable: false, targetFound: null, error: 'missing target id' };
+    }
+    const fetchImpl = options.fetchImpl || fetch;
+    const timeoutMs = options.timeoutMs || 1_500;
+    try {
+        const versionResponse = await fetchImpl(`http://127.0.0.1:${port}/json/version`, {
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!versionResponse.ok) {
+            return { endpointReachable: false, targetFound: null, error: `DevTools version HTTP ${versionResponse.status}` };
+        }
+    } catch (err) {
+        return { endpointReachable: false, targetFound: null, error: errorMessage(err) };
+    }
+    try {
+        const listResponse = await fetchImpl(`http://127.0.0.1:${port}/json/list`, {
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!listResponse.ok) {
+            return { endpointReachable: true, targetFound: null, error: `DevTools list HTTP ${listResponse.status}` };
+        }
+        const targets = await listResponse.json() as Array<{ id?: string; targetId?: string; url?: string }>;
+        if (!Array.isArray(targets)) {
+            return { endpointReachable: true, targetFound: null, error: 'DevTools target list is not an array' };
+        }
+        const match = targets.find(target => target?.id === targetId || target?.targetId === targetId);
+        return match
+            ? { endpointReachable: true, targetFound: true, ...(typeof match.url === 'string' ? { matchedUrl: match.url } : {}) }
+            : { endpointReachable: true, targetFound: false };
+    } catch (err) {
+        return { endpointReachable: true, targetFound: null, error: errorMessage(err) };
+    }
+}
+
+/** True only when Chrome answered AND the target is still listed. */
+export function isRecoverableCdpDisconnect(liveness: CdpLiveness): boolean {
+    return liveness.endpointReachable === true && liveness.targetFound === true;
+}
+
+function errorMessage(err: unknown): string {
+    return String((err as { message?: string })?.message || err);
+}
+

--- a/src/browser/web-ai/chatgpt-attachments.ts
+++ b/src/browser/web-ai/chatgpt-attachments.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Page } from 'playwright-core';
+import { computeAttachmentTimeouts, setInputFilesResilient } from './chatgpt-upload-surface.js';
 
 export type AttachmentPolicyName = 'inline-only' | 'upload' | 'auto';
 
@@ -36,8 +37,14 @@ const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.he
 const SPREADSHEET_EXTENSIONS = new Set(['.csv', '.tsv', '.xls', '.xlsx']);
 
 // 104.12: uploads delay send-button enablement, so widen the resolved/scan click window when files are attached.
-export function sendButtonTimeoutMs(fileNames: readonly unknown[] = []): number {
-    return Array.isArray(fileNames) && fileNames.length > 0 ? 45_000 : 20_000;
+export function sendButtonTimeoutMs(fileNames: readonly unknown[] = [], totalSizeBytes = 0): number {
+    if (!Array.isArray(fileNames) || fileNames.length === 0) return 20_000;
+    // parity2 060 slices A-03/A-05 (agbrowse :216-219): size-aware — a large
+    // upload legitimately keeps the send button disabled longer than 45s.
+    const bytes = Number(totalSizeBytes) || 0;
+    const UPLOAD_RATE_BYTES_PER_SEC = 1_000_000; // conservative 1MB/s
+    const sizeMs = Math.ceil(bytes / UPLOAD_RATE_BYTES_PER_SEC) * 1000;
+    return Math.max(45_000, 45_000 + sizeMs);
 }
 
 export function preflightAttachment(file: { path: string; sizeBytes: number; basename: string }): AttachmentPreflightResult {
@@ -242,7 +249,22 @@ export async function attachLocalFileLive(
         };
     }
     try {
-        await page.locator(inputSel).first().setInputFiles(file.path, { timeout: 8_000 });
+        // parity2 060 slices A-05/C-11: 50MB-safe CDP-first injection with
+        // size-aware handoff budget.
+        const budgets = computeAttachmentTimeouts([file]);
+        const injected = await setInputFilesResilient(page, inputSel, file.path, {
+            timeoutMs: budgets.handoffMs,
+            totalBytes: budgets.totalBytes,
+            usedFallbacks,
+        });
+        if (!injected.ok) {
+            return {
+                ok: false,
+                stage: 'attachment-upload',
+                error: injected.error,
+                usedFallbacks,
+            };
+        }
     } catch (e) {
         usedFallbacks.push(`setInputFiles-failed:${(e as Error).message}`);
         return {
@@ -253,7 +275,8 @@ export async function attachLocalFileLive(
         };
     }
     // Wait for visible chip evidence (input-only success forbidden) — verify the SPECIFIC file (104.13).
-    const accepted = await waitForAttachmentAcceptedLive(page, { timeoutMs: 30_000, fileNames: [file.basename] });
+    // parity2 060: acceptance window scales with file size.
+    const accepted = await waitForAttachmentAcceptedLive(page, { timeoutMs: computeAttachmentTimeouts([file]).acceptanceMs, fileNames: [file.basename] });
     if (!accepted.ok) {
         return accepted;
     }

--- a/src/browser/web-ai/chatgpt-composer.ts
+++ b/src/browser/web-ai/chatgpt-composer.ts
@@ -184,6 +184,11 @@ export async function submitPromptFromComposer(page: Page, options: VendorEditor
     }
     const clicked = await clickEnabledSendButton(page, options.sendButtonTimeoutMs);
     if (clicked) return { method: 'button' };
+    // parity2 060 slice A-03: attachments pending → Enter may submit early;
+    // report the typed failure sentinel instead (agbrowse composer :163-180).
+    if (options.requireEnabledSendButton) {
+        return { method: 'none', failure: 'send-button-disabled' };
+    }
     await page.keyboard.press('Enter');
     return { method: 'enter' };
 }

--- a/src/browser/web-ai/chatgpt-deep-research-report.ts
+++ b/src/browser/web-ai/chatgpt-deep-research-report.ts
@@ -40,6 +40,33 @@ export function normalizeDeepResearchReportText(text: unknown): string {
     return text.replace(/\r\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
 }
 
+// parity2 090 (D-05, moved from 070): tool-call wrapper markers, incl. Polish.
+const DR_TOOL_CALL_MARKERS = [
+    'called tool',
+    'used tool',
+    'użyto narzędzia',
+    'narzędzie wywołane',
+];
+
+/**
+ * True when the text is a tool-call wrapper placeholder rather than a report.
+ * startsWith, never includes: a genuine report that MENTIONS "called tool"
+ * mid-body is still a report; and the marker must end at a token boundary so
+ * a report titled "Used Tools in Modern Oncology…" is not swallowed.
+ */
+export function looksLikeDeepResearchToolCallCapture(text: unknown): boolean {
+    const answer = normalizeDeepResearchReportText(text)
+        .replace(/^Answer:\s*/i, '')
+        .toLowerCase()
+        .replace(/\s+/g, ' ')
+        .trim();
+    return DR_TOOL_CALL_MARKERS.some((marker) => {
+        if (!answer.startsWith(marker)) return false;
+        const next = answer.charAt(marker.length);
+        return next === '' || !/[\p{L}\p{N}]/u.test(next);
+    });
+}
+
 /**
  * True if the text is an incomplete Deep Research artifact — a planning card,
  * progress/status line, or too short to be a final report. A completed report is
@@ -48,6 +75,7 @@ export function normalizeDeepResearchReportText(text: unknown): string {
 export function isIncompleteDeepResearchText(text: unknown): boolean {
     const norm = normalizeDeepResearchReportText(text);
     if (norm.length < DR_MIN_REPORT_CHARS) return true;
+    if (looksLikeDeepResearchToolCallCapture(norm)) return true;
     const firstLine = (norm.split('\n', 1)[0] ?? '').trim();
     return DR_INCOMPLETE_MARKERS.some((re) => re.test(firstLine));
 }

--- a/src/browser/web-ai/chatgpt-deep-research.ts
+++ b/src/browser/web-ai/chatgpt-deep-research.ts
@@ -62,11 +62,24 @@ async function readLatestAssistant(page: Page): Promise<string> {
     return last.innerText().catch(() => '');
 }
 
-async function isStreaming(page: Page): Promise<boolean> {
+/**
+ * parity2 070 slice D-04: tri-state stop probe — an unreadable probe is
+ * 'unknown', not "not streaming"; extraction requires a POSITIVE 'absent'.
+ */
+async function probeStopState(page: Page): Promise<'visible' | 'absent' | 'unknown'> {
+    let anyUninspected = false;
     for (const sel of STOP_SELECTORS) {
-        if (await page.locator(sel).first().isVisible().catch(() => false)) return true;
+        try {
+            if (await page.locator(sel).first().isVisible()) return 'visible';
+        } catch {
+            anyUninspected = true;
+        }
     }
-    return false;
+    return anyUninspected ? 'unknown' : 'absent';
+}
+
+async function isStreaming(page: Page): Promise<boolean> {
+    return (await probeStopState(page)) === 'visible';
 }
 
 async function hasProgressIndicator(page: Page): Promise<boolean> {
@@ -163,13 +176,18 @@ export async function sendDeepResearch(page: Page, deps: DeepResearchDeps, opts:
     const { prompt, session, timeoutMs = 1_200_000, skipModeActivation = false } = opts;
     const warnings: string[] = [];
 
+    // parity2 070 slice C-03: persist the DR marker — chatgpt-archive's DR guard
+    // reads session.researchMode === 'deep' but nothing ever wrote it.
+    updateSessionResult({ sessionId: session.sessionId, status: session.status, researchMode: 'deep' });
+
     const modeActivated = skipModeActivation ? true : await activateDeepResearchMode(page);
     if (!modeActivated) {
         warnings.push('deep-research-mode-button-not-found-using-prompt-prefix');
     }
 
     if (await isAccountBlocked(page)) {
-        updateSessionStatus(session.sessionId, 'error');
+        // parity2 070 slice C-04: an account block is 'blocked', not a generic error.
+        updateSessionStatus(session.sessionId, 'blocked');
         return {
             ok: false,
             sessionId: session.sessionId,
@@ -209,7 +227,7 @@ export async function sendDeepResearch(page: Page, deps: DeepResearchDeps, opts:
     const blockCheckDeadline = Date.now() + 15_000;
     while (Date.now() < blockCheckDeadline) {
         if (await isAccountBlocked(page)) {
-            updateSessionStatus(session.sessionId, 'error');
+            updateSessionStatus(session.sessionId, 'blocked');
             return {
                 ok: false,
                 sessionId: session.sessionId,
@@ -225,7 +243,6 @@ export async function sendDeepResearch(page: Page, deps: DeepResearchDeps, opts:
         if (progress) researchActivityObserved = true;
         const streaming = await isStreaming(page);
         if (count > baselineCount || streaming || progress) {
-            if (streaming) researchActivityObserved = true;
             break;
         }
         await page.waitForTimeout(500);
@@ -238,12 +255,17 @@ export async function sendDeepResearch(page: Page, deps: DeepResearchDeps, opts:
     while (Date.now() < deadline) {
         await page.waitForTimeout(2000);
 
-        const streaming = await isStreaming(page);
+        const stopState = await probeStopState(page);
         const progress = await hasProgressIndicator(page);
-        if (progress || streaming) researchActivityObserved = true;
+        // parity2 070 slice D-03: only PROGRESS-INDICATOR evidence counts as
+        // research activity. A normal streaming reply would otherwise defeat
+        // the deep-research-not-started gate and get returned as a "report".
+        if (progress) researchActivityObserved = true;
         const count = await countAssistants(page);
 
-        if (count > baselineCount && !streaming && !progress) {
+        // parity2 070 slice D-04: extraction requires POSITIVE stop-absent
+        // evidence — an unreadable probe must not extract a mid-generation report.
+        if (count > baselineCount && stopState === 'absent' && !progress) {
             const latest = (await readLatestAssistant(page)).trim();
             if (latest) {
                 if (latest === stableText) {

--- a/src/browser/web-ai/chatgpt-model.ts
+++ b/src/browser/web-ai/chatgpt-model.ts
@@ -13,6 +13,36 @@ declare const document: { querySelectorAll(selector: string): Iterable<BrowserNo
 
 export type ChatGptModelChoice = 'instant' | 'thinking' | 'pro';
 export type ChatGptEffortChoice = 'light' | 'standard' | 'extended' | 'heavy';
+/** parity2 030 slice 3.1 (C-01): GPT-5.6 family picker vocabulary. */
+export type ChatGptFamilyChoice = 'gpt-5.6-sol' | 'gpt-5.5' | 'o3';
+
+export const CHATGPT_FAMILY_OPTIONS: Readonly<Record<ChatGptFamilyChoice, { label: string }>> = Object.freeze({
+    'gpt-5.6-sol': { label: 'GPT-5.6 Sol' },
+    'gpt-5.5': { label: 'GPT-5.5' },
+    o3: { label: 'o3' },
+});
+
+const FAMILY_ALIASES: Readonly<Record<string, ChatGptFamilyChoice>> = Object.freeze({
+    'gpt-5.6-sol': 'gpt-5.6-sol',
+    'gpt-5.6': 'gpt-5.6-sol',
+    sol: 'gpt-5.6-sol',
+    'gpt-5.5': 'gpt-5.5',
+    o3: 'o3',
+});
+
+export function normalizeChatGptFamilyChoice(family: string | undefined): ChatGptFamilyChoice | null {
+    const key = String(family || '').trim().toLowerCase();
+    return key ? FAMILY_ALIASES[key] || null : null;
+}
+
+/** parity2 030 (C-01): Power-shell selectors — the 5.6 Chat picker renders a
+ * Power menu item whose slider drives tier/effort; menu rows may not exist. */
+export const CHATGPT_POWER_PICKER_ROOT_SELECTOR =
+    '[role="menu"][data-state="open"]:has([role="menuitem"][aria-label="Power"])';
+export const CHATGPT_POWER_SLIDER_VIEW_SELECTOR = [
+    '[data-testid="composer-model-picker-slider-simple-view"]',
+    '[data-testid="composer-model-picker-slider-advanced-view"]',
+].join(', ');
 
 export interface ChatGptModelSelectionEvidence {
     requestedModel: string | null;
@@ -69,7 +99,7 @@ const CHATGPT_COMPOSER_MODEL_PILL_SELECTORS = [
 ] as const;
 
 const CHATGPT_MODEL_MENU_ITEM_SELECTOR = '[data-testid^="model-switcher-gpt-"]';
-const CHATGPT_MODEL_TEXT_BUTTON_PATTERN = /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장)/i;
+const CHATGPT_MODEL_TEXT_BUTTON_PATTERN = /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장|即时|思考|中等|极高|高|Pro 扩展)/i;
 const CHATGPT_OBSERVED_PRO_PILL_LABELS = ['Standard Pro', 'Extended Pro'] as const;
 const CHATGPT_EFFORT_TRIGGER_SELECTORS = [
     '[data-testid*="thinking-effort"]',
@@ -82,9 +112,11 @@ const CHATGPT_EFFORT_TRIGGER_SELECTORS = [
 ] as const;
 
 export const CHATGPT_MODEL_OPTIONS: Record<ChatGptModelChoice, { testIds: string[]; labels: string[] }> = {
-    instant: { testIds: ['model-switcher-gpt-5-5', 'model-switcher-gpt-5-3'], labels: ['Instant', '즉시'] },
-    thinking: { testIds: ['model-switcher-gpt-5-5-thinking', 'model-switcher-gpt-5-5-thinking-thinking-effort'], labels: ['Thinking', 'Medium', 'High', 'Extra High', '중간', '높음', '매우 높음'] },
-    pro: { testIds: ['model-switcher-gpt-5-5-pro', 'model-switcher-gpt-5-5-pro-thinking-effort'], labels: ['Pro', 'Heavy', 'Pro Standard', 'Pro Extended', 'Pro 확장', '프로 확장'] },
+    // parity2 030 slice 3.2 (C-20): zh projections added per label set — each list is
+    // its old literal PLUS only the locale variants of those same terms (agbrowse G25).
+    instant: { testIds: ['model-switcher-gpt-5-5', 'model-switcher-gpt-5-3'], labels: ['Instant', '즉시', '即时'] },
+    thinking: { testIds: ['model-switcher-gpt-5-5-thinking', 'model-switcher-gpt-5-5-thinking-thinking-effort'], labels: ['Thinking', 'Medium', 'High', 'Extra High', '중간', '높음', '매우 높음', '思考', '中等', '高', '极高'] },
+    pro: { testIds: ['model-switcher-gpt-5-5-pro', 'model-switcher-gpt-5-5-pro-thinking-effort'], labels: ['Pro', 'Heavy', 'Pro Standard', 'Pro Extended', 'Pro 확장', '프로 확장', 'Pro 扩展'] },
 };
 
 export const CHATGPT_MODEL_EFFORT_OPTIONS: Record<'thinking' | 'pro', { triggerTestIds: string[]; efforts: Partial<Record<ChatGptEffortChoice, string>> }> = {
@@ -111,25 +143,25 @@ const CHATGPT_SIMPLIFIED_INTELLIGENCE_OPTIONS: Readonly<Record<ChatGptModelChoic
     efforts: Readonly<Partial<Record<ChatGptEffortChoice, readonly string[]>>>;
 }>> = {
     instant: {
-        defaultLabels: ['Instant', '즉시'],
+        defaultLabels: ['Instant', '즉시', '即时'],
         efforts: {
-            light: ['Instant', '즉시'],
+            light: ['Instant', '즉시', '即时'],
         },
     },
     thinking: {
-        defaultLabels: ['Medium', '중간'],
+        defaultLabels: ['Medium', '중간', '中等'],
         efforts: {
-            light: ['Instant', '즉시'],
-            standard: ['Medium', '중간'],
-            extended: ['High', '높음'],
-            heavy: ['Extra High', '매우 높음'],
+            light: ['Instant', '즉시', '即时'],
+            standard: ['Medium', '중간', '中等'],
+            extended: ['High', '높음', '高'],
+            heavy: ['Extra High', '매우 높음', '极高'],
         },
     },
     pro: {
-        defaultLabels: ['Pro Extended', 'Pro 확장', '프로 확장'],
+        defaultLabels: ['Pro Extended', 'Pro 확장', '프로 확장', 'Pro 扩展'],
         efforts: {
-            standard: ['Pro Extended', 'Pro 확장', '프로 확장'],
-            extended: ['Pro Extended', 'Pro 확장', '프로 확장'],
+            standard: ['Pro Extended', 'Pro 확장', '프로 확장', 'Pro 扩展'],
+            extended: ['Pro Extended', 'Pro 확장', '프로 확장', 'Pro 扩展'],
         },
     },
 };
@@ -143,9 +175,13 @@ const MODEL_ALIASES: Record<string, ChatGptModelChoice> = {
     think: 'thinking',
     'gpt-5-5-thinking': 'thinking',
     'gpt-5.5-thinking': 'thinking',
+    'gpt-5-6-thinking': 'thinking',
+    'gpt-5.6-thinking': 'thinking',
     pro: 'pro',
     'gpt-5-5-pro': 'pro',
     'gpt-5.5-pro': 'pro',
+    'gpt-5-6-pro': 'pro',
+    'gpt-5.6-pro': 'pro',
 };
 
 const EFFORT_ALIASES: Record<string, ChatGptEffortChoice> = {
@@ -235,33 +271,80 @@ export async function selectChatGptModel(page: Page, model: string | undefined, 
         });
     }
     if (requested && currentModel !== requested) {
-        const option = await findModelOption(page, requested);
-        if (!option) throw new WebAiError({
-            errorCode: 'provider.model-mismatch',
-            stage: 'provider-select-mode',
-            vendor: 'chatgpt',
-            retryHint: 'model-fallback',
-            message: `ChatGPT model option not found: ${requested}`,
-            evidence: { requested },
-        });
-        await option.click({ timeout: 5_000 });
-        await page.waitForTimeout(750).catch(() => undefined);
-        await openModelMenu(page, usedFallbacks);
-        currentModel = await readCheckedModel(page, requested);
-        modelChanged = true;
+        // parity2 030 slice 3.1 (C-01): bounded retry (menu re-render race) with a
+        // Power-slider fallback — on the 5.6 Power shell the menu rows may not
+        // exist at all and the slider IS the selection control.
+        let attempt = 0;
+        const MODEL_SELECT_MAX_ATTEMPTS = 3;
+        while (currentModel !== requested && attempt < MODEL_SELECT_MAX_ATTEMPTS) {
+            attempt += 1;
+            const option = await findModelOption(page, requested);
+            if (!option) {
+                if (!(await isChatGptPowerPickerOpen(page))) {
+                    await openModelMenu(page, usedFallbacks).catch(() => undefined);
+                }
+                if (await isChatGptPowerPickerOpen(page)
+                    && await selectChatGptPowerTierBySlider(page, requested, { effort: requestedEffort || null, usedFallbacks })) {
+                    await page.waitForTimeout(400).catch(() => undefined);
+                    currentModel = await readCheckedModel(page, requested);
+                    modelChanged = true;
+                    continue;
+                }
+                throw new WebAiError({
+                    errorCode: 'provider.model-mismatch',
+                    stage: 'provider-select-mode',
+                    vendor: 'chatgpt',
+                    retryHint: 'model-fallback',
+                    message: `ChatGPT model option not found: ${requested}`,
+                    evidence: { requested },
+                });
+            }
+            await option.click({ timeout: 5_000 });
+            await page.waitForTimeout(750).catch(() => undefined);
+            await openModelMenu(page, usedFallbacks);
+            currentModel = await readCheckedModel(page, requested);
+            modelChanged = true;
+        }
+        if (currentModel !== requested && !warnings.includes('model-selection-unverified')) {
+            warnings.push('model-selection-unverified');
+        }
     }
 
     let selectedEffort: { selected: ChatGptEffortChoice; changed: boolean } | null = null;
     if (requestedEffort) {
-        try {
-            selectedEffort = await selectChatGptEffort(page, targetModel, requestedEffort, usedFallbacks);
-            await openModelMenu(page, usedFallbacks);
-        } catch (err) {
-            if (!isSelectionUnavailable(err)) throw err;
-            usedFallbacks.push('reasoning-effort-unavailable-current-effort');
-            warnings.push(`reasoning effort ${requestedEffort} was not enforced: ${errorMessage(err)}`);
-            await closeModelMenu(page);
+        // parity2 030 (C-01): the Power shell's 5-stop slider IS the effort
+        // control for thinking — try it before the legacy effort-portal path.
+        let sliderApplied = false;
+        if (targetModel === 'thinking') {
+            await openModelMenu(page, usedFallbacks).catch(() => undefined);
+            if (await isChatGptPowerPickerOpen(page)
+                && await selectChatGptPowerTierBySlider(page, 'thinking', { effort: requestedEffort, usedFallbacks })) {
+                const stop = await readChatGptPowerSliderState(page);
+                if (effortChoiceFromPowerTierLabel(stop.label, stop.index) === requestedEffort) {
+                    selectedEffort = { selected: requestedEffort, changed: true };
+                    usedFallbacks.push('thinking-effort-power-slider-direct');
+                    sliderApplied = true;
+                }
+            }
         }
+        if (!sliderApplied) {
+            try {
+                selectedEffort = await selectChatGptEffort(page, targetModel, requestedEffort, usedFallbacks);
+                await openModelMenu(page, usedFallbacks);
+            } catch (err) {
+                if (!isSelectionUnavailable(err)) throw err;
+                usedFallbacks.push('reasoning-effort-unavailable-current-effort');
+                warnings.push(`reasoning effort ${requestedEffort} was not enforced: ${errorMessage(err)}`);
+                await closeModelMenu(page);
+            }
+        }
+    }
+    // Effort observation MUST be captured while the Power shell is still open:
+    // the tier string lives inside the shell that closeModelMenu() unmounts.
+    let observedEffort: ChatGptEffortChoice | null = null;
+    if (requestedEffort && targetModel === 'thinking' && await isChatGptPowerPickerOpen(page)) {
+        const stop = await readChatGptPowerSliderState(page);
+        observedEffort = effortChoiceFromPowerTierLabel(stop.label, stop.index);
     }
     const after = await readCheckedModel(page, targetModel);
     await closeModelMenu(page);
@@ -269,11 +352,23 @@ export async function selectChatGptModel(page: Page, model: string | undefined, 
         usedFallbacks.push('model-verification-unavailable-current-model');
         warnings.push(`model ${targetModel} was not verified; current detected model is ${after || 'unknown'}`);
     }
+    // parity2 030 (C-01): effort is its own verification axis — a wrong tier must
+    // not report as verified just because the model axis matched.
+    const effortVerified = !requestedEffort
+        || targetModel !== 'thinking'
+        || selectedEffort?.selected === requestedEffort
+        || observedEffort === requestedEffort;
+    if (requestedEffort && !effortVerified) {
+        usedFallbacks.push('effort-verification-unavailable-current-effort');
+        warnings.push('effort-selection-unverified');
+        warnings.push(`effort ${requestedEffort} was not applied; observed ${observedEffort || 'unknown'}`);
+    }
+    const effortReportable = effortVerified ? selectedEffort : null;
     return {
         requested: requested || targetModel,
         selected: after,
-        alreadySelected: !modelChanged && !selectedEffort?.changed,
-        effort: selectedEffort?.selected || null,
+        alreadySelected: !modelChanged && !effortReportable?.changed && effortVerified,
+        effort: effortReportable?.selected || null,
         requestedEffort: requestedEffort || null,
         usedFallbacks,
         warnings,
@@ -281,7 +376,7 @@ export async function selectChatGptModel(page: Page, model: string | undefined, 
             requestedModel: model ?? null,
             resolvedLabel: after,
             normalizedModel: targetModel,
-            verified: after === targetModel,
+            verified: after === targetModel && effortVerified,
         }),
     };
 }
@@ -655,6 +750,12 @@ function requiredEffortMenuLabels(model: ChatGptModelChoice, effort: ChatGptEffo
 }
 
 async function readCheckedModel(page: Page, expectedModel: ChatGptModelChoice | null = null): Promise<ChatGptModelChoice | null> {
+    // parity2 030 (C-01): on the Power shell there are no checked radio rows —
+    // the slider state is the selection evidence.
+    if (await isChatGptPowerPickerOpen(page)) {
+        const state = await readChatGptPowerSliderState(page);
+        if (state.choice) return state.choice;
+    }
     for (const [choice, option] of Object.entries(CHATGPT_MODEL_OPTIONS) as Array<[ChatGptModelChoice, typeof CHATGPT_MODEL_OPTIONS[ChatGptModelChoice]]>) {
         for (const testId of option.testIds) {
             const checked = await page.locator(`[role="menuitemradio"][data-testid="${testId}"][aria-checked="true"], [data-testid="${testId}"][aria-checked="true"]`).first().isVisible().catch(() => false);
@@ -726,6 +827,8 @@ async function readActiveEffortPill(page: Page): Promise<string> {
 }
 
 async function isModelMenuOpen(page: Page): Promise<boolean> {
+    // parity2 030 (C-01): the 5.6 Power shell counts as an open model menu.
+    if (await isChatGptPowerPickerOpen(page)) return true;
     const legacyOpen = await page.locator(CHATGPT_MODEL_MENU_ITEM_SELECTOR)
         .filter({ hasText: CHATGPT_MODEL_TEXT_BUTTON_PATTERN })
         .evaluateAll((items: BrowserNodeLike[]) => items.some((item: BrowserNodeLike) => {
@@ -756,9 +859,11 @@ function effortLabelPattern(label: string): RegExp {
 }
 
 export function modelChoiceFromText(text: string): ChatGptModelChoice | null {
-    if (/\b(Instant|Fast)\b|즉시/i.test(text)) return 'instant';
-    if (/\b(Pro Standard|Pro Extended)\b|Pro 확장|프로 확장/i.test(text)) return 'pro';
-    if (/\b(Medium|High|Extra High)\b|중간|높음|매우 높음/i.test(text)) return 'thinking';
+    // parity2 030 slice 3.2 (C-20): CJK terms use Han-script boundaries — \b is
+    // meaningless for them ("GPT-5.5即时" must match; a bare "高" inside "极高" must not).
+    if (/\b(Instant|Fast)\b|즉시|(?<!\p{Script=Han})即时(?!\p{Script=Han})/iu.test(text)) return 'instant';
+    if (/\b(Pro Standard|Pro Extended)\b|Pro 확장|프로 확장|(?<!\p{Script=Han})Pro 扩展(?!\p{Script=Han})/iu.test(text)) return 'pro';
+    if (/\b(Medium|High|Extra High)\b|중간|높음|매우 높음|(?<!\p{Script=Han})(思考|中等|极高|高)(?!\p{Script=Han})/iu.test(text)) return 'thinking';
     if (/\b(Thinking|Think)\b/i.test(text)) return 'thinking';
     if (/\b(Pro|Heavy)\b/i.test(text)) return 'pro';
     return null;
@@ -837,4 +942,149 @@ function isLegacyProModelLabel(text: string): boolean {
 
 function escapeRegExp(value: string): string {
     return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ── Power shell (parity2 030 slice 3.1, C-01) ───────────────────────────────
+// The GPT-5.6 Chat picker renders a "Power" menu item whose 5-stop slider IS
+// the tier/effort control: 0 Instant, 1 Medium, 2 High, 3 Extra High, 4 Pro.
+// Menu rows may not exist at all on this shell, so selection must be able to
+// fall back to driving the slider with keyboard arrows (agbrowse 45ec48a).
+
+/** Slider stop → CJ effort vocabulary (standard=Medium, extended=High, heavy=Extra High). */
+const CHATGPT_POWER_STOP_EFFORT: Readonly<Record<number, ChatGptEffortChoice>> = Object.freeze({
+    1: 'standard',
+    2: 'extended',
+    3: 'heavy',
+});
+
+const CHATGPT_POWER_TIER_INDEX: Readonly<Record<ChatGptModelChoice, number>> = Object.freeze({
+    instant: 0,
+    thinking: 2,
+    pro: 4,
+});
+
+const POWER_EFFORT_STOP_LABELS: Readonly<Record<ChatGptEffortChoice, readonly string[]>> = Object.freeze({
+    light: ['Instant', '즉시', '即时'],
+    standard: ['Medium', '중간', '中等'],
+    extended: ['High', '높음', '高'],
+    heavy: ['Extra High', '매우 높음', '极高'],
+});
+
+export async function isChatGptPowerPickerOpen(page: Page): Promise<boolean> {
+    const root = page.locator(CHATGPT_POWER_PICKER_ROOT_SELECTOR).first();
+    if (await root.isVisible().catch(() => false)) return true;
+    const slider = page.locator(CHATGPT_POWER_SLIDER_VIEW_SELECTOR).first();
+    return root === slider ? false : await slider.isVisible().catch(() => false);
+}
+
+/**
+ * Resolve the thinking effort actually shown by a Power tier label. Label first
+ * ("Extra High, 4 of 5."), aria-valuenow index as cross-check. Fails CLOSED:
+ * when both are available and disagree, the effort is not verified.
+ */
+export function effortChoiceFromPowerTierLabel(label: string | null | undefined, index: number | null | undefined): ChatGptEffortChoice | null {
+    const firstLine = String(label || '').split(/\r?\n/)[0] || '';
+    const stripped = firstLine.replace(/,\s*\d+\s+of\s+\d+\.?$/i, '').trim();
+    let fromLabel: ChatGptEffortChoice | null = null;
+    for (const effort of ['standard', 'extended', 'heavy'] as const) {
+        if (POWER_EFFORT_STOP_LABELS[effort].some(l => menuTextHasExactLine(stripped, l))) {
+            fromLabel = effort;
+            break;
+        }
+    }
+    const hasIndex = Number.isFinite(index as number);
+    const fromIndex = hasIndex ? (CHATGPT_POWER_STOP_EFFORT[index as number] ?? null) : null;
+    if (fromLabel && hasIndex) return fromLabel === fromIndex ? fromLabel : null;
+    return fromLabel || fromIndex;
+}
+
+function modelChoiceFromPowerSimpleText(text: string): ChatGptModelChoice | null {
+    const first = String(text || '').split(/\r?\n/)[0] || '';
+    // "High, 3 of 5." / "Pro, 5 of 5."
+    const label = first.replace(/,\s*\d+\s+of\s+\d+\.?$/i, '').trim();
+    if (/^(Pro|Pro 확장|프로 확장|Pro 扩展)/i.test(label)) return 'pro';
+    if (/^(Instant|즉시|即时)/i.test(label)) return 'instant';
+    if (/^(Thinking|Medium|High|Extra High|중간|높음|매우 높음|思考|中等|极高|高)/i.test(label)) return 'thinking';
+    return modelChoiceFromText(label);
+}
+
+export async function readChatGptPowerSliderState(page: Page): Promise<{ index: number | null; choice: ChatGptModelChoice | null; label: string | null }> {
+    const simple = page.locator('[data-testid="composer-model-picker-slider-simple-view"]').first();
+    const simpleText = (await simple.innerText({ timeout: 500 }).catch(() => '')).trim();
+    const choiceFromSimple = simpleText ? modelChoiceFromPowerSimpleText(simpleText) : null;
+    const slider = page.locator(
+        '[data-testid="composer-model-picker-slider-simple-view"] [role="slider"], [role="menu"][data-state="open"] [role="slider"]',
+    ).first();
+    const nowStr = await slider.getAttribute('aria-valuenow').catch(() => null);
+    const index = nowStr != null && nowStr !== '' ? Number(nowStr) : null;
+    if (choiceFromSimple) return { index: Number.isFinite(index as number) ? (index as number) : null, choice: choiceFromSimple, label: simpleText || choiceFromSimple };
+    if (Number.isFinite(index as number)) {
+        // 0 Instant, 1 Medium, 2 High, 3 Extra High, 4 Pro — middle three are thinking.
+        const byIndex: ChatGptModelChoice[] = ['instant', 'thinking', 'thinking', 'thinking', 'pro'];
+        const mapped = byIndex[index as number] || null;
+        return { index: index as number, choice: mapped, label: simpleText || mapped };
+    }
+    return { index: null, choice: null, label: simpleText || null };
+}
+
+function powerTierIndexForChoice(choice: ChatGptModelChoice, effort: ChatGptEffortChoice | null = null): number {
+    if (choice === 'instant') return CHATGPT_POWER_TIER_INDEX.instant;
+    if (choice === 'pro') return CHATGPT_POWER_TIER_INDEX.pro;
+    if (effort === 'standard') return 1;
+    if (effort === 'heavy') return 3;
+    if (effort === 'extended') return 2;
+    return CHATGPT_POWER_TIER_INDEX.thinking;
+}
+
+/**
+ * Drive the Chat Power slider with keyboard arrows until the shell reports the
+ * requested choice (and effort stop for thinking). Returns true on success.
+ */
+export async function selectChatGptPowerTierBySlider(
+    page: Page,
+    choice: ChatGptModelChoice,
+    options: { effort?: ChatGptEffortChoice | null; usedFallbacks?: string[] } = {},
+): Promise<boolean> {
+    if (!(await isChatGptPowerPickerOpen(page))) return false;
+    const effort = options.effort || null;
+    const usedFallbacks = options.usedFallbacks || [];
+    const targetIndex = powerTierIndexForChoice(choice, effort);
+    const power = page.locator('[role="menuitem"][aria-label="Power"]').first();
+    if (!(await power.isVisible().catch(() => false))) return false;
+    await power.focus({ timeout: 1_000 }).catch(() => undefined);
+    await power.click({ timeout: 2_000 }).catch(() => undefined);
+    await page.waitForTimeout(150).catch(() => undefined);
+    let stagnant = 0;
+    let previousIndex: number | null = null;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+        const state = await readChatGptPowerSliderState(page);
+        if (state.choice === choice) {
+            if (choice !== 'thinking' || effort == null || state.index == null || state.index === targetIndex) {
+                usedFallbacks.push('chat-power-slider');
+                return true;
+            }
+        }
+        const currentIndex = state.index != null ? state.index : (
+            state.choice === 'instant' ? 0
+                : state.choice === 'pro' ? 4
+                    : 2
+        );
+        if (currentIndex === targetIndex && state.choice === choice) {
+            usedFallbacks.push('chat-power-slider');
+            return true;
+        }
+        if (previousIndex != null && previousIndex === currentIndex) stagnant += 1;
+        else stagnant = 0;
+        previousIndex = currentIndex;
+        if (stagnant >= 2) break;
+        const key = currentIndex > targetIndex ? 'ArrowLeft' : 'ArrowRight';
+        await page.keyboard.press(key).catch(() => undefined);
+        await page.waitForTimeout(250).catch(() => undefined);
+    }
+    const finalState = await readChatGptPowerSliderState(page);
+    if (finalState.choice === choice) {
+        usedFallbacks.push('chat-power-slider');
+        return true;
+    }
+    return false;
 }

--- a/src/browser/web-ai/chatgpt-model.ts
+++ b/src/browser/web-ai/chatgpt-model.ts
@@ -37,6 +37,7 @@ export function normalizeChatGptFamilyChoice(family: string | undefined): ChatGp
 
 /** parity2 030 (C-01): Power-shell selectors — the 5.6 Chat picker renders a
  * Power menu item whose slider drives tier/effort; menu rows may not exist. */
+export const CHATGPT_SURFACE_RADIO_SELECTOR = 'button[role="radio"]';
 export const CHATGPT_POWER_PICKER_ROOT_SELECTOR =
     '[role="menu"][data-state="open"]:has([role="menuitem"][aria-label="Power"])';
 export const CHATGPT_POWER_SLIDER_VIEW_SELECTOR = [

--- a/src/browser/web-ai/chatgpt-multi-turn.ts
+++ b/src/browser/web-ai/chatgpt-multi-turn.ts
@@ -2,6 +2,7 @@ import type { Page } from 'playwright-core';
 import { updateSessionResult, appendSessionArtifact } from './session.js';
 import { trySaveTranscript } from './session-artifacts.js';
 import { createChatGptEditorAdapter } from './vendor-editor-contract.js';
+import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 import type { WebAiSessionRecord, WebAiTurnRecord } from './types.js';
 
 // Re-exported alias preserves the public `TurnResult` name while reusing the
@@ -34,9 +35,17 @@ async function readLatestAssistant(page: Page): Promise<string> {
     return last.innerText().catch(() => '');
 }
 
-async function isStreaming(page: Page): Promise<boolean> {
-    const stop = await page.locator('[data-testid="stop-button"], button[aria-label="Stop generating"]').count();
-    return stop > 0;
+/**
+ * parity2 070 slice D-02: tri-state probe — an unreadable count is 'unknown',
+ * which BLOCKS completion instead of reading as "not streaming".
+ */
+async function probeStopState(page: Page): Promise<'visible' | 'absent' | 'unknown'> {
+    try {
+        const stop = await page.locator('[data-testid="stop-button"], button[aria-label="Stop generating"]').count();
+        return stop > 0 ? 'visible' : 'absent';
+    } catch {
+        return 'unknown';
+    }
 }
 
 async function submitTurn(page: Page, deps: MultiTurnDeps, opts: { prompt: string }): Promise<void> {
@@ -62,21 +71,23 @@ async function submitTurn(page: Page, deps: MultiTurnDeps, opts: { prompt: strin
 async function pollTurn(page: Page, opts: {
     baselineAssistantCount: number;
     timeoutMs?: number;
+    deadlineToken?: PollDeadlineToken;
 }): Promise<{ ok: boolean; answerText: string; warnings: string[] }> {
     const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
     let stableText = '';
     let stableSince = 0;
 
-    while (Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 500));
+    while (Date.now() < deadline && !opts.deadlineToken?.expired) {
+        // parity2 070 slice D-02: cap the tick by the remaining budget.
+        await new Promise((r) => setTimeout(r, Math.min(500, Math.max(1, deadline - Date.now()))));
 
         const count = await countAssistants(page);
         if (count <= opts.baselineAssistantCount) continue;
 
         const latest = (await readLatestAssistant(page)).trim();
-        const streaming = await isStreaming(page);
+        const stopState = await probeStopState(page);
 
-        if (latest && !streaming) {
+        if (latest && stopState === 'absent') {
             if (latest === stableText) {
                 if (Date.now() - stableSince >= 1500) {
                     return { ok: true, answerText: latest, warnings: [] };
@@ -85,7 +96,9 @@ async function pollTurn(page: Page, opts: {
                 stableText = latest;
                 stableSince = Date.now();
             }
-        } else if (streaming) {
+        } else if (stopState !== 'absent') {
+            // visible OR unknown both reset stability: an unreadable probe must
+            // not let a half-written answer pass as stable.
             stableText = '';
             stableSince = 0;
         }
@@ -98,7 +111,37 @@ export async function sendMultiTurn(page: Page, deps: MultiTurnDeps, opts: {
     followUps: string[];
     session: WebAiSessionRecord;
     timeoutPerTurn?: number;
+    /** Test/ops override for the outer sequence bound; defaults to a floor of 60s or turns*budget+30s. */
+    outerBudgetMs?: number;
 }): Promise<MultiTurnResult> {
+    const { followUps, session, timeoutPerTurn = 120_000 } = opts;
+    // parity2 070 slice D-01: the WHOLE follow-up sequence runs under a hard
+    // outer deadline — per-turn budgets alone let a stalled probe hold the
+    // caller indefinitely, and a losing run could still write to the session.
+    const outerBudgetMs = opts.outerBudgetMs ?? Math.max(60_000, followUps.length * timeoutPerTurn + 30_000);
+    return withPollDeadline<MultiTurnResult>(
+        (_hardDeadline, token) => sendMultiTurnInner(page, deps, { ...opts, timeoutPerTurn }, token),
+        {
+            timeoutMs: outerBudgetMs,
+            onExpired: () => ({
+                ok: false,
+                sessionId: session.sessionId,
+                conversationUrl: page.url?.() || session.conversationUrl || '',
+                turns: [],
+                finalAnswer: null,
+                warnings: ['multi-turn-deadline-expired'],
+                finalStatus: 'partial',
+                transcriptMarkdown: '',
+            }),
+        },
+    );
+}
+
+async function sendMultiTurnInner(page: Page, deps: MultiTurnDeps, opts: {
+    followUps: string[];
+    session: WebAiSessionRecord;
+    timeoutPerTurn?: number;
+}, deadlineToken: PollDeadlineToken): Promise<MultiTurnResult> {
     const { followUps, session, timeoutPerTurn = 120_000 } = opts;
     const turns: TurnResult[] = [];
     const allWarnings: string[] = [];
@@ -109,12 +152,18 @@ export async function sendMultiTurn(page: Page, deps: MultiTurnDeps, opts: {
     let turnIndex = existingTurns.length;
 
     for (const prompt of followUps) {
+        // parity2 070 slice D-01: a losing run must not start another turn (or
+        // write) after the caller has been answered.
+        if (deadlineToken.expired) {
+            allWarnings.push('multi-turn-deadline-expired');
+            break;
+        }
         const sentAt = new Date().toISOString();
         const baselineAssistantCount = await countAssistants(page);
 
         try {
             await submitTurn(page, deps, { prompt });
-            const result = await pollTurn(page, { baselineAssistantCount, timeoutMs: timeoutPerTurn });
+            const result = await pollTurn(page, { baselineAssistantCount, timeoutMs: timeoutPerTurn, deadlineToken });
 
             const turn: TurnResult = {
                 index: turnIndex,
@@ -130,9 +179,9 @@ export async function sendMultiTurn(page: Page, deps: MultiTurnDeps, opts: {
 
             const allTurns = [...existingTurns, ...turns];
             if (result.answerText) finalAnswer = result.answerText;
-            updateSessionResult({
+            if (!deadlineToken.expired) updateSessionResult({
                 sessionId: session.sessionId,
-                status: result.ok ? 'streaming' : 'error',
+                status: result.ok ? 'streaming' : 'partial',
                 turns: allTurns,
                 followUpCount: allTurns.length,
                 ...(result.answerText ? { answerText: result.answerText } : {}),
@@ -155,9 +204,9 @@ export async function sendMultiTurn(page: Page, deps: MultiTurnDeps, opts: {
             turnIndex++;
 
             const allTurns = [...existingTurns, ...turns];
-            updateSessionResult({
+            if (!deadlineToken.expired) updateSessionResult({
                 sessionId: session.sessionId,
-                status: 'error',
+                status: 'partial',
                 turns: allTurns,
                 followUpCount: allTurns.length,
             });
@@ -177,9 +226,11 @@ export async function sendMultiTurn(page: Page, deps: MultiTurnDeps, opts: {
         else allWarnings.push(`artifact-save-failed:${saved.stage}:${saved.error}`);
     }
 
-    updateSessionResult({
+    if (!deadlineToken.expired) updateSessionResult({
         sessionId: session.sessionId,
-        status: ok ? 'complete' : 'error',
+        // parity2 070 slice C-04: a partial multi-turn is resumable — 'error'
+        // destroyed that signal.
+        status: ok ? 'complete' : 'partial',
         conversationUrl: page.url(),
         turns: allTurns,
         followUpCount: allTurns.length,

--- a/src/browser/web-ai/chatgpt-response-dom.ts
+++ b/src/browser/web-ai/chatgpt-response-dom.ts
@@ -1,9 +1,12 @@
-import type { Locator, Page } from 'playwright-core';
+import type { Page } from 'playwright-core';
 
 /**
- * ChatGPT assistant-turn DOM readers with descendant de-duplication. Strict-TS port of
- * agbrowse web-ai/chatgpt-response-dom.mjs (parity catalog 106.13) — a nested assistant
- * match must never double-count its parent's text.
+ * ChatGPT assistant-turn DOM readers. Full strict-TS port of agbrowse
+ * web-ai/chatgpt-response-dom.mjs (parity2 040 slice 4.1, catalog C-09):
+ * composer-scoped tri-state stop probe, main-region scoping, role-verified
+ * top-level turn resolution, completed-reasoning grammar with activity
+ * strata, wrapped/wrapperless correlated snapshots in one DOM-order pass,
+ * and unread-vs-empty locator fallback.
  */
 
 export const CHATGPT_ASSISTANT_SELECTORS: string[] = [
@@ -12,16 +15,108 @@ export const CHATGPT_ASSISTANT_SELECTORS: string[] = [
     'article[data-testid^="conversation-turn"]',
 ];
 
+// parity2 040 (C-09/G1b): form-scoped stop selector — page-wide "any
+// Stop-labelled button" matched dictation/voice/read-aloud/sidebar controls.
 export const CHATGPT_STOP_SELECTORS: string[] = [
     'button[data-testid="stop-button"]',
-    'button[aria-label*="Stop" i]',
+    'form button[aria-label*="Stop" i]:not([aria-label*="dictat" i]):not([aria-label*="voice" i]):not([aria-label*="read" i])',
 ];
 
+export const CHATGPT_TURN_SELECTORS: string[] = [
+    'article[data-testid^="conversation-turn"]',
+    'div[data-testid^="conversation-turn"]',
+    'section[data-testid^="conversation-turn"]',
+];
+
+export type ChatGptTurnOrderingInPage = 'ordered' | 'stale' | 'unverifiable';
+export type ChatGptStopVerdict = 'visible' | 'absent' | 'unknown';
+export type ChatGptActivityStrength = 'strong' | 'weak' | 'none' | 'unknown';
+export interface ChatGptActivityState { strength: ChatGptActivityStrength; evidence: string }
+export interface ChatGptAssistantSnapshot {
+    text: string;
+    messageId: string | null;
+    turnId: string | null;
+    turnIndex: number;
+}
+export type ChatGptCorrelatedSnapshot = ChatGptAssistantSnapshot & { source: 'wrapped' | 'wrapperless'; domOrder: number };
+
+type AnyNode = any;
+declare const document: any;
+declare const window: any;
+declare const Node: any;
+declare const HTMLElement: any;
+declare const HTMLProgressElement: any;
+
 /**
- * Browser-context helper. Keep self-contained so Playwright can serialize it into
- * page.evaluate without relying on module closures.
+ * Browser-context helper. Reports whether the latest assistant turn follows the
+ * latest user turn. Returns a VERDICT, not a boolean — "cannot verify" and
+ * "verified ordered" are different facts. Never reports 'unknown' itself; only
+ * the Node-side wrapper's catch produces that value.
  */
-export function readTopLevelAssistantTexts(selectors: string[]): string[] {
+export function readAssistantTurnOrderingInPage(selectors: string[]): ChatGptTurnOrderingInPage {
+    const turns: AnyNode[] = Array.from(document.querySelectorAll(selectors.join(', ')));
+    const roleOf = (turn: AnyNode) => turn.getAttribute('data-message-author-role')
+        || turn.querySelector('[data-message-author-role]')?.getAttribute('data-message-author-role');
+    const lastAssistantTurn = turns.filter((turn) => roleOf(turn) === 'assistant').at(-1);
+    const lastUserTurn = turns.filter((turn) => roleOf(turn) === 'user').at(-1);
+    if (!lastUserTurn) return 'unverifiable';
+    if (!lastAssistantTurn) return 'stale';
+    return lastUserTurn.compareDocumentPosition(lastAssistantTurn) & Node.DOCUMENT_POSITION_FOLLOWING
+        ? 'ordered'
+        : 'stale';
+}
+
+/**
+ * Node-side probe: is a composer-scoped stop button visible within scope?
+ * Reports a VERDICT: 'unknown' whenever the selectors and nodes could not be
+ * fully enumerated; a visible node short-circuits to 'visible'. EVERY match is
+ * inspected, not just the first — ChatGPT can render a hidden stop node ahead
+ * of the live one.
+ */
+export async function probeStopButton(scope: AnyNode): Promise<ChatGptStopVerdict> {
+    if (!scope || typeof scope.locator !== 'function') return 'unknown';
+    let anySelectorUninspected = false;
+    for (const selector of CHATGPT_STOP_SELECTORS) {
+        let locator: AnyNode;
+        try { locator = scope.locator(selector); } catch { anySelectorUninspected = true; continue; }
+        if (!locator || typeof locator.all !== 'function') { anySelectorUninspected = true; continue; }
+        let nodes: AnyNode[];
+        try { nodes = await locator.all(); } catch { anySelectorUninspected = true; continue; }
+        if (!Array.isArray(nodes)) { anySelectorUninspected = true; continue; }
+        let anyNodeUninspected = false;
+        for (const node of nodes) {
+            if (typeof node?.isVisible !== 'function') { anyNodeUninspected = true; continue; }
+            try {
+                if (await node.isVisible()) return 'visible';
+            } catch { anyNodeUninspected = true; }
+        }
+        if (anyNodeUninspected) anySelectorUninspected = true;
+    }
+    return anySelectorUninspected ? 'unknown' : 'absent';
+}
+
+/** Back-compatible boolean view of the stop probe. */
+export async function anyStopButtonVisible(scope: AnyNode): Promise<boolean> {
+    return (await probeStopButton(scope)) === 'visible';
+}
+
+/**
+ * Narrow a page to its main conversation region when it exposes one — sidebar
+ * history titles poison page-wide text matching. Returns null only on a FAILED
+ * lookup ("no usable scope"), which probeStopButton reports as 'unknown'.
+ */
+export function scopeToMainRegion(page: AnyNode): AnyNode {
+    let main: AnyNode;
+    try { main = page?.locator?.('main'); } catch { return null; }
+    if (main && typeof main.locator === 'function') return main;
+    return page;
+}
+
+/**
+ * Browser-context: resolve role-verified, top-level assistant turns in document
+ * order. Wrapper-collapsed and descendant-de-duplicated.
+ */
+export function resolveTopLevelAssistantTurns(selectors: string[]): AnyNode[] {
     const activeSelectors = Array.isArray(selectors) && selectors.length
         ? selectors
         : [
@@ -29,43 +124,287 @@ export function readTopLevelAssistantTexts(selectors: string[]): string[] {
             '[data-turn="assistant"]',
             'article[data-testid^="conversation-turn"]',
         ];
-    const isInsideAnotherMatchedNode = (el: Element, matched: Element[]): boolean =>
-        matched.some((other) => other !== el && typeof other.contains === 'function' && other.contains(el));
-
-    for (const selector of activeSelectors) {
-        const matched = Array.from(document.querySelectorAll(selector));
-        const topLevel = matched.filter((el) => !isInsideAnotherMatchedNode(el, matched));
-        const texts = topLevel
-            .map((el) => String((el as HTMLElement).innerText || el.textContent || '').trim())
-            .filter(Boolean);
-        if (texts.length) return texts;
+    const roleSelectors = [
+        '[data-message-author-role="assistant"]',
+        '[data-turn="assistant"]',
+    ];
+    const roleNodes: AnyNode[] = [];
+    for (const selector of roleSelectors) {
+        for (const node of Array.from(document.querySelectorAll(selector))) {
+            if (!roleNodes.includes(node)) roleNodes.push(node);
+        }
     }
-    return [];
+    const turns: AnyNode[] = [];
+    for (const roleNode of roleNodes) {
+        const wrapperSelectors = activeSelectors.filter(selector => !roleSelectors.includes(selector));
+        const candidate = wrapperSelectors.length && typeof roleNode.closest === 'function'
+            ? roleNode.closest(wrapperSelectors.join(', ')) || roleNode
+            : roleNode;
+        if (turns.some(turn => turn === candidate || turn.contains(candidate))) continue;
+        for (let i = turns.length - 1; i >= 0; i--) {
+            if (candidate.contains(turns[i])) turns.splice(i, 1);
+        }
+        turns.push(candidate);
+    }
+    return turns;
 }
 
 /**
- * Fallback for environments where page.evaluate fails but Playwright locators still
- * work. Applies the same descendant de-duplication rule as readTopLevelAssistantTexts.
+ * Browser-context: live-generation evidence with STRENGTH strata. A visible
+ * stop button or live progress is strong; a mounted sidecar still reading
+ * "Thinking" is weak; a completed-reasoning summary ("Thought for 12s") is
+ * neither. Anchored grammar keeps a growing trace from reading as completion.
+ */
+export function readChatGptStreamingState({ assistantSelectors, stopSelectors, resolverSource }: { assistantSelectors: string[]; stopSelectors: string[]; resolverSource?: string }): ChatGptActivityState {
+    const UNIT = '(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)';
+    const NUMERIC = `\\d+(?:\\.\\d+)?\\s*${UNIT}`;
+    const COMPLETED_SUMMARY = new RegExp(
+        '^(?:(?:reasoning|pro thinking)\\s*)?thought for '
+        + `(?:${NUMERIC}(?:\\s+${NUMERIC})*|(?:a|an) [a-z]+(?: [a-z]+){0,2})`
+        + '(?: edit)?$',
+    );
+    const isVisible = (node: AnyNode): boolean => {
+        if (!(node instanceof HTMLElement)) return false;
+        const rect = node.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+    };
+    const norm = (value: unknown): string => String(value || '').toLowerCase().replace(/\s+/g, ' ').trim();
+    const hasLiveProgress = (scope: AnyNode): boolean => {
+        let nodes: AnyNode;
+        try { nodes = scope.querySelectorAll('progress, [role="progressbar"]'); } catch { return false; }
+        return Array.from(nodes).some((node: AnyNode) => {
+            if (!isVisible(node)) return false;
+            if (node instanceof HTMLProgressElement) {
+                if (!node.hasAttribute('value')) return true;
+                return Number.isFinite(node.value) && Number.isFinite(node.max) ? node.value < node.max : true;
+            }
+            const rawNow = node.getAttribute('aria-valuenow');
+            if (rawNow == null) return true;
+            const now = Number(rawNow);
+            const rawMax = node.getAttribute('aria-valuemax');
+            const max = rawMax != null && Number.isFinite(Number(rawMax)) ? Number(rawMax) : 100;
+            return Number.isFinite(now) ? now < max : true;
+        });
+    };
+
+    for (const selector of stopSelectors) {
+        let nodes: AnyNode;
+        try { nodes = document.querySelectorAll(selector); } catch { continue; }
+        if (Array.from(nodes).some(isVisible)) return { strength: 'strong', evidence: 'stop-button' };
+    }
+
+    let assistantNodes: AnyNode[] = [];
+    try {
+        const resolver = resolverSource
+            ? (0, eval)(`(${resolverSource})`)
+            : resolveTopLevelAssistantTurns;
+        assistantNodes = resolver(assistantSelectors);
+    } catch { /* selector drift fails closed */ }
+    const latestAssistant = assistantNodes.at(-1);
+    if (latestAssistant) {
+        if (hasLiveProgress(latestAssistant)) return { strength: 'strong', evidence: 'turn-progress' };
+    }
+
+    let panels: AnyNode;
+    try {
+        panels = document.querySelectorAll(
+            'aside, [role="complementary"], [role="dialog"], [data-testid*="thinking" i], [data-testid*="reasoning" i], [class*="sidecar" i]',
+        );
+    } catch {
+        return { strength: 'none', evidence: '' };
+    }
+    let weakVerdict: ChatGptActivityState | null = null;
+    for (const panel of Array.from(panels) as AnyNode[]) {
+        if (!isVisible(panel)) continue;
+        const metadata = norm([
+            panel.getAttribute('aria-label'),
+            panel.getAttribute('data-testid'),
+            panel.getAttribute('class'),
+        ].filter(Boolean).join(' '));
+        const verifiedThinkingPanel = metadata.includes('thinking')
+            || metadata.includes('reasoning')
+            || metadata.includes('sidecar');
+        if (!verifiedThinkingPanel) continue;
+        const rect = panel.getBoundingClientRect();
+        const rightSide = rect.left >= window.innerWidth * 0.35
+            && rect.width >= 180
+            && rect.height >= 120;
+        if (!rightSide) continue;
+        if (hasLiveProgress(panel)) return { strength: 'strong', evidence: 'panel-progress' };
+        const visibleText = norm(panel.textContent);
+        if (COMPLETED_SUMMARY.test(visibleText)) continue;
+        if (visibleText.includes('thought for ')) {
+            weakVerdict = weakVerdict || { strength: 'weak', evidence: 'panel-trace' };
+            continue;
+        }
+        if (visibleText.includes('thinking')
+            || visibleText.includes('reasoning')
+            || visibleText.includes('pro thinking')) {
+            weakVerdict = weakVerdict || { strength: 'weak', evidence: 'panel-text' };
+        }
+    }
+    return weakVerdict || { strength: 'none', evidence: '' };
+}
+
+/**
+ * Back-compatible boolean view of an activity verdict. 'unknown' reads as
+ * INACTIVE here — safe only for consumers gating success on independent
+ * terminal evidence.
+ */
+export function isActiveState(state: ChatGptActivityState | boolean | null | undefined): boolean {
+    if (typeof state === 'boolean') return state;
+    return Boolean(state && state.strength !== 'none' && state.strength !== 'unknown');
+}
+
+/**
+ * Browser-context: single acquisition for both snapshot sources sharing one
+ * document-order coordinate space. Wrapperless markdown only qualifies when it
+ * DOM-FOLLOWS the latest user node. `ok` distinguishes a successful empty
+ * acquisition from a failure.
+ */
+export function readAssistantSnapshotSources({ assistantSelectors, resolverSource, userSelectors, markdownSelectors }: { assistantSelectors: string[]; resolverSource?: string; userSelectors?: string[]; markdownSelectors?: string[] }): { ok: true; wrapped: ChatGptCorrelatedSnapshot[]; wrapperless: ChatGptCorrelatedSnapshot[] } {
+    const USER_SELECTORS = (userSelectors && userSelectors.length) ? userSelectors : [
+        '[data-message-author-role="user"]',
+        '[data-turn="user"]',
+    ];
+    const MARKDOWN_SELECTORS = (markdownSelectors && markdownSelectors.length) ? markdownSelectors : [
+        '.markdown',
+        '[data-message-content]',
+    ];
+    const WRAPPER_SELECTORS = [
+        '[data-message-author-role]',
+        '[data-turn]',
+        'article[data-testid^="conversation-turn"]',
+    ];
+
+    const FOLLOWING = document?.defaultView?.Node?.DOCUMENT_POSITION_FOLLOWING ?? 4;
+    const isVisible = (node: AnyNode): boolean => {
+        const rect = node.getBoundingClientRect?.();
+        return Boolean(rect) && rect.width > 0 && rect.height > 0;
+    };
+    const orderNodes = (nodes: AnyNode[]): AnyNode[] => {
+        const unique = Array.from(new Set(nodes));
+        unique.sort((a, b) => (a.compareDocumentPosition(b) & FOLLOWING) ? -1 : 1);
+        return unique;
+    };
+    const textOf = (node: AnyNode): string => String(node.innerText || node.textContent || '').trim();
+    const describe = (node: AnyNode) => {
+        const messageNode = node.matches?.('[data-message-id]') ? node : node.querySelector?.('[data-message-id]');
+        const turnNode = node.matches?.('[data-testid^="conversation-turn"]')
+            ? node
+            : node.querySelector?.('[data-testid^="conversation-turn"]');
+        return {
+            text: textOf(node),
+            messageId: messageNode?.getAttribute?.('data-message-id') || null,
+            turnId: turnNode?.getAttribute?.('data-testid') || null,
+        };
+    };
+
+    let wrappedNodes: AnyNode[] = [];
+    try {
+        const resolver = resolverSource ? (0, eval)(`(${resolverSource})`) : null;
+        wrappedNodes = resolver ? (resolver(assistantSelectors) || []) : [];
+    } catch { wrappedNodes = []; }
+
+    const userNodes = orderNodes(USER_SELECTORS.flatMap(
+        (selector: string) => Array.from(document.querySelectorAll(selector))));
+    const latestUser = userNodes[userNodes.length - 1] || null;
+
+    const wrapperlessNodes = orderNodes(MARKDOWN_SELECTORS.flatMap(
+        (selector: string) => Array.from(document.querySelectorAll(selector))))
+        .filter((node: AnyNode) => isVisible(node))
+        .filter((node: AnyNode) => !node.closest?.(WRAPPER_SELECTORS.join(', ')))
+        .filter((node: AnyNode) => Boolean(latestUser)
+            && (latestUser.compareDocumentPosition(node) & FOLLOWING) !== 0)
+        .filter((node: AnyNode) => textOf(node));
+
+    const order = new Map(orderNodes([...wrappedNodes, ...wrapperlessNodes])
+        .map((node, index) => [node, index]));
+
+    return {
+        ok: true,
+        wrapped: wrappedNodes.map((node: AnyNode, turnIndex: number) => ({
+            ...describe(node), turnIndex, source: 'wrapped' as const, domOrder: order.get(node) ?? turnIndex,
+        })),
+        wrapperless: wrapperlessNodes.map((node: AnyNode) => ({
+            ...describe(node), turnIndex: -1, source: 'wrapperless' as const, domOrder: order.get(node) ?? 0,
+        })),
+    };
+}
+
+/** Browser-context: snapshots (text + provenance) of top-level assistant turns. */
+export function readTopLevelAssistantSnapshots(input: string[] | { selectors: string[]; resolverSource?: string }): ChatGptAssistantSnapshot[] {
+    const selectors = Array.isArray(input) ? input : input?.selectors;
+    const resolverSource = Array.isArray(input) ? '' : input?.resolverSource;
+    const resolver = resolverSource
+        ? (0, eval)(`(${resolverSource})`)
+        : resolveTopLevelAssistantTurns;
+    return resolver(selectors as string[]).map((node: AnyNode, turnIndex: number) => {
+        const messageNode = node.matches?.('[data-message-id]')
+            ? node
+            : node.querySelector?.('[data-message-id]');
+        const turnNode = node.matches?.('[data-testid^="conversation-turn"]')
+            ? node
+            : node.querySelector?.('[data-testid^="conversation-turn"]');
+        return {
+            text: String(node.innerText || node.textContent || '').trim(),
+            messageId: messageNode?.getAttribute?.('data-message-id') || null,
+            turnId: turnNode?.getAttribute?.('data-testid') || null,
+            turnIndex,
+        };
+    }).filter((snapshot: ChatGptAssistantSnapshot) => Boolean(snapshot.text));
+}
+
+/** Browser-context helper: texts of top-level assistant turns. */
+export function readTopLevelAssistantTexts(selectors: string[]): string[] {
+    return readTopLevelAssistantSnapshots(selectors).map(snapshot => snapshot.text);
+}
+
+/**
+ * Locator-based fallback. Reports whether the read HAPPENED, not just what it
+ * found: a PARTIAL read is not a smaller success — it corrupts positional
+ * baselines. `ok: true` with an empty list means every path was examined.
  */
 export async function readTopLevelAssistantTextsFromLocators(
     page: Page,
     selectors: string[] = CHATGPT_ASSISTANT_SELECTORS,
-): Promise<string[]> {
+): Promise<{ ok: boolean; texts: string[] }> {
+    let anySelectorFailed = false;
     for (const selector of selectors) {
-        const locators: Locator[] = await page.locator(selector).all().catch(() => []);
-        const texts: string[] = [];
-        for (const locator of locators) {
-            const text = await locator.evaluate((node: Element, activeSelector: string) => {
-                const matched = Array.from(document.querySelectorAll(activeSelector));
-                const nested = matched.some((other) =>
-                    other !== node && typeof other.contains === 'function' && other.contains(node));
-                if (nested) return '';
-                return String((node as HTMLElement).innerText || node.textContent || '').trim();
-            }, selector).catch(() => '');
-            const trimmed = String(text || '').trim();
-            if (trimmed) texts.push(trimmed);
+        let locators: AnyNode[];
+        try {
+            locators = await (page as AnyNode).locator(selector).all();
+            if (!Array.isArray(locators)) throw new Error('locator.all() did not return a list');
+        } catch {
+            anySelectorFailed = true;
+            continue;
         }
-        if (texts.length) return texts;
+        const texts: string[] = [];
+        let anyNodeUnread = false;
+        for (const locator of locators) {
+            let text = '';
+            let read = true;
+            if (typeof locator.evaluate === 'function') {
+                text = await locator.evaluate((node: AnyNode, activeSelector: string) => {
+                    const matched = Array.from(document.querySelectorAll(activeSelector));
+                    const nested = matched.some((other: AnyNode) =>
+                        other !== node && typeof other.contains === 'function' && other.contains(node));
+                    if (nested) return '';
+                    return String(node.innerText || node.textContent || '').trim();
+                }, selector).catch(() => { read = false; return ''; });
+            } else {
+                text = await locator.innerText().catch(() => { read = false; return ''; });
+            }
+            if (!read) anyNodeUnread = true;
+            text = String(text || '').trim();
+            if (text) texts.push(text);
+        }
+        if (anyNodeUnread) {
+            anySelectorFailed = true;
+            continue;
+        }
+        if (texts.length) return { ok: true, texts };
     }
-    return [];
+    return { ok: !anySelectorFailed, texts: [] };
 }
+

--- a/src/browser/web-ai/chatgpt-response.ts
+++ b/src/browser/web-ai/chatgpt-response.ts
@@ -124,9 +124,11 @@ async function readAssistantTexts(page: Page): Promise<string[]> {
     // match never double-counts its parent's text. page.evaluate first, locator fallback.
     const viaEvaluate = await page.evaluate(readTopLevelAssistantTexts, ASSISTANT_TURN_SELECTORS)
         .catch(() => [] as string[]);
+    // parity2 040 (C-09): the locator fallback now reports unread-vs-empty; a
+    // partial read is discarded upstream, so only the texts survive here.
     const texts = viaEvaluate.length
         ? viaEvaluate
-        : await readTopLevelAssistantTextsFromLocators(page, ASSISTANT_TURN_SELECTORS);
+        : (await readTopLevelAssistantTextsFromLocators(page, ASSISTANT_TURN_SELECTORS)).texts;
     return texts.map(normalizeAssistantText).filter(Boolean);
 }
 

--- a/src/browser/web-ai/chatgpt-response.ts
+++ b/src/browser/web-ai/chatgpt-response.ts
@@ -16,6 +16,7 @@ import { captureCopiedResponseText, CHATGPT_COPY_SELECTORS, preferCopiedText } f
 import { resolveActionTarget } from './self-heal.js';
 import { isPageDeathError } from './interstitial.js';
 import { createTraceContext, getSessionTrace, recordTraceStep } from './action-trace.js';
+import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 import type { ResolveActionTargetResult, TargetCandidate } from './self-heal.js';
 import type { TraceContext, TraceStep } from './action-trace.js';
 import type { Page } from 'playwright-core';
@@ -130,6 +131,24 @@ async function readAssistantTexts(page: Page): Promise<string[]> {
 }
 
 export async function captureAssistantResponse(page: Page, options: CaptureOptions): Promise<ResponseCaptureResult> {
+    // parity2 010 slice 1.1 (C-04): the loop below checks its deadline only BETWEEN
+    // awaited probes, so a single never-settling evaluate/locator call would defeat
+    // the timeout. The hard-deadline race answers the caller regardless; the token
+    // lets the losing tick refuse late side effects.
+    const timeoutMs = Math.max(1000, options.timeoutMs);
+    return withPollDeadline(
+        (_hardDeadline, token) => captureAssistantResponseInner(page, options, token),
+        {
+            timeoutMs,
+            onExpired: () => ({
+                ok: false,
+                warnings: ['poll-deadline-expired: a browser probe outlived the timeout'],
+            } as ResponseCaptureResult),
+        },
+    );
+}
+
+async function captureAssistantResponseInner(page: Page, options: CaptureOptions, deadlineToken: PollDeadlineToken): Promise<ResponseCaptureResult> {
     const transcript = new ActionTranscript();
     const resolverTrace = createTraceContext('chatgpt-response');
     const pollIntervalMs = Math.max(100, options.pollIntervalMs ?? 500);
@@ -144,7 +163,7 @@ export async function captureAssistantResponse(page: Page, options: CaptureOptio
         ? observeAssistantResponse(page, { baselineAssistantCount: options.minTurnIndex, timeoutMs: observerBudgetMs })
         : null;
 
-    while (Date.now() < deadline) {
+    while (Date.now() < deadline && !deadlineToken.expired) {
         try {
             // 104.18: per-tick guard — if the held tab drifted to a different chat, stop polling the
             // wrong thread and report it so the caller can rebind instead of timing out on stale DOM.

--- a/src/browser/web-ai/chatgpt-response.ts
+++ b/src/browser/web-ai/chatgpt-response.ts
@@ -9,7 +9,17 @@
 
 import type { ResponseCaptureResult } from './provider-adapter.js';
 import { ActionTranscript } from '../primitives.js';
-import { readTopLevelAssistantTexts, readTopLevelAssistantTextsFromLocators } from './chatgpt-response-dom.js';
+import {
+    readTopLevelAssistantTexts,
+    readTopLevelAssistantTextsFromLocators,
+    readAssistantTurnOrderingInPage,
+    probeStopButton,
+    scopeToMainRegion,
+    resolveTopLevelAssistantTurns,
+    CHATGPT_ASSISTANT_SELECTORS,
+    type ChatGptTurnOrderingInPage,
+    type ChatGptStopVerdict,
+} from './chatgpt-response-dom.js';
 import { observeAssistantResponse, recoverAssistantResponse } from './chatgpt-response-observer.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
 import { captureCopiedResponseText, CHATGPT_COPY_SELECTORS, preferCopiedText } from './copy-markdown.js';
@@ -57,6 +67,13 @@ const PLACEHOLDER_PATTERNS: RegExp[] = [
     /^searching the web…?$/i,
     /^reading documents?$/i,
     /^analyzing files?$/i,
+    // parity2 050 slice B-10: placeholder drift since the 2606 port (agbrowse chatgpt.mjs:103-118).
+    /^stopped thinking$/i,
+    /^reasoning$/i,
+    /^deep thinking$/i,
+    /^searching…?$/i,
+    /^browsing…?$/i,
+    /^chatgpt said: answer now$/i,
     /^\s*$/,
 ];
 
@@ -81,6 +98,8 @@ export interface AssistantSnapshot {
     latestNewText?: string;
     /** True while a stop/streaming indicator is visible. */
     streaming: boolean;
+    /** parity2 050 (B-03): tri-state activity verdict; 'unknown' = failed read, fail closed. */
+    activity?: 'visible' | 'absent' | 'unknown';
     /** True when ChatGPT routed the answer into a Canvas surface. */
     canvasOpened: boolean;
 }
@@ -107,7 +126,10 @@ export interface CaptureOptions {
 
 export async function readAssistantSnapshot(page: Page, minTurnIndex: number, promptText = ''): Promise<AssistantSnapshot> {
     const allTexts = await readAssistantTexts(page);
-    const streaming = await isStreaming(page);
+    // parity2 050 slice B-03: tri-state verdict; 'unknown' must NOT read as
+    // "not streaming" — the caller demands a quiet window before accepting.
+    const activity = await probeActivity(page);
+    const streaming = activity === 'visible';
     const canvasOpened = await isCanvasOpened(page);
     const newTexts = allTexts.slice(minTurnIndex);
     const latestNewText = pickLatestRealAnswer(newTexts, promptText);
@@ -115,6 +137,7 @@ export async function readAssistantSnapshot(page: Page, minTurnIndex: number, pr
         assistantCount: allTexts.length,
         latestNewText,
         streaming,
+        activity,
         canvasOpened,
     });
 }
@@ -122,8 +145,12 @@ export async function readAssistantSnapshot(page: Page, minTurnIndex: number, pr
 async function readAssistantTexts(page: Page): Promise<string[]> {
     // Descendant-dedup (catalog 106.13): prefer top-level assistant nodes so a nested
     // match never double-counts its parent's text. page.evaluate first, locator fallback.
-    const viaEvaluate = await page.evaluate(readTopLevelAssistantTexts, ASSISTANT_TURN_SELECTORS)
-        .catch(() => [] as string[]);
+    // parity2 050 slice B-08: each snapshot read races a 10s cap so one
+    // huge-DOM evaluate cannot eat the whole poll budget.
+    const viaEvaluate = await withPollDeadline<string[]>(
+        () => page.evaluate(readTopLevelAssistantTexts, ASSISTANT_TURN_SELECTORS).catch(() => [] as string[]),
+        { timeoutMs: 10_000, onExpired: () => [] as string[] },
+    );
     // parity2 040 (C-09): the locator fallback now reports unread-vs-empty; a
     // partial read is discarded upstream, so only the texts survive here.
     const texts = viaEvaluate.length
@@ -154,6 +181,9 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
     const transcript = new ActionTranscript();
     const resolverTrace = createTraceContext('chatgpt-response');
     const pollIntervalMs = Math.max(100, options.pollIntervalMs ?? 500);
+    // parity2 050 slice B-12: stderr progress heartbeat for long polls.
+    const pollStartedAt = Date.now();
+    let lastHeartbeatAt = pollStartedAt;
     // The post-loop tiers (copy fallback, 3rd-tier recovery) must run INSIDE the
     // outer hard deadline, so the loop stops early enough to leave them room:
     // 20% of the budget, clamped to [200ms, 2s].
@@ -197,14 +227,31 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
             }
             if (!snap.streaming && snap.latestNewText) {
                 if (snap.latestNewText === stableText) {
-                    const finished = await isResponseFinished(page);
+                    const finished = await isResponseFinished(page, options.minTurnIndex);
+                    // parity2 050 slice B-03: an UNKNOWN activity probe is not
+                    // "not streaming" — demand the long quiet window and never
+                    // take the fast finished path on top of a failed read.
+                    const activityUnknown = snap.activity === 'unknown';
                     const textLen = snap.latestNewText.length;
-                    const adaptiveMs = finished ? 1000
+                    const adaptiveMs = (finished && !activityUnknown) ? 1000
+                        : activityUnknown ? 5000
                         : textLen < 16 ? 8000
                         : textLen < 40 ? 3000
                         : textLen < 500 ? 2000
                         : 3000;
                     if (stableSince !== null && Date.now() - stableSince >= adaptiveMs) {
+                        // parity2 050 slice B-01: ordering gate — text that does
+                        // not verifiably FOLLOW the latest user turn is stale
+                        // history, not the answer. 'unknown' (failed read) and
+                        // 'stale' both refuse; 'unverifiable' (no user turn)
+                        // passes, as upstream.
+                        const ordering = await readTurnOrdering(page);
+                        if (ordering === 'stale' || ordering === 'unknown') {
+                            transcript.warn(`assistant-ordering-${ordering === 'stale' ? 'stale' : 'unverified'}`);
+                            stableSince = null;
+                            stableText = undefined;
+                            continue;
+                        }
                         if (options.allowCopyMarkdownFallback) {
                             const copyTarget = await resolveOptionalChatGptCopyTarget(page, resolverTrace);
                             const copied = await captureCopiedResponseText(page, CHATGPT_COPY_SELECTORS, { copyTarget });
@@ -231,6 +278,11 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
             } else {
                 await wait(pollIntervalMs);
             }
+            if (Date.now() - lastHeartbeatAt >= 30_000) {
+                lastHeartbeatAt = Date.now();
+                const phase = snap.streaming ? 'streaming' : (stableSince !== null ? 'stabilizing' : 'settling');
+                process.stderr.write(`[poll] ${Math.round((Date.now() - pollStartedAt) / 1000)}s — ${phase}\n`);
+            }
         } catch (pollErr) {
             // 104.18: a crashed/closed tab is recoverable — surface it as a typed result instead of
             // throwing past the poll boundary, so the caller can relaunch + resume the session.
@@ -246,7 +298,13 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
         }
     }
 
-    if (options.allowCopyMarkdownFallback && stableText) {
+    // parity2 050 slice B-01/B-07: the post-timeout copy path must not admit
+    // text the loop's gates refused — ordering applies here too.
+    const postLoopOrdering = stableText ? await readTurnOrdering(page) : null;
+    // Terminal path: only POSITIVE staleness refuses; unknown/unverifiable fall
+    // through to tiers carrying their own gates.
+    const postLoopOrderingOk = postLoopOrdering !== 'stale';
+    if (options.allowCopyMarkdownFallback && stableText && postLoopOrderingOk) {
         const copyTarget = await resolveOptionalChatGptCopyTarget(page, resolverTrace);
         const copied = await captureCopiedResponseText(page, CHATGPT_COPY_SELECTORS, { copyTarget });
         const copiedText = preferCopiedText(stableText, copied);
@@ -263,11 +321,33 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
         baselineAssistantCount: options.minTurnIndex,
         isFinalAnswer: (t) => !isPlaceholderAssistantText(t),
         readStreaming: () => isStreaming(page),
-        readFinished: () => isResponseFinished(page),
+        readFinished: () => isResponseFinished(page, options.minTurnIndex),
     });
-    if (recovered?.text && !recovered.streaming && (recovered.finished || recovered.responseStableMs > 0)) {
-        transcript.fallback('recovery');
-        return withResolverTrace({ ok: true, answerText: normalizeAssistantText(recovered.text), usedFallbacks: transcript.usedFallbacks, warnings: transcript.warnings }, resolverTrace);
+    if (recovered?.text && !recovered.streaming) {
+        // parity2 050 slice B-01 (recovery gate): the ordering gate applies to
+        // recovered text too — agbrowse re-applies it on the recovery path.
+        const recoveryOrdering = await readTurnOrdering(page);
+        if (recoveryOrdering === 'stale') {
+            transcript.warn('assistant-ordering-stale-recovery');
+            return withResolverTrace(stripUndefined({ ok: false, usedFallbacks: transcript.usedFallbacks, warnings: transcript.warnings }), resolverTrace);
+        }
+        // parity2 050 slice B-07: mere stability (responseStableMs > 0) is NOT
+        // completion — the old acceptance admitted half-written answers. Only
+        // identity-pinned FINISHED evidence completes; stable-but-unfinished
+        // text is reported as a deferred 'polling' outcome so the caller keeps
+        // the session alive instead of persisting a truncated answer.
+        if (recovered.finished) {
+            transcript.fallback('recovery');
+            return withResolverTrace({ ok: true, answerText: normalizeAssistantText(recovered.text), usedFallbacks: transcript.usedFallbacks, warnings: transcript.warnings }, resolverTrace);
+        }
+        transcript.warn('recovery-text-unfinished-deferred');
+        return withResolverTrace(stripUndefined({
+            ok: false,
+            polling: true,
+            answerText: normalizeAssistantText(recovered.text),
+            usedFallbacks: transcript.usedFallbacks,
+            warnings: transcript.warnings,
+        }), resolverTrace);
     }
 
     return withResolverTrace(stripUndefined({ ok: false, answerText: stableText, usedFallbacks: transcript.usedFallbacks, warnings: transcript.warnings }), resolverTrace);
@@ -353,18 +433,70 @@ function pickLatestRealAnswer(texts: string[], promptText: string): string | und
     return undefined;
 }
 
-async function isStreaming(page: Page): Promise<boolean> {
-    for (const selector of STOP_BUTTON_SELECTORS) {
-        try {
-            if (await page.locator(selector).first().isVisible().catch(() => false)) return true;
-        } catch {
-            // ignore
-        }
-    }
-    return false;
+/**
+ * parity2 050 slice B-03: activity is a VERDICT, not a boolean. An unreadable
+ * stop probe reads as 'unknown' — the exact stall-disguised-as-complete case
+ * the old catch(() => false) admitted. The probe is composer/main-scoped so
+ * dictation/voice/read-aloud/sidebar Stop buttons never count as streaming.
+ */
+async function probeActivity(page: Page): Promise<ChatGptStopVerdict> {
+    const scope = scopeToMainRegion(page);
+    return probeStopButton(scope);
 }
 
-async function isResponseFinished(page: Page): Promise<boolean> {
+async function isStreaming(page: Page): Promise<boolean> {
+    return (await probeActivity(page)) === 'visible';
+}
+
+/**
+ * parity2 050 slice B-01: turn-ordering gate. 'unknown' (failed read) is
+ * fail-closed — stale historical text must never be admitted as the answer.
+ */
+async function readTurnOrdering(page: Page): Promise<ChatGptTurnOrderingInPage | 'unknown'> {
+    try {
+        const verdict = await page.evaluate(readAssistantTurnOrderingInPage, CHATGPT_ASSISTANT_SELECTORS);
+        // A malformed result (test double, stripped serialization) is a FAILED
+        // observation, not evidence either way.
+        return verdict === 'ordered' || verdict === 'stale' || verdict === 'unverifiable' ? verdict : 'unknown';
+    } catch {
+        return 'unknown';
+    }
+}
+
+/**
+ * parity2 050 slice B-05: identity-pinned completion. The old page-wide
+ * .last() scan let a PREVIOUS turn's action bar mark a still-streaming answer
+ * finished. The finished-action buttons must live inside the LATEST top-level
+ * assistant turn at or past the baseline index.
+ */
+async function isResponseFinished(page: Page, minTurnIndex = 0): Promise<boolean> {
+    try {
+        const result = await page.evaluate(
+            ({ finishedSelector, minTurnIndex, resolverSource, selectors }: { finishedSelector: string; minTurnIndex: number; resolverSource: string; selectors: string[] }) => {
+                const resolver = (0, eval)(`(${resolverSource})`);
+                const turns = resolver(selectors);
+                for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex--) {
+                    if (turnIndex < minTurnIndex) break;
+                    const turn = turns[turnIndex];
+                    return Boolean(turn.querySelector(finishedSelector));
+                }
+                return false;
+            }, {
+                finishedSelector: FINISHED_ACTIONS_SELECTOR,
+                minTurnIndex,
+                resolverSource: resolveTopLevelAssistantTurns.toString(),
+                selectors: CHATGPT_ASSISTANT_SELECTORS,
+            });
+        if (typeof result === 'boolean') return result;
+        // Malformed result (test double / stripped serialization): fall through
+        // to the legacy visibility scan rather than inventing "not finished".
+        return await legacyFinishedScan(page);
+    } catch {
+        return await legacyFinishedScan(page);
+    }
+}
+
+async function legacyFinishedScan(page: Page): Promise<boolean> {
     try {
         for (const sel of FINISHED_ACTIONS_SELECTOR.split(', ')) {
             const count = await page.locator(sel).count().catch(() => 0);

--- a/src/browser/web-ai/chatgpt-response.ts
+++ b/src/browser/web-ai/chatgpt-response.ts
@@ -152,7 +152,12 @@ async function captureAssistantResponseInner(page: Page, options: CaptureOptions
     const transcript = new ActionTranscript();
     const resolverTrace = createTraceContext('chatgpt-response');
     const pollIntervalMs = Math.max(100, options.pollIntervalMs ?? 500);
-    const deadline = Date.now() + Math.max(1000, options.timeoutMs);
+    // The post-loop tiers (copy fallback, 3rd-tier recovery) must run INSIDE the
+    // outer hard deadline, so the loop stops early enough to leave them room:
+    // 20% of the budget, clamped to [200ms, 2s].
+    const budgetMs = Math.max(1000, options.timeoutMs);
+    const recoveryReserveMs = Math.min(2000, Math.max(200, Math.floor(budgetMs * 0.2)));
+    const deadline = Date.now() + Math.max(200, budgetMs - recoveryReserveMs);
     let stableSince: number | null = null;
     let stableText: string | undefined;
 

--- a/src/browser/web-ai/chatgpt-upload-surface.ts
+++ b/src/browser/web-ai/chatgpt-upload-surface.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path';
+import { basename, resolve } from 'node:path';
 import type { Page, Locator } from 'playwright-core';
 
 // Parity catalog 102 (chatgpt-upload-surface, "BEHIND"). Strict-TS port of agbrowse
@@ -253,3 +253,132 @@ function extractExtension(name: string): string {
     const idx = name.lastIndexOf('.');
     return idx < 0 ? '' : name.slice(idx).toLowerCase();
 }
+
+// ── Size-aware upload budgets + CDP 50MB-safe injection (parity2 060, C-11/A-05) ──
+
+export const DEFAULT_ATTACHMENT_UPLOAD_TIMEOUT_MS = 60_000;
+/**
+ * Playwright treats connectOverCDP browsers as remote and streams file bytes
+ * over the driver websocket with a hard ~50MB per-file limit
+ * (microsoft/playwright#34192). cli-jaw drives a LOCAL Chrome, so raw CDP
+ * `DOM.setFileInputFiles` with local absolute paths transfers zero bytes and
+ * has no size limit. Above this threshold we inject via CDP first.
+ */
+export const CDP_INJECTION_THRESHOLD_BYTES = 45 * 1024 * 1024;
+const PLAYWRIGHT_TRANSFER_LIMIT_PATTERN = /50 ?mb|larger than/i;
+const ACCEPTANCE_BYTES_PER_SECOND = 250 * 1024;
+const HANDOFF_BYTES_PER_SECOND = 5 * 1024 * 1024;
+const SEND_READY_BYTES_PER_SECOND = 1024 * 1024;
+const ACCEPTANCE_CEILING_MS = 900_000;
+const HANDOFF_CEILING_MS = 300_000;
+const SEND_READY_CEILING_MS = 300_000;
+
+function clampMs(value: number, min: number, max: number): number {
+    return Math.floor(Math.min(Math.max(value, min), max));
+}
+
+/**
+ * Size-aware timeout budgets for one attachment batch. Explicit
+ * `attachmentUploadTimeoutMs` (option or JAW_ATTACHMENT_UPLOAD_TIMEOUT_MS env)
+ * wins for the browser handoff; acceptance and send-readiness scale with total
+ * bytes so a 100MB upload is not judged by a fixed 45/60s window.
+ */
+export function computeAttachmentTimeouts(
+    files: Array<{ sizeBytes?: number }> = [],
+    options: { attachmentUploadTimeoutMs?: number | string | null } = {},
+): { totalBytes: number; handoffMs: number; acceptanceMs: number; sendReadyMs: number } {
+    const list = Array.isArray(files) ? files : [];
+    const totalBytes = list.reduce((sum, file) => sum + (Number(file?.sizeBytes) || 0), 0);
+    const explicit = options.attachmentUploadTimeoutMs ?? process.env['JAW_ATTACHMENT_UPLOAD_TIMEOUT_MS'] ?? process.env['AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS'];
+    const explicitMs = (explicit === undefined || explicit === null || explicit === '') ? NaN : Number(explicit);
+    const handoffMs = Number.isFinite(explicitMs) && explicitMs > 0
+        ? Math.round(explicitMs)
+        : clampMs(
+            DEFAULT_ATTACHMENT_UPLOAD_TIMEOUT_MS + (totalBytes / HANDOFF_BYTES_PER_SECOND) * 1000,
+            DEFAULT_ATTACHMENT_UPLOAD_TIMEOUT_MS,
+            HANDOFF_CEILING_MS,
+        );
+    const acceptanceBaseMs = list.length > 1 ? 60_000 : 45_000;
+    let acceptanceMs = clampMs(
+        acceptanceBaseMs + (totalBytes / ACCEPTANCE_BYTES_PER_SECOND) * 1000,
+        acceptanceBaseMs,
+        ACCEPTANCE_CEILING_MS,
+    );
+    const acceptanceFloorMs = Number(process.env['JAW_ATTACHMENT_ACCEPT_TIMEOUT_MS']);
+    if (Number.isFinite(acceptanceFloorMs) && acceptanceFloorMs > 0) {
+        acceptanceMs = Math.max(acceptanceMs, Math.round(acceptanceFloorMs));
+    }
+    const sendReadyMs = list.length === 0
+        ? 20_000
+        : clampMs(45_000 + (totalBytes / SEND_READY_BYTES_PER_SECOND) * 1000, 45_000, SEND_READY_CEILING_MS);
+    return { totalBytes, handoffMs, acceptanceMs, sendReadyMs };
+}
+
+/**
+ * Inject local file paths into a file input through raw CDP
+ * `DOM.setFileInputFiles`. Zero-byte transfer, no Playwright 50MB limit.
+ * Degrades to `{ ok: false }` on fake/unit-test pages without a CDP session.
+ */
+export async function setInputFilesViaCdp(page: Page, inputSel: string, filePaths: string | string[]): Promise<{ ok: true } | { ok: false; error: string }> {
+    const anyPage = page as unknown as { context?: () => { newCDPSession?: (p: unknown) => Promise<{ send: (m: string, p?: Record<string, unknown>) => Promise<unknown>; detach?: () => Promise<void> }> } };
+    const context = typeof anyPage?.context === 'function' ? anyPage.context() : null;
+    if (!context || typeof context.newCDPSession !== 'function') {
+        return { ok: false, error: 'cdp session unavailable on this page' };
+    }
+    let session: { detach?: () => Promise<void> } | null = null;
+    try {
+        const cdp = await context.newCDPSession(page);
+        session = cdp;
+        const files = (Array.isArray(filePaths) ? filePaths : [filePaths]).map(p => resolve(String(p)));
+        const doc = await cdp.send('DOM.getDocument') as { root?: { nodeId?: number } };
+        const rootNodeId = doc?.root?.nodeId;
+        if (!rootNodeId) return { ok: false, error: 'cdp DOM.getDocument returned no root node' };
+        const node = await cdp.send('DOM.querySelector', { nodeId: rootNodeId, selector: inputSel }) as { nodeId?: number };
+        if (!node?.nodeId) return { ok: false, error: `cdp querySelector found no node for ${inputSel}` };
+        await cdp.send('DOM.setFileInputFiles', { files, nodeId: node.nodeId });
+        return { ok: true };
+    } catch (e) {
+        return { ok: false, error: `cdp setFileInputFiles failed: ${(e as { message?: string })?.message || e}` };
+    } finally {
+        await session?.detach?.().catch(() => undefined);
+    }
+}
+
+/**
+ * Set files on a discovered input with the 50MB-safe strategy: CDP-first for
+ * large batches, Playwright setInputFiles otherwise, each falling back to the
+ * other. Records the effective method in `usedFallbacks`.
+ */
+export async function setInputFilesResilient(
+    page: Page,
+    inputSel: string,
+    filePaths: string | string[],
+    { timeoutMs = 8_000, totalBytes = 0, usedFallbacks = [] }: { timeoutMs?: number; totalBytes?: number; usedFallbacks?: string[] } = {},
+): Promise<{ ok: true } | { ok: false; error: string }> {
+    const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
+    const preferCdp = Number(totalBytes) >= CDP_INJECTION_THRESHOLD_BYTES;
+    if (preferCdp) {
+        const viaCdp = await setInputFilesViaCdp(page, inputSel, paths);
+        if (viaCdp.ok) {
+            usedFallbacks.push('cdp-set-input-files');
+            return { ok: true };
+        }
+        usedFallbacks.push(`cdp-set-input-files-failed:${viaCdp.error}`);
+    }
+    try {
+        await page.locator(inputSel).first().setInputFiles(paths, { timeout: timeoutMs });
+        return { ok: true };
+    } catch (e) {
+        const message = String((e as Error)?.message || e);
+        if (!preferCdp && PLAYWRIGHT_TRANSFER_LIMIT_PATTERN.test(message)) {
+            const viaCdp = await setInputFilesViaCdp(page, inputSel, paths);
+            if (viaCdp.ok) {
+                usedFallbacks.push('cdp-set-input-files-after-limit');
+                return { ok: true };
+            }
+            usedFallbacks.push(`cdp-set-input-files-failed:${viaCdp.error}`);
+        }
+        return { ok: false, error: `setInputFiles failed: ${message}` };
+    }
+}
+

--- a/src/browser/web-ai/chatgpt-work-picker.ts
+++ b/src/browser/web-ai/chatgpt-work-picker.ts
@@ -1,0 +1,321 @@
+// ChatGPT Work surface picker + submit + poll (parity2 8b, catalog C-02/B1).
+//
+// Ported core of agbrowse web-ai/chatgpt-work-picker.mjs (1,246 lines): the
+// Power 1..6 mapping, input normalizers, picker state read, ensureWorkSurface,
+// keyboard-driven setWorkPower, button-only submitWorkPrompt with commit
+// verification, main-region-scoped readWorkTaskState (tri-state stop probe,
+// unknown fails closed), and the reattach guards. Live-DOM selectors mirror
+// the 2026-07-10 smoke contract (aria-hidden Radix thumb; Power menuitem is
+// the keyboard target).
+
+import { WebAiError } from './errors.js';
+import { detectChatGptComposerSurface } from './product-surfaces.js';
+import { probeStopButton, scopeToMainRegion } from './chatgpt-response-dom.js';
+
+type WorkAnyPage = any;
+
+export interface PowerMapping {
+    power: number;
+    domValue: number;
+    compactLabel: string;
+    model: string;
+    effort: string;
+}
+
+export const WORK_POWER_MAP: readonly PowerMapping[] = Object.freeze([
+    { power: 1, domValue: 0, compactLabel: '5.6 Terra Light', model: 'GPT-5.6 Terra', effort: 'Light' },
+    { power: 2, domValue: 1, compactLabel: '5.6 Sol Light', model: 'GPT-5.6 Sol', effort: 'Light' },
+    { power: 3, domValue: 2, compactLabel: '5.6 Sol Medium', model: 'GPT-5.6 Sol', effort: 'Medium' },
+    { power: 4, domValue: 3, compactLabel: '5.6 Sol High', model: 'GPT-5.6 Sol', effort: 'High' },
+    { power: 5, domValue: 4, compactLabel: '5.6 Sol Extra High', model: 'GPT-5.6 Sol', effort: 'Extra High' },
+    { power: 6, domValue: 5, compactLabel: '5.6 Sol Ultra', model: 'GPT-5.6 Sol', effort: 'Ultra' },
+]);
+
+const WORK_SIMPLE_VIEW_SELECTOR = '[data-testid="composer-model-picker-slider-simple-view"]';
+const WORK_ADVANCED_VIEW_SELECTOR = '[data-testid="composer-model-picker-slider-advanced-view"]';
+const WORK_SLIDER_SELECTOR = `${WORK_SIMPLE_VIEW_SELECTOR} [role="slider"]`;
+const WORK_POWER_CONTROL_SELECTOR = '[role="menuitem"][aria-label="Power"]';
+const WORK_FAST_CHECKBOX_SELECTOR = '[role="menuitemcheckbox"][aria-label*="fast mode" i]';
+const WORK_SEND_BUTTON_SELECTOR = 'form button[data-testid="send-button"]';
+const CONVERSATION_TURN_SELECTOR = 'article[data-testid^="conversation-turn"], div[data-testid^="conversation-turn"]';
+const WORK_COMMIT_TIMEOUT_MS = 30_000;
+
+/** Validate and normalize a public Power integer (1..6). Rejects before any browser mutation. */
+export function normalizeWorkPower(input: unknown): PowerMapping {
+    const n = Number(input);
+    if (!Number.isInteger(n) || n < 1 || n > 6) {
+        throw new WebAiError({
+            errorCode: 'internal.unhandled',
+            stage: 'provider-work-preflight',
+            message: `Power must be an integer 1..6, got: ${JSON.stringify(input)}`,
+            retryHint: 'fix-power',
+        });
+    }
+    return WORK_POWER_MAP[n - 1]!;
+}
+
+/** Normalize speed input. Unspecified means no speed mutation. */
+export function normalizeWorkSpeed(input: unknown): 'standard' | 'fast' | null {
+    if (input == null || input === '') return null;
+    const key = String(input).trim().toLowerCase();
+    if (key === 'standard' || key === 'fast') return key;
+    throw new WebAiError({
+        errorCode: 'internal.unhandled',
+        stage: 'provider-work-preflight',
+        message: `Speed must be 'standard' or 'fast', got: ${JSON.stringify(input)}`,
+        retryHint: 'retry-speed',
+    });
+}
+
+export interface WorkPickerState {
+    power: number | null;
+    domValue: number | null;
+    domMin: number | null;
+    domMax: number | null;
+    valueText: string | null;
+    compactLabel: string | null;
+    model: string | null;
+    effort: string | null;
+    speed: string | null;
+    fastChecked: boolean | null;
+    simpleViewVisible: boolean;
+    advancedViewVisible: boolean;
+}
+
+/** Read the current Work picker state from the DOM without mutations. */
+export async function readWorkPickerState(page: WorkAnyPage): Promise<WorkPickerState> {
+    const simpleVisible = await page.locator(WORK_SIMPLE_VIEW_SELECTOR).first().isVisible().catch(() => false);
+    const advancedVisible = await page.locator(WORK_ADVANCED_VIEW_SELECTOR).first().isVisible().catch(() => false);
+    const slider = page.locator(WORK_SLIDER_SELECTOR).first();
+    // The live 5.6 thumb is aria-hidden (visibility checks lie); presence in
+    // the simple view plus readable attributes is the observation contract.
+    const sliderPresent = (await page.locator(WORK_SLIDER_SELECTOR).count().catch(() => 0)) > 0;
+
+    let domValue: number | null = null;
+    let domMin: number | null = null;
+    let domMax: number | null = null;
+    let valueText: string | null = null;
+    if (sliderPresent) {
+        const nowStr = await slider.getAttribute('aria-valuenow').catch(() => null);
+        const minStr = await slider.getAttribute('aria-valuemin').catch(() => null);
+        const maxStr = await slider.getAttribute('aria-valuemax').catch(() => null);
+        valueText = await slider.getAttribute('aria-valuetext').catch(() => null);
+        domValue = nowStr != null ? Number(nowStr) : null;
+        domMin = minStr != null ? Number(minStr) : null;
+        domMax = maxStr != null ? Number(maxStr) : null;
+    }
+    const power = domValue != null ? domValue + 1 : null;
+    const compactLabel = valueText ? valueText.replace(/,\s*\d+\s+of\s+\d+\.?$/, '').trim() : null;
+
+    let model: string | null = null;
+    let effort: string | null = null;
+    let speed: string | null = null;
+    if (advancedVisible) {
+        const modelLabel = await page.locator('[role="menuitem"][aria-label^="Model"]').first().getAttribute('aria-label').catch(() => null);
+        const effortLabel = await page.locator('[role="menuitem"][aria-label^="Effort"]').first().getAttribute('aria-label').catch(() => null);
+        const speedLabel = await page.locator('[role="menuitem"][aria-label^="Speed"]').first().getAttribute('aria-label').catch(() => null);
+        model = modelLabel ? modelLabel.replace(/^Model\s*/i, '').trim() : null;
+        effort = effortLabel ? effortLabel.replace(/^Effort\s*/i, '').trim() : null;
+        speed = speedLabel ? speedLabel.replace(/^Speed\s*/i, '').trim().toLowerCase() : null;
+    }
+    const fastEl = page.locator(WORK_FAST_CHECKBOX_SELECTOR).first();
+    const fastVisible = await fastEl.isVisible().catch(() => false);
+    let fastChecked: boolean | null = null;
+    if (fastVisible) {
+        const checkedStr = await fastEl.getAttribute('aria-checked').catch(() => null);
+        fastChecked = checkedStr === 'true';
+    }
+    if (speed == null && fastChecked != null) speed = fastChecked ? 'fast' : 'standard';
+    if (power != null && model == null) {
+        const mapping = WORK_POWER_MAP[power - 1];
+        if (mapping) {
+            model = model || mapping.model;
+            effort = effort || mapping.effort;
+        }
+    }
+    return { power, domValue, domMin, domMax, valueText, compactLabel, model, effort, speed, fastChecked, simpleViewVisible: simpleVisible, advancedViewVisible: advancedVisible };
+}
+
+/** Ensure the Work surface is active; fails closed on ambiguous/legacy. */
+export async function ensureWorkSurface(page: WorkAnyPage): Promise<{ switched: boolean; detection: Awaited<ReturnType<typeof detectChatGptComposerSurface>> }> {
+    const detection = await detectChatGptComposerSurface(page);
+    if (detection.surface === 'work') return { switched: false, detection };
+    if (detection.surface !== 'chat' || detection.ui !== 'toggle') {
+        throw new WebAiError({
+            errorCode: 'provider.work-surface-unsupported',
+            stage: 'provider-work-select',
+            message: `cannot switch to Work from surface=${detection.surface ?? 'none'} (ui=${detection.ui})`,
+            retryHint: 'open-chat',
+            evidence: detection.evidence as unknown as Record<string, unknown>,
+        });
+    }
+    const workRadio = page.locator('button[role="radio"]').filter({ hasText: /^Work$/i }).first();
+    if (!(await workRadio.isVisible().catch(() => false))) {
+        throw new WebAiError({
+            errorCode: 'provider.work-surface-unsupported',
+            stage: 'provider-work-select',
+            message: 'Work radio not visible',
+            retryHint: 'reload-page',
+        });
+    }
+    await workRadio.click({ timeout: 3000 });
+    await page.waitForTimeout?.(300)?.catch?.(() => undefined);
+    const after = await detectChatGptComposerSurface(page);
+    if (after.surface !== 'work') {
+        throw new WebAiError({
+            errorCode: 'provider.work-surface-unsupported',
+            stage: 'provider-work-select',
+            message: `Work switch did not verify (post-click surface: ${after.surface ?? 'none'})`,
+            retryHint: 'retry-work-send',
+            evidence: after.evidence as unknown as Record<string, unknown>,
+        });
+    }
+    return { switched: true, detection: after };
+}
+
+/** Set the Work Power slider to the target value using bounded arrow-key transitions. */
+export async function setWorkPower(page: WorkAnyPage, target: PowerMapping): Promise<WorkPickerState> {
+    const powerControl = page.locator(WORK_POWER_CONTROL_SELECTOR).first();
+    const controlVisible = await powerControl.isVisible().catch(() => false);
+    if (!controlVisible) {
+        throw new WebAiError({ errorCode: 'provider.work-state-unknown', stage: 'provider-work-select', message: 'Power control not visible in the open Work picker', retryHint: 'open-picker' });
+    }
+    const slider = page.locator(WORK_SLIDER_SELECTOR).first();
+    if ((await page.locator(WORK_SLIDER_SELECTOR).count().catch(() => 0)) === 0) {
+        await powerControl.click({ timeout: 3000 });
+        await page.waitForTimeout?.(300)?.catch?.(() => undefined);
+    }
+    if ((await page.locator(WORK_SLIDER_SELECTOR).count().catch(() => 0)) === 0) {
+        throw new WebAiError({ errorCode: 'provider.work-state-unknown', stage: 'provider-work-select', message: 'Power slider not present after activating the Power control', retryHint: 'open-picker' });
+    }
+    const nowStr = await slider.getAttribute('aria-valuenow').catch(() => null);
+    const current = nowStr != null ? Number(nowStr) : null;
+    if (current == null) {
+        throw new WebAiError({ errorCode: 'provider.work-state-unknown', stage: 'provider-work-select', message: 'Power slider aria-valuenow not readable', retryHint: 'reload-page' });
+    }
+    const diff = target.domValue - current;
+    if (diff !== 0) {
+        await powerControl.focus().catch(() => undefined);
+        const key = diff > 0 ? 'ArrowRight' : 'ArrowLeft';
+        for (let i = 0; i < Math.abs(diff); i++) {
+            await powerControl.press(key);
+            await page.waitForTimeout?.(150)?.catch?.(() => undefined);
+        }
+    }
+    const state = await readWorkPickerState(page);
+    if (state.domValue !== target.domValue) {
+        throw new WebAiError({ errorCode: 'provider.work-state-unknown', stage: 'provider-work-select', message: `Power slider did not reach target ${target.domValue} (actual: ${state.domValue})`, retryHint: 'retry-power', evidence: state as unknown as Record<string, unknown> });
+    }
+    return state;
+}
+
+export type WorkTaskStatus = 'running' | 'complete' | 'unknown';
+
+/**
+ * Read Work task state, main-region-scoped (sidebar titles poison page-wide
+ * matching). An unreadable stop probe is UNKNOWN and fails closed — a leftover
+ * Copy button on an earlier turn must not read as "finished".
+ */
+export async function readWorkTaskState(page: WorkAnyPage): Promise<{ surface: 'work'; status: WorkTaskStatus; answerText: string | null; evidence: Record<string, unknown> }> {
+    const mainRegion = scopeToMainRegion(page);
+    const stopProbe = await probeStopButton(mainRegion);
+    const stopVisible = stopProbe === 'visible';
+    const thinkingEl = mainRegion?.getByText?.('Thinking', { exact: true });
+    const thinkingVisible = thinkingEl ? await thinkingEl.first().isVisible().catch(() => false) : false;
+    if (stopVisible || thinkingVisible) {
+        return { surface: 'work', status: 'running', answerText: null, evidence: { stopVisible, stopProbe, thinkingVisible, capturedAt: new Date().toISOString() } };
+    }
+    if (stopProbe === 'unknown') {
+        return { surface: 'work', status: 'unknown', answerText: null, evidence: { stopVisible: null, stopProbe, thinkingVisible, capturedAt: new Date().toISOString() } };
+    }
+    const copyBtn = mainRegion.locator('button[aria-label*="Copy" i]').first();
+    const copyVisible = await copyBtn.isVisible().catch(() => false);
+    if (copyVisible) {
+        const assistantTurns = mainRegion.locator('[data-message-author-role="assistant"]');
+        const count = await assistantTurns.count().catch(() => 0);
+        let answerText: string | null = null;
+        if (count > 0) answerText = await assistantTurns.last().textContent().catch(() => null);
+        return { surface: 'work', status: 'complete', answerText: answerText ? answerText.trim() : null, evidence: { copyVisible, stopVisible: false, stopProbe, assistantTurnCount: count, capturedAt: new Date().toISOString() } };
+    }
+    return { surface: 'work', status: 'unknown', answerText: null, evidence: { stopVisible, stopProbe, thinkingVisible, copyVisible, capturedAt: new Date().toISOString() } };
+}
+
+/**
+ * Submit the Work prompt by clicking the SCOPED send button, then verify commit
+ * evidence (committed user turn + running indicators). NEVER falls back to
+ * keyboard Enter — ProseMirror + IME composition can leak characters.
+ */
+export async function submitWorkPrompt(page: WorkAnyPage, prompt: string, options: { commitTimeoutMs?: number; baselineUrl?: string | null } = {}): Promise<{ committed: boolean; taskUrl: string | null; turnsCount: number; warnings: string[] }> {
+    const commitTimeout = options.commitTimeoutMs || WORK_COMMIT_TIMEOUT_MS;
+    const sendBtn = page.locator(WORK_SEND_BUTTON_SELECTOR).first();
+    if (!(await sendBtn.isVisible().catch(() => false))) {
+        throw new WebAiError({ errorCode: 'provider.work-submit-unverified', stage: 'work-submit', message: 'Work send button (data-testid="send-button" inside form) not visible', retryHint: 'reload-page' });
+    }
+    if (!(await sendBtn.isEnabled().catch(() => false))) {
+        throw new WebAiError({ errorCode: 'provider.work-submit-unverified', stage: 'work-submit', message: 'Work send button is disabled — prompt may not have been inserted', retryHint: 'check-composer' });
+    }
+    await sendBtn.click({ timeout: 5000 });
+
+    const deadline = Date.now() + commitTimeout;
+    const normalizedPrompt = prompt.toLowerCase().replace(/\s+/g, ' ').trim();
+    const promptPrefix = normalizedPrompt.slice(0, Math.min(normalizedPrompt.length, 120));
+    // Sticky: if the stop button was ever unreadable, neither success nor
+    // timeout may claim it was checked.
+    let lastStopProbe: 'visible' | 'absent' | 'unknown' | null = null;
+    const warnings: string[] = [];
+    while (Date.now() <= deadline) {
+        const turnLocators = await page.locator(CONVERSATION_TURN_SELECTOR).all().catch(() => [] as WorkAnyPage[]);
+        let hasPromptTurn = false;
+        for (const loc of turnLocators) {
+            const text = String(await loc.innerText().catch(() => '')).trim();
+            const normalized = text.toLowerCase().replace(/\s+/g, ' ').trim();
+            if (promptPrefix && normalized.includes(promptPrefix)) { hasPromptTurn = true; break; }
+        }
+        const mainRegion = scopeToMainRegion(page);
+        const stopProbe = await probeStopButton(mainRegion);
+        if (stopProbe === 'unknown') lastStopProbe = 'unknown';
+        else if (lastStopProbe !== 'unknown') lastStopProbe = stopProbe;
+        if (hasPromptTurn && (stopProbe === 'visible' || turnLocators.length > 0)) {
+            const taskUrl = typeof page.url === 'function' ? page.url() : null;
+            const finalWarnings = lastStopProbe === 'unknown' ? [...warnings, 'work-stop-probe-unverified'] : warnings;
+            return { committed: true, taskUrl, turnsCount: turnLocators.length, warnings: finalWarnings };
+        }
+        await page.waitForTimeout?.(500)?.catch?.(() => undefined);
+    }
+    throw new WebAiError({
+        errorCode: 'provider.work-submit-unverified',
+        stage: 'work-submit',
+        message: `Work prompt commit not verified within ${commitTimeout}ms`,
+        retryHint: 'retry-work-send',
+        evidence: { lastStopProbe },
+    });
+}
+
+/**
+ * Reattach guard: a running Work session must be polled on ITS OWN target —
+ * running-task reattach is not supported in v1; and a bare-origin
+ * conversationUrl session must never resolve against the generic origin.
+ */
+export function assertWorkSessionPollable(session: { sessionId?: string; targetId?: string; conversationUrl?: string | null }, actualTargetId: string | null): void {
+    if (session.targetId && actualTargetId && actualTargetId !== session.targetId) {
+        throw new WebAiError({
+            errorCode: 'provider.work-reattach-unverified',
+            stage: 'work-poll',
+            message: `Work session target mismatch: expected ${session.targetId}, got ${actualTargetId}. Running-task reattach is not supported in v1.`,
+            retryHint: 'reattach-session',
+            evidence: { sessionId: session.sessionId, expectedTargetId: session.targetId, actualTargetId },
+        });
+    }
+    const url = session.conversationUrl || '';
+    const isBareOrigin = /^https:\/\/(chatgpt\.com|chat\.openai\.com)\/?$/.test(url);
+    if (isBareOrigin) {
+        throw new WebAiError({
+            errorCode: 'provider.work-reattach-unverified',
+            stage: 'work-poll',
+            message: `Work session ${session.sessionId} has bare-origin conversationUrl (${url}); refusing to poll the wrong tab`,
+            retryHint: 'resend-work',
+            evidence: { sessionId: session.sessionId, conversationUrl: url, surface: 'work' },
+        });
+    }
+}
+

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -58,6 +58,7 @@ import { withPollDeadline } from './poll-deadline.js';
 import { probeTabAlive, isSafeChatGptConversationUrl } from './tab-recovery.js';
 import { probeCdpLiveness } from './cdp-liveness.js';
 import { detectChatGptComposerSurface } from './product-surfaces.js';
+import { withActiveCommand } from './active-command-store.js';
 import type {
     QuestionEnvelopeInput,
     WebAiOutput,
@@ -603,13 +604,32 @@ export async function poll(port: number, input: {
         }
         return null;
     };
-    const result = await captureAssistantResponse(page, {
+    // parity2 110 fix (final-audit F2): the long-running poll registers itself
+    // in the cross-process active-command store so tab cleanup in OTHER
+    // processes cannot reclaim this tab mid-poll. Best-effort: a store failure
+    // must not block the poll (it degrades to the old unprotected behavior,
+    // observed via the warning).
+    let result: Awaited<ReturnType<typeof captureAssistantResponse>>;
+    const captureArgs = {
         minTurnIndex: baseline.assistantCount,
         timeoutMs,
         promptText: '',
         allowCopyMarkdownFallback: input.allowCopyMarkdownFallback === true,
         driftCheck,
-    });
+    };
+    try {
+        result = await withActiveCommand(
+            { command: 'web-ai-poll', owner: 'cli-jaw', targetId, ...(session ? { sessionId: session.sessionId } : {}), ttlMs: timeoutMs + 60_000 },
+            () => captureAssistantResponse(page, captureArgs),
+        );
+    } catch (err) {
+        if ((err as { code?: string })?.code === 'active-command.store-unavailable' || (err as { code?: string })?.code === 'active-command.target-owned') {
+            result = await captureAssistantResponse(page, captureArgs);
+            result.warnings.push(`active-command-unprotected:${(err as { code?: string }).code}`);
+        } else {
+            throw err;
+        }
+    }
     // 104.18: surface a per-tick drift/crash bail-out as a typed, (for crashes) recoverable outcome.
     if (result.drift) {
         if (session) updateSessionStatus(session.sessionId, result.drift.status === 'tab-crashed' ? 'crashed' : session.status);
@@ -1001,12 +1021,13 @@ export async function stop(port: number, input: { vendor?: string; session?: str
     return { ok: true, vendor: 'chatgpt', status: 'blocked', url: currentUrl, warnings: ['sent Escape to stop generation'] };
 }
 
-export async function diagnose(port: number, input: { vendor?: string; stage?: string } = {}): Promise<{ ok: boolean; diagnostics?: ReturnType<typeof toJsonDiagnostics> }> {
+export async function diagnose(port: number, input: { vendor?: string; stage?: string; session?: string } = {}): Promise<{ ok: boolean; diagnostics?: ReturnType<typeof toJsonDiagnostics> }> {
     const vendor = parseVendor(input.vendor);
     const stage = (input.stage as WebAiFailureStage) || 'unknown';
     const page = await requireActivePage(port).catch(() => null);
     if (!page) return { ok: false };
-    const diagnostics = await captureWebAiDiagnostics({ stage, page });
+    // parity2 110 fix (F1): an explicit session persists the bundle as an artifact.
+    const diagnostics = await captureWebAiDiagnostics({ stage, page, ...(input.session ? { sessionId: String(input.session) } : {}) });
     return { ok: true, diagnostics: toJsonDiagnostics({ ...diagnostics, vendor }) };
 }
 

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -54,6 +54,7 @@ import { selectChatGptComposerTools } from './chatgpt-tools.js';
 import { sendDeepResearch } from './chatgpt-deep-research.js';
 import { sendMultiTurn } from './chatgpt-multi-turn.js';
 import { withPollDeadline } from './poll-deadline.js';
+import { probeTabAlive, isSafeChatGptConversationUrl } from './tab-recovery.js';
 import type {
     QuestionEnvelopeInput,
     WebAiOutput,
@@ -194,9 +195,19 @@ async function withSessionPage<T>(port: number, sessionId: string, fn: (ctx: Ses
     async function resolvePage(forceRecover = false) {
         const current = getSession(sessionId);
         if (!current) throw new Error(`Session not found: ${sessionId}`);
-        const alive = current.targetId ? !!(await getPageByTargetId(port, current.targetId).catch(() => null)) : false;
-        if (!alive || forceRecover) {
-            const tab = await createTab(port, current.conversationUrl || current.url || 'https://chatgpt.com', { activate: false });
+        // parity2 020 slice 2.3 (B3/C-10): a probe failure is NOT death. The old
+        // catch(() => null) treated any transient CDP error as a dead tab and
+        // immediately rebound the session to a fresh one, abandoning a live
+        // conversation. Liveness is tri-state and UNKNOWN fails closed.
+        const liveness = await probeTabAlive(port, current.targetId);
+        if (liveness === 'unknown' && !forceRecover) {
+            throw new Error(`Session ${sessionId} tab liveness could not be verified (targetId ${current.targetId}); refusing to replace a possibly-live tab. Error: tab.liveness-unverified`);
+        }
+        if (liveness === 'dead' || forceRecover) {
+            const recoveryUrl = isSafeChatGptConversationUrl(current.conversationUrl)
+                ? (current.conversationUrl as string)
+                : 'https://chatgpt.com';
+            const tab = await createTab(port, recoveryUrl, { activate: false });
             const page = await waitForPageByTargetId(port, tab.targetId);
             updateSessionResult({ sessionId, status: current.status, tabState: { createdAt: current.tabState?.createdAt || new Date().toISOString(), lastActiveAt: new Date().toISOString(), recoveryCount: (current.tabState?.recoveryCount || 0) + 1, closeCount: current.tabState?.closeCount || 0 } });
             const recovered = getSession(sessionId);

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -283,7 +283,19 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
         }).catch(() => null)
         : null;
     await waitForStableAssistantCount(page);
-    const assistantCount = await countAssistantMessages(page);
+    // parity2 060 slice A-02: a failed baseline read must abort the send
+    // PRE-MUTATION — a 0-count baseline poisons every later poll.
+    const assistantCountOrNull = await countAssistantMessagesOrNull(page);
+    if (assistantCountOrNull === null) {
+        throw new WebAiError({
+            errorCode: 'provider.baseline-unverified',
+            stage: 'send-baseline',
+            vendor: 'chatgpt',
+            retryHint: 'retry',
+            message: 'assistant baseline could not be read; refusing to send (a 0 baseline would re-admit the whole conversation as new)',
+        });
+    }
+    const assistantCount = assistantCountOrNull;
     const baseline = saveBaseline({
         vendor: envelope.vendor,
         targetId,
@@ -378,17 +390,43 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
         }
         // 104.12: hand the resolved send target + upload-aware timeout to the submit path.
         const sendSelector = sendTarget.ok ? sendTarget.target?.selector : null;
-        await liveAdapter.submitPrompt({
+        const totalUploadBytes = uploadPaths.reduce((total, p) => total + (localFileInfo(p).sizeBytes || 0), 0);
+        const submitResult = await liveAdapter.submitPrompt({
             ...(sendSelector ? { sendTarget: { selector: sendSelector, resolution: sendTarget.resolutionSource } } : {}),
-            sendButtonTimeoutMs: sendButtonTimeoutMs(uploadPaths),
+            sendButtonTimeoutMs: sendButtonTimeoutMs(uploadPaths, totalUploadBytes),
+            // parity2 060 slice A-03: never Enter-submit while uploads pend.
+            requireEnabledSendButton: uploadPaths.length > 0,
         });
+        if (submitResult.failure === 'send-button-disabled') {
+            throw new WebAiError({
+                errorCode: 'provider.send-click',
+                stage: 'send-click',
+                vendor: 'chatgpt',
+                retryHint: 'retry-send',
+                message: 'send button never became enabled while attachments were pending',
+            });
+        }
         await liveAdapter.verifyPromptCommitted(rendered.composerText, commitBaseline);
         for (const uploadPath of uploadPaths) {
             // eslint-disable-next-line no-await-in-loop -- evidence follows upload order.
             const sentAttachment = await verifySentTurnAttachmentLive(page, localFileInfo(uploadPath));
             if (!sentAttachment.ok) {
-                usedFallbacks.push('sent-attachment-evidence-unavailable');
-                attachmentWarnings.push(`sent attachment evidence unavailable after submit: ${sentAttachment.error}`);
+                // parity2 060 slice A-04: a missing sent-attachment chip is a
+                // FAILURE by default (the model answers without the file);
+                // JAW_SENT_ATTACHMENT_POLICY=warn restores the old warning.
+                if (String(process.env['JAW_SENT_ATTACHMENT_POLICY'] || '').toLowerCase() === 'warn') {
+                    usedFallbacks.push('sent-attachment-evidence-unavailable');
+                    attachmentWarnings.push(`sent attachment evidence unavailable after submit: ${sentAttachment.error}`);
+                } else {
+                    throw new WebAiError({
+                        errorCode: 'provider.sent-attachment-missing',
+                        stage: 'send-verify',
+                        vendor: 'chatgpt',
+                        retryHint: 'retry-send',
+                        message: `sent attachment not verified in the committed turn: ${sentAttachment.error}`,
+                        evidence: { uploadPath },
+                    });
+                }
             }
         }
         updateSessionStatus(session.sessionId, 'streaming');
@@ -1026,6 +1064,42 @@ async function requireActivePage(port: number): Promise<Page> {
 
 async function countAssistantMessages(page: Page): Promise<number> {
     return (await readAssistantMessages(page)).length;
+}
+
+/**
+ * parity2 060 slice A-02: baseline counter with NULL semantics. A failed read
+ * is NOT zero — recording 0 re-admits the whole conversation as "new" on every
+ * later poll. The send path must throw pre-mutation instead.
+ */
+async function countAssistantMessagesOrNull(page: Page): Promise<number | null> {
+    const evaluated = await page.evaluate?.((selectors: readonly string[]) => {
+        for (const selector of selectors) {
+            const texts = Array.from(document.querySelectorAll(selector))
+                .map((el: TextNodeLike) => String(el.innerText || el.textContent || '').trim())
+                .filter(Boolean);
+            if (texts.length) return texts;
+        }
+        return [];
+    }, ASSISTANT_SELECTORS).catch(() => null);
+    if (evaluated === null) {
+        // evaluate failed — try the locator path, but report null on failure
+        // rather than an empty success.
+        try {
+            const messages: string[] = [];
+            for (const selector of ASSISTANT_SELECTORS) {
+                const locators = await page.locator(selector).all();
+                for (const locator of locators) {
+                    const text = cleanAssistantText(await locator.innerText().catch(() => ''));
+                    if (text) messages.push(text);
+                }
+                if (messages.length > 0) break;
+            }
+            return messages.length;
+        } catch {
+            return null;
+        }
+    }
+    return evaluated.map(cleanAssistantText).filter(Boolean).length;
 }
 
 async function waitForStableAssistantCount(page: Page, timeoutMs = 8_000): Promise<void> {

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -32,6 +32,7 @@ import {
 } from './session.js';
 import { captureAssistantResponse } from './chatgpt-response.js';
 import { saveAssistantDownloadableFiles } from './chatgpt-files.js';
+import { collectImages } from './chatgpt-images.js';
 import { resolveTimeoutDefaultSec } from './tier-timeout.js';
 import { selectChatGptModel } from './chatgpt-model.js';
 import { withAnswerArtifact } from './answer-artifact.js';
@@ -55,6 +56,7 @@ import { sendDeepResearch } from './chatgpt-deep-research.js';
 import { sendMultiTurn } from './chatgpt-multi-turn.js';
 import { withPollDeadline } from './poll-deadline.js';
 import { probeTabAlive, isSafeChatGptConversationUrl } from './tab-recovery.js';
+import { probeCdpLiveness } from './cdp-liveness.js';
 import type {
     QuestionEnvelopeInput,
     WebAiOutput,
@@ -525,6 +527,17 @@ export async function poll(port: number, input: {
         if (baselineConvoId && currentConvoId && baselineConvoId !== currentConvoId) {
             return `conversation changed: ${baselineConvoId} → ${currentConvoId}`;
         }
+        // parity2 050 slice B-02: per-tick target-identity verification. The
+        // single upfront assertSameTarget said nothing about later ticks — a
+        // tab swap mid-poll rebinds the read to the wrong target. Probe the
+        // out-of-band target list; a MISMATCH bails, an unreadable probe does
+        // not (drift bail-out must be positive evidence).
+        if (session?.targetId) {
+            const liveness = await probeCdpLiveness({ port, targetId: session.targetId }).catch(() => null);
+            if (liveness && liveness.endpointReachable && liveness.targetFound === false) {
+                return `session target ${session.targetId} no longer exists`;
+            }
+        }
         return null;
     };
     const result = await captureAssistantResponse(page, {
@@ -571,6 +584,19 @@ export async function poll(port: number, input: {
                     { sessionId: session.sessionId, baselineAssistantCount: baseline.assistantCount },
                 );
                 if (fileResult.warnings.length) result.warnings.push(...fileResult.warnings);
+                // parity2 050 slice B-06: generated-image capture was ported
+                // (chatgpt-images.ts collectImages) but never invoked — wire it
+                // into the same post-completion artifact pass. Best-effort:
+                // failures become warnings, never a thrown error.
+                try {
+                    const imageResult = await collectImages(
+                        fileCdp as unknown as Parameters<typeof collectImages>[0],
+                        { sessionId: session.sessionId, baselineAssistantCount: baseline.assistantCount },
+                    );
+                    if (imageResult.warnings?.length) result.warnings.push(...imageResult.warnings);
+                } catch (err) {
+                    result.warnings.push(`image-capture-failed:${(err as Error)?.message || 'unknown'}`);
+                }
             } catch (err) {
                 result.warnings.push(`file-artifact-capture-failed:${(err as Error)?.message || 'unknown'}`);
             } finally {

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -53,6 +53,7 @@ import { detectInterstitial, isPageDeathError } from './interstitial.js';
 import { selectChatGptComposerTools } from './chatgpt-tools.js';
 import { sendDeepResearch } from './chatgpt-deep-research.js';
 import { sendMultiTurn } from './chatgpt-multi-turn.js';
+import { withPollDeadline } from './poll-deadline.js';
 import type {
     QuestionEnvelopeInput,
     WebAiOutput,
@@ -987,17 +988,24 @@ async function countAssistantMessages(page: Page): Promise<number> {
 }
 
 async function waitForStableAssistantCount(page: Page, timeoutMs = 8_000): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    let previous = -1;
-    let stableReads = 0;
-    while (Date.now() < deadline) {
-        const count = await countAssistantMessages(page).catch(() => 0);
-        if (count === previous) stableReads++;
-        else stableReads = 0;
-        previous = count;
-        if (stableReads >= 2) return;
-        await page.waitForTimeout(500).catch(() => undefined);
-    }
+    // parity2 010 slice 1.1 (C-04): hard-bounded — a stalled readAssistantMessages
+    // evaluate would otherwise hold this helper past its budget.
+    await withPollDeadline<void>(
+        async (_hardDeadline, token) => {
+            const deadline = Date.now() + timeoutMs;
+            let previous = -1;
+            let stableReads = 0;
+            while (Date.now() < deadline && !token.expired) {
+                const count = await countAssistantMessages(page).catch(() => 0);
+                if (count === previous) stableReads++;
+                else stableReads = 0;
+                previous = count;
+                if (stableReads >= 2) return;
+                await page.waitForTimeout(500).catch(() => undefined);
+            }
+        },
+        { timeoutMs, onExpired: () => undefined },
+    );
 }
 
 async function readAssistantMessages(page: Page): Promise<string[]> {

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -57,6 +57,7 @@ import { sendMultiTurn } from './chatgpt-multi-turn.js';
 import { withPollDeadline } from './poll-deadline.js';
 import { probeTabAlive, isSafeChatGptConversationUrl } from './tab-recovery.js';
 import { probeCdpLiveness } from './cdp-liveness.js';
+import { detectChatGptComposerSurface } from './product-surfaces.js';
 import type {
     QuestionEnvelopeInput,
     WebAiOutput,
@@ -261,6 +262,30 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
             retryHint: interstitial.retryHint,
             message: `ChatGPT blocked by ${interstitial.kind}: ${interstitial.evidence}`,
             evidence: interstitial,
+        });
+    }
+    // parity2 080 slice 8a (C-03): Work/Chat surface preflight, fail-closed.
+    // On a Work-enabled account a chat prompt would otherwise silently land in
+    // the Work surface (whose submit/poll semantics differ — port pending, 8b).
+    const surfaceDetection = await detectChatGptComposerSurface(page).catch(() => null);
+    if (surfaceDetection?.surface === 'ambiguous') {
+        throw new WebAiError({
+            errorCode: 'provider.surface-ambiguous',
+            stage: 'provider-surface',
+            vendor: 'chatgpt',
+            retryHint: 'retry',
+            message: 'ChatGPT Chat/Work surface state is ambiguous; refusing to send rather than guessing the surface',
+            evidence: surfaceDetection.evidence as unknown as Record<string, unknown>,
+        });
+    }
+    if (surfaceDetection?.surface === 'work') {
+        throw new WebAiError({
+            errorCode: 'provider.work-surface-unsupported',
+            stage: 'provider-surface',
+            vendor: 'chatgpt',
+            retryHint: 'open-chat',
+            message: 'the composer is on the ChatGPT Work surface, which cli-jaw cannot drive yet (parity2 8b pending); switch to Chat or open a chat conversation',
+            evidence: surfaceDetection.evidence as unknown as Record<string, unknown>,
         });
     }
     const contextPack = await prepareContextForBrowser(input);

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -284,7 +284,7 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
             stage: 'provider-surface',
             vendor: 'chatgpt',
             retryHint: 'open-chat',
-            message: 'the composer is on the ChatGPT Work surface, which cli-jaw cannot drive yet (parity2 8b pending); switch to Chat or open a chat conversation',
+            message: 'the composer is on the ChatGPT Work surface; the generic chat send cannot drive it — switch to Chat, or use the Work primitives (chatgpt-work-picker: ensureWorkSurface/setWorkPower/submitWorkPrompt)',
             evidence: surfaceDetection.evidence as unknown as Record<string, unknown>,
         });
     }

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -512,6 +512,10 @@ export async function poll(port: number, input: {
         : session?.timeoutMs ? session.timeoutMs / 1000
         : resolveTimeoutDefaultSec({}, vendor);
     const timeoutMs = timeoutSec * 1000;
+    // parity2 040 slice 4.3 (C-06): the finalizer's side-effect phases re-check
+    // this bound so a losing run cannot write/pool after the caller timed out.
+    const pollDeadlineAt = Date.now() + timeoutMs;
+    const pollStillActive = () => Date.now() < pollDeadlineAt;
     // 104.18: per-tick conversation-drift guard. baseline.url is the chat we committed to; if the
     // held page later sits on a *different* /c/<id>, we're polling the wrong thread. The expected
     // fresh-chat none→id transition is NOT flagged (it only fires when both ids exist and differ).
@@ -576,7 +580,7 @@ export async function poll(port: number, input: {
     }
     if (result.canvas) {
         if (session) {
-            await finalizeProviderTab({ vendor, session, port, url: currentUrl, answerText: result.answerText || '' });
+            await finalizeProviderTab({ vendor, session, port, url: currentUrl, answerText: result.answerText || '', stillActive: pollStillActive });
         }
         const output = decorateCompletedOutput(stripUndefined({
             ok: true,
@@ -602,7 +606,7 @@ export async function poll(port: number, input: {
     }
     if (result.ok) {
         if (session) {
-            await finalizeProviderTab({ vendor, session, port, url: currentUrl, answerText: result.answerText || '' });
+            await finalizeProviderTab({ vendor, session, port, url: currentUrl, answerText: result.answerText || '', stillActive: pollStillActive });
         }
         const output = decorateCompletedOutput(stripUndefined({
             ok: true,

--- a/src/browser/web-ai/chatgpt.ts
+++ b/src/browser/web-ai/chatgpt.ts
@@ -268,7 +268,13 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
     // parity2 080 slice 8a (C-03): Work/Chat surface preflight, fail-closed.
     // On a Work-enabled account a chat prompt would otherwise silently land in
     // the Work surface (whose submit/poll semantics differ — port pending, 8b).
-    const surfaceDetection = await detectChatGptComposerSurface(page).catch(() => null);
+    // parity2 110 (final-audit F6): a THROWN probe must not silently skip a gate
+    // advertised as fail-closed — record the degradation so it is observable.
+    let surfaceProbeFailed: string | null = null;
+    const surfaceDetection = await detectChatGptComposerSurface(page).catch((err: unknown) => {
+        surfaceProbeFailed = String((err as Error)?.message || err);
+        return null;
+    });
     if (surfaceDetection?.surface === 'ambiguous') {
         throw new WebAiError({
             errorCode: 'provider.surface-ambiguous',
@@ -368,6 +374,7 @@ export async function send(port: number, input: QuestionEnvelopeInput = {}): Pro
     };
     const adapter = createChatGptEditorAdapter(page, editorOptions);
     const attachmentWarnings: string[] = [];
+    if (surfaceProbeFailed) attachmentWarnings.push(`surface-probe-failed:${surfaceProbeFailed}`);
     const usedFallbacks: string[] = [];
     try {
         const composerTarget = await resolveTargetForIntent(page, {

--- a/src/browser/web-ai/cli-sessions.ts
+++ b/src/browser/web-ai/cli-sessions.ts
@@ -2,6 +2,7 @@ import { poll as chatgptPoll } from './chatgpt.js';
 import { geminiPoll } from './gemini-live.js';
 import { grokPoll } from './grok-live.js';
 import { WebAiError } from './errors.js';
+import { isDurableConversationUrl } from './conversation-url.js';
 import { getSession, listSessions, pruneSessions } from './session.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
 import type { WebAiVendor, WebAiSessionStatus } from './types.js';
@@ -127,6 +128,19 @@ export async function runSessionsCommand(
         }
         if (currentUrl !== targetUrl) {
             if (input.navigate === true) {
+                // parity2 020 slice 2.1 (B4/C-10): never navigate a reattach to a
+                // non-durable ChatGPT URL — a bare origin or smuggled string would
+                // land on a home tab (or worse), not the conversation.
+                if (session.vendor === 'chatgpt' && !isDurableConversationUrl(targetUrl)) {
+                    return {
+                        ok: false,
+                        status: 'reattach-failed',
+                        sessionId: id,
+                        vendor: session.vendor,
+                        error: `session URL is not a durable ChatGPT conversation URL (${targetUrl}); refusing navigation`,
+                        warnings: [],
+                    };
+                }
                 await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 });
                 return { ok: true, status: 'reattached', sessionId: id, vendor: session.vendor, url: targetUrl, warnings: [`navigated from ${currentUrl} to ${targetUrl}`] };
             }

--- a/src/browser/web-ai/cli-sessions.ts
+++ b/src/browser/web-ai/cli-sessions.ts
@@ -5,6 +5,7 @@ import { WebAiError } from './errors.js';
 import { isDurableConversationUrl } from './conversation-url.js';
 import { getSession, listSessions, pruneSessions } from './session.js';
 import { buildSessionDoctorReport } from './session-doctor.js';
+import { listActiveCommands } from './active-command-store.js';
 import { probeTabAlive } from './tab-recovery.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
 import type { WebAiVendor, WebAiSessionStatus } from './types.js';
@@ -107,10 +108,9 @@ export async function runSessionsCommand(
         const port = deps.port ?? 0;
         const report = await buildSessionDoctorReport({
             getSession: (sessionId) => getSession(sessionId),
-            // Cross-process command-lock/active-command visibility lands with the
-            // active-command store (parity2 100 / B8); until then report none.
+            // parity2 100 (B8): real cross-process active-command visibility.
             readSessionCommandLock: () => null,
-            listActiveCommands: async () => [],
+            listActiveCommands: async (scope) => listActiveCommands({ active: true, ...(scope?.browserProfileKey ? { browserProfileKey: scope.browserProfileKey } : {}) }),
             verifySessionTab: async (session) => {
                 const liveness = await probeTabAlive(port, (session as { targetId?: string }).targetId);
                 if (liveness === 'alive') return { valid: true };

--- a/src/browser/web-ai/cli-sessions.ts
+++ b/src/browser/web-ai/cli-sessions.ts
@@ -4,10 +4,14 @@ import { grokPoll } from './grok-live.js';
 import { WebAiError } from './errors.js';
 import { isDurableConversationUrl } from './conversation-url.js';
 import { getSession, listSessions, pruneSessions } from './session.js';
+import { buildSessionDoctorReport } from './session-doctor.js';
+import { probeTabAlive } from './tab-recovery.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
 import type { WebAiVendor, WebAiSessionStatus } from './types.js';
 
-const SESSIONS_SUBCOMMANDS = new Set(['list', 'show', 'resume', 'reattach', 'prune']);
+// parity2 070 slice C-05: 'doctor' was advertised by session-doctor's own help
+// text but never routed.
+const SESSIONS_SUBCOMMANDS = new Set(['list', 'show', 'resume', 'reattach', 'prune', 'doctor']);
 
 const SESSION_DURATION_RE = /^(\d+)\s*([smhdw]?)$/i;
 const DURATION_MS: Record<string, number> = { '': 1000, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 };
@@ -97,20 +101,69 @@ export async function runSessionsCommand(
         if (!session) throw new WebAiError({ errorCode: 'internal.unhandled', stage: 'internal', retryHint: 'report', message: `no session record for ${id}`, evidence: { sessionId: id } });
         return { ok: true, status: 'show', session, vendor: session.vendor, warnings: [] };
     }
+    if (sub === 'doctor') {
+        const id = rest[0] || input.session;
+        if (!id) throw new WebAiError({ errorCode: 'internal.unhandled', stage: 'internal', retryHint: 'report', message: 'sessions doctor <id> requires a sessionId' });
+        const port = deps.port ?? 0;
+        const report = await buildSessionDoctorReport({
+            getSession: (sessionId) => getSession(sessionId),
+            // Cross-process command-lock/active-command visibility lands with the
+            // active-command store (parity2 100 / B8); until then report none.
+            readSessionCommandLock: () => null,
+            listActiveCommands: async () => [],
+            verifySessionTab: async (session) => {
+                const liveness = await probeTabAlive(port, (session as { targetId?: string }).targetId);
+                if (liveness === 'alive') return { valid: true };
+                if (liveness === 'dead') return { valid: false, needsRecovery: true, error: 'target not found' };
+                return { valid: false, error: 'tab liveness could not be verified' };
+            },
+            getPort: () => port,
+        }, id, { navigate: input.navigate === true });
+        return report as unknown as Record<string, unknown>;
+    }
     if (sub === 'resume') {
         const id = rest[0] || input.session;
         if (!id) throw new WebAiError({ errorCode: 'internal.unhandled', stage: 'internal', retryHint: 'report', message: 'sessions resume <id> requires a sessionId (positional or --session)' });
         const session = getSession(id);
         if (!session) throw new WebAiError({ errorCode: 'internal.unhandled', stage: 'internal', retryHint: 'report', message: `no session record for ${id}`, evidence: { sessionId: id } });
+        const pollInputBase: { timeout?: number } = {};
+        // parity2 070 slice C-01: refuse expired sessions and clamp the poll
+        // budget to the stored deadline — a bare pollFn call granted a fresh
+        // full default budget to a session whose deadline already passed.
+        const deadlineMs = Date.parse(session.createdAt || '') + (Number(session.timeoutMs) || 0);
+        if (Number.isFinite(deadlineMs)) {
+            const remainingMs = deadlineMs - Date.now();
+            if (remainingMs <= 0) {
+                return {
+                    ok: false,
+                    status: 'timeout',
+                    sessionId: id,
+                    vendor: session.vendor,
+                    error: `session deadline already passed (${new Date(deadlineMs).toISOString()}); start a new send`,
+                    warnings: [],
+                };
+            }
+            (pollInputBase as { timeout?: number }).timeout = Math.max(1, Math.floor(remainingMs / 1000));
+        }
         const pollInput = {
             vendor: session.vendor,
             session: id,
             allowCopyMarkdownFallback: input.allowCopyMarkdownFallback === true,
+            ...pollInputBase,
         };
         const port = deps.port ?? 0;
         const pollFn = session.vendor === 'gemini' ? geminiPoll : session.vendor === 'grok' ? grokPoll : chatgptPoll;
         const result = await pollFn(port, pollInput);
-        return { ...result, status: result.status || 'resumed' };
+        // parity2 070 slice C-02 (partial): a Deep Research session resumed
+        // through the generic poll gets a warning so callers know the report
+        // pipeline (frame read / report-shape rejection) was not applied. The
+        // full resumeDeepResearch port (target-scope + not-started + re-bind)
+        // is tracked in the 070 doc as its remaining slice.
+        const warnings = Array.isArray((result as { warnings?: unknown }).warnings) ? (result as { warnings: string[] }).warnings : [];
+        if (session.vendor === 'chatgpt' && session.researchMode === 'deep') {
+            warnings.push('deep-research-resume-generic-poll: report-pipeline reread not applied');
+        }
+        return { ...result, warnings, status: result.status || 'resumed' };
     }
     if (sub === 'reattach') {
         const id = rest[0] || input.session;

--- a/src/browser/web-ai/composer-interstitial.ts
+++ b/src/browser/web-ai/composer-interstitial.ts
@@ -1,0 +1,38 @@
+// Shared composer-readiness interstitial classification (parity2 090, B5/C-12).
+//
+// ChatGPT already does this inline; this gives Grok and Gemini the same
+// behavior: when the composer never appears, ask a bounded probe whether an
+// interstitial is the reason, and only then replace the composer error with a
+// typed provider.interstitial carrying the detector's own retry hint.
+
+import { detectInterstitial } from './interstitial.js';
+import { WebAiError } from './errors.js';
+import type { Page } from 'playwright-core';
+
+/**
+ * Re-classify a composer-readiness failure as a provider interstitial when a
+ * bounded probe finds one. Returns the interstitial error to throw, or null
+ * when the original failure should stand — a probe failure must never replace
+ * the real composer error.
+ */
+export async function classifyComposerInterstitial(
+    page: Page,
+    vendor: 'chatgpt' | 'grok' | 'gemini',
+    cause: unknown,
+    { detect }: { detect?: typeof detectInterstitial } = {},
+): Promise<WebAiError | null> {
+    const probe = typeof detect === 'function' ? detect : detectInterstitial;
+    const verdict = await Promise.resolve()
+        .then(() => probe(page))
+        .catch(() => null);
+    if (!verdict || verdict.kind === 'none') return null;
+    return new WebAiError({
+        errorCode: 'provider.interstitial',
+        stage: 'provider-interstitial',
+        vendor,
+        retryHint: verdict.retryHint,
+        message: `${vendor} interstitial blocked composer readiness: ${verdict.kind}`,
+        evidence: verdict as unknown as Record<string, unknown>,
+        cause,
+    });
+}

--- a/src/browser/web-ai/conversation-url.ts
+++ b/src/browser/web-ai/conversation-url.ts
@@ -1,0 +1,34 @@
+// Durable ChatGPT conversation-URL validation.
+//
+// Ported from agbrowse `web-ai/conversation-url.mjs` (parity2 020 slice 2.1,
+// catalog B4/C-10). A conversation URL is durable only when it is https, on a
+// known ChatGPT host, portless, traversal-free, and carries a `/c/<id>` path
+// segment. Anything else — bare origins, foreign hosts, smuggling strings —
+// must never be persisted as a conversationUrl or navigated to by recovery.
+
+const CHATGPT_HOSTS = new Set(['chatgpt.com', 'chat.openai.com']);
+const DURABLE_CONVERSATION_PATH = /(?:^|\/)c\/([A-Za-z0-9-]+)(?=\/|$)/;
+
+/** Extract a durable ChatGPT conversation id, or null when the URL is unsafe. */
+export function extractDurableConversationId(candidate: string | null | undefined): string | null {
+    if (typeof candidate !== 'string' || candidate === '') return null;
+    try {
+        const url = new URL(candidate);
+        const components = candidate.match(/^https:\/\/([^/?#]*)([^?#]*)/);
+        const authority = components?.[1] || '';
+        const pathname = components?.[2] || '';
+        if (authority.includes('..') || authority.includes('\\') || authority.includes('\0')) return null;
+        if (pathname.includes('..') || pathname.includes('\\') || pathname.includes('\0')) return null;
+        if (url.protocol !== 'https:') return null;
+        if (url.port !== '' || authority.toLowerCase() !== url.hostname) return null;
+        if (!CHATGPT_HOSTS.has(url.hostname)) return null;
+        return url.pathname.match(DURABLE_CONVERSATION_PATH)?.[1] || null;
+    } catch {
+        return null;
+    }
+}
+
+export function isDurableConversationUrl(candidate: string | null | undefined): boolean {
+    return extractDurableConversationId(candidate) !== null;
+}
+

--- a/src/browser/web-ai/diagnostics.ts
+++ b/src/browser/web-ai/diagnostics.ts
@@ -8,6 +8,8 @@
 
 import { captureBrowserDiagnostics } from '../primitives.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
+import { trySaveDiagnosticsArtifact } from './session-artifacts.js';
+import { appendSessionArtifact } from './session.js';
 
 export type WebAiFailureStage =
     | 'status'
@@ -59,6 +61,12 @@ export interface DiagnosticsCaptureOptions {
     enableScreenshot?: boolean;
     /** Cap for any free-form diagnostic text. */
     maxChars?: number;
+    /** parity2 090 slice 4 (B7): when set, the diagnostics bundle is persisted
+     * as a session artifact (bounded DOM summary + best-effort screenshot) and
+     * its ref lands in artifactRefs. Never throws. */
+    sessionId?: string;
+    /** Best-effort CDP screenshot provider (Page.captureScreenshot). */
+    getCdpSession?: () => Promise<{ send(method: string, params?: Record<string, unknown>): Promise<unknown>; detach?(): Promise<void> } | null>;
 }
 
 const DEFAULT_MAX_CHARS = 1024;
@@ -215,6 +223,48 @@ export async function captureWebAiDiagnostics(
         chipNodes: await safeCount(page, '[data-testid*="attachment" i], [aria-label*="attachment" i]'),
         progressNodes: await safeCount(page, '[role="progressbar"]'),
     };
+    // parity2 090 slice 4 (B7): persist the bundle as a session artifact.
+    // artifactRefs was initialized empty and never filled — the sink existed,
+    // the pipe was missing. Best-effort: failures become warnings.
+    if (options.sessionId) {
+        let screenshotBuffer: Buffer | null = null;
+        if (options.enableScreenshot && options.getCdpSession) {
+            try {
+                const cdp = await options.getCdpSession();
+                if (cdp) {
+                    try {
+                        const shot = await cdp.send('Page.captureScreenshot', { format: 'jpeg', quality: 60 }) as { data?: string };
+                        if (shot?.data) screenshotBuffer = Buffer.from(shot.data, 'base64');
+                    } finally {
+                        await cdp.detach?.().catch(() => undefined);
+                    }
+                }
+            } catch (err) {
+                out.warnings.push(`diagnostics-screenshot-failed:${(err as Error)?.message || 'unknown'}`);
+            }
+        }
+        const saved = trySaveDiagnosticsArtifact(options.sessionId, {
+            context: out.stage,
+            domJson: {
+                stage: out.stage,
+                url: out.url,
+                title: out.title,
+                selectorCounts: out.selectorCounts,
+                sendButtonStates: out.sendButtonStates,
+                stopVisible: out.stopVisible,
+                assistantTurnCount: out.assistantTurnCount,
+                conversationTurnCount: out.conversationTurnCount,
+                uploadSignals: out.uploadSignals,
+            },
+            screenshotBuffer,
+        });
+        if (saved.ok) {
+            out.artifactRefs.push(String((saved.descriptor as { path?: string })?.path || 'diagnostics-artifact'));
+            appendSessionArtifact(options.sessionId, saved.descriptor);
+        } else {
+            out.warnings.push(`diagnostics-artifact-save-failed:${saved.stage}:${saved.error}`);
+        }
+    }
     return out;
 }
 

--- a/src/browser/web-ai/errors.ts
+++ b/src/browser/web-ai/errors.ts
@@ -30,6 +30,8 @@ export interface WebAiErrorInit {
     selectorsTried?: string[];
     evidence?: unknown;
     cause?: unknown;
+    /** parity2 100 (C-18): id of the policy/contract rule that produced this error. */
+    ruleId?: string;
 }
 
 export interface WebAiErrorJson {
@@ -42,6 +44,7 @@ export interface WebAiErrorJson {
     mutationAllowed: boolean;
     selectorsTried: string[];
     evidence: unknown;
+    ruleId?: string;
 }
 
 export class WebAiError extends Error {
@@ -52,6 +55,7 @@ export class WebAiError extends Error {
     mutationAllowed: boolean;
     selectorsTried: string[];
     evidence: unknown;
+    ruleId?: string;
 
     constructor(init: WebAiErrorInit = {}) {
         super(init.message || init.errorCode || 'web-ai error');
@@ -64,6 +68,7 @@ export class WebAiError extends Error {
         this.selectorsTried = Array.isArray(init.selectorsTried) ? init.selectorsTried : [];
         this.evidence = init.evidence ?? null;
         if (init.cause !== undefined) (this as { cause?: unknown }).cause = init.cause;
+        if (init.ruleId !== undefined) this.ruleId = init.ruleId;
     }
 
     toJSON(): WebAiErrorJson {
@@ -108,7 +113,7 @@ export function contextError(init: WebAiErrorInit = {}): WebAiError {
     return new WebAiError(init);
 }
 
-export function toErrorJson(err: WebAiError | { name?: string; errorCode?: string; stage?: string; message?: string; retryHint?: string; vendor?: string; mutationAllowed?: boolean; selectorsTried?: string[]; evidence?: unknown }): WebAiErrorJson {
+export function toErrorJson(err: WebAiError | { name?: string; errorCode?: string; stage?: string; message?: string; retryHint?: string; vendor?: string; mutationAllowed?: boolean; selectorsTried?: string[]; evidence?: unknown; ruleId?: string }): WebAiErrorJson {
     const out: WebAiErrorJson = {
         name: err?.name || 'WebAiError',
         errorCode: err?.errorCode || 'internal.unhandled',
@@ -120,6 +125,7 @@ export function toErrorJson(err: WebAiError | { name?: string; errorCode?: strin
         evidence: err?.evidence ?? null,
     };
     if (err?.vendor) out.vendor = err.vendor;
+    if (err?.ruleId) out.ruleId = err.ruleId;
     return out;
 }
 

--- a/src/browser/web-ai/gemini-live.ts
+++ b/src/browser/web-ai/gemini-live.ts
@@ -35,6 +35,9 @@ import { selectGeminiModel } from './gemini-model.js';
 import { geminiCapabilityStatus } from './gemini-capabilities.js';
 import { preflightAttachment } from './chatgpt-attachments.js';
 import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
+import { classifyComposerInterstitial } from './composer-interstitial.js';
+import { WebAiError } from './errors.js';
+import { isPageDeathError } from './interstitial.js';
 
 const GEMINI_HOSTS = new Set(['gemini.google.com']);
 const GEMINI_UPLOAD_SELECTORS = [
@@ -309,7 +312,13 @@ export async function geminiSend(port: number, input: QuestionEnvelopeInput = {}
 
     await openFreshGeminiChat(page, warnings);
     const inputSel = await findFirstSelector(page, GEMINI_DEEP_THINK_SELECTORS.input, 10_000);
-    if (!inputSel) throw new Error('gemini composer not visible');
+    if (!inputSel) {
+        // parity2 090 slice 1 (B5/C-12): before throwing the generic composer
+        // error, check whether an interstitial is the real reason.
+        const composerError = new Error('gemini composer not visible');
+        const interstitialError = await classifyComposerInterstitial(page, 'gemini', composerError);
+        throw interstitialError ?? composerError;
+    }
 
     const selectedModel = await selectGeminiModel(page, input.model);
     if (selectedModel) {
@@ -512,13 +521,14 @@ async function dismissBlockingOverlays(page: Page, warnings: string[]): Promise<
 
 export async function geminiPoll(port: number, input: { timeout?: number | string; session?: string; allowCopyMarkdownFallback?: boolean } = {}): Promise<WebAiOutput> {
     const tab = await getActiveTab(port);
-    if (!tab.tab) throw new Error('no active tab');
+    // parity2 090 slice 3 (E-06): typed errors for errorCode/retryHint consumers.
+    if (!tab.tab) throw new WebAiError({ errorCode: 'cdp.target-mismatch', stage: 'poll-timeout', vendor: 'gemini', retryHint: 'open-gemini', message: 'no active tab' });
     const page = await getActivePage(port);
-    if (!page) throw new Error('no active page');
+    if (!page) throw new WebAiError({ errorCode: 'cdp.target-mismatch', stage: 'poll-timeout', vendor: 'gemini', retryHint: 'open-gemini', message: 'no active page' });
     const session = input.session ? getSession(input.session) : findSessionByTarget('gemini', tab.tab.targetId);
     if (session) assertSameTarget(session, tab.tab.targetId);
     const baseline = getBaseline('gemini', tab.tab.targetId);
-    if (!baseline) throw new Error('baseline required. Run web-ai send --vendor gemini first.');
+    if (!baseline) throw new WebAiError({ errorCode: 'provider.baseline-missing', stage: 'poll-timeout', vendor: 'gemini', retryHint: 'send-first', message: 'baseline required. Run web-ai send --vendor gemini first.' });
     const timeoutMs = Math.max(
         GEMINI_DEEP_THINK_CONSTRAINTS.minimumWaitMs,
         Number(input.timeout || 1200) * 1000,
@@ -556,14 +566,28 @@ async function geminiPollInner(
     deadlineToken: PollDeadlineToken,
 ): Promise<WebAiOutput> {
     const deadline = Date.now() + timeoutMs;
-    const completionSel = GEMINI_DEEP_THINK_SELECTORS.completionSignal[0];
-    const responseSel = GEMINI_DEEP_THINK_SELECTORS.responseTurn[0];
+    // parity2 090 slice 2 (E-02): scan ALL selector alternatives — [0]-only
+    // reads break silently when Gemini ships the next DOM variant.
+    const completionSels = GEMINI_DEEP_THINK_SELECTORS.completionSignal;
+    const responseSels = GEMINI_DEEP_THINK_SELECTORS.responseTurn;
     const textSel = GEMINI_DEEP_THINK_SELECTORS.responseText[0];
     while (Date.now() < deadline && !deadlineToken.expired) {
-        const turns = await page.locator(responseSel).count().catch(() => 0);
+        // parity2 090 slice 2 (E-03): a crashed/closed tab surfaces as a typed
+        // recoverable outcome instead of an unhandled throw.
+        try {
+        let responseSel = responseSels[0]!;
+        let turns = 0;
+        for (const sel of responseSels) {
+            const count = await page.locator(sel).count().catch(() => 0);
+            if (count > 0) { responseSel = sel; turns = count; break; }
+        }
         if (turns > baseline.assistantCount) {
             const lastTurn = page.locator(responseSel).nth(turns - 1);
-            const completed = await lastTurn.locator(completionSel).count().catch(() => 0);
+            let completed = 0;
+            for (const sel of completionSels) {
+                completed = await lastTurn.locator(sel).count().catch(() => 0);
+                if (completed > 0) break;
+            }
             if (completed > 0) {
                 const text = await readGeminiResponseText(lastTurn, textSel);
                 if (text && text.trim()) {
@@ -601,6 +625,24 @@ async function geminiPollInner(
             }
         }
         await page.waitForTimeout(2_000).catch(() => undefined);
+        } catch (pollErr) {
+            if (isPageDeathError(pollErr)) {
+                if (session) updateSessionStatus(session.sessionId, 'crashed');
+                return {
+                    ok: false,
+                    vendor: 'gemini',
+                    status: 'tab-crashed',
+                    url: page.url?.() || '',
+                    baseline,
+                    ...(session ? { sessionId: session.sessionId, next: 'poll' as const } : {}),
+                    usedFallbacks: [],
+                    warnings: ['tab-crashed-during-poll'],
+                    error: String((pollErr as Error)?.message || pollErr),
+                    recoverable: true,
+                } as WebAiOutput;
+            }
+            throw pollErr;
+        }
     }
     if (session) updateSessionStatus(session.sessionId, 'timeout');
     if (session) updateSessionResult({ sessionId: session.sessionId, status: 'timeout', url: page.url(), conversationUrl: page.url() });

--- a/src/browser/web-ai/gemini-live.ts
+++ b/src/browser/web-ai/gemini-live.ts
@@ -38,6 +38,7 @@ import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 import { classifyComposerInterstitial } from './composer-interstitial.js';
 import { WebAiError } from './errors.js';
 import { isPageDeathError } from './interstitial.js';
+import { resolveTimeoutDefaultSec } from './tier-timeout.js';
 
 const GEMINI_HOSTS = new Set(['gemini.google.com']);
 const GEMINI_UPLOAD_SELECTORS = [
@@ -529,9 +530,14 @@ export async function geminiPoll(port: number, input: { timeout?: number | strin
     if (session) assertSameTarget(session, tab.tab.targetId);
     const baseline = getBaseline('gemini', tab.tab.targetId);
     if (!baseline) throw new WebAiError({ errorCode: 'provider.baseline-missing', stage: 'poll-timeout', vendor: 'gemini', retryHint: 'send-first', message: 'baseline required. Run web-ai send --vendor gemini first.' });
+    // parity2 110 fix (final-audit F3): route the default budget through the
+    // tier table — a deep-think session gets its 3600s tier instead of the
+    // flat 1200s. Explicit input.timeout always wins.
+    const sessionModel = (session?.envelopeSummary as { model?: string } | undefined)?.model;
+    const defaultSec = resolveTimeoutDefaultSec(sessionModel ? { model: sessionModel } : {}, 'gemini');
     const timeoutMs = Math.max(
         GEMINI_DEEP_THINK_CONSTRAINTS.minimumWaitMs,
-        Number(input.timeout || 1200) * 1000,
+        (Number(input.timeout) > 0 ? Number(input.timeout) : defaultSec) * 1000,
     );
     // parity2 010 slice 1.1 (C-04): hard bound — a stalled locator/evaluate call
     // must not outlive the timeout even though the loop only checks between awaits.

--- a/src/browser/web-ai/gemini-live.ts
+++ b/src/browser/web-ai/gemini-live.ts
@@ -34,6 +34,7 @@ import { captureCopiedResponseText, GEMINI_COPY_SELECTORS, preferCopiedText } fr
 import { selectGeminiModel } from './gemini-model.js';
 import { geminiCapabilityStatus } from './gemini-capabilities.js';
 import { preflightAttachment } from './chatgpt-attachments.js';
+import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 
 const GEMINI_HOSTS = new Set(['gemini.google.com']);
 const GEMINI_UPLOAD_SELECTORS = [
@@ -522,11 +523,43 @@ export async function geminiPoll(port: number, input: { timeout?: number | strin
         GEMINI_DEEP_THINK_CONSTRAINTS.minimumWaitMs,
         Number(input.timeout || 1200) * 1000,
     );
+    // parity2 010 slice 1.1 (C-04): hard bound — a stalled locator/evaluate call
+    // must not outlive the timeout even though the loop only checks between awaits.
+    return withPollDeadline<WebAiOutput>(
+        (_hardDeadline, token) => geminiPollInner(page, input, session, baseline, timeoutMs, token),
+        {
+            timeoutMs,
+            onExpired: () => {
+                if (session) updateSessionStatus(session.sessionId, 'timeout');
+                return {
+                    ok: false,
+                    vendor: 'gemini' as const,
+                    status: 'timeout' as const,
+                    url: page.url(),
+                    baseline,
+                    ...(session ? { sessionId: session.sessionId, next: 'poll' as const } : {}),
+                    usedFallbacks: [],
+                    warnings: ['poll-deadline-expired: a browser probe outlived the timeout'],
+                    error: 'timed out waiting for gemini deep-think response',
+                };
+            },
+        },
+    );
+}
+
+async function geminiPollInner(
+    page: Page,
+    input: { timeout?: number | string; session?: string; allowCopyMarkdownFallback?: boolean },
+    session: ReturnType<typeof getSession>,
+    baseline: NonNullable<ReturnType<typeof getBaseline>>,
+    timeoutMs: number,
+    deadlineToken: PollDeadlineToken,
+): Promise<WebAiOutput> {
     const deadline = Date.now() + timeoutMs;
     const completionSel = GEMINI_DEEP_THINK_SELECTORS.completionSignal[0];
     const responseSel = GEMINI_DEEP_THINK_SELECTORS.responseTurn[0];
     const textSel = GEMINI_DEEP_THINK_SELECTORS.responseText[0];
-    while (Date.now() < deadline) {
+    while (Date.now() < deadline && !deadlineToken.expired) {
         const turns = await page.locator(responseSel).count().catch(() => 0);
         if (turns > baseline.assistantCount) {
             const lastTurn = page.locator(responseSel).nth(turns - 1);

--- a/src/browser/web-ai/grok-live.ts
+++ b/src/browser/web-ai/grok-live.ts
@@ -18,6 +18,7 @@ import { hasContextPackaging, prepareContextForBrowser, summarizeContextPack } f
 
 export const GROK_CONTEXT_PACK_WARNING = 'grok-context-pack-not-recommended: prefer inline prompts plus optional --file uploads for Grok; ChatGPT or Gemini handle context packages more reliably.';
 import type { QuestionEnvelopeInput, WebAiOutput } from './types.js';
+import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 import type { WebAiFailureStage } from './diagnostics.js';
 import { attachLocalFileLive } from './chatgpt-attachments.js';
 import { captureCopiedResponseText, GROK_COPY_SELECTORS, preferCopiedText } from './copy-markdown.js';
@@ -210,10 +211,41 @@ export async function grokPoll(port: number, input: { timeout?: number | string;
     if (!baseline) throw new Error('baseline required. Run web-ai send --vendor grok first.');
 
     const timeoutMs = Math.max(1, Number(input.timeout || 600)) * 1000;
+    // parity2 010 slice 1.1 (C-04): hard bound over the whole poll.
+    return withPollDeadline<WebAiOutput>(
+        (_hardDeadline, token) => grokPollInner(page, input, session, baseline, timeoutMs, token),
+        {
+            timeoutMs,
+            onExpired: () => {
+                if (session) updateSessionStatus(session.sessionId, 'timeout');
+                return {
+                    ok: false,
+                    vendor: 'grok' as const,
+                    status: 'timeout' as const,
+                    url: page.url(),
+                    baseline,
+                    ...(session ? { sessionId: session.sessionId, next: 'poll' as const } : {}),
+                    usedFallbacks: [],
+                    warnings: ['poll-deadline-expired: a browser probe outlived the timeout'],
+                    error: 'timed out waiting for grok response',
+                };
+            },
+        },
+    );
+}
+
+async function grokPollInner(
+    page: Page,
+    input: { timeout?: number | string; session?: string; allowCopyMarkdownFallback?: boolean },
+    session: ReturnType<typeof getSession>,
+    baseline: NonNullable<ReturnType<typeof getBaseline>>,
+    timeoutMs: number,
+    deadlineToken: PollDeadlineToken,
+): Promise<WebAiOutput> {
     const deadline = Date.now() + timeoutMs;
     let stableText = '';
     let stableSince = 0;
-    while (Date.now() < deadline) {
+    while (Date.now() < deadline && !deadlineToken.expired) {
         const answers = await readGrokAssistantMessages(page);
         const latest = answers.slice(baseline.assistantCount).at(-1) || '';
         const streaming = await isGrokStreaming(page);

--- a/src/browser/web-ai/grok-live.ts
+++ b/src/browser/web-ai/grok-live.ts
@@ -21,6 +21,7 @@ import type { QuestionEnvelopeInput, WebAiOutput } from './types.js';
 import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
 import { classifyComposerInterstitial } from './composer-interstitial.js';
 import { isPageDeathError } from './interstitial.js';
+import { resolveTimeoutDefaultSec } from './tier-timeout.js';
 import type { WebAiFailureStage } from './diagnostics.js';
 import { attachLocalFileLive } from './chatgpt-attachments.js';
 import { captureCopiedResponseText, GROK_COPY_SELECTORS, preferCopiedText } from './copy-markdown.js';
@@ -219,7 +220,11 @@ export async function grokPoll(port: number, input: { timeout?: number | string;
     const baseline = getBaseline('grok', tab.tab.targetId);
     if (!baseline) throw new WebAiError({ errorCode: 'provider.baseline-missing', stage: 'poll-timeout', vendor: 'grok', retryHint: 'send-first', message: 'baseline required. Run web-ai send --vendor grok first.' });
 
-    const timeoutMs = Math.max(1, Number(input.timeout || 600)) * 1000;
+    // parity2 110 fix (final-audit F3): tier-aware default — grok-heavy gets
+    // its 3600s tier instead of the flat 600s. Explicit input.timeout wins.
+    const sessionModel = (session?.envelopeSummary as { model?: string } | undefined)?.model;
+    const defaultSec = resolveTimeoutDefaultSec(sessionModel ? { model: sessionModel } : {}, 'grok');
+    const timeoutMs = Math.max(1, Number(input.timeout) > 0 ? Number(input.timeout) : defaultSec) * 1000;
     // parity2 010 slice 1.1 (C-04): hard bound over the whole poll.
     return withPollDeadline<WebAiOutput>(
         (_hardDeadline, token) => grokPollInner(page, input, session, baseline, timeoutMs, token),

--- a/src/browser/web-ai/grok-live.ts
+++ b/src/browser/web-ai/grok-live.ts
@@ -19,6 +19,8 @@ import { hasContextPackaging, prepareContextForBrowser, summarizeContextPack } f
 export const GROK_CONTEXT_PACK_WARNING = 'grok-context-pack-not-recommended: prefer inline prompts plus optional --file uploads for Grok; ChatGPT or Gemini handle context packages more reliably.';
 import type { QuestionEnvelopeInput, WebAiOutput } from './types.js';
 import { withPollDeadline, type PollDeadlineToken } from './poll-deadline.js';
+import { classifyComposerInterstitial } from './composer-interstitial.js';
+import { isPageDeathError } from './interstitial.js';
 import type { WebAiFailureStage } from './diagnostics.js';
 import { attachLocalFileLive } from './chatgpt-attachments.js';
 import { captureCopiedResponseText, GROK_COPY_SELECTORS, preferCopiedText } from './copy-markdown.js';
@@ -140,7 +142,13 @@ export async function grokSend(port: number, input: QuestionEnvelopeInput = {}):
 
     await openFreshGrokChat(page, warnings);
     const composerSel = await findFirstSelector(page, GROK_SELECTORS.composer, 10_000);
-    if (!composerSel) throw new Error('grok composer not visible');
+    if (!composerSel) {
+        // parity2 090 slice 1 (B5/C-12): interstitial re-classification before
+        // the generic composer error.
+        const composerError = new Error('grok composer not visible');
+        const interstitialError = await classifyComposerInterstitial(page, 'grok', composerError);
+        throw interstitialError ?? composerError;
+    }
     const selectedModel = await selectGrokModel(page, input.model);
 
     const assistantCount = await countGrokAssistantMessages(page);
@@ -200,15 +208,16 @@ function localFileInfo(filePath: string): { path: string; basename: string; size
 
 export async function grokPoll(port: number, input: { timeout?: number | string; session?: string; allowCopyMarkdownFallback?: boolean } = {}): Promise<WebAiOutput> {
     const tab = await getActiveTab(port);
-    if (!tab.tab) throw new Error('no active tab');
+    // parity2 090 slice 3 (E-06): typed errors so errorCode/retryHint consumers see them.
+    if (!tab.tab) throw new WebAiError({ errorCode: 'cdp.target-mismatch', stage: 'poll-timeout', vendor: 'grok', retryHint: 'open-grok', message: 'no active tab' });
     const page = await getActivePage(port);
-    if (!page) throw new Error('no active page');
-    if (!isGrokUrl(page.url())) throw new Error(`active tab is not grok.com (${page.url()})`);
+    if (!page) throw new WebAiError({ errorCode: 'cdp.target-mismatch', stage: 'poll-timeout', vendor: 'grok', retryHint: 'open-grok', message: 'no active page' });
+    if (!isGrokUrl(page.url())) throw new WebAiError({ errorCode: 'cdp.target-mismatch', stage: 'poll-timeout', vendor: 'grok', retryHint: 'open-grok', message: `active tab is not grok.com (${page.url()})` });
 
     const session = input.session ? getSession(input.session) : findSessionByTarget('grok', tab.tab.targetId);
     if (session) assertSameTarget(session, tab.tab.targetId);
     const baseline = getBaseline('grok', tab.tab.targetId);
-    if (!baseline) throw new Error('baseline required. Run web-ai send --vendor grok first.');
+    if (!baseline) throw new WebAiError({ errorCode: 'provider.baseline-missing', stage: 'poll-timeout', vendor: 'grok', retryHint: 'send-first', message: 'baseline required. Run web-ai send --vendor grok first.' });
 
     const timeoutMs = Math.max(1, Number(input.timeout || 600)) * 1000;
     // parity2 010 slice 1.1 (C-04): hard bound over the whole poll.
@@ -246,6 +255,8 @@ async function grokPollInner(
     let stableText = '';
     let stableSince = 0;
     while (Date.now() < deadline && !deadlineToken.expired) {
+        // parity2 090 slice 2 (E-03): crashed tab → typed recoverable outcome.
+        try {
         const answers = await readGrokAssistantMessages(page);
         const latest = answers.slice(baseline.assistantCount).at(-1) || '';
         const streaming = await isGrokStreaming(page);
@@ -288,6 +299,24 @@ async function grokPollInner(
             stableSince = 0;
         }
         await page.waitForTimeout(500).catch(() => undefined);
+        } catch (pollErr) {
+            if (isPageDeathError(pollErr)) {
+                if (session) updateSessionStatus(session.sessionId, 'crashed');
+                return {
+                    ok: false,
+                    vendor: 'grok',
+                    status: 'tab-crashed',
+                    url: page.url?.() || '',
+                    baseline,
+                    ...(session ? { sessionId: session.sessionId, next: 'poll' as const } : {}),
+                    usedFallbacks: [],
+                    warnings: ['tab-crashed-during-poll'],
+                    error: String((pollErr as Error)?.message || pollErr),
+                    recoverable: true,
+                } as WebAiOutput;
+            }
+            throw pollErr;
+        }
     }
     if (session) updateSessionStatus(session.sessionId, 'timeout');
     if (session) updateSessionResult({ sessionId: session.sessionId, status: 'timeout', url: page.url(), conversationUrl: page.url() });

--- a/src/browser/web-ai/poll-deadline.ts
+++ b/src/browser/web-ai/poll-deadline.ts
@@ -1,0 +1,138 @@
+// A hard bound on how long a provider poll may take.
+//
+// Ported from agbrowse `web-ai/poll-deadline.mjs` (parity round-2, catalog
+// C-04/B2 — devlog/_plan/260821_agbrowse_webai_parity2/010). The provider poll
+// loops check their deadline only BETWEEN awaited browser probes, so a single
+// never-settling `page.evaluate`, locator call or CDP call defeats the caller's
+// timeout entirely — the loop never gets to look at the clock again. Capping
+// the sleeps does not help: the sleep is not where the time goes.
+//
+// The race is the only thing that makes the bound real, because a stalled
+// probe cannot be cancelled. The losing work keeps running; what this
+// guarantees is that the CALLER stops waiting for it.
+
+/** How often the expiry timer re-checks the clock. */
+const POLL_EXPIRY_CHECK_MS = 250;
+
+/** Thrown or resolved so an expired run cannot deliver a normal envelope. */
+export const POLL_EXPIRED: unique symbol = Symbol('poll-expired');
+export type PollExpired = typeof POLL_EXPIRED;
+
+/** Real elapsed time, immune to a mocked or frozen `Date.now`. */
+export function monotonicNowMs(): number {
+    return Number(process.hrtime.bigint() / 1_000_000n);
+}
+
+export interface PollDeadlineToken {
+    /** Flipped once the caller has been answered. */
+    expired: boolean;
+    /** Reported-clock deadline in ms. */
+    hardDeadline: number;
+    /**
+     * Shorten the bound once the run has learned its real deadline; takes an
+     * ABSOLUTE time and never lengthens the bound.
+     */
+    tighten?: (deadlineAt: number) => void;
+}
+
+export interface PollDeadlineOptions<T> {
+    /** Anchor for the reported-clock ceiling; defaults to now. Work that can
+     * block — a session store read, for instance — happens before this
+     * function is reached and must not be free time. */
+    startedAt?: number;
+    /** Anchor for the monotonic ceiling; defaults to now. */
+    monotonicStartMs?: number;
+    timeoutMs: number;
+    onExpired: () => T;
+}
+
+/**
+ * Run `runFn` under a hard deadline and return its result, or `onExpired()`.
+ *
+ * `runFn` receives the deadline and a token whose `expired` flag is set the
+ * moment the caller is answered. A run that is still mid-tick can read that
+ * flag to refuse starting new side effects — the losing work is not cancelled,
+ * so without the flag it would happily finish and write.
+ */
+export async function withPollDeadline<T>(
+    runFn: (hardDeadline: number, token: PollDeadlineToken) => Promise<T>,
+    { startedAt, monotonicStartMs, timeoutMs, onExpired }: PollDeadlineOptions<T>,
+): Promise<T> {
+    const started = startedAt === undefined ? Date.now() : startedAt;
+    const monotonicStart = monotonicStartMs === undefined ? monotonicNowMs() : monotonicStartMs;
+    let hardDeadline = started + timeoutMs;
+    let budgetMs = timeoutMs;
+    let expire: (value: PollExpired) => void = () => undefined;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    /** Re-armable from `tighten`, which may move the deadline inward. */
+    let rearm: () => void = () => undefined;
+    const expiry = new Promise<PollExpired>(resolve => {
+        expire = resolve;
+        // Deferring to the reported clock ALONE is unbounded: a frozen or
+        // mocked `Date.now` never reaches the deadline, so the timer re-arms
+        // forever and the poll returns NOTHING — strictly worse than the
+        // overrun this exists to prevent.
+        //
+        // Two independent ceilings, because `Date.now` is not trustworthy here:
+        // tests step it, and a stalled or rewound system clock would otherwise
+        // leave the deadline unreachable.
+        //
+        //   - the reported clock reaching `hardDeadline`
+        //   - MONOTONIC time exceeding the same budget
+        //
+        // The monotonic one is what makes the promise real: whatever the clock
+        // claims, the caller waits at most one budget plus a check interval.
+        // Tests that step the clock faster than real time still finish on the
+        // first ceiling, so they are not cut short.
+        const arm = (): void => {
+            const remaining = hardDeadline - Date.now();
+            const monotonicElapsedMs = monotonicNowMs() - monotonicStart;
+            if (remaining <= 0 || monotonicElapsedMs >= budgetMs + POLL_EXPIRY_CHECK_MS) { resolve(POLL_EXPIRED); return; }
+            timer = setTimeout(arm, Math.min(remaining, POLL_EXPIRY_CHECK_MS));
+        };
+        rearm = arm;
+        arm();
+    });
+    const token: PollDeadlineToken = { expired: false, hardDeadline };
+    // Only ever TIGHTENS. A run that learns its real deadline after the race is
+    // armed — because reading it would have blocked the event loop, which is
+    // the thing being bounded — can hand it back here. Letting it extend would
+    // turn the bound into a suggestion, so a later deadline is ignored.
+    //
+    // ABSOLUTE, not a duration. A remainder computed after a slow read means
+    // "this long from NOW"; anchoring it to `started` charged the read twice
+    // and threw away that much of the caller's budget.
+    token.tighten = (nextDeadlineAt: number): void => {
+        if (!Number.isFinite(nextDeadlineAt) || nextDeadlineAt >= hardDeadline) return;
+        hardDeadline = nextDeadlineAt;
+        budgetMs = Math.max(0, nextDeadlineAt - started);
+        token.hardDeadline = nextDeadlineAt;
+        // Re-arm at once: the pending timer may be sleeping past the new
+        // deadline, and waiting out its old delay is time the caller was not
+        // promised.
+        if (timer) clearTimeout(timer);
+        rearm();
+    };
+    try {
+        const run = runFn(hardDeadline, token).then(
+            // Normalise BOTH settlement paths before the race: a stalled promise
+            // that settles just after the deadline can have its continuation
+            // scheduled ahead of the timer, and would otherwise deliver a normal
+            // result — or a normal error — past the bound.
+            (result): T | PollExpired => (Date.now() >= hardDeadline ? POLL_EXPIRED : result),
+            (err: unknown): Promise<never> | PollExpired => (Date.now() >= hardDeadline || err === POLL_EXPIRED
+                ? POLL_EXPIRED
+                : Promise.reject(err)),
+        );
+        const outcome = await Promise.race([run, expiry]);
+        if (outcome !== POLL_EXPIRED) return outcome;
+        return onExpired();
+    } finally {
+        // Order matters: the loser may still be mid-tick, and this is what makes
+        // its next side effect refuse to start instead of writing.
+        token.expired = true;
+        if (timer) clearTimeout(timer);
+        expire(POLL_EXPIRED);
+    }
+}
+

--- a/src/browser/web-ai/product-surfaces.ts
+++ b/src/browser/web-ai/product-surfaces.ts
@@ -83,3 +83,159 @@ async function detectBySelector(
     }
     return { id, available: evidence.length > 0, evidence, mutationAllowed: false };
 }
+
+// ── Work/Chat composer-surface detection (parity2 080 slice 8a, C-03) ───────
+// Ported from agbrowse product-surfaces.mjs:100-291. Fail-closed: 'ambiguous'
+// refuses rather than guesses; legacy (toggle-less) pages consult the
+// structured sidebar conversation probe.
+
+import { extractDurableConversationId } from './conversation-url.js';
+import { CHATGPT_SURFACE_RADIO_SELECTOR } from './chatgpt-model.js';
+
+export type ChatGptComposerSurface = 'chat' | 'work' | 'ambiguous' | null;
+export interface WorkConversationProbe {
+    state: 'work' | 'chat' | 'unresolved';
+    evidence: Record<string, unknown>;
+}
+export interface ComposerSurfaceDetection {
+    ui: 'toggle' | 'legacy';
+    surface: ChatGptComposerSurface;
+    evidence: {
+        chat: { visible: boolean; checked: boolean | null; dataState: string | null } | null;
+        work: { visible: boolean; checked: boolean | null; dataState: string | null } | null;
+        conversation?: WorkConversationProbe;
+    };
+}
+
+type SurfaceAnyNode = any;
+declare const location: any;
+declare const HTMLElement: any;
+
+/**
+ * Browser-context probe. Classifies the CURRENT conversation page as Work or
+ * Chat from structured sidebar evidence only: renderer-owned anchors, a
+ * structured Work-badge leaf span, same-origin exact-id matching, and POSITIVE
+ * chat metadata (absent labels stay unresolved rather than defaulting to Chat).
+ */
+export function readWorkConversationState({ expectedId }: { expectedId: string }): WorkConversationProbe {
+    const normalize = (value: unknown) => String(value || '').toLowerCase().replace(/\s+/g, ' ').trim();
+    const idFromPath = (value: unknown) =>
+        (String(value || '').match(/(?:^|\/)c\/([A-Za-z0-9-]+)(?=\/|$)/) || [])[1] || null;
+    const isStructuredWorkBadge = (node: SurfaceAnyNode) =>
+        node instanceof HTMLElement
+        && node.tagName === 'SPAN'
+        && normalize(node.textContent) === 'work'
+        && node.childElementCount === 0
+        && !node.hasAttribute('dir')
+        && node.classList.contains('shrink-0')
+        && Boolean(node.parentElement?.matches('span.flex.items-center'));
+
+    const conversationId = idFromPath(location.pathname);
+    if (!conversationId) return { state: 'unresolved', evidence: { reason: 'not-a-conversation-url' } };
+    if (expectedId && conversationId !== expectedId) {
+        return { state: 'unresolved', evidence: { reason: 'navigation-race', expectedId, conversationId } };
+    }
+
+    const links = (Array.from(document.querySelectorAll('a.__menu-item[href*="/c/"]')) as SurfaceAnyNode[]).filter((node) => {
+        try {
+            const url = new URL(node.getAttribute('href') || '', location.origin);
+            return url.origin === location.origin && idFromPath(url.pathname) === conversationId;
+        } catch { return false; }
+    });
+    if (links.length === 0) {
+        return { state: 'unresolved', evidence: { reason: 'conversation-anchor-not-found', conversationId } };
+    }
+    if (links.some((link) => (Array.from(link.querySelectorAll('span')) as SurfaceAnyNode[]).some(isStructuredWorkBadge))) {
+        return { state: 'work', evidence: { conversationId, matched: links.length } };
+    }
+    const ariaLabels = links.map((link) => normalize(link.getAttribute('aria-label'))).filter(Boolean);
+    if (ariaLabels.length === 0 || ariaLabels.some((aria) => /,\s*work\s*$/.test(aria))) {
+        return {
+            state: 'unresolved',
+            evidence: { reason: 'no-positive-chat-metadata', conversationId, matched: links.length },
+        };
+    }
+    return { state: 'chat', evidence: { conversationId, matched: links.length } };
+}
+
+/** Node-side wrapper: establishes the conversation id BEFORE evaluating. */
+export async function detectChatGptWorkConversation(page: SurfaceAnyNode): Promise<WorkConversationProbe> {
+    let conversationId: string | null = null;
+    try {
+        conversationId = typeof page?.url === 'function' ? extractDurableConversationId(page.url()) : null;
+    } catch {
+        conversationId = null;
+    }
+    if (!conversationId) return { state: 'unresolved', evidence: { reason: 'not-a-conversation-url' } };
+    if (typeof page?.evaluate !== 'function') {
+        return { state: 'unresolved', evidence: { reason: 'probe-unavailable', conversationId } };
+    }
+    const probe = await page.evaluate(readWorkConversationState, { expectedId: conversationId })
+        .catch(() => null);
+    return probe && typeof probe.state === 'string'
+        ? probe
+        : { state: 'unresolved', evidence: { reason: 'probe-failed', conversationId } };
+}
+
+async function legacySurfaceDetection(page: SurfaceAnyNode): Promise<ComposerSurfaceDetection> {
+    const conversation = await detectChatGptWorkConversation(page);
+    const surface: ChatGptComposerSurface = conversation.state === 'work' ? 'work'
+        : conversation.state === 'chat' ? 'chat'
+        : null;
+    return { ui: 'legacy', surface, evidence: { chat: null, work: null, conversation } };
+}
+
+/**
+ * Read the exact role=radio Chat/Work header buttons, fail-closed:
+ *  1. Both radios absent → legacy probe.
+ *  2. Both visible, exactly one active with consistent aria-checked + data-state → surface.
+ *  3. Attribute mismatch / one-sided / both-active / both-inactive → 'ambiguous'.
+ *  4. No mutations.
+ */
+export async function detectChatGptComposerSurface(page: SurfaceAnyNode): Promise<ComposerSurfaceDetection> {
+    const radios = page.locator(CHATGPT_SURFACE_RADIO_SELECTOR);
+    const count = await radios.count().catch(() => 0);
+    if (count === 0) return legacySurfaceDetection(page);
+
+    const entries: Array<{ text: string; checked: boolean | null; dataState: string | null; visible: boolean }> = [];
+    for (let i = 0; i < count; i++) {
+        const el = radios.nth(i);
+        const visible = await el.isVisible().catch(() => false);
+        const text = ((await el.textContent().catch(() => '')) || '').trim();
+        const checked = await el.getAttribute('aria-checked').catch(() => null);
+        const dataState = await el.getAttribute('data-state').catch(() => null);
+        entries.push({
+            text,
+            checked: checked === 'true' ? true : checked === 'false' ? false : null,
+            dataState,
+            visible,
+        });
+    }
+
+    const chat = entries.find((e) => /^chat$/i.test(e.text)) || null;
+    const work = entries.find((e) => /^work$/i.test(e.text)) || null;
+    if (!chat && !work) return legacySurfaceDetection(page);
+
+    const chatEvid = chat ? { visible: chat.visible, checked: chat.checked, dataState: chat.dataState } : null;
+    const workEvid = work ? { visible: work.visible, checked: work.checked, dataState: work.dataState } : null;
+
+    if (!chat || !work || !chat.visible || !work.visible) {
+        return { ui: 'toggle', surface: 'ambiguous', evidence: { chat: chatEvid, work: workEvid } };
+    }
+    const chatActive = chat.checked === true && chat.dataState === 'on';
+    const chatInactive = chat.checked === false && chat.dataState === 'off';
+    const workActive = work.checked === true && work.dataState === 'on';
+    const workInactive = work.checked === false && work.dataState === 'off';
+    if (chatActive && workInactive) return { ui: 'toggle', surface: 'chat', evidence: { chat: chatEvid, work: workEvid } };
+    if (workActive && chatInactive) return { ui: 'toggle', surface: 'work', evidence: { chat: chatEvid, work: workEvid } };
+    return { ui: 'toggle', surface: 'ambiguous', evidence: { chat: chatEvid, work: workEvid } };
+}
+
+/** Work availability, independent of whether Work is currently active. */
+export async function detectChatGptWorkAvailability(page: SurfaceAnyNode): Promise<{ available: boolean; active: boolean; evidence: ComposerSurfaceDetection }> {
+    const detection = await detectChatGptComposerSurface(page);
+    const available = detection.evidence.work?.visible === true;
+    const active = detection.surface === 'work';
+    return { available, active, evidence: detection };
+}
+

--- a/src/browser/web-ai/provider-adapter.ts
+++ b/src/browser/web-ai/provider-adapter.ts
@@ -29,6 +29,9 @@ export interface ResponseCaptureResult {
     warnings: string[];
     // 104.18: per-tick poll bail-out — the conversation drifted, or the tab crashed (recoverable).
     drift?: { status: 'conversation-mismatch' | 'tab-crashed'; reason: string; recoverable?: boolean };
+    // parity2 050 (B-07): recovery found stable-but-UNFINISHED text; the caller
+    // should keep polling instead of persisting a truncated answer.
+    polling?: boolean;
 }
 
 export interface WebAiProviderAdapter {

--- a/src/browser/web-ai/session-store.ts
+++ b/src/browser/web-ai/session-store.ts
@@ -55,7 +55,7 @@ export interface PruneResult {
     remaining: number;
 }
 
-function storePath(): string {
+export function storePath(): string {
     return join(JAW_HOME, STORE_FILE);
 }
 
@@ -94,17 +94,42 @@ function encodeRandom(): string {
 }
 
 export function readSessionStore(): SessionStore {
+    return readSessionStoreObserved().store;
+}
+
+/**
+ * parity2 010 slice 1.3 (C-08, mirrors agbrowse 9d49c31/107233e): a corrupt or
+ * schema-invalid store must be OBSERVED, not silently collapsed into "no
+ * sessions". Read paths get the empty store plus a marker; write paths consult
+ * the marker and refuse (see assertStoreReadable) so a parse failure cannot
+ * silently discard every session record on the next write.
+ */
+export function readSessionStoreObserved(): { store: SessionStore; storeReadFailed?: { path: string; reason: string } } {
     const path = storePath();
-    if (!existsSync(path)) return { version: SESSION_STORE_VERSION, sessions: [] };
+    if (!existsSync(path)) return { store: { version: SESSION_STORE_VERSION, sessions: [] } };
     try {
         const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<SessionStore>;
-        if (!parsed || typeof parsed !== 'object') return { version: SESSION_STORE_VERSION, sessions: [] };
+        if (!parsed || typeof parsed !== 'object') {
+            return { store: { version: SESSION_STORE_VERSION, sessions: [] }, storeReadFailed: { path, reason: 'not-an-object' } };
+        }
         if (!Array.isArray(parsed.sessions)) parsed.sessions = [];
         if (typeof parsed.version !== 'number') parsed.version = SESSION_STORE_VERSION;
-        return parsed as SessionStore;
-    } catch {
-        return { version: SESSION_STORE_VERSION, sessions: [] };
+        return { store: parsed as SessionStore };
+    } catch (err) {
+        return { store: { version: SESSION_STORE_VERSION, sessions: [] }, storeReadFailed: { path, reason: String((err as Error)?.message || err) } };
     }
+}
+
+/** Throws `session-store-read-failed` when the on-disk store is unreadable. Write paths call this so a corrupt store is never silently overwritten with an empty one. */
+export function assertStoreReadable(): void {
+    const { storeReadFailed } = readSessionStoreObserved();
+    if (!storeReadFailed) return;
+    throw new WebAiError({
+        errorCode: 'session-store-read-failed',
+        stage: 'session-store-read',
+        retryHint: `inspect or move the corrupt store at ${storeReadFailed.path} (${storeReadFailed.reason})`,
+        message: `web-ai session store unreadable: ${storeReadFailed.path} — ${storeReadFailed.reason}`,
+    });
 }
 
 function readSessionStoreLocked(): SessionStore {
@@ -230,6 +255,7 @@ export async function patchSessionAsync(
 ): Promise<StoredSession | null | DeadlinePassed> {
     return withStoreLockAsync(() => {
         if (stillActive?.() === false) return DEADLINE_PASSED;
+        assertStoreReadable();
         const store = readSessionStore();
         const idx = store.sessions.findIndex(s => s.sessionId === sessionId);
         if (idx < 0) return null;
@@ -248,6 +274,7 @@ export async function insertSessionAsync(
 ): Promise<StoredSession | DeadlinePassed> {
     return withStoreLockAsync(() => {
         if (stillActive?.() === false) return DEADLINE_PASSED;
+        assertStoreReadable();
         const store = readSessionStore();
         store.sessions.push(session);
         writeSessionStore(store);
@@ -293,6 +320,7 @@ function sleepBlockingMs(ms: number): void {
 
 export function insertSession(session: StoredSession): StoredSession {
     return withStoreLock(() => {
+        assertStoreReadable();
         const store = readSessionStore();
         store.sessions.push(session);
         writeSessionStore(store);
@@ -302,6 +330,7 @@ export function insertSession(session: StoredSession): StoredSession {
 
 export function patchSession(sessionId: string, patch: Partial<StoredSession>): StoredSession | null {
     return withStoreLock(() => {
+        assertStoreReadable();
         const store = readSessionStore();
         const idx = store.sessions.findIndex(s => s.sessionId === sessionId);
         if (idx < 0) return null;

--- a/src/browser/web-ai/session-store.ts
+++ b/src/browser/web-ai/session-store.ts
@@ -147,6 +147,13 @@ export function withStoreLock<T>(fn: () => T): T {
                 try { unlinkSync(path); } catch { /* races resolve naturally */ }
                 continue;
             }
+            // parity2 010 slice 1.2 (C-05): the old Atomics.wait sleep here froze
+            // the WHOLE event loop for the retry interval, suspending any
+            // deadline timer the caller held — the exact bound this store sits
+            // under. Sync callers now spin on the reported clock without
+            // blocking the loop's timers... except they still block, so the
+            // sync form is kept ONLY for read paths and bounded writes off the
+            // deadline path; deadline-path writers use withStoreLockAsync.
             sleepBlockingMs(LOCK_RETRY_MS);
         }
     }
@@ -155,6 +162,96 @@ export function withStoreLock<T>(fn: () => T): T {
         stage: 'session-store-lock',
         retryHint: 'retry',
         message: `web-ai session store: failed to acquire lock at ${path} after ${LOCK_RETRY_LIMIT} attempts`,
+    });
+}
+
+/**
+ * Returned when a caller's deadline passed while the lock was being waited for.
+ *
+ * Distinct from `null` (no such session), because the two need different
+ * handling: one is a missing record, the other is a write that must not happen.
+ * (parity2 010 slice 1.2, mirrors agbrowse session-store.mjs DEADLINE_PASSED.)
+ */
+export const DEADLINE_PASSED: unique symbol = Symbol('store-write-deadline-passed');
+export type DeadlinePassed = typeof DEADLINE_PASSED;
+
+/**
+ * Awaitable store lock. Same on-disk protocol as {@link withStoreLock}, but the
+ * retry wait is an async sleep, so the caller's event loop — and any deadline
+ * timer racing this write — keeps running while we wait.
+ */
+export async function withStoreLockAsync<T>(fn: () => T): Promise<T> {
+    const path = lockPath();
+    mkdirSync(dirname(path), { recursive: true });
+    let attempts = 0;
+    while (attempts < LOCK_RETRY_LIMIT) {
+        try {
+            const fd = openSync(path, 'wx');
+            closeSync(fd);
+            const tmpMeta = `${path}.meta.${process.pid}`;
+            try {
+                writeFileSync(tmpMeta, JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }));
+                renameSync(tmpMeta, `${path}.meta`);
+            } catch { try { unlinkSync(tmpMeta); } catch { /* cleanup */ } }
+            try {
+                return fn();
+            } finally {
+                try { unlinkSync(`${path}.meta`); } catch { /* already gone */ }
+                try { unlinkSync(path); } catch { /* already gone */ }
+            }
+        } catch (err) {
+            if ((err as { code?: string })?.code !== 'EEXIST') throw err;
+            attempts += 1;
+            if (isStaleLock(path)) {
+                try { unlinkSync(`${path}.meta`); } catch { /* may not exist */ }
+                try { unlinkSync(path); } catch { /* races resolve naturally */ }
+                continue;
+            }
+            await new Promise(resolve => setTimeout(resolve, LOCK_RETRY_MS));
+        }
+    }
+    throw new WebAiError({
+        errorCode: 'internal.unhandled',
+        stage: 'session-store-lock',
+        retryHint: 'retry',
+        message: `web-ai session store: failed to acquire lock at ${path} after ${LOCK_RETRY_LIMIT} attempts`,
+    });
+}
+
+/**
+ * Deadline-aware async patch. The predicate is re-checked AFTER the lock is
+ * held — the wait for the lock is exactly the gap where a deadline can pass,
+ * and a check taken before it says nothing about this moment (agbrowse 523635d).
+ */
+export async function patchSessionAsync(
+    sessionId: string,
+    patch: Partial<StoredSession>,
+    stillActive?: () => boolean,
+): Promise<StoredSession | null | DeadlinePassed> {
+    return withStoreLockAsync(() => {
+        if (stillActive?.() === false) return DEADLINE_PASSED;
+        const store = readSessionStore();
+        const idx = store.sessions.findIndex(s => s.sessionId === sessionId);
+        if (idx < 0) return null;
+        const existing = store.sessions[idx]!;
+        const merged: StoredSession = { ...existing, ...patch, sessionId: existing.sessionId, vendor: patch.vendor ?? existing.vendor, status: patch.status ?? existing.status, createdAt: patch.createdAt ?? existing.createdAt };
+        store.sessions[idx] = merged;
+        writeSessionStore(store);
+        return merged;
+    });
+}
+
+/** Deadline-aware async insert (see {@link patchSessionAsync}). */
+export async function insertSessionAsync(
+    session: StoredSession,
+    stillActive?: () => boolean,
+): Promise<StoredSession | DeadlinePassed> {
+    return withStoreLockAsync(() => {
+        if (stillActive?.() === false) return DEADLINE_PASSED;
+        const store = readSessionStore();
+        store.sessions.push(session);
+        writeSessionStore(store);
+        return session;
     });
 }
 

--- a/src/browser/web-ai/session.ts
+++ b/src/browser/web-ai/session.ts
@@ -256,6 +256,8 @@ export function updateSessionResult(input: {
     turns?: import('./types.js').WebAiTurnRecord[];
     followUpCount?: number;
     modelSelection?: import('./chatgpt-model.js').ChatGptModelSelectionEvidence;
+    // parity2 070 slice C-03: DR marker consumed by chatgpt-archive's guard + resume routing.
+    researchMode?: string | null;
 }): WebAiSessionRecord | null {
     loadPersistentStore();
     const record = sessions.get(input.sessionId);
@@ -272,6 +274,7 @@ export function updateSessionResult(input: {
     if (input.turns !== undefined) record.turns = input.turns;
     if (input.followUpCount !== undefined) record.followUpCount = input.followUpCount;
     if (input.modelSelection !== undefined) record.modelSelection = input.modelSelection;
+    if (input.researchMode !== undefined) record.researchMode = input.researchMode;
     if (input.answerText !== undefined) {
         record.answerText = input.answerText;
         record.lastSeenTextHash = createHash('sha256').update(input.answerText).digest('hex');

--- a/src/browser/web-ai/session.ts
+++ b/src/browser/web-ai/session.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { JAW_HOME } from '../../core/config.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
+import { isDurableConversationUrl } from './conversation-url.js';
 import type {
     CommittedTurnBaseline,
     QuestionEnvelope,
@@ -375,8 +376,11 @@ export function pruneSessions(input: {
 export function discoverConversationUrl(sessionId: string, candidateUrl: string): boolean {
     const session = getSession(sessionId);
     if (!session) return false;
-    const hasConvoId = /\/c\/[a-f0-9-]+/i.test(candidateUrl);
-    const currentIsRoot = !session.conversationUrl || !session.conversationUrl.includes('/c/');
+    // parity2 020 slice 2.1 (B4/C-10): substring '/c/' admitted foreign hosts,
+    // http, ports, and traversal strings — and recovery later NAVIGATES to the
+    // stored value. Only a durable-safe URL may be persisted.
+    const hasConvoId = isDurableConversationUrl(candidateUrl);
+    const currentIsRoot = !isDurableConversationUrl(session.conversationUrl);
     if (hasConvoId && currentIsRoot) {
         updateSessionResult({ sessionId, status: session.status, conversationUrl: candidateUrl });
         return true;

--- a/src/browser/web-ai/tab-finalizer.ts
+++ b/src/browser/web-ai/tab-finalizer.ts
@@ -10,9 +10,24 @@ export interface FinalizeProviderTabInput {
     answerText: string;
     owner?: string;
     sessionType?: string;
+    /**
+     * parity2 040 slice 4.3 (C-06): re-checked before EVERY side-effect phase,
+     * not once at entry. Each phase can block long enough for the caller's
+     * deadline to pass inside it; a losing run must not write the answer or
+     * pool the tab after its caller was already handed a timeout.
+     */
+    stillActive?: () => boolean;
 }
 
-export async function finalizeProviderTab(input: FinalizeProviderTabInput): Promise<void> {
+export interface FinalizeProviderTabResult {
+    finalized: boolean;
+    skippedReason?: 'poll-deadline-exceeded';
+    pooled?: boolean;
+}
+
+export async function finalizeProviderTab(input: FinalizeProviderTabInput): Promise<FinalizeProviderTabResult> {
+    const expired = () => input.stillActive?.() === false;
+    if (expired()) return { finalized: false, skippedReason: 'poll-deadline-exceeded' };
     updateSessionResult({
         sessionId: input.session.sessionId,
         status: 'complete',
@@ -20,10 +35,16 @@ export async function finalizeProviderTab(input: FinalizeProviderTabInput): Prom
         conversationUrl: input.url,
         answerText: input.answerText,
     });
+    // Re-checked AFTER the session write: the store lock can retry long enough
+    // for a deadline to pass inside it, and pooling then would recycle a tab
+    // nobody is waiting on.
+    if (expired()) return { finalized: true, skippedReason: 'poll-deadline-exceeded' };
     await poolTab(input.vendor, input.session.targetId, input.url, {
         owner: input.owner || 'cli-jaw',
         sessionType: input.sessionType || 'jaw',
         sessionId: input.session.sessionId,
         port: input.port,
     });
+    return { finalized: true, pooled: true };
 }
+

--- a/src/browser/web-ai/tab-lease-store.ts
+++ b/src/browser/web-ai/tab-lease-store.ts
@@ -125,24 +125,36 @@ function poolTtlMs(): number {
     return parseDuration(process.env["JAW_BROWSER_PROVIDER_POOL_TTL"] || process.env["AGBROWSE_PROVIDER_POOL_TTL"] || '15m');
 }
 
+/**
+ * parity2 010 slice 1.4 (C-23, mirrors agbrowse tab-lease-store.mjs cdf93ce):
+ * provider-limit envs accept ONLY plain decimal integers. `Number(...)` was too
+ * permissive — it admitted '1e3', '0x10', '  12  ', and Infinity-adjacent
+ * garbage — while genuinely malformed values silently became the default with
+ * no grammar at all. Digits-only, safe-integer, with an allowZero option.
+ */
+export function parseProviderLimitEnv(value: string | undefined, fallback: number, options: { allowZero?: boolean } = {}): number {
+    const text = String(value ?? '').trim();
+    if (!/^\d+$/.test(text)) return fallback;
+    const parsed = Number(text);
+    if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed)) return fallback;
+    if (options.allowZero ? parsed < 0 : parsed <= 0) return fallback;
+    return parsed;
+}
+
 function poolMaxPerKey(): number {
-    const parsed = Number(process.env["JAW_BROWSER_PROVIDER_POOL_MAX_PER_KEY"] || process.env["AGBROWSE_PROVIDER_POOL_MAX_PER_KEY"] || DEFAULT_POOL_MAX_PER_KEY);
-    return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_POOL_MAX_PER_KEY;
+    return parseProviderLimitEnv(process.env["JAW_BROWSER_PROVIDER_POOL_MAX_PER_KEY"] || process.env["AGBROWSE_PROVIDER_POOL_MAX_PER_KEY"], DEFAULT_POOL_MAX_PER_KEY, { allowZero: true });
 }
 
 function poolGlobalMax(): number {
-    const parsed = Number(process.env["JAW_BROWSER_PROVIDER_POOL_GLOBAL_MAX"] || process.env["AGBROWSE_PROVIDER_POOL_GLOBAL_MAX"] || DEFAULT_POOL_GLOBAL_MAX);
-    return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_POOL_GLOBAL_MAX;
+    return parseProviderLimitEnv(process.env["JAW_BROWSER_PROVIDER_POOL_GLOBAL_MAX"] || process.env["AGBROWSE_PROVIDER_POOL_GLOBAL_MAX"], DEFAULT_POOL_GLOBAL_MAX, { allowZero: true });
 }
 
 function activeMaxPerKey(): number {
-    const parsed = Number(process.env["JAW_BROWSER_PROVIDER_ACTIVE_MAX_PER_KEY"] || process.env["AGBROWSE_PROVIDER_ACTIVE_MAX_PER_KEY"] || DEFAULT_ACTIVE_MAX_PER_KEY);
-    return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_ACTIVE_MAX_PER_KEY;
+    return parseProviderLimitEnv(process.env["JAW_BROWSER_PROVIDER_ACTIVE_MAX_PER_KEY"] || process.env["AGBROWSE_PROVIDER_ACTIVE_MAX_PER_KEY"], DEFAULT_ACTIVE_MAX_PER_KEY);
 }
 
 function activeGlobalMax(): number {
-    const parsed = Number(process.env["JAW_BROWSER_PROVIDER_ACTIVE_GLOBAL_MAX"] || process.env["AGBROWSE_PROVIDER_ACTIVE_GLOBAL_MAX"] || DEFAULT_ACTIVE_GLOBAL_MAX);
-    return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_ACTIVE_GLOBAL_MAX;
+    return parseProviderLimitEnv(process.env["JAW_BROWSER_PROVIDER_ACTIVE_GLOBAL_MAX"] || process.env["AGBROWSE_PROVIDER_ACTIVE_GLOBAL_MAX"], DEFAULT_ACTIVE_GLOBAL_MAX);
 }
 
 /**

--- a/src/browser/web-ai/tab-pool.ts
+++ b/src/browser/web-ai/tab-pool.ts
@@ -7,6 +7,7 @@ import {
     type LeaseScopeInput,
 } from './tab-lease-store.js';
 import { stripUndefined } from '../../core/strip-undefined.js';
+import { activeCommandTargetIds } from './active-command-store.js';
 import type { WebAiVendor } from './types.js';
 
 export interface PoolTabOptions extends Partial<LeaseScopeInput> {
@@ -61,7 +62,10 @@ export async function unpoolTab(vendor: WebAiVendor, targetId: string | null | u
 }
 
 export async function cleanupPoolTabs(port: number): Promise<{ closed: number; closedTabs: string[] }> {
-    return cleanupLeasedTabs(port);
+    // parity2 100 (B8): tabs owned by RUNNING cross-process commands are
+    // protected from reclamation — the seat existed but nothing filled it.
+    const protectedIds = await activeCommandTargetIds().catch(() => new Set<string>());
+    return cleanupLeasedTabs(port, { activeCommandTargetIds: protectedIds });
 }
 
 export async function getPoolStats(): Promise<Record<string, number>> {

--- a/src/browser/web-ai/tab-pool.ts
+++ b/src/browser/web-ai/tab-pool.ts
@@ -64,7 +64,9 @@ export async function unpoolTab(vendor: WebAiVendor, targetId: string | null | u
 export async function cleanupPoolTabs(port: number): Promise<{ closed: number; closedTabs: string[] }> {
     // parity2 100 (B8): tabs owned by RUNNING cross-process commands are
     // protected from reclamation — the seat existed but nothing filled it.
-    const protectedIds = await activeCommandTargetIds().catch(() => new Set<string>());
+    // parity2 110 fix (F2): a corrupt/unreadable command store must not
+    // silently unprotect running tabs — refuse the cleanup instead.
+    const protectedIds = await activeCommandTargetIds();
     return cleanupLeasedTabs(port, { activeCommandTargetIds: protectedIds });
 }
 

--- a/src/browser/web-ai/tab-recovery.ts
+++ b/src/browser/web-ai/tab-recovery.ts
@@ -1,0 +1,50 @@
+// Fail-closed session-tab recovery guards.
+//
+// Ported subset of agbrowse `web-ai/tab-recovery.mjs` (parity2 020 slice 2.3,
+// catalog B3/C-10). The semantics that matter:
+//   - tab liveness is tri-state: alive / dead / unknown;
+//   - UNKNOWN NEVER replaces a tab — creating a new one would rebind the
+//     session target and abandon a live conversation;
+//   - replacement requires proven-dead PLUS a durable-safe target URL;
+//   - stored/live URL compatibility is a real check, not a substring poke.
+
+import { probeCdpLiveness } from './cdp-liveness.js';
+import { isDurableConversationUrl } from './conversation-url.js';
+
+export type TabLiveness = 'alive' | 'dead' | 'unknown';
+
+/**
+ * Probe whether a tab target is alive via the out-of-band DevTools endpoint.
+ * An unreachable endpoint or a probe error is UNKNOWN, not dead: we could not
+ * observe the tab, so we may not replace it.
+ */
+export async function probeTabAlive(port: number, targetId: string | null | undefined): Promise<TabLiveness> {
+    if (!targetId) return 'unknown';
+    const liveness = await probeCdpLiveness({ port, targetId });
+    if (!liveness.endpointReachable) return 'unknown';
+    if (liveness.targetFound === true) return 'alive';
+    if (liveness.targetFound === false) return 'dead';
+    return 'unknown';
+}
+
+/** A recovery navigation target is safe only when durable (`/c/<id>`, https, known host). */
+export function isSafeChatGptConversationUrl(url: string | null | undefined): boolean {
+    return isDurableConversationUrl(url);
+}
+
+/** Stored vs live URL compatibility (agbrowse tab-recovery.mjs urlsCompatible). */
+export function urlsCompatible(storedUrl: string | null | undefined, liveUrl: string | null | undefined): boolean {
+    if (!storedUrl || !liveUrl) return false;
+    if (storedUrl === liveUrl) return true;
+    try {
+        const a = new URL(storedUrl);
+        const b = new URL(liveUrl);
+        if (a.hostname !== b.hostname) return false;
+        const aPath = a.pathname.replace(/\/+$/, '') || '/';
+        const bPath = b.pathname.replace(/\/+$/, '') || '/';
+        return aPath === bPath || aPath === '/' || bPath.startsWith(`${aPath}/`);
+    } catch {
+        return false;
+    }
+}
+

--- a/src/browser/web-ai/tier-timeout.ts
+++ b/src/browser/web-ai/tier-timeout.ts
@@ -13,19 +13,28 @@ import { normalizeGrokModelChoice } from './grok-model.js';
 export const TIER_DEFAULT_TIMEOUT_SEC: Readonly<Record<string, number>> = Object.freeze({
     instant: 120,
     thinking: 600,
-    pro: 3600,
+    // parity2 030 slice 3.3 (C-19): vendor-specific long-reasoning tiers stay
+    // independent so one budget change cannot silently change another
+    // provider's behavior. Pro runs get 1.5h (agbrowse chatgpt-pro), Grok
+    // Heavy 1h. Legacy 'pro' key kept as an alias for existing callers.
+    'chatgpt-pro': 5400,
+    pro: 5400,
+    'grok-heavy': 3600,
     'deep-research': 3600,
 });
 
-/** Long-reasoning ceiling (seconds), exported for cross-module reuse (e.g. lease TTLs). */
-export const PRO_TIMEOUT_SEC = TIER_DEFAULT_TIMEOUT_SEC['pro'];
+/** ChatGPT Pro ceiling (seconds), exported for cross-module reuse (e.g. lease TTLs). */
+export const CHATGPT_PRO_TIMEOUT_SEC = TIER_DEFAULT_TIMEOUT_SEC['chatgpt-pro'];
+/** Backward-compatible alias; new consumers use CHATGPT_PRO_TIMEOUT_SEC. */
+export const PRO_TIMEOUT_SEC = CHATGPT_PRO_TIMEOUT_SEC;
 
-const FALLBACK_TIMEOUT_SEC = 1200;
+/** parity2 030 slice 3.3 (C-19): per-vendor defaults — Grok answers fast, so its unknown-tier budget is tighter. */
+const VENDOR_DEFAULT_TIMEOUT_SEC: Readonly<Record<string, number>> = Object.freeze({ chatgpt: 1200, gemini: 1200, grok: 600 });
 
-/** Resolve a tier name to a default timeout (seconds), falling back to 1200s when unknown. */
-export function tierDefaultTimeoutSec(tier: string | null): number {
+/** Resolve a tier name to a default timeout (seconds), falling back to the vendor default, then 1200s. */
+export function tierDefaultTimeoutSec(tier: string | null, vendor: string = 'chatgpt'): number {
     if (tier && TIER_DEFAULT_TIMEOUT_SEC[tier] != null) return TIER_DEFAULT_TIMEOUT_SEC[tier];
-    return FALLBACK_TIMEOUT_SEC;
+    return VENDOR_DEFAULT_TIMEOUT_SEC[vendor] || 1200;
 }
 
 /**
@@ -43,7 +52,7 @@ export function deriveTimeoutTier(vendor: WebAiVendor, model: string | undefined
     }
     if (vendor === 'grok') {
         const m = normalizeGrokModelChoice(model);
-        if (m === 'heavy') return 'pro';
+        if (m === 'heavy') return 'grok-heavy';
         if (m === 'fast') return 'instant';
         return m ? 'thinking' : null;
     }
@@ -57,5 +66,5 @@ export function resolveTimeoutDefaultSec(
     input: { model?: string; research?: string } = {},
     vendor: WebAiVendor = 'chatgpt',
 ): number {
-    return tierDefaultTimeoutSec(deriveTimeoutTier(vendor, input.model, input.research));
+    return tierDefaultTimeoutSec(deriveTimeoutTier(vendor, input.model, input.research), vendor);
 }

--- a/src/browser/web-ai/types.ts
+++ b/src/browser/web-ai/types.ts
@@ -81,7 +81,10 @@ export interface CommittedTurnBaseline {
     capturedAt: string;
 }
 
-export type WebAiSessionStatus = 'sent' | 'streaming' | 'complete' | 'timeout' | 'error' | 'crashed';
+// parity2 070 slice C-04: 'partial' (multi-turn stopped mid-sequence, resumable),
+// 'blocked' (DR account block — not a generic error), 'stale' (watcher-marked).
+// Storing these as 'error' lost the resumability signal.
+export type WebAiSessionStatus = 'sent' | 'streaming' | 'complete' | 'timeout' | 'error' | 'crashed' | 'partial' | 'blocked' | 'stale';
 
 export interface WebAiSessionTabState {
     createdAt: string;
@@ -125,6 +128,9 @@ export interface WebAiSessionRecord {
     timeoutMs: number;
     notifyOnComplete?: boolean;
     capabilityMode?: string;
+    // parity2 070 slice C-03: 'deep' marks a Deep Research session — the archive
+    // DR-guard reads it and resume routing needs it (it was read but never written).
+    researchMode?: string | null;
     answerText?: string;
     answerArtifact?: import('./answer-artifact.js').AnswerArtifact;
     sourceAudit?: import('./source-audit.js').SourceAuditResult;

--- a/src/browser/web-ai/vendor-editor-contract.ts
+++ b/src/browser/web-ai/vendor-editor-contract.ts
@@ -22,10 +22,13 @@ export interface PromptCommitResult {
 }
 
 export interface PromptSubmitResult {
-    method: 'button' | 'enter';
+    method: 'button' | 'enter' | 'none';
     // 104.12: which resolver-verified target was clicked, when the resolved-send path won.
     selector?: string;
     resolution?: unknown;
+    // parity2 060 slice A-03: submit refused because the send button never
+    // enabled while attachments were pending (no blind Enter fallback).
+    failure?: 'send-button-disabled';
 }
 
 // 104.12: resolver-verified targets carry the self-healed selector + its resolution provenance.
@@ -47,6 +50,9 @@ export interface VendorEditorAdapterOptions {
     composerTarget?: ComposerTarget;
     sendTarget?: SendTarget;
     sendButtonTimeoutMs?: number;
+    // parity2 060 slice A-03: with attachments pending, an Enter fallback can
+    // submit BEFORE uploads finish; require the enabled send button instead.
+    requireEnabledSendButton?: boolean;
 }
 
 export interface VendorEditorAdapter {

--- a/src/browser/web-ai/watcher.ts
+++ b/src/browser/web-ai/watcher.ts
@@ -6,6 +6,7 @@ import {
     incrementRecoveryCount,
     listSessions,
     setSessionNotifyOnComplete,
+    updateSessionProgress,
     updateSessionResult,
     updateSessionStatus,
 } from './session.js';
@@ -181,6 +182,17 @@ async function runTick(input: StartWebAiWatcherInput, state: WatcherRuntimeState
             return;
         }
         if (result.ok && result.status === 'complete') {
+            // parity2 040 slice 4.2 (C-07): a poll can report complete while the
+            // page is still streaming (false-complete). When the persisted
+            // streaming state disagrees, DEFER finalization — keep polling and
+            // record the typed warning; the next non-streaming poll finalizes.
+            const persisted = getSession(input.sessionId);
+            if (persisted?.lastStreamingState === 'streaming' && !result.answerText) {
+                updateSessionResult({ sessionId: input.sessionId, status: 'streaming' });
+                updateSessionProgress(input.sessionId, { lastStreamingState: 'streaming' });
+                scheduleTick(input, state, normalizedPollIntervalMs(input.pollIntervalSeconds));
+                return;
+            }
             updateSessionResult({
                 sessionId: input.sessionId,
                 status: 'complete',

--- a/src/browser/web-ai/watcher.ts
+++ b/src/browser/web-ai/watcher.ts
@@ -11,6 +11,7 @@ import {
 } from './session.js';
 import { isPageDeathError } from './interstitial.js';
 import { acquireWatcherSessionLock, type WatcherSessionLock } from './watcher-lock.js';
+import { withPollDeadline } from './poll-deadline.js';
 import type { WebAiOutput, WebAiSessionRecord, WebAiVendor } from './types.js';
 
 export interface StartWebAiWatcherInput {
@@ -127,12 +128,27 @@ async function runTick(input: StartWebAiWatcherInput, state: WatcherRuntimeState
     try {
         let result: WebAiOutput;
         try {
-            result = await runSerializedPoll(() => input.pollOnce(stripUndefined({
-                vendor: input.vendor,
-                session: input.sessionId,
-                timeout: POLL_TICK_SECONDS,
-                allowCopyMarkdownFallback: input.allowCopyMarkdownFallback,
-            })));
+            // parity2 010 slice 1.1 (C-04): the tick asks pollOnce for a
+            // POLL_TICK_SECONDS poll, but a stalled probe inside it could hold the
+            // serialized queue forever — starving every other watcher. Bound the
+            // tick at 2x its budget + grace and treat expiry as a soft retry.
+            const tickBudgetMs = POLL_TICK_SECONDS * 2_000 + 10_000;
+            const TICK_EXPIRED = Symbol('watcher-tick-expired');
+            const bounded = await withPollDeadline<WebAiOutput | typeof TICK_EXPIRED>(
+                () => runSerializedPoll(() => input.pollOnce(stripUndefined({
+                    vendor: input.vendor,
+                    session: input.sessionId,
+                    timeout: POLL_TICK_SECONDS,
+                    allowCopyMarkdownFallback: input.allowCopyMarkdownFallback,
+                }))),
+                { timeoutMs: tickBudgetMs, onExpired: () => TICK_EXPIRED },
+            );
+            if (bounded === TICK_EXPIRED) {
+                // The tick's probe outlived its bound; reschedule rather than hang.
+                scheduleTick(input, state, normalizedPollIntervalMs(input.pollIntervalSeconds));
+                return;
+            }
+            result = bounded;
         } catch (pollErr) {
             const recoveryAttempts = (state as { recoveryAttempts?: number }).recoveryAttempts || 0;
             if (isPageDeathError(pollErr) && recoveryAttempts < 2) {

--- a/src/browser/web-ai/watcher.ts
+++ b/src/browser/web-ai/watcher.ts
@@ -12,6 +12,7 @@ import {
 import { isPageDeathError } from './interstitial.js';
 import { acquireWatcherSessionLock, type WatcherSessionLock } from './watcher-lock.js';
 import { withPollDeadline } from './poll-deadline.js';
+import { probeCdpLiveness, isRecoverableCdpDisconnect } from './cdp-liveness.js';
 import type { WebAiOutput, WebAiSessionRecord, WebAiVendor } from './types.js';
 
 export interface StartWebAiWatcherInput {
@@ -156,6 +157,22 @@ async function runTick(input: StartWebAiWatcherInput, state: WatcherRuntimeState
                 incrementRecoveryCount(input.sessionId);
                 scheduleTick(input, state, normalizedPollIntervalMs(input.pollIntervalSeconds));
                 return;
+            }
+            // parity2 020 slice 2.3 (B6): before treating any other poll error as
+            // terminal, classify the disconnect out-of-band. Chrome alive with the
+            // session's target still listed means the CDP client wobbled, not the
+            // tab — retry the tick instead of killing the watcher.
+            if (recoveryAttempts < 2) {
+                const sessionTargetId = getSession(input.sessionId)?.targetId;
+                if (sessionTargetId) {
+                    const liveness = await probeCdpLiveness({ port: input.port, targetId: sessionTargetId }).catch(() => null);
+                    if (liveness && isRecoverableCdpDisconnect(liveness)) {
+                        (state as { recoveryAttempts?: number }).recoveryAttempts = recoveryAttempts + 1;
+                        incrementRecoveryCount(input.sessionId);
+                        scheduleTick(input, state, normalizedPollIntervalMs(input.pollIntervalSeconds));
+                        return;
+                    }
+                }
             }
             throw pollErr;
         }

--- a/src/browser/web-ai/watcher.ts
+++ b/src/browser/web-ai/watcher.ts
@@ -14,6 +14,8 @@ import { isPageDeathError } from './interstitial.js';
 import { acquireWatcherSessionLock, type WatcherSessionLock } from './watcher-lock.js';
 import { withPollDeadline } from './poll-deadline.js';
 import { probeCdpLiveness, isRecoverableCdpDisconnect } from './cdp-liveness.js';
+import { getActivePage } from '../connection.js';
+import { captureWebAiDiagnostics } from './diagnostics.js';
 import type { WebAiOutput, WebAiSessionRecord, WebAiVendor } from './types.js';
 
 export interface StartWebAiWatcherInput {
@@ -222,6 +224,19 @@ async function runTick(input: StartWebAiWatcherInput, state: WatcherRuntimeState
     } catch (e) {
         state.status = 'error';
         const error = (e as Error).message;
+        // parity2 110 fix (final-audit F1): a terminal watcher error is the
+        // production failure path that persists a diagnostics artifact — the
+        // sink existed but nothing production-side flowed through it.
+        try {
+            const page = await getActivePage(input.port).catch(() => null);
+            if (page) {
+                await captureWebAiDiagnostics({
+                    stage: 'poll-timeout',
+                    page: page as never,
+                    sessionId: input.sessionId,
+                });
+            }
+        } catch { /* diagnostics capture must never become a second failure */ }
         updateSessionResult({
             sessionId: input.sessionId,
             status: 'error',

--- a/src/routes/browser.ts
+++ b/src/routes/browser.ts
@@ -432,6 +432,7 @@ export function registerBrowserRoutes(app: Express, requireAuth: (req: Request, 
             res.json(await browser.webAi.diagnose(cdpPort(req), {
                 vendor: String(req.query["vendor"] || 'chatgpt'),
                 stage: String(req.query["stage"] || 'unknown'),
+                ...(req.query["session"] ? { session: String(req.query["session"]) } : {}),
             }));
         } catch (e: unknown) { res.status(500).json(toWebAiHttpError(e)); }
     });

--- a/tests/unit/browser-web-ai-active-command-store.test.ts
+++ b/tests/unit/browser-web-ai-active-command-store.test.ts
@@ -1,0 +1,60 @@
+// Cycle 10 (parity2 100): cross-process active-command store.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    registerActiveCommand,
+    releaseActiveCommand,
+    heartbeatActiveCommand,
+    listActiveCommands,
+    activeCommandTargetIds,
+    withActiveCommand,
+    ActiveCommandTargetOwnedError,
+} from '../../src/browser/web-ai/active-command-store.ts';
+
+test('AC-1: register/list/release lifecycle', async () => {
+    const cmd = await registerActiveCommand({ command: 'poll', owner: 'test', targetId: 'T-ac-1', ttlMs: 60_000 });
+    assert.equal(cmd.status, 'running');
+    const active = await listActiveCommands({ active: true, targetId: 'T-ac-1' });
+    assert.equal(active.length, 1);
+    const ids = await activeCommandTargetIds();
+    assert.ok(ids.has('T-ac-1'));
+    await releaseActiveCommand(cmd.commandId);
+    const after = await listActiveCommands({ active: true, targetId: 'T-ac-1' });
+    assert.equal(after.length, 0);
+});
+
+test('AC-2: target conflict rejects a second running command on the same tab', async () => {
+    const first = await registerActiveCommand({ command: 'send', targetId: 'T-ac-2', ttlMs: 60_000 });
+    await assert.rejects(
+        registerActiveCommand({ command: 'poll', targetId: 'T-ac-2', ttlMs: 60_000 }),
+        (err: unknown) => err instanceof ActiveCommandTargetOwnedError,
+    );
+    await releaseActiveCommand(first.commandId);
+});
+
+test('AC-3: expired commands stop protecting their tabs', async () => {
+    const cmd = await registerActiveCommand({ command: 'poll', targetId: 'T-ac-3', ttlMs: 1 });
+    await new Promise(r => setTimeout(r, 10));
+    const ids = await activeCommandTargetIds();
+    assert.equal(ids.has('T-ac-3'), false, 'expired command no longer protects the tab');
+    await releaseActiveCommand(cmd.commandId).catch(() => undefined);
+});
+
+test('AC-4: withActiveCommand always releases, heartbeat extends', async () => {
+    let seen: string | null = null;
+    await withActiveCommand({ command: 'wrapped', targetId: 'T-ac-4', ttlMs: 60_000, heartbeatIntervalMs: 0 }, async (cmd) => {
+        seen = cmd.commandId;
+        const hb = await heartbeatActiveCommand(cmd.commandId, { ttlMs: 120_000 });
+        assert.ok(hb);
+    });
+    assert.ok(seen);
+    const after = await listActiveCommands({ active: true, targetId: 'T-ac-4' });
+    assert.equal(after.length, 0);
+    await assert.rejects(
+        withActiveCommand({ command: 'failing', targetId: 'T-ac-4b', heartbeatIntervalMs: 0 }, async () => { throw new Error('boom'); }),
+        /boom/,
+    );
+    const failed = await listActiveCommands({ targetId: 'T-ac-4b' });
+    assert.equal(failed[0]?.status, 'failed');
+});
+

--- a/tests/unit/browser-web-ai-active-command-store.test.ts
+++ b/tests/unit/browser-web-ai-active-command-store.test.ts
@@ -58,3 +58,17 @@ test('AC-4: withActiveCommand always releases, heartbeat extends', async () => {
     assert.equal(failed[0]?.status, 'failed');
 });
 
+test('AC-5: corrupt store is observed, not silently emptied (110/F2)', async () => {
+    const { writeFileSync, mkdirSync } = await import('node:fs');
+    const { dirname, join } = await import('node:path');
+    const { JAW_HOME } = await import('../../src/core/config.ts');
+    const p = join(JAW_HOME, 'web-ai-active-commands.json');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, '{ corrupt !!!', 'utf8');
+    await assert.rejects(
+        listActiveCommands(),
+        (e: unknown) => (e as { code?: string }).code === 'active-command.store-unavailable',
+    );
+    // restore a valid empty store for later tests
+    writeFileSync(p, JSON.stringify({ version: 1, commands: [] }), 'utf8');
+});

--- a/tests/unit/browser-web-ai-capture-gates.test.ts
+++ b/tests/unit/browser-web-ai-capture-gates.test.ts
@@ -1,0 +1,86 @@
+// Cycle 5 (parity2 050): stale-answer admission gates — ordering, tri-state
+// activity, identity-pinned completion, deferred recovery.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { captureAssistantResponse } from '../../src/browser/web-ai/chatgpt-response.ts';
+
+type EvalFn = (...args: never[]) => unknown;
+
+function mkPage(input: {
+    assistantTexts: string[];
+    ordering?: 'ordered' | 'stale' | 'unverifiable';
+    stopVisible?: boolean;
+    stopThrows?: boolean;
+    finishedInLatestTurn?: boolean;
+}): unknown {
+    const page: Record<string, unknown> = {
+        url: () => 'https://chatgpt.com/c/test',
+        waitForTimeout: async () => undefined,
+        evaluate: async (fn: EvalFn, _args?: unknown) => {
+            const src = String(fn);
+            if (src.includes('lastUserTurn') || src.includes('compareDocumentPosition(lastAssistantTurn)')) {
+                if (input.ordering === 'stale') return 'stale';
+                if (input.ordering === 'unverifiable') return 'unverifiable';
+                return 'ordered';
+            }
+            if (src.includes('finishedSelector')) {
+                return Boolean(input.finishedInLatestTurn);
+            }
+            // readTopLevelAssistantTexts
+            return input.assistantTexts;
+        },
+        locator: (selector: string) => ({
+            // scopeToMainRegion returns this locator ('main'); nested locator calls must work.
+            locator: (inner: string) => ({
+                all: async () => {
+                    if (input.stopThrows) throw new Error('cdp lost');
+                    if (inner.includes('stop') || inner.includes('Stop')) {
+                        return input.stopVisible ? [{ isVisible: async () => true }] : [];
+                    }
+                    return [];
+                },
+            }),
+            all: async () => {
+                if (input.stopThrows) throw new Error('cdp lost');
+                if (selector.includes('stop') || selector.includes('Stop')) {
+                    return input.stopVisible ? [{ isVisible: async () => true }] : [];
+                }
+                return [];
+            },
+            first: () => ({ isVisible: async () => false }),
+            count: async () => 0,
+            last: () => ({ isVisible: async () => false }),
+        }),
+    };
+    return page;
+}
+
+test('C5-ORD-1: stale ordering refuses the answer (poll times out instead of admitting history)', async () => {
+    const page = mkPage({ assistantTexts: ['old history answer'], ordering: 'stale', finishedInLatestTurn: true });
+    const result = await captureAssistantResponse(page as never, {
+        minTurnIndex: 0, timeoutMs: 2_500, pollIntervalMs: 50,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(result.warnings.some(w => w.includes('assistant-ordering-stale')), JSON.stringify(result.warnings));
+});
+
+test('C5-ORD-2: ordered text is accepted', async () => {
+    const page = mkPage({ assistantTexts: ['a real answer'], ordering: 'ordered', finishedInLatestTurn: true });
+    const result = await captureAssistantResponse(page as never, {
+        minTurnIndex: 0, timeoutMs: 6_000, pollIntervalMs: 50,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.answerText, 'a real answer');
+});
+
+test('C5-ACT-1: unreadable stop probe demands the long quiet window (no fast finish)', async () => {
+    // stopThrows makes activity 'unknown'; with a 2.5s budget the 5s unknown
+    // window cannot elapse, and without finished evidence the recovery tier
+    // must DEFER (polling) instead of accepting the half-written text.
+    const page = mkPage({ assistantTexts: ['half-written ans'], ordering: 'ordered', stopThrows: true, finishedInLatestTurn: false });
+    const result = await captureAssistantResponse(page as never, {
+        minTurnIndex: 0, timeoutMs: 2_500, pollIntervalMs: 50,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.polling, true, 'stable-but-unfinished recovery defers');
+});

--- a/tests/unit/browser-web-ai-chatgpt-contract.test.ts
+++ b/tests/unit/browser-web-ai-chatgpt-contract.test.ts
@@ -25,7 +25,9 @@ test('BWAC-002: active tab must be verified before web-ai actions', () => {
 });
 
 test('BWAC-003: send captures baseline before prompt insertion', () => {
-    const assistantIndex = chatgptSrc.indexOf('const assistantCount = await countAssistantMessages');
+    // parity2 060 (A-02): the baseline read is now null-semantics
+    // (countAssistantMessagesOrNull) and aborts pre-mutation on a failed read.
+    const assistantIndex = chatgptSrc.indexOf('const assistantCountOrNull = await countAssistantMessagesOrNull');
     // 104.12: adapter variable may be the resolver-aware `liveAdapter`; match the method, not the var name.
     const insertIndex = chatgptSrc.indexOf('.insertPrompt(');
     assert.ok(assistantIndex > -1);

--- a/tests/unit/browser-web-ai-conversation-url-recovery.test.ts
+++ b/tests/unit/browser-web-ai-conversation-url-recovery.test.ts
@@ -1,0 +1,74 @@
+// Cycle 2 (parity2 020): durable conversation-URL validation, CDP liveness
+// classification, and fail-closed recovery semantics.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractDurableConversationId, isDurableConversationUrl } from '../../src/browser/web-ai/conversation-url.ts';
+import { probeCdpLiveness, isRecoverableCdpDisconnect } from '../../src/browser/web-ai/cdp-liveness.ts';
+import { probeTabAlive, isSafeChatGptConversationUrl, urlsCompatible } from '../../src/browser/web-ai/tab-recovery.ts';
+
+test('CU-001: canonical conversation URLs are durable', () => {
+    assert.equal(extractDurableConversationId('https://chatgpt.com/c/abc-123'), 'abc-123');
+    assert.equal(extractDurableConversationId('https://chat.openai.com/c/ABC123'), 'ABC123');
+    assert.equal(extractDurableConversationId('https://chatgpt.com/g/g-xyz/c/id-1'), 'id-1');
+});
+
+test('CU-002: unsafe URLs are rejected', () => {
+    for (const bad of [
+        'http://chatgpt.com/c/x',              // not https
+        'https://evil.example/c/x',            // foreign host
+        'https://chatgpt.com:8443/c/x',        // explicit port
+        'https://chatgpt.com/c/../y',          // traversal
+        'https://chatgpt.com/\\c/x',         // backslash smuggling
+        'https://chatgpt.com/',                // bare origin
+        'https://chatgpt.com/work',            // no /c/ id
+        '', null, undefined,
+    ]) {
+        assert.equal(isDurableConversationUrl(bad as string), false, `should reject: ${bad}`);
+    }
+});
+
+test('CDP-001: liveness decision table', async () => {
+    const mkFetch = (version: boolean, list: unknown) => (async (url: string) => {
+        if (String(url).includes('/json/version')) {
+            if (!version) throw new Error('ECONNREFUSED');
+            return { ok: true } as Response;
+        }
+        return { ok: true, json: async () => list } as unknown as Response;
+    }) as typeof fetch;
+
+    const alive = await probeCdpLiveness({ port: 9222, targetId: 'T1', fetchImpl: mkFetch(true, [{ id: 'T1', url: 'https://chatgpt.com/c/x' }]) });
+    assert.equal(isRecoverableCdpDisconnect(alive), true);
+    assert.equal(alive.matchedUrl, 'https://chatgpt.com/c/x');
+
+    const gone = await probeCdpLiveness({ port: 9222, targetId: 'T1', fetchImpl: mkFetch(true, [{ id: 'T2' }]) });
+    assert.deepEqual({ reach: gone.endpointReachable, found: gone.targetFound }, { reach: true, found: false });
+    assert.equal(isRecoverableCdpDisconnect(gone), false);
+
+    const down = await probeCdpLiveness({ port: 9222, targetId: 'T1', fetchImpl: mkFetch(false, []) });
+    assert.equal(down.endpointReachable, false);
+    assert.equal(isRecoverableCdpDisconnect(down), false);
+});
+
+test('TR-001: probeTabAlive maps liveness fail-closed', async () => {
+    // No targetId → unknown (never dead)
+    assert.equal(await probeTabAlive(9222, null), 'unknown');
+    assert.equal(await probeTabAlive(9222, ''), 'unknown');
+    // Endpoint down → unknown (we could not observe; may not replace)
+    const dead = await probeTabAlive(1, 'T1'); // nothing listens on port 1
+    assert.equal(dead, 'unknown');
+});
+
+test('TR-002: urlsCompatible matches agbrowse semantics', () => {
+    assert.equal(urlsCompatible('https://chatgpt.com/c/x', 'https://chatgpt.com/c/x'), true);
+    assert.equal(urlsCompatible('https://chatgpt.com/c/x', 'https://chatgpt.com/c/x/sub'), true);
+    assert.equal(urlsCompatible('https://chatgpt.com/', 'https://chatgpt.com/c/x'), true); // root is compatible
+    assert.equal(urlsCompatible('https://chatgpt.com/c/x', 'https://chatgpt.com/c/y'), false);
+    assert.equal(urlsCompatible('https://chatgpt.com/c/x', 'https://evil.example/c/x'), false);
+    assert.equal(urlsCompatible(null, 'https://chatgpt.com/'), false);
+});
+
+test('TR-003: isSafeChatGptConversationUrl delegates to durable validation', () => {
+    assert.equal(isSafeChatGptConversationUrl('https://chatgpt.com/c/abc'), true);
+    assert.equal(isSafeChatGptConversationUrl('https://chatgpt.com/'), false);
+});
+

--- a/tests/unit/browser-web-ai-lease-env-grammar.test.ts
+++ b/tests/unit/browser-web-ai-lease-env-grammar.test.ts
@@ -1,0 +1,26 @@
+// Cycle 1 slice 1.4 (parity2 010): provider-limit env grammar is strict digits-only
+// (agbrowse tab-lease-store.mjs cdf93ce parity — silent fallback, strict grammar).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseProviderLimitEnv } from '../../src/browser/web-ai/tab-lease-store.ts';
+
+test('LS-ENV1: plain decimal integers are honored', () => {
+    assert.equal(parseProviderLimitEnv('7', 5), 7);
+    assert.equal(parseProviderLimitEnv('0', 5, { allowZero: true }), 0);
+});
+
+test('LS-ENV2: garbage and non-decimal grammars fall back to the default', () => {
+    assert.equal(parseProviderLimitEnv('banana', 5), 5);
+    assert.equal(parseProviderLimitEnv('1e3', 5), 5);
+    assert.equal(parseProviderLimitEnv('0x10', 5), 5);
+    assert.equal(parseProviderLimitEnv('-3', 5), 5);
+    assert.equal(parseProviderLimitEnv('3.5', 5), 5);
+    assert.equal(parseProviderLimitEnv('', 5), 5);
+    assert.equal(parseProviderLimitEnv(undefined, 5), 5);
+});
+
+test('LS-ENV3: zero rejected unless allowZero', () => {
+    assert.equal(parseProviderLimitEnv('0', 5), 5);
+    assert.equal(parseProviderLimitEnv('0', 5, { allowZero: true }), 0);
+});
+

--- a/tests/unit/browser-web-ai-model-power-family.test.ts
+++ b/tests/unit/browser-web-ai-model-power-family.test.ts
@@ -1,0 +1,61 @@
+// Cycle 3 (parity2 030): GPT-5.6 family vocabulary, Power tier label mapping,
+// zh label projections, and the effort-verification axis surface.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    normalizeChatGptFamilyChoice,
+    CHATGPT_FAMILY_OPTIONS,
+    effortChoiceFromPowerTierLabel,
+    normalizeChatGptModelChoice,
+    normalizeChatGptEffortChoice,
+    CHATGPT_MODEL_OPTIONS,
+    normalizeModelPickerText,
+    modelChoiceFromText,
+} from '../../src/browser/web-ai/chatgpt-model.ts';
+
+test('MP-FAM-1: family normalization table', () => {
+    assert.equal(normalizeChatGptFamilyChoice('gpt-5.6-sol'), 'gpt-5.6-sol');
+    assert.equal(normalizeChatGptFamilyChoice('GPT-5.6'), 'gpt-5.6-sol');
+    assert.equal(normalizeChatGptFamilyChoice('sol'), 'gpt-5.6-sol');
+    assert.equal(normalizeChatGptFamilyChoice('gpt-5.5'), 'gpt-5.5');
+    assert.equal(normalizeChatGptFamilyChoice('o3'), 'o3');
+    assert.equal(normalizeChatGptFamilyChoice('gpt-4'), null);
+    assert.equal(normalizeChatGptFamilyChoice(undefined), null);
+    assert.equal(CHATGPT_FAMILY_OPTIONS['gpt-5.6-sol'].label, 'GPT-5.6 Sol');
+});
+
+test('MP-PWR-1: power tier label resolves effort, label-first with index cross-check', () => {
+    // label alone
+    assert.equal(effortChoiceFromPowerTierLabel('Extra High, 4 of 5.', null), 'heavy');
+    assert.equal(effortChoiceFromPowerTierLabel('Medium, 2 of 5.', null), 'standard');
+    assert.equal(effortChoiceFromPowerTierLabel('High', null), 'extended');
+    // index alone (1 Medium, 2 High, 3 Extra High)
+    assert.equal(effortChoiceFromPowerTierLabel(null, 1), 'standard');
+    assert.equal(effortChoiceFromPowerTierLabel(null, 2), 'extended');
+    assert.equal(effortChoiceFromPowerTierLabel(null, 3), 'heavy');
+    // agreement
+    assert.equal(effortChoiceFromPowerTierLabel('High, 3 of 5.', 2), 'extended');
+    // DISAGREEMENT fails closed
+    assert.equal(effortChoiceFromPowerTierLabel('Extra High, 4 of 5.', 1), null);
+    // zh labels
+    assert.equal(effortChoiceFromPowerTierLabel('极高, 4 of 5.', null), 'heavy');
+    assert.equal(effortChoiceFromPowerTierLabel('中等', null), 'standard');
+});
+
+test('MP-ZH-1: zh model labels resolve to the same canonical choices', () => {
+    assert.equal(modelChoiceFromText('即时'), 'instant');
+    assert.equal(modelChoiceFromText('思考'), normalizeChatGptModelChoice('thinking') ? modelChoiceFromText('思考') : null);
+    assert.ok(CHATGPT_MODEL_OPTIONS.instant.labels.includes('即时'));
+    assert.ok(CHATGPT_MODEL_OPTIONS.thinking.labels.includes('中等'));
+    assert.ok(CHATGPT_MODEL_OPTIONS.pro.labels.includes('Pro 扩展'));
+    // normalization keeps CJK
+    assert.equal(normalizeModelPickerText('  即时 '), '即时');
+});
+
+test('MP-ALIAS-1: 5.6 model aliases map into the canonical trio', () => {
+    assert.equal(normalizeChatGptModelChoice('gpt-5.6-thinking'), 'thinking');
+    assert.equal(normalizeChatGptModelChoice('gpt-5.6-pro'), 'pro');
+    assert.equal(normalizeChatGptEffortChoice('high'), 'extended');
+    assert.equal(normalizeChatGptEffortChoice('heavy'), 'heavy');
+});
+

--- a/tests/unit/browser-web-ai-poll-deadline.test.ts
+++ b/tests/unit/browser-web-ai-poll-deadline.test.ts
@@ -1,0 +1,85 @@
+// Cycle 1 (devlog/_plan/260821_agbrowse_webai_parity2/010 slice 1.1):
+// the deadline must be real even when a probe never settles, and the token
+// must let a mid-tick loser refuse new side effects.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withPollDeadline, POLL_EXPIRED, monotonicNowMs, type PollDeadlineToken } from '../../src/browser/web-ai/poll-deadline.ts';
+
+test('withPollDeadline answers with onExpired when the probe never settles', async () => {
+    const t0 = monotonicNowMs();
+    let sawToken: PollDeadlineToken | null = null;
+    const result = await withPollDeadline<string>(
+        async (_deadline, token) => {
+            sawToken = token;
+            await new Promise<never>(() => { /* never settles */ });
+            return 'unreachable';
+        },
+        { timeoutMs: 500, onExpired: () => 'expired' },
+    );
+    const elapsed = monotonicNowMs() - t0;
+    assert.equal(result, 'expired');
+    // budget + one check interval + slack
+    assert.ok(elapsed < 500 + 250 + 1000, `took ${elapsed}ms`);
+    assert.ok(sawToken, 'runFn received a token');
+    assert.equal(sawToken!.expired, true, 'token.expired flips once the caller is answered');
+});
+
+test('withPollDeadline returns the result when the run wins', async () => {
+    const result = await withPollDeadline<string>(
+        async () => 'ok',
+        { timeoutMs: 5_000, onExpired: () => 'expired' },
+    );
+    assert.equal(result, 'ok');
+});
+
+test('a result settling after the deadline is normalised to expiry', async () => {
+    const result = await withPollDeadline<string>(
+        async (hardDeadline) => {
+            await new Promise(r => setTimeout(r, (hardDeadline - Date.now()) + 400));
+            return 'late';
+        },
+        { timeoutMs: 300, onExpired: () => 'expired' },
+    );
+    assert.equal(result, 'expired');
+});
+
+test('errors inside the budget propagate; POLL_EXPIRED rejection maps to onExpired', async () => {
+    await assert.rejects(
+        withPollDeadline<string>(async () => { throw new Error('real failure'); }, { timeoutMs: 5_000, onExpired: () => 'expired' }),
+        /real failure/,
+    );
+    const mapped = await withPollDeadline<string>(
+        async () => { throw POLL_EXPIRED; },
+        { timeoutMs: 5_000, onExpired: () => 'expired' },
+    );
+    assert.equal(mapped, 'expired');
+});
+
+test('tighten only shortens the bound and re-arms the timer', async () => {
+    const t0 = monotonicNowMs();
+    const result = await withPollDeadline<string>(
+        async (_deadline, token) => {
+            token.tighten?.(Date.now() + 60_000); // extension attempt — ignored
+            token.tighten?.(Date.now() + 300);    // real tighten
+            await new Promise<never>(() => { /* never settles */ });
+            return 'unreachable';
+        },
+        { timeoutMs: 30_000, onExpired: () => 'expired' },
+    );
+    const elapsed = monotonicNowMs() - t0;
+    assert.equal(result, 'expired');
+    assert.ok(elapsed < 5_000, `tightened run answered in ${elapsed}ms, not the original 30s`);
+});
+
+test('startedAt anchors the budget so pre-call blocking time is charged', async () => {
+    const result = await withPollDeadline<string>(
+        async () => {
+            await new Promise(r => setTimeout(r, 250));
+            return 'ok';
+        },
+        { startedAt: Date.now() - 10_000, timeoutMs: 10_100, onExpired: () => 'expired' },
+    );
+    // 10s of the 10.1s budget already spent before the call; a 250ms run overruns.
+    assert.equal(result, 'expired');
+});
+

--- a/tests/unit/browser-web-ai-response-dom-verdicts.test.ts
+++ b/tests/unit/browser-web-ai-response-dom-verdicts.test.ts
@@ -1,0 +1,84 @@
+// Cycle 4 (parity2 040): tri-state stop probe, ordering verdict, activity
+// strata grammar, unread-vs-empty, and finalizer deadline fencing.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    probeStopButton,
+    readTopLevelAssistantTextsFromLocators,
+    isActiveState,
+    CHATGPT_STOP_SELECTORS,
+} from '../../src/browser/web-ai/chatgpt-response-dom.ts';
+import { finalizeProviderTab } from '../../src/browser/web-ai/tab-finalizer.ts';
+import { createSession, getSession } from '../../src/browser/web-ai/session.ts';
+
+function mkLocator(nodes: unknown[]): unknown {
+    return { locator: () => ({ all: async () => nodes }) };
+}
+
+test('RD-STOP-1: visible stop node short-circuits to visible', async () => {
+    const scope = mkLocator([{ isVisible: async () => true }]);
+    assert.equal(await probeStopButton(scope), 'visible');
+});
+
+test('RD-STOP-2: unreadable probe is unknown, never absent', async () => {
+    const throwing = { locator: () => ({ all: async () => { throw new Error('cdp lost'); } }) };
+    assert.equal(await probeStopButton(throwing), 'unknown');
+    const partial = mkLocator([{ /* no isVisible */ }]);
+    assert.equal(await probeStopButton(partial), 'unknown');
+    assert.equal(await probeStopButton(null), 'unknown');
+});
+
+test('RD-STOP-3: fully-inspected empty scope is absent', async () => {
+    const scope = mkLocator([]);
+    assert.equal(await probeStopButton(scope), 'absent');
+});
+
+test('RD-STOP-4: form-scoped stop selector excludes dictation/voice/read-aloud', () => {
+    const labelled = CHATGPT_STOP_SELECTORS[1]!;
+    assert.match(labelled, /^form /);
+    assert.match(labelled, /dictat/);
+    assert.match(labelled, /voice/);
+});
+
+test('RD-LOC-1: partial locator read reports ok:false, not a smaller success', async () => {
+    const page = {
+        locator: () => ({
+            all: async () => [
+                { evaluate: async () => 'first turn' },
+                { evaluate: async () => { throw new Error('detached'); } },
+            ],
+        }),
+    };
+    const res = await readTopLevelAssistantTextsFromLocators(page as never, ['[x]']);
+    assert.equal(res.ok, false);
+    assert.deepEqual(res.texts, []);
+});
+
+test('RD-ACT-1: activity strength boolean view treats unknown as inactive', () => {
+    assert.equal(isActiveState({ strength: 'strong', evidence: 'stop-button' }), true);
+    assert.equal(isActiveState({ strength: 'weak', evidence: 'panel-text' }), true);
+    assert.equal(isActiveState({ strength: 'none', evidence: '' }), false);
+    assert.equal(isActiveState({ strength: 'unknown', evidence: '' }), false);
+});
+
+test('FIN-1: finalizer refuses all side effects once expired at entry', async () => {
+    const session = createSession({ vendor: 'chatgpt', targetId: 'T-fin-1', url: 'https://chatgpt.com/c/x', timeoutMs: 60_000, envelope: { vendor: 'chatgpt', question: 'q' }, assistantCount: 0 } as never);
+    const res = await finalizeProviderTab({
+        vendor: 'chatgpt', session, port: 1, url: 'https://chatgpt.com/c/x', answerText: 'answer',
+        stillActive: () => false,
+    });
+    assert.deepEqual(res, { finalized: false, skippedReason: 'poll-deadline-exceeded' });
+    assert.notEqual(getSession(session.sessionId)?.status, 'complete');
+});
+
+test('FIN-2: deadline passing between write and pool skips the pool phase only', async () => {
+    const session = createSession({ vendor: 'chatgpt', targetId: 'T-fin-2', url: 'https://chatgpt.com/c/y', timeoutMs: 60_000, envelope: { vendor: 'chatgpt', question: 'q' }, assistantCount: 0 } as never);
+    let calls = 0;
+    const res = await finalizeProviderTab({
+        vendor: 'chatgpt', session, port: 1, url: 'https://chatgpt.com/c/y', answerText: 'answer',
+        stillActive: () => { calls += 1; return calls <= 1; }, // active at entry, expired at re-check
+    });
+    assert.equal(res.finalized, true);
+    assert.equal(res.skippedReason, 'poll-deadline-exceeded');
+    assert.equal(getSession(session.sessionId)?.status, 'complete');
+});

--- a/tests/unit/browser-web-ai-resume-dr-multiturn.test.ts
+++ b/tests/unit/browser-web-ai-resume-dr-multiturn.test.ts
@@ -1,0 +1,58 @@
+// Cycle 7 (parity2 070): resume expiry, DR activity gate, multi-turn deadline.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runSessionsCommand } from '../../src/browser/web-ai/cli-sessions.ts';
+import { createSession, getSession } from '../../src/browser/web-ai/session.ts';
+import { sendMultiTurn } from '../../src/browser/web-ai/chatgpt-multi-turn.ts';
+
+function mkSession(overrides: Record<string, unknown> = {}) {
+    return createSession({
+        vendor: 'chatgpt', targetId: 'T-c7-' + Math.random().toString(36).slice(2), url: 'https://chatgpt.com/c/x',
+        envelope: { vendor: 'chatgpt', question: 'q' }, assistantCount: 0, timeoutMs: 60_000,
+        ...overrides,
+    } as never);
+}
+
+test('C7-RESUME-1: expired session refuses resume with a typed timeout outcome', async () => {
+    const session = mkSession({ timeoutMs: 1 });
+    // ensure the deadline has passed
+    await new Promise(r => setTimeout(r, 10));
+    const result = await runSessionsCommand(['resume', session.sessionId], {}, {}, {});
+    assert.equal(result['ok'], false);
+    assert.equal(result['status'], 'timeout');
+    assert.match(String(result['error']), /deadline already passed/);
+});
+
+test('C7-DOCTOR-1: sessions doctor is routed and returns a report', async () => {
+    const session = mkSession();
+    const result = await runSessionsCommand(['doctor', session.sessionId], {}, {}, {});
+    assert.equal(result['status'], 'session-doctor');
+    assert.equal(result['sessionId'], session.sessionId);
+});
+
+test('C7-MT-1: multi-turn outer deadline answers with the expiry envelope, no post-deadline writes', async () => {
+    const session = mkSession();
+    const preStatus = getSession(session.sessionId)?.status;
+    const page = {
+        url: () => 'https://chatgpt.com/c/x',
+        locator: () => ({
+            count: async () => { await new Promise(() => undefined); return 0; }, // never settles
+            all: async () => [],
+        }),
+        waitForTimeout: async () => undefined,
+        keyboard: { press: async () => undefined },
+        evaluate: async () => false,
+    };
+    const result = await sendMultiTurn(page as never, {}, {
+        followUps: ['follow-up 1'],
+        session,
+        timeoutPerTurn: 400,
+        outerBudgetMs: 1_500,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(result.warnings.includes('multi-turn-deadline-expired'), JSON.stringify(result.warnings));
+    assert.equal(result.finalStatus, 'partial');
+    // the losing run must not have flipped the session to complete/error after expiry
+    const post = getSession(session.sessionId)?.status;
+    assert.equal(post, preStatus);
+});

--- a/tests/unit/browser-web-ai-send-gates.test.ts
+++ b/tests/unit/browser-web-ai-send-gates.test.ts
@@ -1,0 +1,60 @@
+// Cycle 6 (parity2 060): send-flow fail-closed gates.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sendButtonTimeoutMs } from '../../src/browser/web-ai/chatgpt-attachments.ts';
+import { computeAttachmentTimeouts, CDP_INJECTION_THRESHOLD_BYTES } from '../../src/browser/web-ai/chatgpt-upload-surface.ts';
+import { submitPromptFromComposer } from '../../src/browser/web-ai/chatgpt-composer.ts';
+
+test('C6-SUBMIT-1: requireEnabledSendButton refuses Enter fallback with typed sentinel', async () => {
+    const page = {
+        evaluate: async () => false,
+        locator: () => ({
+            first: () => ({ isVisible: async () => false, isEnabled: async () => false, click: async () => undefined, evaluate: async () => null }),
+            count: async () => 0,
+            all: async () => [],
+        }),
+        getByRole: () => ({ count: async () => 0 }),
+        keyboard: { press: async () => { throw new Error('Enter must not be pressed with attachments pending'); } },
+        waitForTimeout: async () => undefined,
+    };
+    const result = await submitPromptFromComposer(page as never, { requireEnabledSendButton: true, sendButtonTimeoutMs: 200 });
+    assert.equal(result.method, 'none');
+    assert.equal(result.failure, 'send-button-disabled');
+});
+
+test('C6-SUBMIT-2: without the gate, Enter fallback still works', async () => {
+    let enterPressed = false;
+    const page = {
+        evaluate: async () => false,
+        locator: () => ({
+            first: () => ({ isVisible: async () => false, isEnabled: async () => false, click: async () => undefined, evaluate: async () => null }),
+            count: async () => 0,
+            all: async () => [],
+        }),
+        getByRole: () => ({ count: async () => 0 }),
+        keyboard: { press: async () => { enterPressed = true; } },
+        waitForTimeout: async () => undefined,
+    };
+    const result = await submitPromptFromComposer(page as never, { sendButtonTimeoutMs: 200 });
+    assert.equal(result.method, 'enter');
+    assert.equal(enterPressed, true);
+});
+
+test('C6-BUDGET-1: sendButtonTimeoutMs scales with total bytes', () => {
+    assert.equal(sendButtonTimeoutMs([]), 20_000);
+    const small = sendButtonTimeoutMs(['a.txt'], 1024);
+    const big = sendButtonTimeoutMs(['a.bin'], 100 * 1024 * 1024);
+    assert.ok(small >= 45_000);
+    assert.ok(big > small, `big (${big}) must exceed small (${small})`);
+});
+
+test('C6-BUDGET-2: computeAttachmentTimeouts scales and respects explicit override', () => {
+    const base = computeAttachmentTimeouts([{ sizeBytes: 1024 }]);
+    const big = computeAttachmentTimeouts([{ sizeBytes: 200 * 1024 * 1024 }]);
+    assert.ok(big.handoffMs > base.handoffMs);
+    assert.ok(big.acceptanceMs > base.acceptanceMs);
+    assert.ok(big.sendReadyMs > base.sendReadyMs);
+    const explicit = computeAttachmentTimeouts([{ sizeBytes: 200 * 1024 * 1024 }], { attachmentUploadTimeoutMs: 12_345 });
+    assert.equal(explicit.handoffMs, 12_345);
+    assert.ok(CDP_INJECTION_THRESHOLD_BYTES > 40 * 1024 * 1024);
+});

--- a/tests/unit/browser-web-ai-session-store-async.test.ts
+++ b/tests/unit/browser-web-ai-session-store-async.test.ts
@@ -1,0 +1,57 @@
+// Cycle 1 slice 1.2 (parity2 010): the async store lock must not freeze the
+// event loop while waiting, and a deadline that passes DURING the lock wait
+// must refuse the write.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    withStoreLock,
+    withStoreLockAsync,
+    insertSessionAsync,
+    patchSessionAsync,
+    insertSession,
+    listStoredSessions,
+    DEADLINE_PASSED,
+} from '../../src/browser/web-ai/session-store.ts';
+
+test('SS-A1: withStoreLockAsync keeps timers running while waiting for a held lock', async () => {
+    // Hold the lock in the sync form, and while held, start an async acquisition.
+    let timerFired = false;
+    const timer = setTimeout(() => { timerFired = true; }, 50);
+    const result = await withStoreLock(() => {
+        // The async acquisition must WAIT (lock held) without freezing the loop.
+        const pending = withStoreLockAsync(() => 'acquired-later');
+        // Give the event loop a beat inside the held section via a microtask chain;
+        // the sync holder returns immediately after starting the async wait.
+        return pending;
+    });
+    await new Promise(r => setTimeout(r, 120));
+    clearTimeout(timer);
+    assert.equal(await result, 'acquired-later');
+    assert.equal(timerFired, true, 'a 50ms timer fired while the async lock was waiting — loop not frozen');
+});
+
+test('SS-A2: patchSessionAsync refuses the write when the deadline passed during the wait', async () => {
+    insertSession({ sessionId: 'sess-dl-1', vendor: 'chatgpt', status: 'sent', createdAt: new Date().toISOString() });
+    const outcome = await patchSessionAsync('sess-dl-1', { status: 'complete' }, () => false);
+    assert.equal(outcome, DEADLINE_PASSED);
+    const row = listStoredSessions({ sessionId: 'sess-dl-1' })[0];
+    assert.equal(row?.status, 'sent', 'refused write left disk unchanged');
+});
+
+test('SS-A3: patchSessionAsync writes when still active; null for missing session', async () => {
+    insertSession({ sessionId: 'sess-dl-2', vendor: 'chatgpt', status: 'sent', createdAt: new Date().toISOString() });
+    const ok = await patchSessionAsync('sess-dl-2', { status: 'complete' }, () => true);
+    assert.ok(ok && ok !== DEADLINE_PASSED && ok.status === 'complete');
+    const missing = await patchSessionAsync('sess-none', { status: 'complete' });
+    assert.equal(missing, null);
+});
+
+test('SS-A4: insertSessionAsync honors the stillActive gate', async () => {
+    const refused = await insertSessionAsync({ sessionId: 'sess-dl-3', vendor: 'grok', status: 'sent', createdAt: new Date().toISOString() }, () => false);
+    assert.equal(refused, DEADLINE_PASSED);
+    assert.equal(listStoredSessions({ sessionId: 'sess-dl-3' }).length, 0);
+    const written = await insertSessionAsync({ sessionId: 'sess-dl-4', vendor: 'grok', status: 'sent', createdAt: new Date().toISOString() });
+    assert.ok(written !== DEADLINE_PASSED);
+    assert.equal(listStoredSessions({ sessionId: 'sess-dl-4' }).length, 1);
+});
+

--- a/tests/unit/browser-web-ai-session-store-corrupt.test.ts
+++ b/tests/unit/browser-web-ai-session-store-corrupt.test.ts
@@ -1,0 +1,41 @@
+// Cycle 1 slices 1.3 + 1.4 (parity2 010): corrupt store observed, env grammar strict.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import {
+    readSessionStore,
+    readSessionStoreObserved,
+    assertStoreReadable,
+    insertSession,
+    storePath,
+} from '../../src/browser/web-ai/session-store.ts';
+
+function corruptStore(): void {
+    const p = storePath();
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, '{ not json !!!', 'utf8');
+}
+
+test('SS-C1: corrupt store read is observed, not silently collapsed', () => {
+    corruptStore();
+    const { store, storeReadFailed } = readSessionStoreObserved();
+    assert.equal(store.sessions.length, 0);
+    assert.ok(storeReadFailed, 'marker set');
+    assert.ok(storeReadFailed!.path.length > 0);
+    // legacy read shape still returns the empty store for read-only callers
+    assert.equal(readSessionStore().sessions.length, 0);
+});
+
+test('SS-C2: write path throws session-store-read-failed over a corrupt store', () => {
+    corruptStore();
+    assert.throws(() => assertStoreReadable(), /session store unreadable/);
+    assert.throws(
+        () => insertSession({ sessionId: 'sess-corrupt-1', vendor: 'chatgpt', status: 'sent', createdAt: new Date().toISOString() }),
+        (err: unknown) => (err as { errorCode?: string }).errorCode === 'session-store-read-failed',
+    );
+    // disk unchanged: the corrupt payload was not overwritten with an empty store
+    const { storeReadFailed } = readSessionStoreObserved();
+    assert.ok(storeReadFailed, 'corrupt file still present, not clobbered');
+});
+

--- a/tests/unit/browser-web-ai-surface-detection.test.ts
+++ b/tests/unit/browser-web-ai-surface-detection.test.ts
@@ -1,0 +1,64 @@
+// Cycle 8a (parity2 080): Work/Chat surface detection, fail-closed.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectChatGptComposerSurface, detectChatGptWorkAvailability } from '../../src/browser/web-ai/product-surfaces.ts';
+
+function radioPage(entries: Array<{ text: string; checked: string | null; dataState: string | null; visible?: boolean }>, probeState = 'unresolved'): unknown {
+    return {
+        url: () => 'https://chatgpt.com/c/abc-123',
+        evaluate: async () => ({ state: probeState, evidence: {} }),
+        locator: () => ({
+            count: async () => entries.length,
+            nth: (i: number) => ({
+                isVisible: async () => entries[i]?.visible !== false,
+                textContent: async () => entries[i]?.text ?? '',
+                getAttribute: async (name: string) => name === 'aria-checked' ? entries[i]?.checked ?? null : entries[i]?.dataState ?? null,
+            }),
+        }),
+    };
+}
+
+test('C8-SURF-1: chat active + work inactive → chat', async () => {
+    const page = radioPage([
+        { text: 'Chat', checked: 'true', dataState: 'on' },
+        { text: 'Work', checked: 'false', dataState: 'off' },
+    ]);
+    const d = await detectChatGptComposerSurface(page as never);
+    assert.deepEqual({ ui: d.ui, surface: d.surface }, { ui: 'toggle', surface: 'chat' });
+});
+
+test('C8-SURF-2: work active → work; availability reflects both', async () => {
+    const page = radioPage([
+        { text: 'Chat', checked: 'false', dataState: 'off' },
+        { text: 'Work', checked: 'true', dataState: 'on' },
+    ]);
+    const d = await detectChatGptComposerSurface(page as never);
+    assert.equal(d.surface, 'work');
+    const avail = await detectChatGptWorkAvailability(page as never);
+    assert.deepEqual({ available: avail.available, active: avail.active }, { available: true, active: true });
+});
+
+test('C8-SURF-3: attribute mismatch / one-sided / both-active are AMBIGUOUS, never a guess', async () => {
+    for (const entries of [
+        [{ text: 'Chat', checked: 'true', dataState: 'off' }, { text: 'Work', checked: 'false', dataState: 'off' }], // mismatch
+        [{ text: 'Chat', checked: 'true', dataState: 'on' }], // one-sided
+        [{ text: 'Chat', checked: 'true', dataState: 'on' }, { text: 'Work', checked: 'true', dataState: 'on' }], // both active
+        [{ text: 'Chat', checked: 'true', dataState: 'on' }, { text: 'Work', checked: 'false', dataState: 'off', visible: false }], // hidden work
+    ] as never[]) {
+        const d = await detectChatGptComposerSurface(radioPage(entries as never) as never);
+        assert.equal(d.surface, 'ambiguous', JSON.stringify(entries));
+    }
+});
+
+test('C8-SURF-4: no toggle radios → legacy probe decides (work conversation detected)', async () => {
+    const page = radioPage([], 'work');
+    const d = await detectChatGptComposerSurface(page as never);
+    assert.deepEqual({ ui: d.ui, surface: d.surface }, { ui: 'legacy', surface: 'work' });
+});
+
+test('C8-SURF-5: legacy probe unresolved → surface null (send proceeds as chat-legacy)', async () => {
+    const page = radioPage([], 'unresolved');
+    const d = await detectChatGptComposerSurface(page as never);
+    assert.deepEqual({ ui: d.ui, surface: d.surface }, { ui: 'legacy', surface: null });
+});
+

--- a/tests/unit/browser-web-ai-tier-timeout.test.ts
+++ b/tests/unit/browser-web-ai-tier-timeout.test.ts
@@ -10,11 +10,15 @@ import {
 test('BWAI-TIER-001: tier table + lookup (deep-research/pro → 1h, unknown → 1200)', () => {
     assert.equal(TIER_DEFAULT_TIMEOUT_SEC['deep-research'], 3600);
     assert.equal(tierDefaultTimeoutSec('deep-research'), 3600);
-    assert.equal(tierDefaultTimeoutSec('pro'), 3600);
+    assert.equal(tierDefaultTimeoutSec('pro'), 5400);
+    assert.equal(tierDefaultTimeoutSec('chatgpt-pro'), 5400);
+    assert.equal(tierDefaultTimeoutSec('grok-heavy'), 3600);
     assert.equal(tierDefaultTimeoutSec('thinking'), 600);
     assert.equal(tierDefaultTimeoutSec('instant'), 120);
     assert.equal(tierDefaultTimeoutSec(null), 1200);
     assert.equal(tierDefaultTimeoutSec('bogus'), 1200);
+    assert.equal(tierDefaultTimeoutSec(null, 'grok'), 600);
+    assert.equal(tierDefaultTimeoutSec('bogus', 'gemini'), 1200);
 });
 
 test('BWAI-TIER-002: chatgpt deep-research resolves to a 1h default (catalog 105.4 bug)', () => {
@@ -26,7 +30,8 @@ test('BWAI-TIER-002: chatgpt deep-research resolves to a 1h default (catalog 105
 });
 
 test('BWAI-TIER-003: chatgpt model choices map to tiers', () => {
-    assert.equal(resolveTimeoutDefaultSec({ model: 'pro' }, 'chatgpt'), 3600);
+    // parity2 030 slice 3.3 (C-19): Pro runs get the 1.5h agbrowse chatgpt-pro budget.
+    assert.equal(resolveTimeoutDefaultSec({ model: 'pro' }, 'chatgpt'), 5400);
     assert.equal(resolveTimeoutDefaultSec({ model: 'instant' }, 'chatgpt'), 120);
     assert.equal(resolveTimeoutDefaultSec({ model: 'thinking' }, 'chatgpt'), 600);
 });

--- a/tests/unit/browser-web-ai-vendor-diag-hardening.test.ts
+++ b/tests/unit/browser-web-ai-vendor-diag-hardening.test.ts
@@ -1,0 +1,44 @@
+// Cycle 9 (parity2 090): vendor hardening + diagnostics wiring + DR marker.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyComposerInterstitial } from '../../src/browser/web-ai/composer-interstitial.ts';
+import { looksLikeDeepResearchToolCallCapture, isIncompleteDeepResearchText } from '../../src/browser/web-ai/chatgpt-deep-research-report.ts';
+import { captureWebAiDiagnostics } from '../../src/browser/web-ai/diagnostics.ts';
+import { createSession, getSession } from '../../src/browser/web-ai/session.ts';
+
+test('C9-INT-1: interstitial verdict becomes a typed provider error; probe failure keeps the original', async () => {
+    const detect = async () => ({ kind: 'cloudflare' as const, evidence: 'checking your browser', retryHint: 'wait-and-retry' });
+    const err = await classifyComposerInterstitial({} as never, 'gemini', new Error('composer'), { detect: detect as never });
+    assert.ok(err);
+    assert.equal((err as { errorCode?: string }).errorCode, 'provider.interstitial');
+    const throwing = async () => { throw new Error('probe died'); };
+    const none = await classifyComposerInterstitial({} as never, 'grok', new Error('composer'), { detect: throwing as never });
+    assert.equal(none, null);
+});
+
+test('C9-DR-1: tool-call wrappers rejected as reports; boundary respected', () => {
+    const longPad = ' report body '.repeat(50);
+    assert.equal(looksLikeDeepResearchToolCallCapture('Called tool: Deep Research App' + longPad), true);
+    assert.equal(looksLikeDeepResearchToolCallCapture('Answer: used tool — browsing' + longPad), true);
+    // token boundary: a report TITLED "Used Tools…" is NOT a wrapper
+    assert.equal(looksLikeDeepResearchToolCallCapture('Used Toolsets in Modern Oncology' + longPad), false);
+    assert.equal(isIncompleteDeepResearchText('Called tool: Deep Research App' + longPad), true);
+});
+
+test('C9-DIAG-1: diagnostics with a sessionId persists an artifact ref', async () => {
+    const session = createSession({
+        vendor: 'chatgpt', targetId: 'T-diag', url: 'https://chatgpt.com/c/x',
+        envelope: { vendor: 'chatgpt', question: 'q' }, assistantCount: 0, timeoutMs: 60_000,
+    } as never);
+    const page = {
+        url: () => 'https://chatgpt.com/c/x',
+        title: async () => 'test',
+        locator: () => ({ count: async () => 0, first: () => ({ isVisible: async () => false }) }),
+        evaluate: async () => ({ url: 'https://chatgpt.com/c/x', title: 'test', selectorCounts: {}, visibleCounts: {}, warnings: [] }),
+    };
+    const diag = await captureWebAiDiagnostics({ stage: 'send-click', page: page as never, sessionId: session.sessionId });
+    assert.ok(diag.artifactRefs.length >= 1, JSON.stringify({ refs: diag.artifactRefs, warnings: diag.warnings }));
+    const record = getSession(session.sessionId);
+    assert.ok((record?.artifacts || []).length >= 1, 'artifact descriptor appended to the session');
+});
+

--- a/tests/unit/browser-web-ai-work-picker.test.ts
+++ b/tests/unit/browser-web-ai-work-picker.test.ts
@@ -1,0 +1,101 @@
+// Cycle 8b (parity2): Work picker core contracts.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    WORK_POWER_MAP,
+    normalizeWorkPower,
+    normalizeWorkSpeed,
+    readWorkPickerState,
+    readWorkTaskState,
+    assertWorkSessionPollable,
+} from '../../src/browser/web-ai/chatgpt-work-picker.ts';
+
+test('W8B-MAP-1: power mapping table 1..6', () => {
+    assert.equal(WORK_POWER_MAP.length, 6);
+    assert.deepEqual(normalizeWorkPower(1), { power: 1, domValue: 0, compactLabel: '5.6 Terra Light', model: 'GPT-5.6 Terra', effort: 'Light' });
+    assert.equal(normalizeWorkPower(6).effort, 'Ultra');
+    assert.equal(normalizeWorkPower('4').model, 'GPT-5.6 Sol');
+    for (const bad of [0, 7, 1.5, 'banana', null, undefined]) {
+        assert.throws(() => normalizeWorkPower(bad), (e: unknown) => (e as { retryHint?: string }).retryHint === 'fix-power', String(bad));
+    }
+    assert.equal(normalizeWorkSpeed(null), null);
+    assert.equal(normalizeWorkSpeed('fast'), 'fast');
+    assert.throws(() => normalizeWorkSpeed('turbo'));
+});
+
+function pickerPage(input: { domValue?: number | null; valueText?: string | null; simple?: boolean }): unknown {
+    return {
+        locator: (sel: string) => ({
+            first: () => ({
+                isVisible: async () => sel.includes('simple-view') ? input.simple !== false : false,
+                getAttribute: async (name: string) => {
+                    if (name === 'aria-valuenow') return input.domValue != null ? String(input.domValue) : null;
+                    if (name === 'aria-valuemin') return '0';
+                    if (name === 'aria-valuemax') return '5';
+                    if (name === 'aria-valuetext') return input.valueText ?? null;
+                    return null;
+                },
+            }),
+            count: async () => sel.includes('[role="slider"]') ? 1 : 0,
+        }),
+    };
+}
+
+test('W8B-STATE-1: picker state derives power/model/effort from the slider', async () => {
+    const state = await readWorkPickerState(pickerPage({ domValue: 3, valueText: '5.6 Sol High, 4 of 6.' }) as never);
+    assert.equal(state.power, 4);
+    assert.equal(state.compactLabel, '5.6 Sol High');
+    assert.equal(state.model, 'GPT-5.6 Sol');
+    assert.equal(state.effort, 'High');
+});
+
+function taskPage(input: { stop: 'visible' | 'absent' | 'throws'; copyVisible?: boolean; answer?: string }): unknown {
+    const page: Record<string, unknown> = {
+        locator: (sel: string) => ({
+            // scopeToMainRegion('main') returns this same shape
+            locator: (inner: string) => page['locator'] instanceof Function ? (page['locator'] as (s: string) => unknown)(inner) : null,
+            all: async () => {
+                if (sel.includes('stop') || sel.includes('Stop')) {
+                    if (input.stop === 'throws') throw new Error('unreadable');
+                    return input.stop === 'visible' ? [{ isVisible: async () => true }] : [];
+                }
+                return [];
+            },
+            first: () => ({
+                isVisible: async () => sel.includes('Copy') ? Boolean(input.copyVisible) : false,
+                textContent: async () => input.answer ?? null,
+            }),
+            count: async () => sel.includes('assistant') ? (input.answer ? 1 : 0) : 0,
+            last: () => ({ textContent: async () => input.answer ?? null }),
+            getByText: () => null,
+        }),
+        getByText: () => null,
+    };
+    return page;
+}
+
+test('W8B-TASK-1: running when stop visible; unknown fails closed on unreadable probe', async () => {
+    const running = await readWorkTaskState(taskPage({ stop: 'visible' }) as never);
+    assert.equal(running.status, 'running');
+    const unknown = await readWorkTaskState(taskPage({ stop: 'throws', copyVisible: true, answer: 'partial' }) as never);
+    assert.equal(unknown.status, 'unknown', 'leftover Copy must not read as finished when the stop probe failed');
+});
+
+test('W8B-TASK-2: complete only with copy evidence and readable absent stop', async () => {
+    const complete = await readWorkTaskState(taskPage({ stop: 'absent', copyVisible: true, answer: 'the answer' }) as never);
+    assert.equal(complete.status, 'complete');
+    assert.equal(complete.answerText, 'the answer');
+});
+
+test('W8B-GUARD-1: reattach guards reject target mismatch and bare-origin URLs', () => {
+    assert.throws(
+        () => assertWorkSessionPollable({ sessionId: 's1', targetId: 'T1', conversationUrl: 'https://chatgpt.com/c/x' }, 'T2'),
+        (e: unknown) => (e as { errorCode?: string }).errorCode === 'provider.work-reattach-unverified',
+    );
+    assert.throws(
+        () => assertWorkSessionPollable({ sessionId: 's2', targetId: 'T1', conversationUrl: 'https://chatgpt.com/' }, 'T1'),
+        (e: unknown) => (e as { retryHint?: string }).retryHint === 'resend-work',
+    );
+    assert.doesNotThrow(() => assertWorkSessionPollable({ sessionId: 's3', targetId: 'T1', conversationUrl: 'https://chatgpt.com/c/x' }, 'T1'));
+});
+


### PR DESCRIPTION
Port agbrowse web-ai capabilities into cli-jaw through the parity2 docs-first PABCD cycle. Includes hard poll deadlines, fail-closed recovery and capture gates, GPT-5.6 Power UI support, send/upload hardening, DR/multi-turn integrity, Work surface primitives, vendor diagnostics, and active-command protection. Local gates: TypeScript clean; remaining test failures are the pinned non-web-ai baseline.