### PR TITLE
chore: promote v2.17.13

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.13-preview.20260822094757",
+  "version": "2.17.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.13-preview.20260822094757",
+      "version": "2.17.13",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.13-preview.20260822094757",
+  "version": "2.17.13",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.13-preview.20260822094757",
+  "version": "2.17.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.13-preview.20260822094757",
+      "version": "2.17.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.13-preview.20260822094757",
+  "version": "2.17.13",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Promotes certified preview 2.17.13-preview.20260822094757 at d3e8b58a515b3b0cbd3475e4a8c4daf05b5da99f. Tests: https://github.com/lidge-jun/cli-jaw/actions/runs/32543667001