### PR TITLE
fix(messaging): #419 리뷰 결함 3건 재적용 — UTF-8 디코딩, 큐 클로저 누수, malformed 허용목록

### DIFF
--- a/src/slack/auto-join.ts
+++ b/src/slack/auto-join.ts
@@ -15,6 +15,7 @@
 
 import { log } from '../core/logger.js';
 import { redactChannelSecrets } from '../messaging/redact.js';
+import { MALFORMED_SLACK_ALLOWLIST } from './events.js';
 import {
     listSlackConversations,
     joinSlackConversation,
@@ -187,6 +188,12 @@ export type SlackAutoJoinOptions = {
      * outside it would hand the agent read access to channels the same
      * operator deliberately put out of reach (#406 is the mirror of this
      * mistake). Auto-join stays inside the line the operator drew.
+     *
+     * A MALFORMED value is a third case, and the one that used to fail open.
+     * `readSlackAllowlist` reports it as a single unmatchable sentinel, which
+     * denies every channel inbound. Read here as an ordinary one-entry list it
+     * would merely skip everything — right by accident, and only for as long as
+     * the sentinel stays unmatchable. It is now detected and stops the run.
      */
     allowlist?: readonly string[];
 };
@@ -204,6 +211,18 @@ export async function runSlackAutoJoin(opts: SlackAutoJoinOptions): Promise<Slac
     };
     const { token, config } = opts;
     if (!config.enabled || !token) return result;
+
+    // A malformed inbound allowlist means the operator's boundary could not be
+    // read. Joining is a VISIBLE workspace mutation, so an unreadable boundary
+    // must stop the run outright rather than be treated as one odd channel name
+    // that happens to match nothing. Skipping every channel would look the same
+    // today and silently start joining the moment the sentinel changes.
+    if ((opts.allowlist ?? []).includes(MALFORMED_SLACK_ALLOWLIST)) {
+        result.abortedReason = 'malformed_allowlist';
+        log.warn('[slack:autojoin] slack.channelIds is malformed — refusing to join any channel.'
+            + ' Fix the allowlist (an array of channel ids) and restart.');
+        return result;
+    }
 
     const sleep = opts.sleep ?? defaultSleep;
     const signal = opts.signal;

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -85,12 +85,6 @@ let forwarderHandler: BroadcastListener | null = null;
 let selfUserId: string | null = null;
 let slackInitLock = false;
 /**
- * Listeners waiting on a queued agent result. Tracked so shutdown can drop
- * them immediately instead of leaving them armed for their 5-minute timeout,
- * which would let a post-shutdown result fire against a dead transport.
- */
-const pendingQueueWaiters = new Set<() => void>();
-/**
  * Request ids a live queued-reply listener is already waiting on. The
  * target-reply forwarder checks this so a result does not get posted twice: once
  * by the requester that is still here, once by the fallback that exists for the
@@ -469,6 +463,9 @@ async function slackOrchestrate(
         // else would hold it. Handing back the winner's promise makes both paths
         // converge on the same completion.
         let terminal: Promise<void> | null = null;
+        // Assigned immediately below, but referenced by finishExpired, which is
+        // defined first. Declared here so the terminal claim can unregister.
+        let unregister: () => void = () => {};
         const claimTerminal = (run: () => Promise<void>): Promise<void> => {
             if (!terminal) {
                 terminal = run().catch(e => log.info('[slack:queue]', logErrorText(e)));
@@ -477,18 +474,28 @@ async function slackOrchestrate(
         };
         const finishExpired = (signal?: AbortSignal) => claimTerminal(async () => {
             disposeListener();
-            // Started together, not in sequence: awaiting the notice first can
-            // eat the whole drain deadline before the reaction is even attempted.
-            await Promise.allSettled([
-                notice.close('expired', signal),
-                ack?.settle('failure') ?? Promise.resolve(),
-            ]);
-            // The in-process handle just closed this notice, so the durable record
-            // has nothing left to restore. Dropping it here is what keeps the next
-            // boot from rewriting a message this turn already dealt with.
-            if (requestId) closeSlackNoticeRecord(requestId);
+            try {
+                // Started together, not in sequence: awaiting the notice first can
+                // eat the whole drain deadline before the reaction is even attempted.
+                await Promise.allSettled([
+                    notice.close('expired', signal),
+                    ack?.settle('failure') ?? Promise.resolve(),
+                ]);
+                // The in-process handle just closed this notice, so the durable
+                // record has nothing left to restore. Dropping it here is what
+                // keeps the next boot from rewriting a message this turn already
+                // dealt with.
+                if (requestId) closeSlackNoticeRecord(requestId);
+            } finally {
+                // Centralized here, as in the Discord path: every terminal route
+                // passes through a claim, so unregistering in one place is what
+                // makes "exactly once" true. The plain timeout used to leave its
+                // registry entry behind, so a later shutdown re-ran a turn that
+                // had already finished.
+                unregister();
+            }
         });
-        const unregister = slackNoticeRegistry.add((signal) => finishExpired(signal));
+        unregister = slackNoticeRegistry.add((signal) => finishExpired(signal));
         const queueHandler = async (type: string, data: Record<string, unknown>) => {
             if (type !== 'orchestrate_done' || !data["text"] || data["origin"] !== 'slack'
                 || data["requestId"] !== requestId) return;
@@ -498,21 +505,28 @@ async function slackOrchestrate(
             // would leave a failed send with neither answer nor notice.
             disposeListener();
             await claimTerminal(async () => {
-                const text = String(data["text"]);
-                const queuedSendResult = await sendSlackText(token, target, text);
-                await notice.close(queuedSendResult.ok ? 'answered' : 'expired');
-                if (queuedSendResult.ok && target.threadId) {
-                    markThreadParticipated(target.targetId, target.threadId);
+                try {
+                    const text = String(data["text"]);
+                    const queuedSendResult = await sendSlackText(token, target, text);
+                    await notice.close(queuedSendResult.ok ? 'answered' : 'expired');
+                    if (queuedSendResult.ok && target.threadId) {
+                        markThreadParticipated(target.targetId, target.threadId);
+                    }
+                    // Settled before the relay for the same reason as the normal
+                    // path: the text is what the user was waiting for, and an
+                    // uncancellable upload must not hold the reaction on running.
+                    await ack?.settle(queuedSendResult.ok ? 'success' : 'failure');
+                    await relaySlackImages(token, target, text).catch(
+                        e => log.error('[slack:queue-send]', logErrorText(e)));
+                    // The notice is closed, so the durable record has nothing
+                    // left to restore on the next boot (#418).
+                    if (requestId) closeSlackNoticeRecord(requestId);
+                } finally {
+                    // Same "exactly once" reasoning as finishExpired: whichever
+                    // path claims the terminal owns the registry cleanup.
+                    unregister();
                 }
-                // Settled before the relay for the same reason as the normal
-                // path: the text is what the user was waiting for, and an
-                // uncancellable upload must not hold the reaction on running.
-                await ack?.settle(queuedSendResult.ok ? 'success' : 'failure');
-                await relaySlackImages(token, target, text).catch(
-                    e => log.error('[slack:queue-send]', logErrorText(e)));
-                if (requestId) closeSlackNoticeRecord(requestId);
             });
-            unregister();
         };
         // Everything below is armed SYNCHRONOUSLY, before any await. A reaction
         // call that takes a moment must not be able to outlive the completion it
@@ -521,7 +535,6 @@ async function slackOrchestrate(
         // standing fallback forwarder instead (#407).
         addBroadcastListener(queueHandler);
         if (requestId) pendingQueueRequestIds.add(requestId);
-        pendingQueueWaiters.add(() => { void finishExpired(); });
         queueTimeout = setTimeout(() => { void finishExpired(); }, 300000);
         // Only now, with the lifecycle armed. Not awaited: the notice below is
         // what the user needs to see, and the reaction is decoration on top.
@@ -1233,8 +1246,13 @@ async function disposeSlackRuntime(): Promise<void> {
     // is still working, while an unbounded await would hold shutdown open on a
     // stuck vendor call. The deadline covers the worst honest chain and the
     // signal cancels whatever is left.
-    for (const dispose of [...pendingQueueWaiters]) dispose();
-    pendingQueueWaiters.clear();
+    //
+    // The registry is the single shutdown route, as on Discord. A parallel
+    // waiter set used to hold one closure per queued turn and was cleared only
+    // here, so a long-lived instance retained every historical turn's token,
+    // target, notice and ACK closure. It also stripped the drain's abort signal:
+    // a QueueNotice pins the signal from its FIRST close, so a waiter closing
+    // without one made the later shutdown signal unreachable.
     await slackNoticeRegistry.drain(SLACK_NOTICE_DRAIN_MS);
     pendingQueueRequestIds.clear();
     socketClient?.stop();

--- a/src/telegram/ipv4-fetch.ts
+++ b/src/telegram/ipv4-fetch.ts
@@ -69,14 +69,25 @@ export function createIpv4Fetch(deps: Ipv4FetchDeps = {}) {
                     : ((headersInit as Record<string, string>) || {}),
             };
             const req = request(opts, (res) => {
-                let data = '';
-                res.on('data', (c: string) => data += c);
-                res.on('end', () => resolve({
-                    ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
-                    status: res.statusCode,
-                    json: () => Promise.resolve(JSON.parse(data)),
-                    text: () => Promise.resolve(data),
-                }));
+                // Collect BYTES and decode once at the end. Concatenating
+                // per-chunk strings decodes each chunk in isolation, so a
+                // multi-byte UTF-8 character split across a chunk boundary is
+                // corrupted into replacement characters — and JSON.parse still
+                // SUCCEEDS on the result, so the damage travels silently into
+                // message text. Telegram payloads are routinely non-ASCII.
+                const chunks: Buffer[] = [];
+                res.on('data', (c: Buffer | string) => {
+                    chunks.push(typeof c === 'string' ? Buffer.from(c, 'utf8') : c);
+                });
+                res.on('end', () => {
+                    const data = Buffer.concat(chunks).toString('utf8');
+                    resolve({
+                        ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
+                        status: res.statusCode,
+                        json: () => Promise.resolve(JSON.parse(data)),
+                        text: () => Promise.resolve(data),
+                    });
+                });
             });
             req.on('error', reject);
             if (signal) {
@@ -93,4 +104,3 @@ export function createIpv4Fetch(deps: Ipv4FetchDeps = {}) {
         });
     };
 }
-

--- a/tests/unit/slack-auto-join.test.ts
+++ b/tests/unit/slack-auto-join.test.ts
@@ -13,6 +13,7 @@ import {
     SLACK_AUTO_JOIN_DEFAULTS,
     type SlackAutoJoinConfig,
 } from '../../src/slack/auto-join.ts';
+import { MALFORMED_SLACK_ALLOWLIST, readSlackAllowlist } from '../../src/slack/events.ts';
 
 type Captured = { method: string; body: Record<string, string> };
 
@@ -122,10 +123,44 @@ test('a stale generation cancels the run even without an abort signal', async ()
         { ok: true },
     ]);
     const result = await runSlackAutoJoin({
-        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        token: 'xoxb-t', config: config(), fetchImpl,
+        // The generation must go stale DURING the run. Flipping it after
+        // runSlackAutoJoin resolves leaves isCurrent() true for the whole scan,
+        // which is how the previous version of this test passed while proving
+        // nothing. The join pacing sleep is the seam that gets us mid-run.
+        sleep: async () => { current = false; },
         isCurrent: () => current,
     });
-    void calls; void result; void (current = false);
+    assert.equal(result.cancelled, true, 'a superseded generation must cancel the run');
+    assert.equal(calls.filter(c => c.method === 'conversations.join').length, 1,
+        'the second join must not fire once the generation is stale');
+});
+
+// A malformed slack.channelIds is not "one channel that matches nothing". It is
+// the operator's boundary being unreadable, and joining is a visible mutation.
+test('a malformed inbound allowlist stops the run instead of joining everything', async () => {
+    const { fetchImpl, calls } = scriptedFetch([
+        page([{ id: 'C_A', name: 'general', is_member: false }], ''),
+        { ok: true },
+    ]);
+    const result = await runSlackAutoJoin({
+        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        allowlist: readSlackAllowlist('not-an-array'),
+    });
+    assert.equal(result.abortedReason, 'malformed_allowlist');
+    assert.deepEqual(result.joined, []);
+    assert.equal(calls.length, 0,
+        'a malformed boundary must stop before conversations.list, not merely skip rows');
+});
+
+test('the malformed sentinel is refused even if it arrives directly', async () => {
+    const { fetchImpl, calls } = scriptedFetch([page([], '')]);
+    const result = await runSlackAutoJoin({
+        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        allowlist: [MALFORMED_SLACK_ALLOWLIST],
+    });
+    assert.equal(result.abortedReason, 'malformed_allowlist');
+    assert.equal(calls.length, 0);
 });
 
 test('one channel refusing does not end the scan', async () => {
@@ -332,4 +367,3 @@ test('the exclude list is scrubbed: non-strings, blanks and hashes', () => {
 test('a non-array exclude value cannot poison the run', () => {
     assert.deepEqual(mergeSlackAutoJoin(undefined, { exclude: 'C_ONE' }).exclude, []);
 });
-

--- a/tests/unit/telegram-fetch-cancel.test.ts
+++ b/tests/unit/telegram-fetch-cancel.test.ts
@@ -73,6 +73,42 @@ test('a request with no signal still completes normally', async () => {
     await new Promise<void>(resolve => server.close(() => resolve()));
 });
 
+// A multi-byte character split across TCP chunks used to be decoded per chunk
+// and corrupted into replacement characters. JSON.parse still succeeded on the
+// result, so nothing failed loudly — the damage only showed up as mojibake in
+// message text, which is a routine case for a Korean-language deployment.
+test('a UTF-8 character split across chunks is decoded intact', async () => {
+    const payload = Buffer.from(JSON.stringify({ ok: true, text: '안녕하세요 세계' }), 'utf8');
+    // The cut MUST land inside a multi-byte character, not merely between two
+    // chunks — a split at an ASCII boundary decodes cleanly either way and the
+    // test would pass against the very bug it exists to catch. '안' starts at
+    // byte 19 and is three bytes wide, so 20 lands mid-syllable. Asserted below
+    // rather than trusted, since the offset moves if the payload is edited.
+    const cut = 20;
+    assert.notEqual(payload.subarray(0, cut).toString('utf8').at(-1), '안',
+        'the cut must fall inside a multi-byte character for this test to bite');
+    const server = createServer((_req, res) => {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(payload.subarray(0, cut));
+        // Flush the first chunk on its own so the second arrives as a separate
+        // 'data' event rather than being coalesced into one buffer.
+        setTimeout(() => res.end(payload.subarray(cut)), 20);
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+        const result = await localFetch()(`http://127.0.0.1:${port}/`, {}) as {
+            json(): Promise<{ text: string }>; text(): Promise<string>;
+        };
+        assert.equal((await result.json()).text, '안녕하세요 세계');
+        assert.equal((await result.text()).includes('\uFFFD'), false,
+            'no replacement characters may survive the chunk boundary');
+    } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+});
+
 test('bot.ts wires the production factory rather than an inline closure', async () => {
     // Guards the seam: an inline reimplementation in bot.ts would make every
     // test above prove only this file.


### PR DESCRIPTION
#419 리뷰에서 확인된 결함 3건입니다. **현재 `main`/`dev` 에 그대로 배포되어 있습니다.**

#421 로 한 번 올렸으나 해당 PR 번호가 다른 작업(`chore(gates): raise strict-baseline`)으로 대체되면서 브랜치와 커밋이 원격에서 사라졌습니다. 로컬에 남아 있던 커밋을 현재 `dev` (`9c6fb22a`) 위로 rebase 해 다시 올립니다.

`src/slack/bot.ts` 는 #418 durable queue-notice store 와 겹쳐 충돌했고, **양쪽을 모두 살려 병합했습니다** — `closeSlackNoticeRecord` 호출은 유지하고 `unregister()` 를 `finally` 로 감쌌습니다.

## 1. Telegram 응답이 청크 경계에서 깨진다

`createIpv4Fetch` 가 각 청크를 개별적으로 문자열 변환해 이어붙입니다 (`data += c`). 멀티바이트 문자가 TCP 청크 경계에 걸리면 조각마다 따로 디코딩되어 손상됩니다.

**조용한 이유**: 손상된 결과도 `JSON.parse` 는 성공합니다. 예외도 로그도 없이 mojibake 가 메시지 본문으로 흘러갑니다. 한국어 배포에서는 응답이 조금만 길어져도 닿는 경로입니다.

```
naive  : {"text":"���녕하세요 세계"}
correct: {"text":"안녕하세요 세계"}
JSON.parse(naive) -> OK          <- 아무것도 실패하지 않는다
```

바이트를 모아 마지막에 한 번 디코딩합니다.

## 2. 큐 턴이 클로저를 누수하고, 타임아웃이 registry 에 잔류한다

한 자리에 두 결함이 있습니다.

**`pendingQueueWaiters` 가 비워지지 않는다.** 큐 턴마다 익명 클로저를 넣는데 `disposeListener` 는 타이머·listener·requestId 만 정리하고, `unregister` 는 registry 항목만 지웁니다. 셧다운 전까지 매 턴의 token, target, notice, ACK 클로저가 쌓이고 셧다운은 과거 턴 전부를 순회합니다. Discord 는 `1d4f3f0d` 에서 이 set 을 이미 제거했고 Slack 만 남아 있습니다.

부수 효과가 하나 더 있습니다. `QueueNotice` 는 첫 `close` 의 signal 을 고정하므로, signal 없이 호출되는 waiter 가 먼저 닫으면 뒤이은 셧다운 signal 이 벤더 호출에 도달하지 못합니다.

**타임아웃 경로가 `unregister` 하지 않는다.** 정상 전달 분기에만 있습니다. 5분 타임아웃으로 끝난 턴은 registry 에 항목을 남겨 이후 셧다운이 이미 종료된 턴을 다시 처리합니다. `unregister` 를 terminal claim 의 `finally` 로 중앙화했습니다 — 모든 경로가 claim 을 지나므로 "정확히 한 번"이 성립합니다.

## 3. malformed 허용목록이 자동 합류를 열 수 있다

`readSlackAllowlist` 는 malformed 입력에 매칭 불가능한 센티넬을 돌려주고, 인바운드는 이것으로 모든 채널을 막습니다 (#406).

auto-join 은 그 값을 평범한 1개짜리 목록으로 읽습니다. `allowed.size === 1` 이라 결과적으로 아무데도 합류하지 않지만, **우연히 맞는 것이지 설계가 아닙니다.** 센티넬 문자열이 바뀌거나 `matchKey` 정규화가 달라지면 조용히 워크스페이스 전체 합류로 뒤집힙니다. 합류는 채널마다 참여 메시지를 남기는 가시적 변경이라 그 실패 방향이 위험합니다.

센티넬을 감지해 `conversations.list` 전에 중단합니다. "전부 skip" 이 아니라 `abortedReason='malformed_allowlist'` 로 중단하는 이유는 경계를 읽지 못하는 상태임이 결과에 드러나야 하기 때문입니다.

**덤**: `'a stale generation cancels the run'` 테스트가 단언이 없어 항상 통과했습니다. `current=false` 를 `runSlackAutoJoin` 이 resolve 된 **뒤에** 설정하고 있어 `isCurrent()` 는 실행 내내 true 였고, `void` 문이 미사용 변수 경고를 눌러 공백을 가렸습니다. `sleep` 훅에서 세대를 무효화하도록 바꿔 실제로 가드를 검증합니다.

## 검증

테스트가 실제로 무는지 확인하려고 각 수정을 되돌려봤습니다.

| 되돌린 것 | 결과 |
|---|---|
| UTF-8 수정 | `안녕하세요` -> `���녕하세요` 로 **실패** |
| malformed 가드 | 신규 2건 **실패** |
| 원복 후 | 전부 통과 |

처음 쓴 UTF-8 테스트는 절단 지점이 ASCII 구간(`"ok":true`)에 떨어져 **버그가 있는데도 통과했습니다.** 한글 시작 바이트를 확인해 옮겼고, 절단이 멀티바이트 문자 내부에 떨어지는지 테스트가 직접 단언하게 했습니다.

- `tsc --noEmit` exit 0
- 변경 모듈을 import 하는 20개 파일 220건: **신규 실패 0건**
- 동일 파일 집합을 pristine `origin/dev` 에서도 돌려 대조했습니다. 남은 실패는 baseline 과 같거나(`doctor --json ... allowlist width`, 단독 실행에서도 재현되는 기존 결함) 파일 순서에 따라 달라지는 공유 상태 flake 입니다 — 단독 실행하면 양쪽 다 통과합니다.

`npm test` 전체(`tests/unit/` 1009개 파일, 파일당 별도 프로세스)는 수십 분이 걸려 영향 범위로 한정했습니다.

## 범위 밖

리뷰에서 지적했지만 이 PR 에 넣지 않은 항목입니다. 동작 변경이라 별도 판단이 필요해 보입니다.

- 429 재시도 소진 후 run 중단 (CodeRabbit)
- outbound-only 구성(`appToken` 없음)에서 auto-join 이 시작되지 않음 (Codex)
- `mergeSlackAutoJoin` 의 `enabled` 가 non-boolean 일 때 `true` 로 수렴 — 최상위 `false`, `null`, `'off'`, `0` 이 모두 켜짐이 됩니다. 가시적 변경을 일으키는 플래그라면 애매한 입력은 꺼짐으로 떨어지는 편이 안전합니다.