### PR TITLE
chore: promote v2.17.14

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.14-preview.20260823022611",
+  "version": "2.17.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.14-preview.20260823022611",
+      "version": "2.17.14",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.13",
+  "version": "2.17.14-preview.20260823022611",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.13",
+      "version": "2.17.14-preview.20260823022611",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.13",
+  "version": "2.17.14-preview.20260823022611",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.14-preview.20260823022611",
+  "version": "2.17.14",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.14-preview.20260823022611",
+  "version": "2.17.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.14-preview.20260823022611",
+      "version": "2.17.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.13",
+  "version": "2.17.14-preview.20260823022611",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.13",
+      "version": "2.17.14-preview.20260823022611",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.13",
+  "version": "2.17.14-preview.20260823022611",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.14-preview.20260823022611",
+  "version": "2.17.14",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
   "type": "module",
   "keywords": [

--- a/src/slack/auto-join.ts
+++ b/src/slack/auto-join.ts
@@ -15,6 +15,7 @@
 
 import { log } from '../core/logger.js';
 import { redactChannelSecrets } from '../messaging/redact.js';
+import { MALFORMED_SLACK_ALLOWLIST } from './events.js';
 import {
     listSlackConversations,
     joinSlackConversation,
@@ -187,6 +188,12 @@ export type SlackAutoJoinOptions = {
      * outside it would hand the agent read access to channels the same
      * operator deliberately put out of reach (#406 is the mirror of this
      * mistake). Auto-join stays inside the line the operator drew.
+     *
+     * A MALFORMED value is a third case, and the one that used to fail open.
+     * `readSlackAllowlist` reports it as a single unmatchable sentinel, which
+     * denies every channel inbound. Read here as an ordinary one-entry list it
+     * would merely skip everything — right by accident, and only for as long as
+     * the sentinel stays unmatchable. It is now detected and stops the run.
      */
     allowlist?: readonly string[];
 };
@@ -204,6 +211,18 @@ export async function runSlackAutoJoin(opts: SlackAutoJoinOptions): Promise<Slac
     };
     const { token, config } = opts;
     if (!config.enabled || !token) return result;
+
+    // A malformed inbound allowlist means the operator's boundary could not be
+    // read. Joining is a VISIBLE workspace mutation, so an unreadable boundary
+    // must stop the run outright rather than be treated as one odd channel name
+    // that happens to match nothing. Skipping every channel would look the same
+    // today and silently start joining the moment the sentinel changes.
+    if ((opts.allowlist ?? []).includes(MALFORMED_SLACK_ALLOWLIST)) {
+        result.abortedReason = 'malformed_allowlist';
+        log.warn('[slack:autojoin] slack.channelIds is malformed — refusing to join any channel.'
+            + ' Fix the allowlist (an array of channel ids) and restart.');
+        return result;
+    }
 
     const sleep = opts.sleep ?? defaultSleep;
     const signal = opts.signal;

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -85,12 +85,6 @@ let forwarderHandler: BroadcastListener | null = null;
 let selfUserId: string | null = null;
 let slackInitLock = false;
 /**
- * Listeners waiting on a queued agent result. Tracked so shutdown can drop
- * them immediately instead of leaving them armed for their 5-minute timeout,
- * which would let a post-shutdown result fire against a dead transport.
- */
-const pendingQueueWaiters = new Set<() => void>();
-/**
  * Request ids a live queued-reply listener is already waiting on. The
  * target-reply forwarder checks this so a result does not get posted twice: once
  * by the requester that is still here, once by the fallback that exists for the
@@ -469,6 +463,9 @@ async function slackOrchestrate(
         // else would hold it. Handing back the winner's promise makes both paths
         // converge on the same completion.
         let terminal: Promise<void> | null = null;
+        // Assigned immediately below, but referenced by finishExpired, which is
+        // defined first. Declared here so the terminal claim can unregister.
+        let unregister: () => void = () => {};
         const claimTerminal = (run: () => Promise<void>): Promise<void> => {
             if (!terminal) {
                 terminal = run().catch(e => log.info('[slack:queue]', logErrorText(e)));
@@ -477,18 +474,28 @@ async function slackOrchestrate(
         };
         const finishExpired = (signal?: AbortSignal) => claimTerminal(async () => {
             disposeListener();
-            // Started together, not in sequence: awaiting the notice first can
-            // eat the whole drain deadline before the reaction is even attempted.
-            await Promise.allSettled([
-                notice.close('expired', signal),
-                ack?.settle('failure') ?? Promise.resolve(),
-            ]);
-            // The in-process handle just closed this notice, so the durable record
-            // has nothing left to restore. Dropping it here is what keeps the next
-            // boot from rewriting a message this turn already dealt with.
-            if (requestId) closeSlackNoticeRecord(requestId);
+            try {
+                // Started together, not in sequence: awaiting the notice first can
+                // eat the whole drain deadline before the reaction is even attempted.
+                await Promise.allSettled([
+                    notice.close('expired', signal),
+                    ack?.settle('failure') ?? Promise.resolve(),
+                ]);
+                // The in-process handle just closed this notice, so the durable
+                // record has nothing left to restore. Dropping it here is what
+                // keeps the next boot from rewriting a message this turn already
+                // dealt with.
+                if (requestId) closeSlackNoticeRecord(requestId);
+            } finally {
+                // Centralized here, as in the Discord path: every terminal route
+                // passes through a claim, so unregistering in one place is what
+                // makes "exactly once" true. The plain timeout used to leave its
+                // registry entry behind, so a later shutdown re-ran a turn that
+                // had already finished.
+                unregister();
+            }
         });
-        const unregister = slackNoticeRegistry.add((signal) => finishExpired(signal));
+        unregister = slackNoticeRegistry.add((signal) => finishExpired(signal));
         const queueHandler = async (type: string, data: Record<string, unknown>) => {
             if (type !== 'orchestrate_done' || !data["text"] || data["origin"] !== 'slack'
                 || data["requestId"] !== requestId) return;
@@ -498,21 +505,28 @@ async function slackOrchestrate(
             // would leave a failed send with neither answer nor notice.
             disposeListener();
             await claimTerminal(async () => {
-                const text = String(data["text"]);
-                const queuedSendResult = await sendSlackText(token, target, text);
-                await notice.close(queuedSendResult.ok ? 'answered' : 'expired');
-                if (queuedSendResult.ok && target.threadId) {
-                    markThreadParticipated(target.targetId, target.threadId);
+                try {
+                    const text = String(data["text"]);
+                    const queuedSendResult = await sendSlackText(token, target, text);
+                    await notice.close(queuedSendResult.ok ? 'answered' : 'expired');
+                    if (queuedSendResult.ok && target.threadId) {
+                        markThreadParticipated(target.targetId, target.threadId);
+                    }
+                    // Settled before the relay for the same reason as the normal
+                    // path: the text is what the user was waiting for, and an
+                    // uncancellable upload must not hold the reaction on running.
+                    await ack?.settle(queuedSendResult.ok ? 'success' : 'failure');
+                    await relaySlackImages(token, target, text).catch(
+                        e => log.error('[slack:queue-send]', logErrorText(e)));
+                    // The notice is closed, so the durable record has nothing
+                    // left to restore on the next boot (#418).
+                    if (requestId) closeSlackNoticeRecord(requestId);
+                } finally {
+                    // Same "exactly once" reasoning as finishExpired: whichever
+                    // path claims the terminal owns the registry cleanup.
+                    unregister();
                 }
-                // Settled before the relay for the same reason as the normal
-                // path: the text is what the user was waiting for, and an
-                // uncancellable upload must not hold the reaction on running.
-                await ack?.settle(queuedSendResult.ok ? 'success' : 'failure');
-                await relaySlackImages(token, target, text).catch(
-                    e => log.error('[slack:queue-send]', logErrorText(e)));
-                if (requestId) closeSlackNoticeRecord(requestId);
             });
-            unregister();
         };
         // Everything below is armed SYNCHRONOUSLY, before any await. A reaction
         // call that takes a moment must not be able to outlive the completion it
@@ -521,7 +535,6 @@ async function slackOrchestrate(
         // standing fallback forwarder instead (#407).
         addBroadcastListener(queueHandler);
         if (requestId) pendingQueueRequestIds.add(requestId);
-        pendingQueueWaiters.add(() => { void finishExpired(); });
         queueTimeout = setTimeout(() => { void finishExpired(); }, 300000);
         // Only now, with the lifecycle armed. Not awaited: the notice below is
         // what the user needs to see, and the reaction is decoration on top.
@@ -1233,8 +1246,13 @@ async function disposeSlackRuntime(): Promise<void> {
     // is still working, while an unbounded await would hold shutdown open on a
     // stuck vendor call. The deadline covers the worst honest chain and the
     // signal cancels whatever is left.
-    for (const dispose of [...pendingQueueWaiters]) dispose();
-    pendingQueueWaiters.clear();
+    //
+    // The registry is the single shutdown route, as on Discord. A parallel
+    // waiter set used to hold one closure per queued turn and was cleared only
+    // here, so a long-lived instance retained every historical turn's token,
+    // target, notice and ACK closure. It also stripped the drain's abort signal:
+    // a QueueNotice pins the signal from its FIRST close, so a waiter closing
+    // without one made the later shutdown signal unreachable.
     await slackNoticeRegistry.drain(SLACK_NOTICE_DRAIN_MS);
     pendingQueueRequestIds.clear();
     socketClient?.stop();

--- a/src/telegram/ipv4-fetch.ts
+++ b/src/telegram/ipv4-fetch.ts
@@ -69,14 +69,25 @@ export function createIpv4Fetch(deps: Ipv4FetchDeps = {}) {
                     : ((headersInit as Record<string, string>) || {}),
             };
             const req = request(opts, (res) => {
-                let data = '';
-                res.on('data', (c: string) => data += c);
-                res.on('end', () => resolve({
-                    ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
-                    status: res.statusCode,
-                    json: () => Promise.resolve(JSON.parse(data)),
-                    text: () => Promise.resolve(data),
-                }));
+                // Collect BYTES and decode once at the end. Concatenating
+                // per-chunk strings decodes each chunk in isolation, so a
+                // multi-byte UTF-8 character split across a chunk boundary is
+                // corrupted into replacement characters — and JSON.parse still
+                // SUCCEEDS on the result, so the damage travels silently into
+                // message text. Telegram payloads are routinely non-ASCII.
+                const chunks: Buffer[] = [];
+                res.on('data', (c: Buffer | string) => {
+                    chunks.push(typeof c === 'string' ? Buffer.from(c, 'utf8') : c);
+                });
+                res.on('end', () => {
+                    const data = Buffer.concat(chunks).toString('utf8');
+                    resolve({
+                        ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
+                        status: res.statusCode,
+                        json: () => Promise.resolve(JSON.parse(data)),
+                        text: () => Promise.resolve(data),
+                    });
+                });
             });
             req.on('error', reject);
             if (signal) {
@@ -93,4 +104,3 @@ export function createIpv4Fetch(deps: Ipv4FetchDeps = {}) {
         });
     };
 }
-

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -19,7 +19,7 @@ aliases: [CLI-JAW Source Structure, str_func, source structure reference]
 
 ```text
 cli-jaw/
-├── server.ts                 ← Express 라우트 base + auth/CORS/rate-limit + WS bootstrap + `register*Routes()` glue + startup stale orc_state guard + graceful shutdown(closeDb) + employee migration + seed defaults + registerAvatarRoutes + async listen bootstrap (await initActiveMessagingRuntime) + orphaned jaw-emp-* cleanup + clearAllEmployeeSessions startup + no-store Vite index serving (733L)
+├── server.ts                 ← Express 라우트 base + auth/CORS/rate-limit + WS bootstrap + `register*Routes()` glue + startup stale orc_state guard + graceful shutdown(closeDb) + employee migration + seed defaults + registerAvatarRoutes + async listen bootstrap (await initActiveMessagingRuntime) + orphaned jaw-emp-* cleanup + clearAllEmployeeSessions startup + no-store Vite index serving (745L)
 ├── lib/                      ← 외부 통합/공용 헬퍼 (5 root files + mcp/ 8 files)
 │   ├── mcp-sync.ts           ← MCP 통합 + 스킬 복사 + softResetSkills + runSkillReset + trusted repair gate + clone cooldown (83L)
 │   ├── mcp/                  ← MCP 모듈 분리 (8 files)
@@ -244,8 +244,8 @@ cli-jaw/
 │   │   └── worklog.ts        ← Worklog CRUD + phase matrix (201L)
 │   ├── telegram/             ← Telegram 인터페이스 (11 files)
 │   │   ├── reactions.ts     ← ACK reaction transport + ReactionTypeEmoji allowlist + notice transport (186L)
-│   │   ├── ipv4-fetch.ts    ← IPv4 fetch factory that honours init.signal (destroys on abort) (96L)
-│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1189L)
+│   │   ├── ipv4-fetch.ts    ← IPv4 fetch factory that honours init.signal (destroys on abort) (106L)
+│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1259L)
 │   │   ├── voice.ts          ← 음성 메시지 → guarded download → STT → tgOrchestrate 파이프라인 (43L)
 │   │   ├── forwarder.ts      ← text 전송 뒤 guarded local-image photo relay + escape/chunk/createForwarder (245L)
 │   │   ├── rich-message.ts   ← Bot API 10.1 rich-first send (sendTelegramMarkdown, 32k chunk, HTML/plaintext fallback) (315L)
@@ -253,8 +253,8 @@ cli-jaw/
 │   │   ├── hub-callback.ts   ← hub-member callback URL SSRF guard (19L)
 │   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (182L)
 │   ├── discord/              ← Discord 인터페이스 (8 files)
-│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (813L)
-│   │   ├── reactions.ts   ← ACK reaction transport + cancellable notice REST (107L)
+│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (878L)
+│   │   ├── reactions.ts   ← ACK reaction transport + cancellable notice REST (122L)
 │   │   ├── commands.ts       ← Discord slash command 등록 + 핸들러 (153L)
 │   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (167L) ✨
 │   │   ├── channel-types.ts  ← Discord channel type helpers (50L) ✨
@@ -262,7 +262,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (67L)
 │   ├── slack/                ← Slack 인터페이스 (21 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (407L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1190L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1261L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (394L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (66L)
 │   │   ├── events.ts         ← inbound gating (self-echo/bot/subtype/allowlist/mention) + Block Kit 텍스트 추출 (283L)

--- a/tests/unit/slack-auto-join.test.ts
+++ b/tests/unit/slack-auto-join.test.ts
@@ -13,6 +13,7 @@ import {
     SLACK_AUTO_JOIN_DEFAULTS,
     type SlackAutoJoinConfig,
 } from '../../src/slack/auto-join.ts';
+import { MALFORMED_SLACK_ALLOWLIST, readSlackAllowlist } from '../../src/slack/events.ts';
 
 type Captured = { method: string; body: Record<string, string> };
 
@@ -122,10 +123,44 @@ test('a stale generation cancels the run even without an abort signal', async ()
         { ok: true },
     ]);
     const result = await runSlackAutoJoin({
-        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        token: 'xoxb-t', config: config(), fetchImpl,
+        // The generation must go stale DURING the run. Flipping it after
+        // runSlackAutoJoin resolves leaves isCurrent() true for the whole scan,
+        // which is how the previous version of this test passed while proving
+        // nothing. The join pacing sleep is the seam that gets us mid-run.
+        sleep: async () => { current = false; },
         isCurrent: () => current,
     });
-    void calls; void result; void (current = false);
+    assert.equal(result.cancelled, true, 'a superseded generation must cancel the run');
+    assert.equal(calls.filter(c => c.method === 'conversations.join').length, 1,
+        'the second join must not fire once the generation is stale');
+});
+
+// A malformed slack.channelIds is not "one channel that matches nothing". It is
+// the operator's boundary being unreadable, and joining is a visible mutation.
+test('a malformed inbound allowlist stops the run instead of joining everything', async () => {
+    const { fetchImpl, calls } = scriptedFetch([
+        page([{ id: 'C_A', name: 'general', is_member: false }], ''),
+        { ok: true },
+    ]);
+    const result = await runSlackAutoJoin({
+        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        allowlist: readSlackAllowlist('not-an-array'),
+    });
+    assert.equal(result.abortedReason, 'malformed_allowlist');
+    assert.deepEqual(result.joined, []);
+    assert.equal(calls.length, 0,
+        'a malformed boundary must stop before conversations.list, not merely skip rows');
+});
+
+test('the malformed sentinel is refused even if it arrives directly', async () => {
+    const { fetchImpl, calls } = scriptedFetch([page([], '')]);
+    const result = await runSlackAutoJoin({
+        token: 'xoxb-t', config: config(), fetchImpl, sleep: noSleep,
+        allowlist: [MALFORMED_SLACK_ALLOWLIST],
+    });
+    assert.equal(result.abortedReason, 'malformed_allowlist');
+    assert.equal(calls.length, 0);
 });
 
 test('one channel refusing does not end the scan', async () => {
@@ -332,4 +367,3 @@ test('the exclude list is scrubbed: non-strings, blanks and hashes', () => {
 test('a non-array exclude value cannot poison the run', () => {
     assert.deepEqual(mergeSlackAutoJoin(undefined, { exclude: 'C_ONE' }).exclude, []);
 });
-

--- a/tests/unit/telegram-fetch-cancel.test.ts
+++ b/tests/unit/telegram-fetch-cancel.test.ts
@@ -73,6 +73,42 @@ test('a request with no signal still completes normally', async () => {
     await new Promise<void>(resolve => server.close(() => resolve()));
 });
 
+// A multi-byte character split across TCP chunks used to be decoded per chunk
+// and corrupted into replacement characters. JSON.parse still succeeded on the
+// result, so nothing failed loudly — the damage only showed up as mojibake in
+// message text, which is a routine case for a Korean-language deployment.
+test('a UTF-8 character split across chunks is decoded intact', async () => {
+    const payload = Buffer.from(JSON.stringify({ ok: true, text: '안녕하세요 세계' }), 'utf8');
+    // The cut MUST land inside a multi-byte character, not merely between two
+    // chunks — a split at an ASCII boundary decodes cleanly either way and the
+    // test would pass against the very bug it exists to catch. '안' starts at
+    // byte 19 and is three bytes wide, so 20 lands mid-syllable. Asserted below
+    // rather than trusted, since the offset moves if the payload is edited.
+    const cut = 20;
+    assert.notEqual(payload.subarray(0, cut).toString('utf8').at(-1), '안',
+        'the cut must fall inside a multi-byte character for this test to bite');
+    const server = createServer((_req, res) => {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(payload.subarray(0, cut));
+        // Flush the first chunk on its own so the second arrives as a separate
+        // 'data' event rather than being coalesced into one buffer.
+        setTimeout(() => res.end(payload.subarray(cut)), 20);
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+        const result = await localFetch()(`http://127.0.0.1:${port}/`, {}) as {
+            json(): Promise<{ text: string }>; text(): Promise<string>;
+        };
+        assert.equal((await result.json()).text, '안녕하세요 세계');
+        assert.equal((await result.text()).includes('\uFFFD'), false,
+            'no replacement characters may survive the chunk boundary');
+    } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+});
+
 test('bot.ts wires the production factory rather than an inline closure', async () => {
     // Guards the seam: an inline reimplementation in bot.ts would make every
     // test above prove only this file.


### PR DESCRIPTION
Promotes certified preview 2.17.14-preview.20260823022611 at 0e472928c18b838a7263ad315c9c30bf10e5d073. Tests: https://github.com/lidge-jun/cli-jaw/actions/runs/32587755400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack auto-join now stops safely when an allowlist is malformed, avoiding unintended API calls or joins.
  * Improved Slack request shutdown and cleanup for queued operations.
  * Telegram responses now correctly preserve UTF-8 characters split across network chunks.

* **Documentation**
  * Updated source-structure line-count references.

* **Tests**
  * Added coverage for malformed allowlists, cancellation behavior, and split UTF-8 responses.

* **Chores**
  * Updated the application version to 2.17.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->