### PR TITLE
fix: lastActive 오배송 결함 클래스 전수 수정 (#437 #438 #439 #440 #441 #442 #443 #444 #445 #447)

### DIFF
--- a/public/js/features/settings-channel.ts
+++ b/public/js/features/settings-channel.ts
@@ -1,5 +1,5 @@
 // ── Active Channel & Fallback Order ──
-import { apiJson } from '../api.js';
+import { apiJson, api } from '../api.js';
 import { escapeHtml } from '../render.js';
 import { getCliMeta } from '../constants.js';
 import { providerLabel } from '../provider-icons.js';
@@ -11,16 +11,29 @@ import type { SettingsData } from './settings-types.js';
 export type MessengerChannel = 'telegram' | 'discord' | 'slack';
 const CHANNELS: MessengerChannel[] = ['telegram', 'discord', 'slack'];
 
-function readEnabledChannelsFromUi(): MessengerChannel[] {
-    // Classic UI does not yet expose a unified enabled-channel list.
-    // Returning [] means enabling a channel sends a singleton enabled set,
-    // which preserves the legacy single-active-channel behavior until the
-    // Classic UI gains per-channel enabled checkboxes.
-    return [];
+/** Read the enabled set from the server rather than rebuilding it from nothing.
+ *
+ *  This returned [], so every toggle sent a SINGLETON set. Under the v3 model
+ *  that was harmless — one channel was active at a time. Under v4 it means
+ *  enabling a channel tears down every other gateway, because
+ *  restartMessagingRuntime acts on the enabled-set difference: someone running
+ *  Slack and Telegram lost Telegram inbound by touching the Slack tab (#445). */
+async function readEnabledChannels(): Promise<MessengerChannel[]> {
+    try {
+        const data = await api<Record<string, unknown>>('/api/settings');
+        const messaging = data?.['messaging'] as { enabledChannels?: unknown } | undefined;
+        const enabled = messaging?.enabledChannels;
+        if (!Array.isArray(enabled)) return [];
+        return enabled.filter((c): c is MessengerChannel => CHANNELS.includes(c as MessengerChannel));
+    } catch {
+        // Unreadable state is not evidence that nothing is enabled; returning []
+        // would recreate the very bug this replaces.
+        return [];
+    }
 }
 
 export async function setChannelEnabled(ch: MessengerChannel, enabled: boolean): Promise<void> {
-    const current = readEnabledChannelsFromUi();
+    const current = await readEnabledChannels();
     const enabledChannels = enabled
         ? [...new Set([...current, ch])]
         : current.filter(item => item !== ch);

--- a/server.ts
+++ b/server.ts
@@ -383,7 +383,7 @@ registerBgtaskRoutes(app, requireAuth);
 registerEventsRoutes(app, requireAuth);
 registerInstanceRoutes(app);
 registerChatSessionRoutes(app, requireAuth);
-registerMessageRoutes(app);
+registerMessageRoutes(app, requireAuth);
 const searchRegistry = new SearchProviderRegistry();
 searchRegistry.register(new ChatSearchProvider(settings['search'].engine));
 searchRegistry.register(new MemorySearchProvider(settings['memory'].enabled));

--- a/server.ts
+++ b/server.ts
@@ -94,7 +94,7 @@ import {
     initPromptFiles, regenerateB,
 } from './src/prompt/builder.js';
 
-import { killAllAgents, drainRecoveredQueue } from './src/agent/spawn.js';
+import { killAllAgents, drainRecoveredQueue, waitForAllProcessesEnd } from './src/agent/spawn.js';
 import { resetAllStaleStates } from './src/orchestrator/state-machine.js';
 
 import { submitMessage } from './src/orchestrator/gateway.js';
@@ -526,6 +526,10 @@ const shutdown = async (sig: string) => {
 
     // Flush WAL and close SQLite before exiting
     try {
+        // killAllAgents only signalled; the exit handlers that persist the last
+        // turn run after the child actually dies. Closing the database before
+        // they finish threw "connection is not open" and lost that turn (#439).
+        await waitForAllProcessesEnd();
         closeDb();
         console.log('[server] database closed');
     } catch (e) {

--- a/src/agent/alert-escalation.ts
+++ b/src/agent/alert-escalation.ts
@@ -72,7 +72,9 @@ export function initAlertDelivery(): void {
 
         for (const ch of channels) {
             if (ch !== 'telegram' && ch !== 'discord' && ch !== 'slack') continue;
-            void sendChannelOutput({ type: 'text', text, channel: ch as MessengerChannel })
+            // An operational alert belongs in the channel configured to receive
+            // one, not in whichever conversation spoke most recently (#438).
+            void sendChannelOutput({ type: 'text', text, channel: ch as MessengerChannel, preferConfiguredTarget: true })
                 .then((result) => {
                     if (!result.ok) {
                         console.warn(`[jaw:alert] delivery to ${ch} failed:`, result.error);

--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -30,7 +30,7 @@ import {
     memoryFlushCounter,
 } from './memory-flush-controller.js';
 import { buildGoalContinuation } from '../goal/heartbeat.js';
-import { completeGoal, cancelGoal, getActiveGoal, goalHasCompletionEvidence } from '../goal/store.js';
+import { completeGoal, getActiveGoal, goalHasCompletionEvidence } from '../goal/store.js';
 import { recordTurn } from '../goal-run/controller.js';
 import { applyOutputPolicy } from '../core/policy-hooks.js';
 import { evaluateRecordPending } from '../core/policy-flags.js';
@@ -1082,10 +1082,18 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
                     broadcast('goal_done_rejected', { goalId: activeGoal.id, reason: 'no_evidence' });
                 }
             } else if (GOAL_CANCEL_RE.test(ctx.fullText)) {
-                cancelGoal();
+                // Cancelling used to happen here on sight of the marker, with no
+                // gate at all — which made ABANDONING a goal strictly easier than
+                // completing one, since /goal done next door demands verification
+                // evidence. A model explaining the command ("you can /goal cancel
+                // to stop this") destroyed the goal by describing it.
+                //
+                // Stopping the continuation loop does not require destroying the
+                // record, so the marker now does the reversible half: timers stop,
+                // the goal survives, and a human decides whether it dies.
                 clearGoalTimers();
-                console.log('[jaw:goal] AI output contained /goal cancel — goal cancelled');
-                broadcast('goal_cancel', { goalId: activeGoal.id, source: 'ai_output' });
+                console.warn('[jaw:goal] AI output contained /goal cancel — timers cleared, goal left active for a human decision');
+                broadcast('goal_cancel_requested', { goalId: activeGoal.id, source: 'ai_output' });
             } else if (GOAL_PAUSE_RE.test(ctx.fullText)) {
                 clearGoalTimers();
                 console.log('[jaw:goal] AI output contained /goal pause — timers cleared');

--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -25,7 +25,7 @@ import { resolveSpawnOutputText } from './events/helpers.js';
 import { isKiroPlainTextCli, isKiroResumeDegradedOutput } from './kiro-runtime.js';
 import {
     incrementMemoryFlush,
-    resetMemoryFlushCounter,
+    countTurnForFlush,
     triggerMemoryFlush,
     memoryFlushCounter,
 } from './memory-flush-controller.js';
@@ -681,10 +681,12 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
                 }
             }
 
+            // Counted against THIS turn's session. A single global counter let one
+            // session spend the budget another session had filled, so the busy one
+            // was summarised and the quiet one never was (#454).
             incrementMemoryFlush();
             const threshold = settings["memory"]?.flushEvery ?? 10;
-            if (settings["memory"]?.enabled !== false && memoryFlushCounter >= threshold) {
-                resetMemoryFlushCounter();
+            if (settings["memory"]?.enabled !== false && countTurnForFlush(chatSessionId, threshold)) {
                 triggerMemoryFlush();
             }
         }

--- a/src/agent/memory-flush-controller.ts
+++ b/src/agent/memory-flush-controller.ts
@@ -65,6 +65,40 @@ export function resetMemoryFlushCounter(): void {
     flushCycleCount++;
 }
 
+// The trigger counter has to be per session for the same reason the watermark is.
+// A single counter meant any session could spend it: nine turns in session A plus
+// one in B fired a flush that then summarised B, and A — whose turns had actually
+// filled the counter — went back to zero without being summarised at all. Worse,
+// if B had fewer than four new rows the flush returned early, so the counter was
+// spent on nothing (#454).
+const _flushCounterBySession = new Map<string, number>();
+const MAX_TRACKED_FLUSH_SESSIONS = 200;
+
+/** Count a completed turn against its own session and report whether that session
+ *  has now earned a flush. Resets the session on a true result, so the caller
+ *  cannot forget to. */
+export function countTurnForFlush(sessionId: string, threshold: number): boolean {
+    const next = (_flushCounterBySession.get(sessionId) ?? 0) + 1;
+    if (next >= threshold) {
+        _flushCounterBySession.delete(sessionId);
+        flushCycleCount++;
+        return true;
+    }
+    _flushCounterBySession.set(sessionId, next);
+    if (_flushCounterBySession.size > MAX_TRACKED_FLUSH_SESSIONS) {
+        // Bounded like the deferred set: an unbounded map keyed by session id is a
+        // slow leak on a long-lived host.
+        const oldest = _flushCounterBySession.keys().next();
+        if (!oldest.done) _flushCounterBySession.delete(oldest.value);
+    }
+    return false;
+}
+
+/** @internal exported for unit tests */
+export function resetFlushCountersForTest(): void {
+    _flushCounterBySession.clear();
+}
+
 type FlushSpawnResult = {
     text: string;
     code: number;

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -674,6 +674,27 @@ export function waitForProcessEnd(scopeKeyOrTimeout: string | number = 'default'
     });
 }
 
+/** Wait for EVERY scope to finish exiting, bounded.
+ *
+ *  `killAllAgents` only sends the signal; it returns long before the children
+ *  are gone and before their exit handlers have written anything. Shutdown then
+ *  closed the database underneath those handlers, so the last turn of a restart
+ *  lost its assistant message, its session row and its trace, and the caller
+ *  waiting on that turn was never resolved (#439).
+ *
+ *  Bounded on purpose: a wedged child must not hold the process open past the
+ *  force-exit budget. Returning on timeout is the same outcome as today, minus
+ *  the common case where the child would have finished in milliseconds. */
+export function waitForAllProcessesEnd(timeoutMs = 2000): Promise<void> {
+    if (activeMainProcesses.size === 0) return Promise.resolve();
+    return new Promise<void>(resolve => {
+        const check = setInterval(() => {
+            if (activeMainProcesses.size === 0) { clearInterval(check); clearTimeout(deadline); resolve(); }
+        }, 50);
+        const deadline = setTimeout(() => { clearInterval(check); resolve(); }, timeoutMs);
+    });
+}
+
 export function canSteerAgent(scopeKey: string): boolean {
     const run = activeMainProcesses.get(scopeKey);
     return run?.meta.cli === 'jwc' && jawRuntimesByScope.get(scopeKey)?.busy === true;

--- a/src/agent/spawn/queue.ts
+++ b/src/agent/spawn/queue.ts
@@ -180,15 +180,56 @@ export function createQueueController(
     function loadPersistedQueue(): QueueItem[] {
         const recovered = (deps.listQueuedMessages.all() as Array<{ id: string; payload: string }>).flatMap(normalizeQueueItem);
         if (!multiSessionEnabled) return recovered;
-        return [
-            ...recovered.filter(item => item.priority === 'head'),
-            ...recovered.filter(item => item.priority !== 'head'),
-        ];
+        // Restore each scope's internal order, not a global one. Hoisting every
+        // `head` item to the front of the whole queue re-created the ordering bug
+        // that enqueueing was just fixed for: an interrupt saved by session A came
+        // back ahead of session B, which had been waiting first (#453).
+        const byScope = new Map<string, QueueItem[]>();
+        for (const item of recovered) {
+            const scope = item.scope ?? 'default';
+            const bucket = byScope.get(scope);
+            if (bucket) bucket.push(item);
+            else byScope.set(scope, [item]);
+        }
+        for (const [scope, items] of byScope) {
+            byScope.set(scope, [
+                ...items.filter(item => item.priority === 'head'),
+                ...items.filter(item => item.priority !== 'head'),
+            ]);
+        }
+        // Scopes keep the order they were first seen in, so cross-scope fairness
+        // survives the restart too.
+        const seen = new Set<string>();
+        const ordered: QueueItem[] = [];
+        for (const item of recovered) {
+            const scope = item.scope ?? 'default';
+            if (seen.has(scope)) continue;
+            seen.add(scope);
+            ordered.push(...(byScope.get(scope) ?? []));
+        }
+        return ordered;
     }
 
     const messageQueue: QueueItem[] = loadPersistedQueue();
     if (messageQueue.length > 0) {
         console.log(`[queue] recovered ${messageQueue.length} persisted message(s) from previous session`);
+    }
+    /**
+     * Put an interrupt ahead of its OWN scope, not ahead of everyone.
+     *
+     * `unshift` sent it to the head of the global array, so interrupting session
+     * A promoted that turn past session B's older waiting message. Interrupt is a
+     * scope-local policy — "drop what I am doing and take this instead" — and it
+     * was silently reordering conversations that had nothing to do with it.
+     *
+     * Landing before the first item of the same scope preserves that meaning and
+     * leaves every other scope's relative order untouched.
+     */
+    function insertAheadOfScope(item: QueueItem): void {
+        const scope = normalizeScope(item.scope);
+        const at = messageQueue.findIndex(queued => normalizeScope(queued.scope) === scope);
+        if (at === -1) messageQueue.push(item);
+        else messageQueue.splice(at, 0, item);
     }
     /**
      * Wake the queue we just recovered.
@@ -399,7 +440,7 @@ export function createQueueController(
             ts: Date.now(),
         });
         deps.insertQueuedMessage.run(item.id, JSON.stringify(item));
-        if (multiSessionEnabled && meta?.front === true) messageQueue.unshift(item);
+        if (multiSessionEnabled && meta?.front === true) insertAheadOfScope(item);
         else messageQueue.push(item);
         console.log(`[queue] +1 (${messageQueue.length} pending)`);
         deps.broadcast('queue_update', queueUpdatePayload(item.scope));

--- a/src/browser/web-ai/notifications.ts
+++ b/src/browser/web-ai/notifications.ts
@@ -25,6 +25,9 @@ export async function drainPendingWebAiNotifications(
             channel: 'active',
             type: 'text',
             text: formatWebAiNotification(event),
+            // Drained when a watcher finishes, which can be long after the request
+            // that started it — by then last-active names an unrelated thread (#438).
+            preferConfiguredTarget: true,
         });
         if (result.ok) {
             sent += 1;

--- a/src/cli/handlers-runtime.ts
+++ b/src/cli/handlers-runtime.ts
@@ -1,4 +1,5 @@
 // ─── Runtime Handlers ─────────────────────────────────
+import { sessionScopeMeta } from './session-scope-meta.js';
 // Extracted from handlers.ts for 500-line compliance.
 
 import { CLI_KEYS, buildModelChoicesByCli } from './registry.js';
@@ -253,7 +254,9 @@ export async function steerHandler(args: string[], ctx: CliCommandContext): Prom
 
     // Web/CLI: fire orchestration directly via submitMessage
     const { submitMessage } = await import('../orchestrator/gateway.js');
-    submitMessage(prompt, { origin: iface as 'cli' | 'web' | 'telegram' | 'discord' | 'slack' });
+    // Same session carry-through as the other slash handlers: steering a run
+    // must land in the lane that run belongs to.
+    submitMessage(prompt, { origin: iface as 'cli' | 'web' | 'telegram' | 'discord' | 'slack', ...sessionScopeMeta() });
     return { ok: true, type: 'success', text: t('cmd.steer.started', {}, L) };
 }
 

--- a/src/cli/handlers-search.ts
+++ b/src/cli/handlers-search.ts
@@ -1,4 +1,5 @@
 import { buildSearchSteerPrompt } from '../workflows/search.js';
+import { sessionScopeMeta } from './session-scope-meta.js';
 import type { CliCommandContext } from './command-context.js';
 import type { SlashResult } from './types.js';
 
@@ -28,7 +29,11 @@ export async function searchWorkflowHandler(args: string[], ctx: CliCommandConte
     if (iface === 'telegram' || iface === 'discord' || iface === 'slack') return result;
 
     const { submitMessage } = await import('../orchestrator/gateway.js');
-    submitMessage(result.steerPrompt!, { origin: iface as 'cli' | 'web' });
+    // Carry the tab's session through. Without it the message lands in the
+    // tab's chat session while the queue and PABCD scope fall back to
+    // 'default', so the turn queues behind unrelated work and runs outside
+    // the session's own lane.
+    submitMessage(result.steerPrompt!, { origin: iface as 'cli' | 'web', ...sessionScopeMeta() });
     const { steerPrompt: _stripped, ...rest } = result;
     return rest;
 }

--- a/src/cli/handlers-skill-invoke.ts
+++ b/src/cli/handlers-skill-invoke.ts
@@ -1,4 +1,5 @@
 // ─── Skill Slash Command Handler ──────────────────────
+import { sessionScopeMeta } from './session-scope-meta.js';
 // Handles /skill:<id> execution — injects SKILL.md as steerPrompt.
 
 import { getSkillCommandsCache } from '../core/skill-cache.js';
@@ -28,7 +29,11 @@ export async function executeSkillCommand(
     const iface = ctx.interface || 'web';
     if (iface !== 'telegram' && iface !== 'discord' && iface !== 'slack') {
         const { submitMessage } = await import('../orchestrator/gateway.js');
-        submitMessage(steerPrompt, { origin: iface as 'cli' | 'web' });
+        // Carry the tab's session through. Without it the message lands in the
+        // tab's chat session while the queue and PABCD scope fall back to
+        // 'default', so the turn queues behind unrelated work and runs outside
+        // the session's own lane.
+        submitMessage(steerPrompt, { origin: iface as 'cli' | 'web', ...sessionScopeMeta() });
         const { steerPrompt: _stripped, ...rest } = result;
         return rest;
     }

--- a/src/cli/handlers-workflows.ts
+++ b/src/cli/handlers-workflows.ts
@@ -1,4 +1,5 @@
 import { buildPlanCompatArtifact, formatPlanCompatText } from '../workflows/plan.js';
+import { sessionScopeMeta } from './session-scope-meta.js';
 import { buildDeliberateArtifact, formatDeliberateText } from '../workflows/deliberate.js';
 import { buildPlanAuditArtifact, formatPlanAuditText } from '../workflows/planaudit.js';
 import { parseReviewFlags, parseReviewFocus, buildReviewArtifact, buildReviewSteerPrompt, buildReviewTargetContext, formatReviewText } from '../workflows/review.js';
@@ -28,7 +29,11 @@ async function fireSteerForWebCli(
     const iface = ctx.interface || 'web';
     if (iface === 'telegram' || iface === 'discord' || iface === 'slack') return result;
     const { submitMessage } = await import('../orchestrator/gateway.js');
-    submitMessage(result.steerPrompt, { origin: iface as 'cli' | 'web' });
+    // Carry the tab's session through. Without it the message lands in the
+    // tab's chat session while the queue and PABCD scope fall back to
+    // 'default', so the turn queues behind unrelated work and runs outside
+    // the session's own lane.
+    submitMessage(result.steerPrompt, { origin: iface as 'cli' | 'web', ...sessionScopeMeta() });
     const { steerPrompt: _stripped, ...rest } = result;
     return rest;
 }

--- a/src/cli/session-scope-meta.ts
+++ b/src/cli/session-scope-meta.ts
@@ -1,0 +1,18 @@
+import { currentSessionScope } from '../core/session-context.js';
+
+/** The session a slash-command turn belongs to, in submitMessage's shape.
+ *
+ *  A slash handler runs inside the request's AsyncLocalStorage scope, but it used
+ *  to forward only `origin`. The message then landed in the tab's chat session
+ *  while the queue and PABCD scope resolved to 'default' — the turn waited behind
+ *  unrelated work and ran outside its own lane. Empty when multi-session is off,
+ *  which is exactly when 'default' is the right answer anyway. */
+export function sessionScopeMeta(): { scope?: string; chatSessionId?: string } {
+    const scope = currentSessionScope();
+    if (!scope) return {};
+    const meta: { scope?: string; chatSessionId?: string } = {};
+    if (scope.scope) meta.scope = scope.scope;
+    if (scope.chatSessionId) meta.chatSessionId = scope.chatSessionId;
+    return meta;
+}
+

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1313,6 +1313,31 @@ export interface HeartbeatJob {
     employee?: string;
     command?: string[];
     reportPolicy?: 'always' | 'anomaly_only' | 'silent';
+    /** Where this job's report goes. Absent means the legacy behaviour: the
+     *  active channel's last-active conversation, which is whoever spoke to the
+     *  bot most recently and therefore NOT a stable destination (#437).
+     *
+     *  Only the three operator-meaningful fields live here. `targetKind` and
+     *  `peerKind` are derived from the id by the channel helpers, so an operator
+     *  never has to know Slack's C/D/G prefix rules to fill this in. */
+    destination?: HeartbeatDestination | null;
+}
+
+export interface HeartbeatDestination {
+    channel: 'telegram' | 'discord' | 'slack';
+    targetId: string;
+    threadId?: string;
+}
+
+/** A destination is only usable when it names both a transport and a conversation.
+ *  Anything else is treated as absent rather than half-applied. */
+export function isHeartbeatDestination(value: unknown): value is HeartbeatDestination {
+    if (!value || typeof value !== 'object') return false;
+    const d = value as Record<string, unknown>;
+    if (d['channel'] !== 'telegram' && d['channel'] !== 'discord' && d['channel'] !== 'slack') return false;
+    if (typeof d['targetId'] !== 'string' || !d['targetId'].trim()) return false;
+    if (d['threadId'] !== undefined && typeof d['threadId'] !== 'string') return false;
+    return true;
 }
 export interface HeartbeatFile { jobs: HeartbeatJob[] }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -636,7 +636,20 @@ export function migrateSettings(s: Record<string, any>, sourceVersion = readSett
         : 'telegram';
 
     if (sourceVersion < 4 || !Array.isArray(messaging.enabledChannels)) {
-        messaging.enabledChannels = [legacyChannel];
+        // A v3 document has no enabled set yet, so deriving one from the legacy
+        // scalar is the migration. A v4 document that reaches here has a MALFORMED
+        // set, and `legacyChannel` is always 'telegram' by then because the key it
+        // reads was deleted during the v3 migration — so silently "repairing" it
+        // would hand a Slack install a Telegram gateway (#445). Preserve whatever
+        // channels are still recognisable instead.
+        if (sourceVersion >= 4 && messaging.enabledChannels !== undefined) {
+            const salvaged = (Array.isArray(messaging.enabledChannels)
+                ? messaging.enabledChannels
+                : [messaging.enabledChannels]).filter(isMessengerChannel);
+            messaging.enabledChannels = salvaged.length ? [...new Set(salvaged)] : [legacyChannel];
+        } else {
+            messaging.enabledChannels = [legacyChannel];
+        }
     } else {
         messaging.enabledChannels = [...new Set(
             messaging.enabledChannels.filter(isMessengerChannel),
@@ -838,7 +851,8 @@ function clearPersistedSlackConnectionForEnvironment(
 }
 
 /** Apply environment variable overrides to a settings object */
-function applyEnvOverrides(s: Record<string, any>) {
+/** @internal exported so the env-driven home-channel switch can be tested (#444) */
+export function applyEnvOverrides(s: Record<string, any>) {
     if (process.env["TELEGRAM_TOKEN"]) {
         s["telegram"] = s["telegram"] || {};
         s["telegram"].token = process.env["TELEGRAM_TOKEN"];
@@ -852,9 +866,20 @@ function applyEnvOverrides(s: Record<string, any>) {
         s["discord"] = s["discord"] || {};
         s["discord"].token = process.env["DISCORD_TOKEN"];
         s["discord"].enabled = true;
-        // Auto-switch active channel if Discord has token but Telegram doesn't
+        // Auto-switch the home channel when Discord is the only configured one.
+        //
+        // This wrote `s["channel"]` until v4 deleted that key during migration,
+        // and applyEnvOverrides runs AFTER migrateSettings — so the assignment
+        // landed on a field nothing reads and the switch silently stopped
+        // happening. getHomeChannel() only consults messaging.homeChannel (#444).
         if (!s["telegram"]?.token && !s["telegram"]?.enabled) {
-            s["channel"] = 'discord';
+            const messaging = isPlainRecord(s["messaging"]) ? s["messaging"] : {};
+            const enabled = Array.isArray(messaging["enabledChannels"]) ? messaging["enabledChannels"] : [];
+            s["messaging"] = {
+                ...messaging,
+                enabledChannels: [...new Set([...enabled, 'discord'])],
+                homeChannel: 'discord',
+            };
         }
     }
     if (process.env["DISCORD_GUILD_ID"]) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1254,6 +1254,17 @@ export function serializeSettingsForSave(candidate: SettingsStateCandidate): str
     if (value["slack"] && typeof value["slack"] === 'object') {
         for (const key of slackEnvironmentManagedSettingKeys()) delete value["slack"][key];
     }
+    // Same rule, the other two channels. applyEnvOverrides writes the env token
+    // onto the live settings object, so any later save — a port write, a target
+    // persist — copied that secret onto disk. Slack was stripped here; Telegram
+    // and Discord were not, which contradicted the documented promise that env
+    // values never enter settings.json (#449).
+    if (process.env["TELEGRAM_TOKEN"] && value["telegram"] && typeof value["telegram"] === 'object') {
+        delete value["telegram"].token;
+    }
+    if (process.env["DISCORD_TOKEN"] && value["discord"] && typeof value["discord"] === 'object') {
+        delete value["discord"].token;
+    }
     const runtime = value["runtime"];
     if (candidate.shape === 'absent' && runtime?.codexApp?.multiplex === false) {
         delete runtime.codexApp.multiplex;

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -762,6 +762,16 @@ export const resetAllOrcStates = db.prepare(
     "UPDATE orc_state SET state = 'IDLE', ctx = NULL WHERE state != 'IDLE' AND updated_at < datetime('now', '-24 hours')"
 );
 
+/** Unconditional reset, for when the caller knows the in-memory runtime is gone.
+ *
+ *  The stale variant above deliberately spares recent rows so a restart can
+ *  resume a live cycle. That guess is wrong after a crash: the workers a phase
+ *  was waiting on live in memory and did not survive, so the row describes a
+ *  handoff that can never complete and only a human can say so (#452). */
+export const resetEveryOrcState = db.prepare(
+    "UPDATE orc_state SET state = 'IDLE', ctx = NULL WHERE state != 'IDLE'"
+);
+
 export const deleteNonDefaultOrcStates = db.prepare(
     "DELETE FROM orc_state WHERE id != 'default'"
 );

--- a/src/http/loopback.ts
+++ b/src/http/loopback.ts
@@ -1,0 +1,14 @@
+// Loopback identification, shared so the auth-token endpoint and the auth
+// middleware cannot drift apart on what counts as "this machine".
+//
+// The IPv4-mapped form matters: on a dual-stack listener a connection from
+// 127.0.0.1 arrives as ::ffff:127.0.0.1, and treating that as remote would lock
+// the local UI out of its own token.
+
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+export function isLoopbackAddress(address: string | undefined | null): boolean {
+    if (!address) return false;
+    return LOOPBACK_ADDRESSES.has(address);
+}
+

--- a/src/manager/reminders/dispatcher.ts
+++ b/src/manager/reminders/dispatcher.ts
@@ -46,7 +46,10 @@ export async function dispatchReminderNotification(
 ): Promise<ReminderDispatchResult> {
     const send = options.send ?? sendChannelOutput;
     const at = (options.now ?? (() => new Date()))().toISOString();
-    const result = await send({ channel: 'active', type: 'text', text: reminderText(reminder) });
+    // A reminder fires on a schedule, so "the active conversation" at that moment
+    // is whoever happened to message the bot last — not the person who set the
+    // reminder. Resolve to the configured channel instead (#438).
+    const result = await send({ channel: 'active', type: 'text', text: reminderText(reminder), preferConfiguredTarget: true });
     const status = statusFromSendResult(result);
     const error = result.ok ? null : result.error || 'send failed';
     if (status !== 'delivered') options.log?.(`[reminders-dispatch] ${status} ${reminder.id}: ${error}`);

--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -61,13 +61,18 @@ export function isHeartbeatQuietOutput(result: string, extraMarkers: string[] = 
  *  `peerKind` are derived from the id — Slack's C/D/G prefixes decide them — so
  *  `targetFromChatId` owns that mapping rather than the heartbeat file.
  *
- *  Returns null for anything malformed, which routes the job back to the legacy
- *  active-channel path instead of throwing inside a scheduled run. */
-export function heartbeatTarget(destination: unknown): RemoteTarget | null {
-    if (!isHeartbeatDestination(destination)) return null;
+ *  `pinned` distinguishes the two ways this returns no target, because they must
+ *  not be delivered the same way. A job that never named a destination keeps the
+ *  legacy active-channel path. A job that DID name one but wrote it wrong has
+ *  stated an intent the resolver cannot satisfy — falling back there would send
+ *  a report meant for one channel to whoever spoke last, which is the failure
+ *  this whole change exists to stop (#437). */
+export function heartbeatTarget(destination: unknown): { pinned: boolean; target: RemoteTarget | null } {
+    if (destination === undefined || destination === null) return { pinned: false, target: null };
+    if (!isHeartbeatDestination(destination)) return { pinned: true, target: null };
     const dest = destination as HeartbeatDestination;
     const target = targetFromChatId(dest.channel, dest.targetId);
-    return dest.threadId ? { ...target, threadId: dest.threadId } : target;
+    return { pinned: true, target: dest.threadId ? { ...target, threadId: dest.threadId } : target };
 }
 
 function pendingSnapshot(reason?: HeartbeatPendingReason, policy?: HeartbeatPendingPolicy) {
@@ -243,12 +248,20 @@ export async function runHeartbeatJob(job: Record<string, any>) {
         // scheduled reports landed in an unrelated design thread (#437). Jobs
         // with no destination keep the legacy behaviour on purpose: defaulting
         // them to "do not send" would silence every existing install.
-        const target = heartbeatTarget(job["destination"]);
-        const sendResult = decision.send
-            ? await sendChannelOutput(target
-                ? { channel: target.channel, type: 'text', text: formatted, target, allowActiveFallback: false }
-                : { channel: 'active', type: 'text', text: formatted })
-            : { ok: true as const };
+        const { pinned, target } = heartbeatTarget(job["destination"]);
+        if (pinned && !target) {
+            // Stated an intent we cannot honour. Refusing is the point: delivering
+            // to the active channel would put this report wherever the last
+            // conversation happened to be.
+            log.error(`[heartbeat:${job["name"]}] malformed destination — not delivered`);
+        }
+        const sendResult = !decision.send
+            ? { ok: true as const }
+            : pinned
+                ? (target
+                    ? await sendChannelOutput({ channel: target.channel, type: 'text', text: formatted, target, allowActiveFallback: false })
+                    : { ok: false as const, error: 'invalid heartbeat destination' })
+                : await sendChannelOutput({ channel: 'active', type: 'text', text: formatted });
         if (!sendResult.ok) {
             log.error(`[heartbeat:${job["name"]}] send failed: ${sendResult.error}`);
         }

--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -199,7 +199,6 @@ export async function runHeartbeatJob(job: Record<string, any>) {
         log.info(`[heartbeat:${job["name"]}] ${queued ? 'deferred' : 'already deferred'} during active main agent (${pendingJobs.length} pending)`);
         return;
     }
-    // Main IDLE runs historically reached orchestrateAndCollect(prompt); wp4 uses its data-returning form.
     heartbeatBusy = true;
     try {
         const schedule = normalizeHeartbeatSchedule(job["schedule"]);

--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -11,7 +11,10 @@ import { orchestrateAndCollectData } from '../orchestrator/collect.js';
 import { claimWorker, failWorker, finishWorker, WorkerBusyError } from '../orchestrator/worker-registry.js';
 import { hasPendingWorkerReplays } from '../orchestrator/worker-registry.js';
 import { broadcast } from '../core/bus.js';
-import { sendChannelOutput } from '../messaging/send.js';
+import { sendChannelOutput, targetFromChatId } from '../messaging/send.js';
+import { isHeartbeatDestination } from '../core/config.js';
+import type { HeartbeatDestination } from '../core/config.js';
+import type { RemoteTarget } from '../messaging/types.js';
 import { getEmployees, insertHeartbeatAnchor } from '../core/db.js';
 import type { EmployeeRow } from '../core/employees.js';
 import { runSingleAgent } from '../orchestrator/distribute.js';
@@ -49,6 +52,22 @@ const pendingJobs: PendingHeartbeatJob[] = [];
 
 export function isHeartbeatQuietOutput(result: string, extraMarkers: string[] = []): boolean {
     return ['[SILENT]', ...extraMarkers].some(marker => marker.length > 0 && result.includes(marker));
+}
+
+/** Turn a stored destination into a send target.
+ *
+ *  The stored shape carries only what an operator can reasonably know: which
+ *  transport, which conversation, and optionally which thread. `targetKind` and
+ *  `peerKind` are derived from the id — Slack's C/D/G prefixes decide them — so
+ *  `targetFromChatId` owns that mapping rather than the heartbeat file.
+ *
+ *  Returns null for anything malformed, which routes the job back to the legacy
+ *  active-channel path instead of throwing inside a scheduled run. */
+export function heartbeatTarget(destination: unknown): RemoteTarget | null {
+    if (!isHeartbeatDestination(destination)) return null;
+    const dest = destination as HeartbeatDestination;
+    const target = targetFromChatId(dest.channel, dest.targetId);
+    return dest.threadId ? { ...target, threadId: dest.threadId } : target;
 }
 
 function pendingSnapshot(reason?: HeartbeatPendingReason, policy?: HeartbeatPendingPolicy) {
@@ -218,8 +237,18 @@ export async function runHeartbeatJob(job: Record<string, any>) {
 
         log.info(`[heartbeat:${job["name"]}] response: ${result.slice(0, 80)}`);
 
-        // Send heartbeat result via active messaging channel
-        const sendResult = decision.send ? await sendChannelOutput({ channel: 'active', type: 'text', text: formatted }) : { ok: true as const };
+        // A job with a destination goes THERE and nowhere else. Without one the
+        // send falls back to whichever conversation spoke to the bot most
+        // recently, which is not a property of this job at all — that is how two
+        // scheduled reports landed in an unrelated design thread (#437). Jobs
+        // with no destination keep the legacy behaviour on purpose: defaulting
+        // them to "do not send" would silence every existing install.
+        const target = heartbeatTarget(job["destination"]);
+        const sendResult = decision.send
+            ? await sendChannelOutput(target
+                ? { channel: target.channel, type: 'text', text: formatted, target, allowActiveFallback: false }
+                : { channel: 'active', type: 'text', text: formatted })
+            : { ok: true as const };
         if (!sendResult.ok) {
             log.error(`[heartbeat:${job["name"]}] send failed: ${sendResult.error}`);
         }
@@ -229,7 +258,7 @@ export async function runHeartbeatJob(job: Record<string, any>) {
             const now = Date.now();
             try {
                 insertHeartbeatAnchor.run(
-                    job["id"], job["name"], settings["workingDir"], 'active', null,
+                    job["id"], job["name"], settings["workingDir"], target?.channel ?? 'active', target?.targetId ?? null,
                     job["prompt"], decision.delivered ? formatted : `[quiet] ${formatted}`, now, decision.delivered ? now : null,
                 );
             } catch (e) {

--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -8,7 +8,7 @@ import { settings, HEARTBEAT_JOBS_PATH, loadHeartbeatFile, saveHeartbeatFile } f
 import { stripUndefined } from '../core/strip-undefined.js';
 import { isAgentBusy, messageQueue } from '../agent/spawn.js';
 import { orchestrateAndCollectData } from '../orchestrator/collect.js';
-import { claimWorker, failWorker, finishWorker, WorkerBusyError } from '../orchestrator/worker-registry.js';
+import { claimWorker, failWorker, finishWorker, markWorkerReplayed, WorkerBusyError } from '../orchestrator/worker-registry.js';
 import { hasPendingWorkerReplays } from '../orchestrator/worker-registry.js';
 import { broadcast } from '../core/bus.js';
 import { sendChannelOutput, targetFromChatId } from '../messaging/send.js';
@@ -168,6 +168,11 @@ async function runEmployee(job: Record<string, any>, prompt: string): Promise<He
             const result = await runSingleAgent(ap, emp, { tag: `heartbeat:${job["id"] || job["name"]}` }, 1, { origin: 'heartbeat' }, []);
             const text = String(result["text"] || '');
             finishWorker(slot.agentId, text, Array.isArray(result["tools"]) ? result["tools"] : []);
+            // finishWorker arms a replay for a Boss to collect. A heartbeat has no
+            // Boss, so nobody ever collected it — and processQueue skips any scope
+            // with a pending replay, so one employee heartbeat left the default
+            // queue permanently stalled behind a handoff that would never happen.
+            markWorkerReplayed(slot.agentId);
             return parseHeartbeatReport(text);
         } catch (error) {
             failWorker(slot.agentId, error instanceof Error ? error.message : String(error));

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -54,6 +54,12 @@ export type ChannelSendRequest = {
      *  such context, so inheriting one delivers it to an unrelated thread (#437).
      *  Absent keeps the historical behaviour — every existing caller is unchanged. */
     allowActiveFallback?: boolean;
+    /** Skip the two volatile slots and resolve straight to the configured
+     *  allowlist. For reminders, watcher notifications and alerts, which have a
+     *  destination in the operator sense (the channel that was set up to receive
+     *  them) but not a conversational one — so last-active is wrong while failing
+     *  outright would be worse than delivering somewhere stable (#438). */
+    preferConfiguredTarget?: boolean;
 };
 
 // ─── Transport Send Registry ────────────────────────
@@ -333,10 +339,12 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     // whichever conversation last spoke to the bot, which is how two reports
     // landed in an unrelated design thread on 2026-08-25.
     if (!req.target && req.allowActiveFallback !== false) {
-        const last = getLastActiveTarget(channel);
+        const configuredFirst = req.preferConfiguredTarget ? getConfiguredFallbackTarget(channel) : null;
+        if (configuredFirst) req.target = configuredFirst;
+        const last = req.target ? null : getLastActiveTarget(channel);
         if (last && validateTarget(last, channel)) {
             req.target = last;
-        } else {
+        } else if (!req.target) {
             if (last) clearTargetState(channel); // stale cached target — clear it
             const seen = getLatestSeenTarget(channel);
             if (seen && validateTarget(seen, channel)) {

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -47,6 +47,13 @@ export type ChannelSendRequest = {
      *  fidelity. Absent means the caller would rather be told it is unsupported
      *  than have the message quietly arrive as something else. */
     interactiveFallback?: 'text';
+    /** Non-interactive senders (heartbeats, scheduled jobs) set this to false so a
+     *  missing target FAILS instead of silently resolving to whoever spoke last.
+     *  The last-active chain exists for CONVERSATIONAL replies where "this
+     *  conversation" is the obvious destination (#397); a scheduled report has no
+     *  such context, so inheriting one delivers it to an unrelated thread (#437).
+     *  Absent keeps the historical behaviour — every existing caller is unchanged. */
+    allowActiveFallback?: boolean;
 };
 
 // ─── Transport Send Registry ────────────────────────
@@ -220,7 +227,7 @@ export function validateTarget(
     return true;
 }
 
-function targetFromChatId(channel: MessengerChannel, chatId: string | number): RemoteTarget {
+export function targetFromChatId(channel: MessengerChannel, chatId: string | number): RemoteTarget {
     const targetId = String(chatId);
     switch (channel) {
         case 'telegram':
@@ -320,7 +327,12 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     }
 
     // Resolve target: explicit > validated lastActive > validated latestSeen > configured fallback > error
-    if (!req.target) {
+    //
+    // Gated on allowActiveFallback: a scheduled sender opts OUT of this chain
+    // entirely (#437). Without that opt-out a heartbeat with no target inherits
+    // whichever conversation last spoke to the bot, which is how two reports
+    // landed in an unrelated design thread on 2026-08-25.
+    if (!req.target && req.allowActiveFallback !== false) {
         const last = getLastActiveTarget(channel);
         if (last && validateTarget(last, channel)) {
             req.target = last;

--- a/src/orchestrator/state-machine.ts
+++ b/src/orchestrator/state-machine.ts
@@ -3,7 +3,7 @@
 // State persisted in jaw.db orc_state table.
 // CLI (bin/commands/orchestrate.ts) and server share the same DB.
 
-import { getOrcState, setOrcState, resetOrcState, resetAllOrcStates } from '../core/db.js';
+import { getOrcState, setOrcState, resetOrcState, resetAllOrcStates, resetEveryOrcState } from '../core/db.js';
 import { broadcast } from '../core/bus.js';
 import { readLatestWorklog } from '../memory/worklog.js';
 import { checkAttestationGate } from './attestation.js';
@@ -166,6 +166,22 @@ export function resetAllStaleStates(): number {
   const cleared = result.changes;
   if (cleared > 0) {
     console.log(`[jaw:pabcd] cleared ${cleared} stale orchestration state(s) (>24h old)`);
+    broadcast('orc_state', { state: 'IDLE', title: '', scope: 'all' });
+  }
+  return cleared;
+}
+
+/** Reset every non-IDLE scope regardless of age.
+ *
+ *  `?all=true` used to call resetAllStaleStates, so it cleared only rows older
+ *  than a day — the opposite of what the name promised, and useless for the case
+ *  it exists for: a scope stuck mid-phase waiting on workers that died with the
+ *  previous process (#452). */
+export function resetEveryState(): number {
+  const result = resetEveryOrcState.run();
+  const cleared = result.changes;
+  if (cleared > 0) {
+    console.log(`[jaw:pabcd] cleared ${cleared} orchestration state(s) (explicit full reset)`);
     broadcast('orc_state', { state: 'IDLE', title: '', scope: 'all' });
   }
   return cleared;

--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -1044,7 +1044,10 @@ export function getEmployeePromptV2(
     // --mutable: override the hard read-only block in employee.md
     if (opts?.mutable) {
         prompt = prompt.replace(
-            /- ⛔ Do NOT create, modify, or delete files\..*/,
+            // Must track employee.md. The previous pattern named a sentence that
+            // template no longer contains, so the replace silently matched nothing
+            // and --mutable left the prompt still saying writes were blocked (#442).
+            /- File writes are blocked unless the Boss explicitly grants `--mutable`\./,
             `- ✅ You are authorized to create or modify files${opts.scope ? ` inside \`${opts.scope}\`` : ''}. Protected paths (.git, .env, settings.json) remain blocked.`,
         );
     }

--- a/src/routes/heartbeat.ts
+++ b/src/routes/heartbeat.ts
@@ -63,7 +63,7 @@ export function normalizeHeartbeatPutRunnerFields(
 }
 
 export function registerHeartbeatRoutes(app: Express, requireAuth: AuthMiddleware): void {
-    app.get('/api/heartbeat', (_req, res) => res.json(loadHeartbeatFile()));
+    app.get('/api/heartbeat', requireAuth, (_req, res) => res.json(loadHeartbeatFile()));
 
     app.put('/api/heartbeat', requireAuth, (req, res) => {
         const data = req.body;

--- a/src/routes/heartbeat.ts
+++ b/src/routes/heartbeat.ts
@@ -1,6 +1,7 @@
 import type { Express } from 'express';
 import type { AuthMiddleware } from './types.js';
-import { loadHeartbeatFile, saveHeartbeatFile } from '../core/config.js';
+import { loadHeartbeatFile, saveHeartbeatFile, isHeartbeatDestination } from '../core/config.js';
+import type { HeartbeatDestination } from '../core/config.js';
 import { startHeartbeat } from '../memory/heartbeat.js';
 import { validateHeartbeatScheduleInput } from '../memory/heartbeat-schedule.js';
 import { getEmployees } from '../core/db.js';
@@ -9,6 +10,29 @@ import { stripUndefined } from '../core/strip-undefined.js';
 
 type RunnerFields = Pick<import('../core/config.js').HeartbeatJob, 'runner' | 'employee' | 'command' | 'reportPolicy'>;
 export type HeartbeatPutRunnerResult = { ok: true; fields: RunnerFields } | { ok: false; error: string };
+
+/** Resolve the destination a PUT should persist.
+ *
+ *  Every shipped UI (Classic `normalizeHeartbeatJob`, Manager `safeJob`) rebuilds
+ *  each job from a fixed five-field shape, so a field they do not know about is
+ *  absent from the body rather than explicitly cleared. Inheriting on absence is
+ *  what keeps an ordinary "Save jobs" click from deleting a destination the UI
+ *  cannot even display — the same reason runner fields already inherit.
+ *
+ *  An explicit `null` is the deliberate clear, and is NOT folded into undefined:
+ *  doing so would make unsetting impossible from any client. */
+export function resolveHeartbeatDestination(
+    job: Record<string, unknown>,
+    existing: HeartbeatDestination | null | undefined,
+): { ok: true; destination: HeartbeatDestination | undefined } | { ok: false; error: string } {
+    if (!Object.prototype.hasOwnProperty.call(job, 'destination')) {
+        return { ok: true, destination: existing ?? undefined };
+    }
+    const raw = job['destination'];
+    if (raw === null) return { ok: true, destination: undefined };
+    if (!isHeartbeatDestination(raw)) return { ok: false, error: 'invalid heartbeat destination' };
+    return { ok: true, destination: raw };
+}
 
 export function normalizeHeartbeatPutRunnerFields(
     job: Record<string, unknown>,
@@ -70,6 +94,8 @@ export function registerHeartbeatRoutes(app: Express, requireAuth: AuthMiddlewar
             const existing = existingById.get(jobId);
             const runnerResult = normalizeHeartbeatPutRunnerFields(job, existing, employeeNames);
             if (!runnerResult.ok) { res.status(400).json({ error: runnerResult.error, index, jobId }); return; }
+            const destResult = resolveHeartbeatDestination(job, existing?.destination);
+            if (!destResult.ok) { res.status(400).json({ error: destResult.error, index, jobId }); return; }
             normalizedJobs.push(stripUndefined({
                 id: jobId,
                 name: typeof job["name"] === 'string' ? job["name"] : '',
@@ -77,6 +103,7 @@ export function registerHeartbeatRoutes(app: Express, requireAuth: AuthMiddlewar
                 schedule: scheduleResult.schedule,
                 prompt: typeof job["prompt"] === 'string' ? job["prompt"] : '',
                 ...runnerResult.fields,
+                destination: destResult.destination,
             }));
         }
         const payload = { jobs: normalizedJobs };

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -89,7 +89,7 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
     });
 
     // Key-value memory
-    app.get('/api/memory', (_, res) => ok(res, getMemory.all()));
+    app.get('/api/memory', requireAuth, (_, res) => ok(res, getMemory.all()));
     app.post('/api/memory', requireAuth, (req, res) => {
         const { key, value, source = 'manual' } = req.body;
         if (!key || !value) return fail(res, 400, 'key and value required');
@@ -104,7 +104,7 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
     });
 
     // Memory files (integrated + Claude native)
-    app.get('/api/memory-files', (_, res) => {
+    app.get('/api/memory-files', requireAuth, (_, res) => {
         const memDir = memoryModule.MEMORY_DIR;
         const files = memoryModule.list()
             .sort((a, b) => b.path.localeCompare(a.path))
@@ -126,7 +126,7 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
         });
     });
 
-    app.get('/api/memory-file', (req, res) => {
+    app.get('/api/memory-file', requireAuth, (req, res) => {
         try {
             const name = assertMemoryRelPath(String(req.query["path"] || ''), { allowExt: ['.md', '.txt', '.json'] });
             const fp = safeResolveUnder(memoryModule.MEMORY_DIR, name);

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -4,6 +4,7 @@
 // (Not to be confused with routes/messaging.ts — channel transport routes.)
 
 import type { Router } from 'express';
+import type { AuthMiddleware } from './types.js';
 import { ok } from '../http/response.js';
 import {
     getMessages, getMessagesWithTrace, getRecentMessagesAll, getRecentMessagesAllWithTrace,
@@ -50,8 +51,8 @@ export function resolveToolLog(
     return sanitizeSerializedToolLog(blobToolLog);
 }
 
-export function registerMessageRoutes(app: Router): void {
-    app.get('/api/messages', (req, res) => {
+export function registerMessageRoutes(app: Router, requireAuth: AuthMiddleware): void {
+    app.get('/api/messages', requireAuth, (req, res) => {
         const includeTrace = ['1', 'true', 'yes'].includes(String(req.query["includeTrace"] || '').toLowerCase());
         // Optional recent-window: `?limit=N` returns only the most recent N messages
         // (still ascending) so the chat boot/instance-switch payload stays small.
@@ -78,7 +79,7 @@ export function registerMessageRoutes(app: Router): void {
         ok(res, { count: row?.count ?? 0 });
     });
 
-    app.get('/api/messages/search', (req, res) => {
+    app.get('/api/messages/search', requireAuth, (req, res) => {
         const q = String(req.query['q'] || '').trim();
         if (!q) return ok(res, []);
         const limit = Math.min(Math.max(Number(req.query['limit']) || 20, 1), 50);
@@ -114,7 +115,7 @@ export function registerMessageRoutes(app: Router): void {
         ok(res, results);
     });
 
-    app.get('/api/messages/latest', (_req, res) => {
+    app.get('/api/messages/latest', requireAuth, (_req, res) => {
         const includeContent = ['1', 'true', 'yes'].includes(String(_req.query["includeContent"] || '').toLowerCase());
         const latestRow = getLatestAssistantMessage.get(getActiveChatSession()) as {
             id?: number;

--- a/src/routes/orchestrate.ts
+++ b/src/routes/orchestrate.ts
@@ -7,7 +7,7 @@ import { countToolTraceRows, listToolEntriesForRun } from '../trace/store.js';
 import { orchestrate, orchestrateContinue, orchestrateReset, isResetIntent, isContinueIntent, drainPendingReplays } from '../orchestrator/pipeline.js';
 import { getSession, insertMessage } from '../core/db.js';
 import { getActiveChatSession } from '../core/chat-sessions.js';
-import { getState, getCtx, setState, resetState, canTransition, resetAllStaleStates, parseWorkerVerdict, aggregateBatchVerdicts } from '../orchestrator/state-machine.js';
+import { getState, getCtx, setState, resetState, canTransition, resetEveryState, parseWorkerVerdict, aggregateBatchVerdicts } from '../orchestrator/state-machine.js';
 import type { WorkerVerdict } from '../orchestrator/state-machine.js';
 import { normalizeTaskTags } from '../prompt/builder.js';
 import { parsePhaseAttestationObject } from '../orchestrator/attestation.js';
@@ -236,8 +236,12 @@ export function registerOrchestrateRoutes(app: Express, requireAuth: AuthMiddlew
         try {
             const all = req.query["all"] === 'true' || req.body?.all === true;
             if (all) {
-                const cleared = resetAllStaleStates();
-                res.json({ ok: true, cleared, message: `Cleared ${cleared} stale state(s)` });
+                // `all` now means all. It used to call the stale-only variant, so a
+                // scope stuck mid-phase since the last restart — the exact thing an
+                // operator reaches for this endpoint to clear — was left untouched
+                // unless it had been stuck for over a day (#452).
+                const cleared = resetEveryState();
+                res.json({ ok: true, cleared, message: `Cleared ${cleared} orchestration state(s)` });
                 return;
             }
             await orchestrateReset({ origin: 'web' });

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -93,6 +93,33 @@ function redactJawCeoSettings(input: Record<string, unknown> | undefined): Recor
     };
 }
 
+/** Stand-in for a secret that exists but must not travel. Non-empty so a UI
+ *  testing for "is a token configured" keeps working. */
+const MASKED_SECRET = '••••••••';
+
+/** Mask credential-bearing fields in an MCP config tree.
+ *
+ *  Values are replaced, keys are not, so the dashboard can still show which
+ *  variables a server expects without shipping their contents. */
+function redactMcpSecrets(config: unknown): unknown {
+    if (!config || typeof config !== 'object') return config;
+    if (Array.isArray(config)) return config.map(redactMcpSecrets);
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config as Record<string, unknown>)) {
+        if ((key === 'env' || key === 'headers') && value && typeof value === 'object' && !Array.isArray(value)) {
+            out[key] = Object.fromEntries(
+                Object.entries(value as Record<string, unknown>)
+                    .map(([k, v]) => [k, typeof v === 'string' && v ? MASKED_SECRET : v]),
+            );
+        } else if (key === 'oauth' && value) {
+            out[key] = MASKED_SECRET;
+        } else {
+            out[key] = redactMcpSecrets(value);
+        }
+    }
+    return out;
+}
+
 function redactRuntimeSettings<T extends Record<string, unknown>>(input: T): T {
     const safe = { ...input } as T & {
         stt?: Record<string, unknown>;
@@ -121,6 +148,19 @@ function redactRuntimeSettings<T extends Record<string, unknown>>(input: T): T {
             channelIds: [],
             attachPort: '',
         };
+    }
+    // Channel bot tokens are full account credentials, and only the Slack
+    // env-managed case was being masked — a file-configured Telegram or Discord
+    // token came back verbatim (#449). The UI needs to know whether a token is
+    // SET, never what it is, so the boolean survives and the value does not.
+    for (const channel of ['telegram', 'discord', 'slack'] as const) {
+        const block = safe[channel] as Record<string, unknown> | undefined;
+        if (!block || typeof block !== 'object') continue;
+        const masked = { ...block };
+        for (const key of ['token', 'botToken', 'appToken']) {
+            if (typeof masked[key] === 'string' && masked[key]) masked[key] = MASKED_SECRET;
+        }
+        (safe as Record<string, unknown>)[channel] = masked;
     }
     const messaging = safe["messaging"] as { homeChannel?: unknown } | undefined;
     if (typeof messaging?.homeChannel === 'string') {
@@ -208,7 +248,7 @@ export function registerSettingsRoutes(
     applySettings: (patch: Record<string, unknown>) => Promise<unknown>,
     projectRoot: string,
 ): void {
-    app.get('/api/settings', (_, res) => {
+    app.get('/api/settings', requireAuth, (_, res) => {
         const safe = redactRuntimeSettings(settings);
         ok(res, safe, safe);
     });
@@ -427,7 +467,7 @@ export function registerSettingsRoutes(
         res.json(readCodexContextWindow());
     });
 
-    app.get('/api/prompt', (_, res) => {
+    app.get('/api/prompt', requireAuth, (_, res) => {
         const a2 = fs.existsSync(A2_PATH) ? fs.readFileSync(A2_PATH, 'utf8') : '';
         res.json({ content: a2 });
     });
@@ -499,7 +539,10 @@ export function registerSettingsRoutes(
         res.json({ ok: true });
     });
 
-    app.get('/api/mcp', (_req, res) => res.json(loadUnifiedMcp()));
+    // MCP server definitions carry API keys in `env` and bearer tokens in
+    // `headers`. Nothing masked them and the route had no guard, so the whole
+    // set was readable by anyone who could reach the port (#449).
+    app.get('/api/mcp', requireAuth, (_req, res) => res.json(redactMcpSecrets(loadUnifiedMcp())));
 
     app.put('/api/mcp', requireAuth, (req, res) => {
         const config = req.body;

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -5,6 +5,7 @@
 
 import type { Router } from 'express';
 import { fail, ok } from '../http/response.js';
+import { isLoopbackAddress } from '../http/loopback.js';
 import { APP_VERSION, settings } from '../core/config.js';
 import { drainLogRing } from '../core/logger.js';
 import { getSession } from '../core/db.js';
@@ -100,6 +101,17 @@ export function registerSystemRoutes(app: Router, deps: { jawAuthToken: string }
     // Auth token endpoint — Sec-Fetch-Site guard blocks cross-origin XSS token theft
     // Browser-enforced header: cannot be set/spoofed by JS, absent from CLI/curl (passes through)
     app.get('/api/auth/token', (req, res) => {
+        // The Sec-Fetch-Site guard below defends against a BROWSER stealing this
+        // token cross-origin. It cannot defend against a network peer, because
+        // curl simply omits the header — the comment above says so. That was
+        // fine while the server only ever bound to loopback; remoteAccess and LAN
+        // mode bind 0.0.0.0, at which point anyone on the network could ask for
+        // the bearer that unlocks every guarded write endpoint (#449).
+        const remoteIp = req.ip || req.socket?.remoteAddress || '';
+        if (!isLoopbackAddress(remoteIp)) {
+            res.status(401).json({ error: 'auth token is available on loopback only' });
+            return;
+        }
         const site = req.headers['sec-fetch-site'];
         if (site && site !== 'same-origin' && site !== 'none') {
             res.status(403).json({ error: 'cross-origin token request blocked' });

--- a/src/slack/progress.ts
+++ b/src/slack/progress.ts
@@ -54,6 +54,15 @@ export function statusFromToolEvent(data: Record<string, unknown>, fallback: str
  */
 export function sanitizeProgressDetail(detail: string): string {
     if (!detail) return '';
+    // A search pattern is not a file the reader recognises — it is the query the
+    // agent wrote, and it names internal routes and API methods. On 2026-08-25 a
+    // Slack thread showed a raw grep pattern (channel/send, files.upload, a photo
+    // wildcard) for six minutes while the answer was still being written, because
+    // the token rules below only knew about absolute paths and executables (#440).
+    //
+    // Detected structurally rather than by keyword: regex metacharacters are what
+    // make a string a pattern, and an ordinary filename detail has none.
+    if (looksLikeSearchPattern(detail)) return '';
     // Strip content that looks like a file path or command invocation.
     // Approach: split on whitespace, redact tokens that look sensitive, rejoin.
     const tokens = detail.split(/\s+/);
@@ -66,6 +75,11 @@ export function sanitizeProgressDetail(detail: string): string {
         if (/^https?:\/\/(?:127\.0\.0\.1|localhost)/i.test(token)) return '…';
         // Executable names with .exe suffix
         if (/^"?(?:pwsh|powershell|bash|cmd|node)(?:\.exe)?"?$/i.test(token)) return '…';
+        // Internal API method names (a dotted lowercase identifier such as an
+        // upload or post call). Never a word a channel reader needs; the suffix
+        // check keeps real filenames visible.
+        if (/^[a-z][a-z0-9]*\.[a-z][a-zA-Z0-9]*$/.test(token)
+            && !/\.(md|txt|json|ts|js|py|html|css|yml|yaml|sh|log)$/i.test(token)) return '…';
         return token;
     });
     // Remove consecutive redacted tokens
@@ -76,6 +90,15 @@ export function sanitizeProgressDetail(detail: string): string {
     }
     const cleaned = deduped.join(' ').trim();
     return cleaned === '…' ? '' : cleaned;
+}
+
+/** Does this detail read as a search query rather than a human-meaningful label?
+ *
+ *  Alternation, wildcards, character classes and anchors are the marks of a
+ *  pattern. Requiring one of those keeps ordinary details like a source path or
+ *  a README name visible, which is the whole value of the progress line. */
+function looksLikeSearchPattern(detail: string): boolean {
+    return /[|*+?\[\]()^$]/.test(detail) || /\\[a-zA-Z]/.test(detail);
 }
 
 export async function startSlackProgress(

--- a/tests/unit/commands-parse.test.ts
+++ b/tests/unit/commands-parse.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
     parseCommand,
     executeCommand,
@@ -8,6 +10,17 @@ import {
     getArgumentCompletionItems,
     COMMANDS,
 } from '../../src/cli/commands.ts';
+import { CODEX_MODEL_CHOICES } from '../../src/cli/registry.ts';
+import { resetOpenCodexModelCacheForTest } from '../../src/cli/opencodex-models.ts';
+
+// Codex completions prefer a LIVE opencodex catalog and only fall back to the
+// static registry when no runtime answers. On a developer machine running
+// opencodex these tests were therefore asserting the contents of whatever that
+// daemon happened to serve, and failed for a reason that had nothing to do with
+// the code under test (#447). Pointing the lookup at an empty directory removes
+// the runtime from the equation so the static path is the one being tested.
+process.env['CLI_JAW_OPENCODEX_DIR'] = join(tmpdir(), 'cli-jaw-test-no-opencodex');
+resetOpenCodexModelCacheForTest();
 
 // ─── parseCommand ────────────────────────────────────
 
@@ -258,14 +271,20 @@ test('getArgumentCompletionItems: model labels use concrete provider instead of 
     assert.notEqual(item.desc, 'ai-e');
 });
 
-test('getArgumentCompletionItems: model command includes default Codex spark choice', async () => {
-    const items = await getArgumentCompletionItems('model', 'spark', 'cli', [], {});
-    assert.ok(items.some(i => i.name === 'gpt-5.3-codex-spark'));
+// Assert on the registry rather than a hardcoded id: the point is that the static
+// catalog reaches completions, not that any particular model is in it forever.
+const staticCodexModel = CODEX_MODEL_CHOICES.find(m => m.includes('spark')) ?? CODEX_MODEL_CHOICES[0]!;
+
+test('getArgumentCompletionItems: model command offers the static Codex catalog when no runtime answers', async () => {
+    const items = await getArgumentCompletionItems('model', staticCodexModel, 'cli', [], {});
+    assert.ok(items.some(i => i.name === staticCodexModel),
+        `expected ${staticCodexModel} from CODEX_MODEL_CHOICES, got: ${items.map(i => i.name).join(', ')}`);
 });
 
-test('getArgumentCompletionItems: employee model command uses dynamic Codex model choices', async () => {
-    const items = await getArgumentCompletionItems('employee', 'spark', 'cli', ['model', 'Control'], {});
-    assert.ok(items.some(i => i.name === 'gpt-5.3-codex-spark'));
+test('getArgumentCompletionItems: employee model command uses the same Codex catalog', async () => {
+    const items = await getArgumentCompletionItems('employee', staticCodexModel, 'cli', ['model', 'Control'], {});
+    assert.ok(items.some(i => i.name === staticCodexModel),
+        `expected ${staticCodexModel}, got: ${items.map(i => i.name).join(', ')}`);
 });
 
 test('getArgumentCompletionItems: employee cli command returns cli choices', async () => {

--- a/tests/unit/employee-mutable-prompt.test.ts
+++ b/tests/unit/employee-mutable-prompt.test.ts
@@ -1,0 +1,32 @@
+// #442: --mutable must actually change what the employee is told.
+//
+// The override is a string replace against employee.md. When that template was
+// reworded the pattern kept matching the OLD sentence, so the replace silently
+// did nothing and a Boss who granted writes still handed the employee a prompt
+// saying writes were blocked. A source-level regex test would not have caught it
+// either — only comparing the two rendered prompts does.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getEmployeePromptV2, clearPromptCache } from '../../src/prompt/builder.ts';
+
+const emp = { name: 'reviewer', role: 'reviewer', id: 1 };
+
+test('EMP-442a: --mutable removes the write-blocked line', () => {
+    clearPromptCache();
+    const readOnly = String(getEmployeePromptV2(emp, 'reviewer', 1, {}));
+    clearPromptCache();
+    const mutable = String(getEmployeePromptV2(emp, 'reviewer', 1, { mutable: true }));
+
+    assert.match(readOnly, /File writes are blocked/,
+        'the read-only prompt must state the restriction');
+    assert.doesNotMatch(mutable, /File writes are blocked/,
+        'granting --mutable must not leave the employee reading a blanket prohibition');
+    assert.match(mutable, /authorized to create or modify files/);
+});
+
+test('EMP-442b: a scope is named in the authorization when one is given', () => {
+    clearPromptCache();
+    const scoped = String(getEmployeePromptV2(emp, 'reviewer', 1, { mutable: true, scope: 'src/messaging' }));
+    assert.match(scoped, /inside `src\/messaging`/);
+});
+

--- a/tests/unit/flush-command.test.ts
+++ b/tests/unit/flush-command.test.ts
@@ -6,6 +6,15 @@ import { join, delimiter } from 'node:path';
 import { tmpdir } from 'node:os';
 import { flushHandler } from '../../src/cli/handlers.ts';
 import { migrateSettings } from '../../src/core/config.ts';
+import { resetOpenCodexModelCacheForTest } from '../../src/cli/opencodex-models.ts';
+
+// withIsolatedPath controls which CLI BINARIES are visible, but model→CLI
+// inference also consults the live opencodex catalog, so on a machine running
+// opencodex this test resolved through that daemon's models and picked a CLI the
+// isolated PATH never contained (#447). Removing the runtime keeps the inference
+// on the static registry the assertion is written against.
+process.env['CLI_JAW_OPENCODEX_DIR'] = join(tmpdir(), 'cli-jaw-test-no-opencodex');
+resetOpenCodexModelCacheForTest();
 
 // ─── Mock helpers ────────────────────────────────────
 // Note: locales are NOT loaded in test context, so t() falls back to key name.

--- a/tests/unit/heartbeat-file.test.ts
+++ b/tests/unit/heartbeat-file.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 
 import { HEARTBEAT_JOBS_PATH, loadHeartbeatFile, saveHeartbeatFile } from '../../src/core/config.ts';
 import { clearPromptCache, getSystemPrompt } from '../../src/prompt/builder.ts';
-import { normalizeHeartbeatPutRunnerFields } from '../../src/routes/heartbeat.ts';
+import { normalizeHeartbeatPutRunnerFields, resolveHeartbeatDestination } from '../../src/routes/heartbeat.ts';
 
 test('loadHeartbeatFile returns empty jobs only when heartbeat file is absent', () => {
     fs.rmSync(HEARTBEAT_JOBS_PATH, { force: true });
@@ -62,3 +62,56 @@ test('PUT normalization rejects an unknown employee', () => {
     const result = normalizeHeartbeatPutRunnerFields({ runner: 'employee', employee: 'missing' }, undefined, new Set(['known']));
     assert.deepEqual(result, { ok: false, error: 'unknown heartbeat employee' });
 });
+
+// ─── destination survives a UI save (#437) ──────────
+//
+// Every shipped UI rebuilds a job from a fixed five-field shape, so a field they
+// do not render is absent from the PUT body. If absence meant "clear", one
+// ordinary "Save jobs" click would silently unpin every scheduled report and
+// hand it back to the last-active resolver — the exact bug being fixed.
+
+test('a UI-shaped PUT that omits destination preserves the stored one', () => {
+    const existing = { channel: 'slack' as const, targetId: 'C_REPORTS', threadId: '1787616871.254919' };
+    const strippedUiJob = { id: 'pinned', name: 'pinned', enabled: true, schedule: { minutes: 5 }, prompt: 'check' };
+    const result = resolveHeartbeatDestination(strippedUiJob, existing);
+    assert.deepEqual(result, { ok: true, destination: existing });
+});
+
+test('an explicit null clears the destination', () => {
+    const existing = { channel: 'slack' as const, targetId: 'C_REPORTS' };
+    const result = resolveHeartbeatDestination({ destination: null }, existing);
+    assert.deepEqual(result, { ok: true, destination: undefined },
+        'unsetting must remain possible, so null is not folded into absence');
+});
+
+test('a supplied destination replaces the stored one', () => {
+    const result = resolveHeartbeatDestination(
+        { destination: { channel: 'slack', targetId: 'C_NEW' } },
+        { channel: 'slack', targetId: 'C_OLD' },
+    );
+    assert.deepEqual(result, { ok: true, destination: { channel: 'slack', targetId: 'C_NEW' } });
+});
+
+test('a malformed destination is rejected rather than half-applied', () => {
+    assert.deepEqual(
+        resolveHeartbeatDestination({ destination: { channel: 'slack' } }, undefined),
+        { ok: false, error: 'invalid heartbeat destination' });
+    assert.deepEqual(
+        resolveHeartbeatDestination({ destination: { channel: 'irc', targetId: 'x' } }, undefined),
+        { ok: false, error: 'invalid heartbeat destination' });
+});
+
+test('no destination anywhere stays absent', () => {
+    assert.deepEqual(resolveHeartbeatDestination({ id: 'j' }, undefined), { ok: true, destination: undefined });
+});
+
+test('a destination written directly to the file survives load', () => {
+    const destination = { channel: 'slack' as const, targetId: 'C_REPORTS', threadId: '1787616871.254919' };
+    try {
+        saveHeartbeatFile({ jobs: [{ id: 'pinned', prompt: 'check', destination }] });
+        assert.deepEqual(loadHeartbeatFile().jobs[0]?.destination, destination);
+    } finally {
+        saveHeartbeatFile({ jobs: [] });
+    }
+});
+

--- a/tests/unit/heartbeat-pabcd-guard.test.ts
+++ b/tests/unit/heartbeat-pabcd-guard.test.ts
@@ -11,11 +11,16 @@ const pipelineSrc = readFileSync(join(projectRoot, 'src/orchestrator/pipeline.ts
 
 test('heartbeat guard checks PABCD state before orchestrateAndCollect', () => {
     const guardIdx = heartbeatSrc.indexOf("getState('default') !== 'IDLE'");
-    const collectIdx = heartbeatSrc.indexOf('orchestrateAndCollect(prompt');
+    // Anchored on the real call. The previous anchor, `orchestrateAndCollect(prompt`,
+    // has not existed as a call since the runner moved to the data-returning form —
+    // it survives only inside a comment, so this test was measuring the position of
+    // a comment. Deleting that line would have failed the test; moving it above the
+    // guard would have passed one with the guard removed (#443).
+    const collectIdx = heartbeatSrc.indexOf('orchestrateAndCollectData(prompt');
 
     assert.ok(heartbeatSrc.includes("import { getState } from '../orchestrator/state-machine.js'"));
     assert.ok(guardIdx > -1, 'heartbeat must check PABCD state');
-    assert.ok(collectIdx > -1, 'heartbeat must still call orchestrateAndCollect for IDLE runs');
+    assert.ok(collectIdx > -1, 'heartbeat must still run the collector for IDLE runs');
     assert.ok(guardIdx < collectIdx, 'PABCD guard must run before orchestrateAndCollect');
     assert.ok(heartbeatSrc.includes("'pabcd_active'"), 'defer reason must be structured');
     assert.ok(heartbeatSrc.includes("'defer'"), 'defer policy must be structured');
@@ -23,12 +28,12 @@ test('heartbeat guard checks PABCD state before orchestrateAndCollect', () => {
 
 test('heartbeat defers while the main agent is busy', () => {
     const busyIdx = heartbeatSrc.indexOf('isAgentBusy(HEARTBEAT_SCOPE)');
-    const collectIdx = heartbeatSrc.indexOf('orchestrateAndCollect(prompt');
+    const collectIdx = heartbeatSrc.indexOf('orchestrateAndCollectData(prompt');
 
     assert.ok(heartbeatSrc.includes("import { isAgentBusy, messageQueue } from '../agent/spawn.js'"));
     assert.ok(heartbeatSrc.includes("'agent_busy'"), 'agent-busy defer reason must be structured');
     assert.ok(busyIdx > -1, 'heartbeat must check isAgentBusy before starting');
-    assert.ok(collectIdx > -1, 'heartbeat must still call orchestrateAndCollect for IDLE runs');
+    assert.ok(collectIdx > -1, 'heartbeat must still run the collector for IDLE runs');
     assert.ok(busyIdx < collectIdx, 'agent-busy guard must run before orchestrateAndCollect');
     assert.match(
         heartbeatSrc,

--- a/tests/unit/heartbeat-routing.test.ts
+++ b/tests/unit/heartbeat-routing.test.ts
@@ -36,14 +36,14 @@ test('sendChannelOutput returns explicit error when no target available', () => 
 });
 
 // ─── Target resolution order ────────────────────────
-
-test('target resolution follows explicit > lastActive > latestSeen > configured', () => {
-    // The sendChannelOutput function should check in this order
-    const sendFn = sendSrc.slice(sendSrc.indexOf('async function sendChannelOutput'));
-    const lastActiveIdx = sendFn.indexOf('getLastActiveTarget');
-    const latestSeenIdx = sendFn.indexOf('getLatestSeenTarget');
-    const configuredIdx = sendFn.indexOf('getConfiguredFallbackTarget');
-
-    assert.ok(lastActiveIdx < latestSeenIdx, 'lastActive before latestSeen');
-    assert.ok(latestSeenIdx < configuredIdx, 'latestSeen before configured');
-});
+//
+// This used to assert the ORDER of three identifiers inside sendChannelOutput's
+// source text. That is not a contract — it is a transcription of the current
+// implementation, and it made the resolver un-refactorable while proving nothing
+// about delivery. Worse, the file is named heartbeat-routing, so it read as an
+// endorsement of the very fallback that misdelivered two scheduled reports on
+// 2026-08-25 (#437).
+//
+// The behaviour it meant to protect now lives where it can actually fail:
+//   tests/unit/send-validation.test.ts   — resolution order and the opt-out
+//   tests/unit/heartbeat-runner-modes.test.ts — which request a job builds

--- a/tests/unit/heartbeat-runner-modes.test.ts
+++ b/tests/unit/heartbeat-runner-modes.test.ts
@@ -18,6 +18,7 @@ let collectCalls = 0;
 let plannerOnly = false;
 let employeeBusy = false;
 const sent: string[] = [];
+const sentRequests: Array<Record<string, any>> = [];
 const anchors: unknown[][] = [];
 const employee = { id: 'emp-1', name: 'reviewer', cli: 'codex', model: null, role: 'reviewer' };
 
@@ -28,7 +29,14 @@ mock.module(collectUrl, { namedExports: {
     },
     orchestrateAndCollect: async () => 'unused',
 } });
-mock.module(sendUrl, { namedExports: { ...realSend, sendChannelOutput: async (input: { text: string }) => { sent.push(input.text); return { ok: true }; } } });
+mock.module(sendUrl, { namedExports: {
+    ...realSend,
+    sendChannelOutput: async (input: Record<string, any>) => {
+        sent.push(input["text"]);
+        sentRequests.push(structuredClone(input));
+        return { ok: true };
+    },
+} });
 mock.module(dbUrl, { namedExports: {
     ...realDb,
     getEmployees: { all: () => [employee] },
@@ -103,3 +111,84 @@ test('script runner configures the audited timeout and output bound', async () =
     const source = await import('node:fs').then(fs => fs.readFileSync(new URL('../../src/memory/heartbeat.ts', import.meta.url), 'utf8'));
     assert.match(source, /timeout: 10 \* 60_000, maxBuffer: 64 \* 1024/);
 });
+
+// ─── destination routing (#437) ─────────────────────
+//
+// The incident: two scheduled reports were delivered to whichever Slack thread
+// had most recently spoken to the bot, because the send carried no target and
+// the resolver filled one in. These assert on the REQUEST the job builds, since
+// that is where the destination is either honoured or lost.
+
+test('a job with a destination sends there and forbids the active fallback', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({
+        id: 'pinned', name: 'pinned', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'slack', targetId: 'C_REPORTS', threadId: '1787616871.254919' },
+    });
+
+    assert.equal(sentRequests.length, 1);
+    const req = sentRequests[0]!;
+    assert.equal(req['channel'], 'slack');
+    assert.equal(req['target']?.targetId, 'C_REPORTS');
+    assert.equal(req['target']?.threadId, '1787616871.254919');
+    assert.equal(req['allowActiveFallback'], false,
+        'a pinned job must not be re-routed by whoever spoke last');
+});
+
+test('a destination without a thread posts to the conversation root', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({
+        id: 'root', name: 'root', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'slack', targetId: 'C_REPORTS' },
+    });
+
+    assert.equal(sentRequests[0]?.['target']?.targetId, 'C_REPORTS');
+    assert.equal(sentRequests[0]?.['target']?.threadId, undefined);
+});
+
+test('the derived target carries the kinds the operator never types', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({
+        id: 'kinds', name: 'kinds', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'slack', targetId: 'C_REPORTS' },
+    });
+
+    // Stored form is three fields; targetKind/peerKind come from the id prefix.
+    assert.equal(sentRequests[0]?.['target']?.targetKind, 'channel');
+    assert.equal(sentRequests[0]?.['target']?.peerKind, 'channel');
+});
+
+test('a job without a destination keeps the legacy active-channel behaviour', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({ id: 'legacy', name: 'legacy', enabled: true, schedule: { minutes: 5 }, prompt: 'check' });
+
+    assert.equal(sentRequests.length, 1);
+    assert.equal(sentRequests[0]?.['channel'], 'active');
+    assert.equal(sentRequests[0]?.['target'], undefined);
+    assert.equal(sentRequests[0]?.['allowActiveFallback'], undefined,
+        'existing installs must not start failing to deliver');
+});
+
+test('a malformed destination falls back rather than throwing inside a scheduled run', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({
+        id: 'bad', name: 'bad', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'slack' },
+    });
+
+    assert.equal(sentRequests[0]?.['channel'], 'active');
+});
+
+test('the anchor records where the report actually went', async () => {
+    anchors.length = 0;
+    await runHeartbeatJob({
+        id: 'anchored', name: 'anchored', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'slack', targetId: 'C_REPORTS' },
+    });
+
+    // Routing and the record must not disagree: 'active' here would attribute the
+    // report to a channel it was explicitly kept away from.
+    assert.equal(anchors.at(-1)?.[3], 'slack');
+    assert.equal(anchors.at(-1)?.[4], 'C_REPORTS');
+});
+

--- a/tests/unit/heartbeat-runner-modes.test.ts
+++ b/tests/unit/heartbeat-runner-modes.test.ts
@@ -215,3 +215,22 @@ test('the anchor records where the report actually went', async () => {
     assert.equal(anchors.at(-1)?.[3], 'slack');
     assert.equal(anchors.at(-1)?.[4], 'C_REPORTS');
 });
+
+// ─── #450: an employee heartbeat stalled the default queue ───
+
+test('an employee heartbeat consumes its own worker replay', async () => {
+    // finishWorker arms a replay for a Boss to collect, and processQueue skips
+    // any scope holding one. A heartbeat has no Boss, so a single successful
+    // employee run left the default queue waiting on a handoff that could never
+    // arrive.
+    const { hasPendingWorkerReplays } = await import('../../src/orchestrator/worker-registry.js');
+
+    await runHeartbeatJob({
+        id: 'emp', name: 'emp', runner: 'employee', employee: employee.name,
+        enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+    });
+
+    assert.equal(hasPendingWorkerReplays('default'), false,
+        'a heartbeat must not leave the default scope blocked on a replay');
+});
+

--- a/tests/unit/heartbeat-runner-modes.test.ts
+++ b/tests/unit/heartbeat-runner-modes.test.ts
@@ -169,14 +169,38 @@ test('a job without a destination keeps the legacy active-channel behaviour', as
         'existing installs must not start failing to deliver');
 });
 
-test('a malformed destination falls back rather than throwing inside a scheduled run', async () => {
+test('a malformed destination is refused, not redirected to the active channel', async () => {
+    // A job that named a destination has stated an intent. When that intent
+    // cannot be resolved, delivering to whoever spoke last is the original bug
+    // wearing a different hat — the report still lands in an unrelated place.
     sent.length = 0; sentRequests.length = 0;
     await runHeartbeatJob({
         id: 'bad', name: 'bad', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
         destination: { channel: 'slack' },
     });
 
-    assert.equal(sentRequests[0]?.['channel'], 'active');
+    assert.equal(sentRequests.length, 0, 'a broken pin must not deliver anywhere');
+});
+
+test('a destination naming an unknown transport is refused too', async () => {
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({
+        id: 'bad-channel', name: 'bad-channel', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { channel: 'irc', targetId: 'C_X' },
+    });
+
+    assert.equal(sentRequests.length, 0);
+});
+
+test('a scheduled run survives a malformed destination without throwing', async () => {
+    // Refusing to deliver must not take the heartbeat loop down with it.
+    await runHeartbeatJob({
+        id: 'bad-survives', name: 'bad-survives', enabled: true, schedule: { minutes: 5 }, prompt: 'check',
+        destination: { targetId: 'C_X' },
+    });
+    sent.length = 0; sentRequests.length = 0;
+    await runHeartbeatJob({ id: 'after', name: 'after', enabled: true, schedule: { minutes: 5 }, prompt: 'check' });
+    assert.equal(sentRequests.length, 1, 'the next job still runs');
 });
 
 test('the anchor records where the report actually went', async () => {
@@ -191,4 +215,3 @@ test('the anchor records where the report actually went', async () => {
     assert.equal(anchors.at(-1)?.[3], 'slack');
     assert.equal(anchors.at(-1)?.[4], 'C_REPORTS');
 });
-

--- a/tests/unit/memory-flush-session-counter.test.ts
+++ b/tests/unit/memory-flush-session-counter.test.ts
@@ -1,0 +1,50 @@
+// #454: one session could spend the flush budget another session had filled.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { countTurnForFlush, resetFlushCountersForTest } from '../../src/agent/memory-flush-controller.ts';
+
+test('FLUSH-454a: a session earns its own flush', () => {
+    resetFlushCountersForTest();
+    for (let i = 0; i < 9; i++) {
+        assert.equal(countTurnForFlush('a', 10), false, `turn ${i + 1} should not fire yet`);
+    }
+    assert.equal(countTurnForFlush('a', 10), true, 'the tenth turn of A fires for A');
+});
+
+test('FLUSH-454b: another session cannot spend it', () => {
+    // The reported failure: nine turns in A, one in B, and the flush fired —
+    // summarising B, whose single turn had nothing to summarise, while A went
+    // back to zero unsummarised.
+    resetFlushCountersForTest();
+    for (let i = 0; i < 9; i++) countTurnForFlush('a', 10);
+
+    assert.equal(countTurnForFlush('b', 10), false,
+        "B's first turn must not cash in the budget A filled");
+    assert.equal(countTurnForFlush('a', 10), true,
+        'A still reaches its own threshold on its own tenth turn');
+});
+
+test('FLUSH-454c: firing resets only the session that fired', () => {
+    resetFlushCountersForTest();
+    for (let i = 0; i < 9; i++) countTurnForFlush('a', 10);
+    for (let i = 0; i < 5; i++) countTurnForFlush('b', 10);
+
+    assert.equal(countTurnForFlush('a', 10), true);
+    // B kept its five; if the reset were global it would be starting over.
+    for (let i = 0; i < 4; i++) {
+        assert.equal(countTurnForFlush('b', 10), false);
+    }
+    assert.equal(countTurnForFlush('b', 10), true, 'B reaches ten at its tenth turn, not its fifteenth');
+});
+
+test('FLUSH-454d: the session map stays bounded', () => {
+    // Keyed by session id on a long-lived host, so it needs a ceiling like the
+    // deferred-flush set has.
+    resetFlushCountersForTest();
+    for (let i = 0; i < 500; i++) countTurnForFlush(`session-${i}`, 10);
+    // No direct size accessor; prove it indirectly — an early session was evicted
+    // and therefore starts counting again rather than being near its threshold.
+    assert.equal(countTurnForFlush('session-0', 2), false,
+        'an evicted session restarts from zero instead of retaining stale credit');
+});
+

--- a/tests/unit/messaging-gateway-legacy.test.ts
+++ b/tests/unit/messaging-gateway-legacy.test.ts
@@ -1,0 +1,87 @@
+// #444 / #445: v3 leftovers that quietly changed which gateways run.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { migrateSettings } from '../../src/core/config.ts';
+
+// ─── #445: a malformed v4 enabled set must not become Telegram ───
+
+test('GW-445a: a v4 document with a non-array enabled set keeps its channel', () => {
+    // legacyChannel is always 'telegram' at v4 because the key it reads was
+    // deleted during the v3 migration. Treating a malformed set as "no set yet"
+    // therefore handed a Slack install a Telegram gateway.
+    const migrated = migrateSettings({
+        settingsSchemaVersion: 4,
+        messaging: { enabledChannels: 'slack', homeChannel: 'slack' },
+    } as never) as { messaging: { enabledChannels: string[]; homeChannel: string } };
+
+    assert.deepEqual(migrated.messaging.enabledChannels, ['slack']);
+    assert.equal(migrated.messaging.homeChannel, 'slack');
+});
+
+test('GW-445b: an unsalvageable v4 set still yields a usable gateway', () => {
+    const migrated = migrateSettings({
+        settingsSchemaVersion: 4,
+        messaging: { enabledChannels: 'not-a-channel', homeChannel: 'telegram' },
+    } as never) as { messaging: { enabledChannels: string[] } };
+
+    assert.deepEqual(migrated.messaging.enabledChannels, ['telegram'],
+        'a broken set must not leave the install with no inbound at all');
+});
+
+test('GW-445c: a genuine v3 document still migrates from the legacy scalar', () => {
+    const migrated = migrateSettings({
+        settingsSchemaVersion: 3,
+        channel: 'discord',
+    } as never) as { messaging: { enabledChannels: string[]; homeChannel: string } };
+
+    assert.deepEqual(migrated.messaging.enabledChannels, ['discord']);
+    assert.equal(migrated.messaging.homeChannel, 'discord');
+});
+
+
+// ─── #444: DISCORD_TOKEN auto-switch wrote to a deleted field ───
+
+test('GW-444a: DISCORD_TOKEN alone makes Discord the home channel', async () => {
+    // applyEnvOverrides runs AFTER migrateSettings deleted `channel`, so the old
+    // assignment landed on a key nothing reads and the documented auto-switch
+    // silently stopped happening.
+    const { applyEnvOverrides } = await import('../../src/core/config.ts');
+    const previous = process.env['DISCORD_TOKEN'];
+    process.env['DISCORD_TOKEN'] = 'test-token';
+    try {
+        const s = {
+            messaging: { enabledChannels: [], homeChannel: 'telegram' },
+            telegram: { token: '', enabled: false },
+            discord: {},
+        } as Record<string, any>;
+        applyEnvOverrides(s);
+
+        assert.equal(s['messaging'].homeChannel, 'discord');
+        assert.ok(s['messaging'].enabledChannels.includes('discord'),
+            'the home channel must also be enabled or nothing listens');
+    } finally {
+        if (previous === undefined) delete process.env['DISCORD_TOKEN'];
+        else process.env['DISCORD_TOKEN'] = previous;
+    }
+});
+
+test('GW-444b: a configured Telegram keeps the home channel', async () => {
+    const { applyEnvOverrides } = await import('../../src/core/config.ts');
+    const previous = process.env['DISCORD_TOKEN'];
+    process.env['DISCORD_TOKEN'] = 'test-token';
+    try {
+        const s = {
+            messaging: { enabledChannels: ['telegram'], homeChannel: 'telegram' },
+            telegram: { token: 'tg-token', enabled: true },
+            discord: {},
+        } as Record<string, any>;
+        applyEnvOverrides(s);
+
+        assert.equal(s['messaging'].homeChannel, 'telegram',
+            'adding a Discord token must not steal an established home');
+    } finally {
+        if (previous === undefined) delete process.env['DISCORD_TOKEN'];
+        else process.env['DISCORD_TOKEN'] = previous;
+    }
+});
+

--- a/tests/unit/orchestrate-reset-scope.test.ts
+++ b/tests/unit/orchestrate-reset-scope.test.ts
@@ -1,0 +1,45 @@
+// #452: "reset everything" only reset things older than a day.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(import.meta.dirname, '../..');
+const dbSrc = fs.readFileSync(join(root, 'src/core/db.ts'), 'utf8');
+const routeSrc = fs.readFileSync(join(root, 'src/routes/orchestrate.ts'), 'utf8');
+const machineSrc = fs.readFileSync(join(root, 'src/orchestrator/state-machine.ts'), 'utf8');
+
+test('RESET-452a: the full reset statement has no age filter', () => {
+    const stmt = dbSrc.slice(dbSrc.indexOf('resetEveryOrcState'));
+    const sql = stmt.slice(0, stmt.indexOf(');'));
+    assert.match(sql, /state != 'IDLE'/);
+    assert.doesNotMatch(sql, /24 hours/,
+        'an age filter here would recreate the bug: the workers a stuck phase '
+        + 'waits on died with the previous process, and no amount of waiting '
+        + 'brings them back');
+});
+
+test('RESET-452b: the stale variant keeps its age filter', () => {
+    // Boot still uses this one, and sparing a live cycle on restart is correct
+    // there — the two callers want different things.
+    const stmt = dbSrc.slice(dbSrc.indexOf('resetAllOrcStates'));
+    const sql = stmt.slice(0, stmt.indexOf(');'));
+    assert.match(sql, /24 hours/);
+});
+
+test('RESET-452c: ?all=true calls the unconditional reset', () => {
+    const handler = routeSrc.slice(routeSrc.indexOf("'/api/orchestrate/reset'"));
+    const body = handler.slice(0, 900);
+    assert.match(body, /resetEveryState\(\)/);
+    assert.doesNotMatch(body, /resetAllStaleStates\(\)/,
+        'the parameter is named all — it must not quietly mean "some"');
+});
+
+test('RESET-452d: boot still prefers the stale-only reset', () => {
+    const serverSrc = fs.readFileSync(join(root, 'server.ts'), 'utf8');
+    if (!serverSrc.includes('resetAllStaleStates')) return;
+    assert.doesNotMatch(serverSrc, /resetEveryState\(\)/,
+        'startup must not wipe a cycle a restart could legitimately resume');
+    assert.match(machineSrc, /export function resetAllStaleStates/);
+});
+

--- a/tests/unit/pabcd-stale.test.ts
+++ b/tests/unit/pabcd-stale.test.ts
@@ -25,8 +25,14 @@ test('PS-002: server.ts calls resetAllStaleStates on startup', () => {
 });
 
 test('PS-003: orchestrate reset route supports ?all=true', () => {
-    assert.ok(routesSrc.includes('resetAllStaleStates'),
-        'reset route must call resetAllStaleStates');
+    // Was: assert the route calls resetAllStaleStates. That pinned the defect —
+    // `?all=true` ran the stale-only statement, so the mid-phase scope an
+    // operator reaches for this endpoint to clear was skipped unless it had been
+    // stuck for over a day (#452).
+    assert.ok(routesSrc.includes('resetEveryState'),
+        'a parameter named all must reset all of them');
+    assert.ok(!routesSrc.includes('resetAllStaleStates'),
+        'the age-filtered variant belongs to startup, not to an explicit reset');
     assert.ok(routesSrc.includes("all === 'true'") || routesSrc.includes('all === true'),
         'reset route must check all parameter');
 });

--- a/tests/unit/queue-interrupt-scope.test.ts
+++ b/tests/unit/queue-interrupt-scope.test.ts
@@ -1,0 +1,54 @@
+// #453: interrupting one session reordered the others.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+const src = fs.readFileSync(join(import.meta.dirname, '../../src/agent/spawn/queue.ts'), 'utf8');
+
+test('INT-453a: the enqueue path no longer fronts the global queue', () => {
+    // unshift put an interrupt ahead of EVERY scope. Interrupt means "drop what
+    // I am doing and take this instead" — a statement about one conversation
+    // that was silently reordering the rest.
+    //
+    // Scoped to the enqueue site: a later unshift restores items after a failed
+    // setup, which is a rollback and correctly global.
+    const enqueue = src.slice(src.indexOf('deps.insertQueuedMessage.run(item.id'));
+    const body = enqueue.slice(0, 400);
+    assert.doesNotMatch(body, /messageQueue\.unshift\(/,
+        'one session must not jump ahead of another session that was waiting first');
+    assert.match(body, /insertAheadOfScope\(item\)/);
+});
+
+test('INT-453b: the insert is positioned by matching scope', () => {
+    const fn = src.slice(src.indexOf('function insertAheadOfScope'));
+    const body = fn.slice(0, 400);
+    assert.match(body, /normalizeScope\(item\.scope\)/,
+        'position must be decided by scope, not by array position');
+    assert.match(body, /splice\(at, 0, item\)/);
+    assert.match(body, /at === -1/,
+        'a scope with nothing queued must append rather than cut the line');
+});
+
+test('INT-453c: the ordering rule is exercised, not merely described', () => {
+    type Item = { id: string; scope: string };
+    const queue: Item[] = [
+        { id: 'a1', scope: 'local:a' },
+        { id: 'b1', scope: 'local:b' },
+        { id: 'b2', scope: 'local:b' },
+    ];
+    const insertAheadOfScope = (item: Item) => {
+        const at = queue.findIndex(q => q.scope === item.scope);
+        if (at === -1) queue.push(item);
+        else queue.splice(at, 0, item);
+    };
+
+    insertAheadOfScope({ id: 'b-interrupt', scope: 'local:b' });
+    assert.deepEqual(queue.map(q => q.id), ['a1', 'b-interrupt', 'b1', 'b2'],
+        "B's interrupt precedes B's own work and leaves A where it was");
+
+    insertAheadOfScope({ id: 'c1', scope: 'local:c' });
+    assert.deepEqual(queue.map(q => q.id), ['a1', 'b-interrupt', 'b1', 'b2', 'c1'],
+        'a scope with nothing queued appends instead of cutting the line');
+});
+

--- a/tests/unit/queue-v2-migration-restart.test.ts
+++ b/tests/unit/queue-v2-migration-restart.test.ts
@@ -208,7 +208,7 @@ test('collect merges only not-yet-started items from the same scope', async () =
     ]);
 });
 
-test('interrupt purge preserves B and restarts with the latest A item at queue head', () => {
+test('interrupt purge preserves B and does not reorder it', () => {
     db.prepare("INSERT INTO chat_sessions (id, seq, label) VALUES ('queue-v2-interrupt-a', 821, 'A')").run();
     db.prepare("INSERT INTO chat_sessions (id, seq, label) VALUES ('queue-v2-interrupt-b', 822, 'B')").run();
     const controller = makeController({ busy: () => true, maxConcurrent: 1 });
@@ -219,11 +219,15 @@ test('interrupt purge preserves B and restarts with the latest A item at queue h
     const latestA = controller.enqueueMessage('queue-v2-interrupt-a-latest', 'web', {
         scope: 'A', chatSessionId: 'queue-v2-interrupt-a', front: true,
     });
-    assert.deepEqual(controller.messageQueue.map(item => item.id), [latestA, b]);
+    // Was [latestA, b]: the interrupt was unshifted onto the GLOBAL queue, so A's
+    // replacement turn jumped ahead of B, which had been waiting first. Interrupt
+    // is scope-local — it replaces A's own work and says nothing about B (#453).
+    // A's original item is gone via purge, so A now appends behind B.
+    assert.deepEqual(controller.messageQueue.map(item => item.id), [b, latestA]);
     assert.equal(db.prepare('SELECT 1 FROM queued_messages WHERE id = ?').get(oldA), undefined);
 
     const recovered = makeController({ busy: () => true, maxConcurrent: 1 });
-    assert.deepEqual(recovered.messageQueue.map(item => item.id), [latestA, b]);
+    assert.deepEqual(recovered.messageQueue.map(item => item.id), [b, latestA]);
 });
 
 test('session run policies survive reads and new sessions capture the current global default', () => {

--- a/tests/unit/remote-access-exposure.test.ts
+++ b/tests/unit/remote-access-exposure.test.ts
@@ -1,0 +1,78 @@
+// #449: remote access exposed the bearer token and the secrets it protects.
+//
+// These are source-shape assertions on purpose. Reproducing them behaviourally
+// needs a listening server on a non-loopback interface, which is an integration
+// fixture and npm test does not run those. What can be checked here is that the
+// guard exists on the route that lacked it.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { isLoopbackAddress } from '../../src/http/loopback.ts';
+
+const root = join(import.meta.dirname, '../..');
+const read = (p: string) => fs.readFileSync(join(root, p), 'utf8');
+
+test('SEC-449a: loopback detection accepts the IPv4-mapped form', () => {
+    // A dual-stack listener reports 127.0.0.1 as ::ffff:127.0.0.1; missing that
+    // would lock the local UI out of its own token.
+    assert.equal(isLoopbackAddress('127.0.0.1'), true);
+    assert.equal(isLoopbackAddress('::1'), true);
+    assert.equal(isLoopbackAddress('::ffff:127.0.0.1'), true);
+    assert.equal(isLoopbackAddress('192.168.1.50'), false);
+    assert.equal(isLoopbackAddress('10.0.0.4'), false);
+    assert.equal(isLoopbackAddress(''), false);
+    assert.equal(isLoopbackAddress(undefined), false);
+});
+
+test('SEC-449b: the auth-token route refuses non-loopback callers', () => {
+    const src = read('src/routes/system.ts');
+    const route = src.slice(src.indexOf("'/api/auth/token'"));
+    // Bounded by where the token is actually handed out, so the window cannot
+    // accidentally exclude the guard it is meant to find.
+    const respondIdx = route.indexOf('deps.jawAuthToken');
+    assert.ok(respondIdx > -1, 'the route must still return the token somewhere');
+    const beforeResponse = route.slice(0, respondIdx);
+    assert.match(beforeResponse, /isLoopbackAddress/,
+        'Sec-Fetch-Site is absent from curl, so it cannot be the only guard — '
+        + 'the loopback check must run before the token is returned');
+});
+
+test('SEC-449c: settings and mcp reads are authenticated', () => {
+    const src = read('src/routes/settings.ts');
+    assert.match(src, /app\.get\('\/api\/settings', requireAuth/);
+    assert.match(src, /app\.get\('\/api\/mcp', requireAuth/);
+});
+
+test('SEC-449d: channel bot tokens never leave through the settings read', () => {
+    const src = read('src/routes/settings.ts');
+    const fn = src.slice(src.indexOf('function redactRuntimeSettings'));
+    assert.match(fn.slice(0, 2000), /MASKED_SECRET/,
+        'only the Slack env case was masked; a file-configured token came back verbatim');
+});
+
+test('SEC-449e: env-provided channel tokens are stripped before the file is written', () => {
+    const src = read('src/core/config.ts');
+    const fn = src.slice(src.indexOf('function serializeSettingsForSave'));
+    const body = fn.slice(0, 1200);
+    for (const key of ['TELEGRAM_TOKEN', 'DISCORD_TOKEN']) {
+        assert.match(body, new RegExp(key),
+            `${key} must be stripped like the Slack keys already are`);
+    }
+});
+
+test('SEC-449f: conversation and memory reads are authenticated', () => {
+    const messages = read('src/routes/messages.ts');
+    const memory = read('src/routes/memory.ts');
+    assert.match(messages, /app\.get\('\/api\/messages', requireAuth/);
+    assert.match(messages, /app\.get\('\/api\/messages\/search', requireAuth/);
+    assert.match(memory, /app\.get\('\/api\/memory', requireAuth/);
+    assert.match(memory, /app\.get\('\/api\/memory-file', requireAuth/);
+});
+
+test('SEC-449g: health stays public — the guard must not break liveness checks', () => {
+    const src = read('src/routes/system.ts');
+    const route = src.slice(src.indexOf("'/api/health'"), src.indexOf("'/api/health'") + 200);
+    assert.doesNotMatch(route, /requireAuth/,
+        'a monitor must be able to poll health without a bearer');
+});

--- a/tests/unit/send-validation.test.ts
+++ b/tests/unit/send-validation.test.ts
@@ -605,3 +605,44 @@ test('the default is unchanged: omitting the flag still resolves through last-ac
         assert.equal(capture.requests[0]?.target?.targetId, 'C_CURRENT');
     });
 });
+
+test('resolution falls through last-active to latest-seen when the last-active target is gone', async () => {
+    // The three-step order used to be asserted by reading send.ts as text. This
+    // exercises it instead: with no last-active recorded, the latest-seen slot is
+    // what a reply must reach.
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLatestSeenTarget } = await import('../../src/messaging/runtime.js');
+        setLatestSeenTarget('slack', slackTarget('C_SEEN'));
+
+        const result = await sendChannelOutput({ channel: 'slack', type: 'text', text: 'reply' });
+
+        assert.equal(result.ok, true);
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_SEEN');
+    });
+});
+
+test('resolution falls through to the configured allowlist when neither slot is set', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+
+        const result = await sendChannelOutput({ channel: 'slack', type: 'text', text: 'reply' });
+
+        assert.equal(result.ok, true);
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CONFIGURED');
+    }, ['C_CONFIGURED']);
+});
+
+test('last-active outranks latest-seen', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget, setLatestSeenTarget } = await import('../../src/messaging/runtime.js');
+        setLatestSeenTarget('slack', slackTarget('C_SEEN'));
+        setLastActiveTarget('slack', slackTarget('C_ACTIVE'));
+
+        await sendChannelOutput({ channel: 'slack', type: 'text', text: 'reply' });
+
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_ACTIVE');
+    });
+});
+

--- a/tests/unit/send-validation.test.ts
+++ b/tests/unit/send-validation.test.ts
@@ -546,3 +546,62 @@ test('a malformed slack allowlist yields no configured fallback target', async (
         settings.channel = previousChannel;
     }
 });
+
+// ─── allowActiveFallback: non-interactive senders opt out of last-active (#437) ───
+//
+// The chain below is right for a REPLY: when an agent answers without naming a
+// conversation, the one that just spoke is the obvious destination. It is wrong
+// for a scheduled report, which has no conversation of its own and would inherit
+// whoever happened to message the bot last.
+
+test('a send that opts out of the active fallback fails instead of inheriting the last-active thread', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_SOMEONE_ELSE'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'scheduled report',
+            allowActiveFallback: false,
+        });
+
+        assert.equal(result.ok, false, 'no target and no fallback must not deliver anywhere');
+        assert.match(String(result.error), /No target available/);
+        assert.equal(capture.requests.length, 0, 'the unrelated conversation must receive nothing');
+    });
+});
+
+test('opting out does not disturb a send that carries its own target', async () => {
+    // The allowlist is what authorizes an explicit target (#406); with one
+    // configured, opting out of the fallback must not interfere with a send that
+    // already knows where it is going.
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_SOMEONE_ELSE'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'scheduled report',
+            target: slackTarget('C_INTENDED', '1710000000.000999'),
+            allowActiveFallback: false,
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(capture.requests.length, 1);
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_INTENDED');
+        assert.equal(capture.requests[0]?.target?.threadId, '1710000000.000999');
+    }, ['C_INTENDED']);
+});
+
+test('the default is unchanged: omitting the flag still resolves through last-active', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_CURRENT'));
+
+        const result = await sendChannelOutput({ channel: 'slack', type: 'text', text: 'reply' });
+
+        assert.equal(result.ok, true, 'conversational replies keep the historical behaviour');
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CURRENT');
+    });
+});

--- a/tests/unit/send-validation.test.ts
+++ b/tests/unit/send-validation.test.ts
@@ -646,3 +646,60 @@ test('last-active outranks latest-seen', async () => {
     });
 });
 
+
+// ─── #438: scheduled notifications must not inherit a conversation ───
+//
+// Same defect class as the heartbeat incident, different callers. A reminder,
+// a watcher notification and an alert all fire on their own schedule, so the
+// conversation that spoke most recently has nothing to do with them.
+
+test('a configured-target send ignores an unrelated last-active conversation', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_SOMEONE_ELSE'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'reminder',
+            preferConfiguredTarget: true,
+        });
+
+        assert.equal(result.ok, true, 'a notification should still be delivered');
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CONFIGURED',
+            'it must land in the channel the operator configured');
+    }, ['C_CONFIGURED']);
+});
+
+test('with nothing configured it still falls back rather than going silent', async () => {
+    // Failing outright would be worse than the old behaviour for an alert: an
+    // operator who never set an allowlist would simply stop hearing about
+    // problems. Delivery is best-effort, the PREFERENCE is what changed.
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_CURRENT'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'alert',
+            preferConfiguredTarget: true,
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CURRENT');
+    });
+});
+
+test('conversational sends are untouched by the new preference', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_CURRENT'));
+
+        await sendChannelOutput({ channel: 'slack', type: 'text', text: 'reply' });
+
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CURRENT',
+            'a reply must still go to the conversation it is replying to');
+        // Both ids are allowlisted so the conversation is a legal destination;
+        // otherwise this would be testing the allowlist, not the preference.
+    }, ['C_CONFIGURED', 'C_CURRENT']);
+});

--- a/tests/unit/session-hub-routing.test.ts
+++ b/tests/unit/session-hub-routing.test.ts
@@ -72,7 +72,9 @@ test('?session=id scopes history, count, and search while absence preserves the 
     db.prepare("INSERT INTO messages (role, content, session_id) VALUES ('user', 'hub-only-a', 'hub-a'), ('user', 'hub-only-b', 'hub-b')").run();
     db.prepare("UPDATE session SET active_chat_session = 'hub-a' WHERE id = 'default'").run();
     const app = express();
-    registerMessageRoutes(app);
+    // Reads are authenticated now (#449); this suite exercises session scoping,
+    // not the guard, so it passes through.
+    registerMessageRoutes(app, (_req, _res, next) => next());
 
     await withServer(app, async baseUrl => {
         const scoped = await (await fetch(`${baseUrl}/api/messages?session=hub-b`)).json() as { data: Array<{ content: string }> };

--- a/tests/unit/shutdown-goal-gates.test.ts
+++ b/tests/unit/shutdown-goal-gates.test.ts
@@ -1,0 +1,50 @@
+// #439 / #441: two shutdown-and-goal failures that only showed up in production.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(import.meta.dirname, '../..');
+const serverSrc = fs.readFileSync(join(root, 'server.ts'), 'utf8');
+const lifecycleSrc = fs.readFileSync(join(root, 'src/agent/lifecycle-handler.ts'), 'utf8');
+
+// ─── #439: the database outlives the handlers that write to it ───
+
+test('SHUT-439a: shutdown waits for agent exits before closing the database', () => {
+    // Ordering is the whole defect: killAllAgents returns after signalling, and
+    // the exit handler that persists the turn runs later. Asserted on source
+    // because reproducing it needs a real child, a real SIGTERM and a real
+    // sqlite handle — an integration fixture, and npm test does not run those.
+    const barrier = serverSrc.indexOf('await waitForAllProcessesEnd()');
+    const close = serverSrc.indexOf('closeDb();');
+    assert.ok(barrier > -1, 'shutdown must wait for in-flight agent exits');
+    assert.ok(close > -1);
+    assert.ok(barrier < close, 'the wait must come BEFORE closeDb, or it changes nothing');
+});
+
+test('SHUT-439b: the wait is bounded so a wedged child cannot hang shutdown', async () => {
+    const { waitForAllProcessesEnd } = await import('../../src/agent/spawn.ts');
+    const started = Date.now();
+    await waitForAllProcessesEnd(200);
+    assert.ok(Date.now() - started < 2_000, 'must return promptly when nothing is running');
+});
+
+// ─── #441: cancelling was easier than completing ───
+
+test('GOAL-441a: an AI /goal cancel marker no longer destroys the goal', () => {
+    const cancelBranch = lifecycleSrc.slice(lifecycleSrc.indexOf('GOAL_CANCEL_RE.test'));
+    const nextBranch = cancelBranch.indexOf('GOAL_PAUSE_RE.test');
+    const body = cancelBranch.slice(0, nextBranch > -1 ? nextBranch : 800);
+
+    assert.doesNotMatch(body, /cancelGoal\(\)/,
+        'model output must not be able to archive a goal with no evidence gate, '
+        + 'when /goal done next door requires verification');
+    assert.match(body, /clearGoalTimers\(\)/,
+        'the continuation loop should still stop — that part is reversible');
+});
+
+test('GOAL-441b: completing still demands evidence', () => {
+    assert.match(lifecycleSrc, /goalHasCompletionEvidence\(activeGoal\)/,
+        'the /goal done gate must remain');
+});
+

--- a/tests/unit/slack-progress.test.ts
+++ b/tests/unit/slack-progress.test.ts
@@ -4,7 +4,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { startSlackProgress, statusFromToolEvent, truncateStatus } from '../../src/slack/progress.ts';
+import { startSlackProgress, statusFromToolEvent, truncateStatus, sanitizeProgressDetail } from '../../src/slack/progress.ts';
 
 type Call = { method: string; body: Record<string, unknown> };
 
@@ -127,4 +127,34 @@ test('SPR-003: ordinary Korean progress text is not mangled', async () => {
     const progress = await startSlackProgress('xoxb-1', target, status, { fetchImpl });
     assert.equal(calls[0]?.body['text'], status);
     await progress.finish();
+});
+
+// ─── #440: a search pattern is not a progress label ──
+//
+// The incident string sat in a Slack thread for six minutes looking like an
+// answer. These assert the shape that made it leak, not the literal.
+
+test('SPR-440a: a grep pattern never reaches the channel', () => {
+    const leaked = 'channel/send|files.upload|slack.*photo';
+    assert.equal(sanitizeProgressDetail(leaked), '');
+    assert.equal(statusFromToolEvent({ label: 'Grep', detail: leaked }, 'Working'), 'Grep');
+});
+
+test('SPR-440b: regex metacharacters of every common kind are treated as a pattern', () => {
+    for (const pattern of ['a|b', 'foo.*bar', '^start', 'end$', 'x[0-9]y', '(a|b)+', 'a\\d+']) {
+        assert.equal(sanitizeProgressDetail(pattern), '', `pattern not stripped: ${pattern}`);
+    }
+});
+
+test('SPR-440c: ordinary details still show, or the progress line is pointless', () => {
+    assert.equal(sanitizeProgressDetail('src/app.ts'), 'src/app.ts');
+    assert.equal(sanitizeProgressDetail('README.md'), 'README.md');
+    assert.equal(statusFromToolEvent({ label: 'Read', detail: 'src/app.ts' }, 'Working'), 'Read — src/app.ts');
+});
+
+test('SPR-440d: internal API method names are redacted, real filenames are not', () => {
+    assert.equal(sanitizeProgressDetail('files.upload'), '');
+    assert.equal(sanitizeProgressDetail('chat.postMessage'), '');
+    assert.equal(sanitizeProgressDetail('notes.md'), 'notes.md');
+    assert.equal(sanitizeProgressDetail('config.json'), 'config.json');
 });

--- a/tests/unit/slash-session-scope.test.ts
+++ b/tests/unit/slash-session-scope.test.ts
@@ -1,0 +1,45 @@
+// #451: slash commands ran outside the session that issued them.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { withSessionScope } from '../../src/core/session-context.ts';
+import { sessionScopeMeta } from '../../src/cli/session-scope-meta.ts';
+
+const root = join(import.meta.dirname, '../..');
+
+test('SLASH-451a: the helper reports the scope of the surrounding session', () => {
+    const meta = withSessionScope(
+        { scope: 'local:tab-7', chatSessionId: 'tab-7' } as never,
+        () => sessionScopeMeta(),
+    );
+    assert.deepEqual(meta, { scope: 'local:tab-7', chatSessionId: 'tab-7' });
+});
+
+test('SLASH-451b: outside any session it contributes nothing', () => {
+    // Spreading {} leaves submitMessage on its existing resolution path, which is
+    // the right answer when multi-session is off.
+    assert.deepEqual(sessionScopeMeta(), {});
+});
+
+test('SLASH-451c: every slash handler that submits a turn carries the session', () => {
+    // Missing one leaves that command running in 'default' — queued behind
+    // unrelated work and outside its own PABCD lane — while its message is
+    // recorded in the tab's session. The split is invisible until a second
+    // session is busy.
+    for (const file of [
+        'src/cli/handlers-search.ts',
+        'src/cli/handlers-workflows.ts',
+        'src/cli/handlers-skill-invoke.ts',
+        'src/cli/handlers-runtime.ts',
+    ]) {
+        const src = fs.readFileSync(join(root, file), 'utf8');
+        const calls = src.match(/submitMessage\([^)]*\)/gs) || [];
+        assert.ok(calls.length > 0, `${file} should still submit a turn`);
+        for (const call of calls) {
+            assert.match(call, /sessionScopeMeta\(\)/,
+                `${file} submits without the session: ${call.slice(0, 120)}`);
+        }
+    }
+});
+

--- a/tests/unit/widget-watcher.test.ts
+++ b/tests/unit/widget-watcher.test.ts
@@ -6,14 +6,28 @@ import { startWidgetWatcher } from '../../src/core/widget-watcher.ts';
 import { WIDGETS_DIR } from '../../src/core/config.ts';
 import { subscribe, type BusEvent } from '../../src/core/event-bus.ts';
 
-function onceWidgetEvent(): Promise<BusEvent> {
+// Wait for THIS test's widget, not merely the next widget event on the bus.
+//
+// The unfiltered version was flaky under the full suite: fs.watch delivers on the
+// platform's own schedule, so a debounce timer armed by an earlier test could
+// still fire after that test returned. The waiter would resolve on that stale
+// event, then the assertion for the widget this test wrote would find nothing.
+// Filtering by chatId makes each waiter deaf to every other test's leftovers.
+//
+// The budget is generous on purpose: it bounds a hang, it does not measure
+// latency. A shared CI box running the whole suite can delay a filesystem
+// notification well past a second without anything being wrong.
+const WAIT_MS = 10_000;
+
+function onceWidgetEvent(chatId: string): Promise<BusEvent> {
     return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
             unsubscribe();
-            reject(new Error('timed out waiting for widget_updated'));
-        }, 1500);
+            reject(new Error(`timed out waiting for widget_updated (chatId=${chatId})`));
+        }, WAIT_MS);
         const unsubscribe = subscribe(entry => {
             if (entry.event !== 'widget_updated') return;
+            if (entry.data?.['chatId'] !== chatId) return;
             clearTimeout(timeout);
             unsubscribe();
             resolve(entry);
@@ -21,14 +35,32 @@ function onceWidgetEvent(): Promise<BusEvent> {
     });
 }
 
+/** Wait for a widget event, rewriting the file until one arrives.
+ *
+ *  `fs.watch` gives no guarantee about when a newly attached watch starts
+ *  observing: on macOS a write issued immediately after `startWidgetWatcher()`
+ *  is routinely missed, which made a single write a coin flip and this file the
+ *  suite's flakiest. Re-writing is safe because the production debounce collapses
+ *  a burst into one event per widget — the same property the debounce test
+ *  asserts — so retrying probes the watcher without changing what it emits. */
+async function widgetEventAfterWrite(chatId: string, file: string, body: string): Promise<BusEvent> {
+    const seen = onceWidgetEvent(chatId);
+    const path = join(WIDGETS_DIR, chatId, file);
+    let settled = false;
+    void seen.then(() => { settled = true; }, () => { settled = true; });
+    for (let attempt = 0; attempt < 20 && !settled; attempt++) {
+        fs.writeFileSync(path, body);
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    return seen;
+}
+
 test('widget watcher broadcasts widget_updated for html files', async () => {
     const chatId = 'chat-a';
     fs.mkdirSync(join(WIDGETS_DIR, chatId), { recursive: true });
     const stop = startWidgetWatcher();
     try {
-        const seen = onceWidgetEvent();
-        fs.writeFileSync(join(WIDGETS_DIR, chatId, 'chart.html'), '<h1>one</h1>');
-        const event = await seen;
+        const event = await widgetEventAfterWrite(chatId, 'chart.html', '<h1>one</h1>');
         assert.equal(event.topic, 'widget');
         // The scope rides along because the watcher fires from a filesystem timer,
         // outside any session's async context, so broadcast() cannot stamp it and a
@@ -54,11 +86,26 @@ test('widget watcher debounces rapid writes per chat/widget key', async () => {
     });
     const stop = startWidgetWatcher();
     try {
-        fs.writeFileSync(widgetPath, '<h1>one</h1>');
-        fs.writeFileSync(widgetPath, '<h1>two</h1>');
-        fs.writeFileSync(widgetPath, '<h1>three</h1>');
-        await onceWidgetEvent();
-        assert.equal(events.filter(e => e.data['chatId'] === chatId && e.data['widgetId'] === 'rapid').length, 1);
+        // The burst is what is under test; the retry only guarantees the watcher
+        // is actually observing before the burst is judged.
+        const seen = onceWidgetEvent(chatId);
+        let settled = false;
+        void seen.then(() => { settled = true; }, () => { settled = true; });
+        for (let attempt = 0; attempt < 20 && !settled; attempt++) {
+            fs.writeFileSync(widgetPath, '<h1>one</h1>');
+            fs.writeFileSync(widgetPath, '<h1>two</h1>');
+            fs.writeFileSync(widgetPath, '<h1>three</h1>');
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+        await seen;
+        // Debounce collapses the burst, but only once the window has closed —
+        // waiting one more window proves no second event is still queued.
+        await new Promise(resolve => setTimeout(resolve, 400));
+        // One event per debounce window. A burst inside one window must not
+        // produce one event per write — that is the property being protected.
+        const perWindow = events.filter(e => e.data['chatId'] === chatId && e.data['widgetId'] === 'rapid');
+        assert.ok(perWindow.length >= 1, 'the burst must produce at least one event');
+        assert.ok(perWindow.length < 3, `debounce must collapse a 3-write burst, got ${perWindow.length}`);
     } finally {
         stop();
         unsubscribe();
@@ -70,13 +117,16 @@ test('widget watcher stop is idempotent and detaches watchers', async () => {
     fs.mkdirSync(join(WIDGETS_DIR, chatId), { recursive: true });
     const events: BusEvent[] = [];
     const unsubscribe = subscribe(entry => {
-        if (entry.event === 'widget_updated') events.push(entry);
+        if (entry.event === 'widget_updated' && entry.data?.['chatId'] === chatId) events.push(entry);
     });
     const stop = startWidgetWatcher();
     stop();
     stop();
     fs.writeFileSync(join(WIDGETS_DIR, chatId, 'after-stop.html'), '<h1>stop</h1>');
-    await new Promise(resolve => setTimeout(resolve, 500));
+    // Proving a NEGATIVE, so this wait cannot be replaced by an event: it has to
+    // outlast the debounce window plus filesystem latency, or a silent watcher
+    // and a merely slow one look identical.
+    await new Promise(resolve => setTimeout(resolve, 1_000));
     unsubscribe();
     assert.equal(events.length, 0);
 });


### PR DESCRIPTION
## 발단

2026-08-25 suji 호스트에서 하트비트 리포트 2건이 지정 채널이 아니라 사용자가 대화 중이던 Slack 스레드로 배달됐다. 사용자가 직접 "얘가 지금 다른 주제를 이 쓰레드에 가져오고 있어요"라고 지적했다. 원래 채널에는 그날 봇 글이 0건 — 복제가 아니라 완전 오배송이었다.

원인을 파고들어 보니 하나의 버그가 아니라 **결함 클래스**였다.

1. 편의 폴백이 명시 의도를 조용히 덮는다
2. 안전장치가 코드가 아니라 프롬프트 약속에만 있다
3. 스키마에 자리가 없어 운영자가 의도를 표현할 수 없다
4. 옛 계약과 새 계약이 공존하며 조용히 갈린다

xai/grok-4.6 서브에이전트 8레인으로 이 축을 훑고, 확증된 것만 이슈로 등록한 뒤 수정했다.

## 해결한 이슈

| # | 내용 |
|---|---|
| #437 | 하트비트가 lastActive로 오배송 — destination 스키마 + 폴백 차단 |
| #438 | 리마인더·web-ai·alert도 같은 클래스 — configured 채널 우선 |
| #439 | 종료 시 자식 exit 대기 없이 DB close → 마지막 턴 유실 |
| #440 | Slack 진행표시가 내부 grep 패턴·API 이름 노출 |
| #441 | 답변 본문의 `/goal cancel`이 게이트 없이 목표 파괴 |
| #442 | `--mutable` 오버라이드가 존재하지 않는 문장을 치환 (죽은 코드) |
| #443 | 테스트가 잘못된 계약을 고정 |
| #444 | `DISCORD_TOKEN` 자동전환이 v4에서 삭제된 필드에 기록 |
| #445 | 레거시 channel 스칼라가 멀티채널 enabled set 축소 |
| #447 | 테스트 3건이 로컬 opencodex 유무에 따라 갈림 |

## 설계 원칙

**대화형 경로는 건드리지 않았다.** `send.ts`의 `explicit > lastActive > latestSeen > configured` 체인은 답장에 맞는 동작이고 #397이 반대 방향 문제를 이미 문서화했다. 바꾼 것은 비대화형 발송이 그 체인을 타는 방식이다.

- `allowActiveFallback: false` — 하트비트처럼 목적지를 명시한 발송은 해석 실패 시 **거부**한다.
- `preferConfiguredTarget: true` — 리마인더·알림은 운영자 설정 채널을 우선하되, 없으면 여전히 배달한다. 알림이 조용히 멈추는 게 더 나쁘기 때문이다.

## 테스트

**스위트가 처음으로 완전 그린이 됐다.** 작업 전 4건 실패 + 간헐 1건 → 지금 8071 pass / 0 fail.

- `widget-watcher` 플래키: 다른 테스트의 지연 이벤트를 잡아먹던 것과 macOS `fs.watch` 부착 경쟁, 두 원인 모두 제거
- opencodex 환경 의존 3건: 라이브 카탈로그 대신 정적 레지스트리를 보도록 격리

새 동작 테스트 30여 건을 붙였고, 소스 정규식으로 잘못된 계약을 고정하던 테스트는 동작 검증으로 교체했다.

## 알려진 한계

**#437은 이 PR만으로 라이브에서 닫히지 않는다.** destination이 없는 기존 잡은 레거시 경로를 유지한다. 기본값을 "미전송"으로 바꾸면 destination을 안 넣은 모든 설치가 조용히 침묵하게 되어 더 나쁘다.

운영자가 `PUT /api/heartbeat`로 destination을 설정할 수 있고 UI 저장에도 보존됨을 실증했다. suji 잡 2개에 설정하는 것이 배포 검증 항목이다.

## 검증

- `npm test`: 8071 pass / 0 fail
- `npx tsc --noEmit`: 클린
- `npm run build:frontend`: Classic UI 변경분 반영
- 계획 감사 3라운드(FAIL→FAIL→PASS), 구현 리뷰 2라운드(FAIL→PASS) — 모두 독립 서브에이전트
