### PR TITLE
test(discord): 취소 동작을 검증 가능하게 하는 scheduler seam (#417)

### DIFF
--- a/src/discord/send-only-client.ts
+++ b/src/discord/send-only-client.ts
@@ -62,8 +62,21 @@ export async function sendDiscordTextRest(
     token: string,
     channelId: string,
     text: string,
-    extra?: { components?: unknown; signal?: AbortSignal },
+    extra?: {
+        components?: unknown;
+        signal?: AbortSignal;
+        /**
+         * Test seam: production passes nothing and gets the cached per-token
+         * scheduler. Without an injection point the cancellation tests can only
+         * reach the real scheduler, which owns rate-limit timers and a live
+         * socket — so they would assert against a stub of the wrong layer, or
+         * not run at all. `openDiscordDm` already takes `fetchImpl` for the
+         * same reason; this is that convention one level up.
+         */
+        scheduler?: DiscordRestScheduler;
+    },
 ): Promise<DiscordRestSendResult> {
+    const scheduler = extra?.scheduler ?? schedulerFor(token);
     const chunks = chunkDiscordMessage(text);
     for (const [index, chunk] of chunks.entries()) {
         // A shutdown abort between chunks is a cancellation, not a vendor
@@ -78,7 +91,7 @@ export async function sendDiscordTextRest(
         }
         const body: Record<string, unknown> = { content: chunk };
         if (index === 0 && extra?.components) body['components'] = extra.components;
-        const result = await schedulerFor(token).schedule({
+        const result = await scheduler.schedule({
             method: 'POST',
             path: `/channels/${encodeURIComponent(channelId)}/messages`,
             routeKey: 'POST:/channels/:channel/messages',

--- a/tests/unit/discord-outbound-cancel.test.ts
+++ b/tests/unit/discord-outbound-cancel.test.ts
@@ -1,0 +1,93 @@
+// Discord outbound cancellation (#417, L3).
+//
+// The design doc called this impossible: "channel.send() 로는 불가능". That was
+// true of discord.js's high-level helper, which forwards no request options — but
+// the repo since grew its own REST scheduler, and that one takes a signal AND
+// applies it while a job is still queued behind a rate limit. So the fix is to
+// route the two channel.send() sites through the scheduler, not to invent a seam.
+//
+// These drive sendDiscordTextRest against an injected scheduler so the assertions
+// are about what production actually calls.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendDiscordTextRest } from '../../src/discord/send-only-client.ts';
+
+type Scheduled = { path: string; body: string; signal?: AbortSignal };
+
+function fakeScheduler(onSchedule?: (job: Scheduled) => void) {
+    const jobs: Scheduled[] = [];
+    return {
+        jobs,
+        scheduler: {
+            schedule: async (req: {
+                path: string;
+                makeInit: () => { body?: unknown } | Promise<{ body?: unknown }>;
+                signal?: AbortSignal;
+            }) => {
+                const init = await req.makeInit();
+                const job: Scheduled = {
+                    path: req.path,
+                    body: String(init.body ?? ''),
+                    ...(req.signal ? { signal: req.signal } : {}),
+                };
+                jobs.push(job);
+                onSchedule?.(job);
+                if (req.signal?.aborted) {
+                    return { ok: false as const, failure: { kind: 'transient', message: 'aborted' } };
+                }
+                return { ok: true as const, value: undefined, status: 200 };
+            },
+        },
+    };
+}
+
+test('the caller signal reaches the scheduled request', async () => {
+    const controller = new AbortController();
+    const { jobs, scheduler } = fakeScheduler();
+
+    await sendDiscordTextRest('tok', '555', 'hello', {
+        signal: controller.signal,
+        scheduler: scheduler as never,
+    });
+
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0]?.signal, controller.signal,
+        'the scheduler honours a signal while queued behind a rate limit — that is why it must arrive');
+});
+
+test('an already-aborted turn schedules nothing', async () => {
+    const { jobs, scheduler } = fakeScheduler();
+
+    const result = await sendDiscordTextRest('tok', '555', 'hello', {
+        signal: AbortSignal.abort(),
+        scheduler: scheduler as never,
+    });
+
+    assert.equal(jobs.length, 0);
+    assert.equal(result.ok, false, 'a cancelled send did not deliver, and must not claim it did');
+});
+
+test('a multi-chunk answer stops at the chunk boundary once aborted', async () => {
+    const controller = new AbortController();
+    const { jobs, scheduler } = fakeScheduler(() => controller.abort());
+    // Two chunks at Discord's 2000-char limit.
+    const long = 'x'.repeat(3_000);
+
+    await sendDiscordTextRest('tok', '555', long, {
+        signal: controller.signal,
+        scheduler: scheduler as never,
+    });
+
+    assert.equal(jobs.length, 1,
+        'without a per-chunk re-check, shutdown still posts the rest of the answer');
+});
+
+test('no signal keeps the previous behaviour', async () => {
+    const { jobs, scheduler } = fakeScheduler();
+    const result = await sendDiscordTextRest('tok', '555', 'hello', { scheduler: scheduler as never });
+    assert.equal(result.ok, true);
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0]?.signal, undefined);
+});
+


### PR DESCRIPTION
## 왜

`sendDiscordTextRest` 는 `schedulerFor(token)` 을 인라인으로 불렀다. 그래서 테스트가 닿을 수 있는 건 캐시된 per-token `DiscordRestScheduler` 뿐이었다 — rate-limit 타이머와 실제 소켓을 소유한 객체다.

결과적으로 취소 동작에 **검증 가능한 표면이 없었다.** 선택지가 둘뿐이었다: 한 계층 아래인 `fetch` 를 스텁하거나(그러면 *큐에 대기 중인* 작업이 신호를 봤는지는 아무것도 말해주지 못한다), 아예 커버하지 않거나.

이게 이 채널에서 특히 문제인 이유가 있다. **스케줄러는 작업이 rate limit 뒤에 대기하는 동안에도 신호를 적용하는 유일한 계층이다.** discord.js 의 `channel.send()` 는 이걸 전혀 못 한다 — 본문 전송을 스케줄러로 우회시킨 이유가 애초에 그거였다. 검증되지 않는 seam 은 그 속성이 조용히 회귀하는 자리다.

## 무엇

`extra.scheduler` 옵션 하나. 프로덕션은 아무것도 넘기지 않으므로 기본 경로는 바이트 단위로 동일하다.

새 관례를 만든 게 아니다 — 같은 파일의 `openDiscordDm` 이 이미 같은 목적으로 `fetchImpl` 을 받는다. 그 관례를 한 계층 위에 적용했다.

## 테스트

닫힌 #431 에서 포팅했다. #417 구현 자체는 promote v2.17.16 으로 이미 main 에 들어갔고, 이 4건이 main 에 대응물이 없던 부분이다.

```
✔ the caller signal reaches the scheduled request
✔ an already-aborted turn schedules nothing
✔ a multi-chunk answer stops at the chunk boundary once aborted
✔ no signal keeps the previous behaviour
```

## 검증

```
npx tsc --noEmit                      exit 0
discord 전체 + outbound-lifecycle     131/131 pass
```

Refs #417
