### PR TITLE
fix(telegram): 취소된 전송을 던지지 말고 결과로 보고 (#417)

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -514,13 +514,19 @@ async function telegramSendHandler(req: ChannelSendRequest): Promise<{ ok: boole
         // legacy HTML→plaintext chain as per-chunk fallback inside the helper.
         // Scoped for shutdown cancellation (#417).
         const outbound = telegramOutboundRegistry.start();
+        let sendResult;
         try {
-            await sendTelegramMarkdown(bot.api, chatId, text, stripUndefined({
+            sendResult = await sendTelegramMarkdown(bot.api, chatId, text, stripUndefined({
                 message_thread_id: messageThreadId,
                 signal: outbound.signal,
             }));
         } finally {
             outbound.done();
+        }
+        // Previously the abort threw past this return, so the handler answered
+        // 500 with a raw message. A cancelled send is a 499, and it is not ok.
+        if (!sendResult.ok) {
+            return { ok: false, error: 'telegram_send_aborted', status: 499, chat_id: chatId, type: 'text' };
         }
         return { ok: true, chat_id: chatId, type: 'text' };
     }
@@ -870,11 +876,26 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                             // lands in the catch below, which closes the notice
                             // as EXPIRED — a cancelled send is never 'answered'.
                             const outbound = telegramOutboundRegistry.start();
+                            let sendResult;
                             try {
-                                await sendTelegramMarkdown(ctx.api, chat.id, body,
+                                sendResult = await sendTelegramMarkdown(ctx.api, chat.id, body,
                                     { ...replyOptsOf(ctx), signal: outbound.signal });
                             } finally {
                                 outbound.done();
+                            }
+                            // A cancelled send delivered nothing, so it takes the
+                            // same path a vendor failure does: the notice stays as
+                            // the only trace of the turn. Reported rather than
+                            // thrown now, so it needs an explicit branch.
+                            if (!sendResult.ok) {
+                                await Promise.allSettled([
+                                    notice.close('expired'),
+                                    ackHandle?.settle('failure') ?? Promise.resolve(),
+                                ]);
+                                if (requestId) closeTelegramNoticeRecord(requestId);
+                                unregister();
+                                reject(new Error('telegram_send_aborted'));
+                                return;
                             }
                         } catch (error) {
                             // The answer never landed, so the notice is not stale —
@@ -1069,11 +1090,18 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
             {
                 // Scoped for shutdown cancellation (#417).
                 const outbound = telegramOutboundRegistry.start();
+                let finalResult;
                 try {
-                    await sendTelegramMarkdown(ctx.api, chat.id, collectedText,
+                    finalResult = await sendTelegramMarkdown(ctx.api, chat.id, collectedText,
                         { ...replyOptsOf(ctx), signal: outbound.signal });
                 } finally {
                     outbound.done();
+                }
+                // Nothing reached the user, so this turn must not be recorded as
+                // a success or relay images for an answer that was never sent.
+                if (!finalResult.ok) {
+                    ackOutcome = 'failure';
+                    return;
                 }
             }
             // The text is what the user was waiting for. Image relay is

--- a/src/telegram/rich-message.ts
+++ b/src/telegram/rich-message.ts
@@ -76,6 +76,26 @@ export interface RichSendOpts {
     signal?: AbortSignal;
 }
 
+/**
+ * Outcome of a Telegram text send.
+ *
+ * Telegram was the one channel that signalled cancellation by throwing, while
+ * `sendSlackText` and `sendDiscordTextRest` returned `ok: false`. That forced
+ * every caller into a try/catch whose catch block could not tell "we cancelled
+ * this" from "Telegram rejected it" without string-matching an Error message —
+ * and the queue-notice path has to tell them apart, because a cancelled answer
+ * must never close a notice as 'answered'.
+ *
+ * `aborted` is a separate flag rather than an error code so a caller can branch
+ * on it without parsing text.
+ */
+export type TelegramSendResult =
+    | { ok: true; aborted?: false }
+    | { ok: false; aborted: true };
+
+const OK: TelegramSendResult = { ok: true };
+const ABORTED: TelegramSendResult = { ok: false, aborted: true };
+
 /** True when the running grammy build exposes sendRichMessage (Bot API 10.1+). */
 export function supportsRichMessage(api: MaybeRichApi): boolean {
     return typeof api.sendRichMessage === 'function';
@@ -268,20 +288,24 @@ function richOpts(opts?: RichSendOpts) {
  * Send markdown text, preferring Bot API 10.1 sendRichMessage; falls back per chunk to
  * parse_mode:'HTML' (re-chunked at 4096), then tag-stripped plaintext. Never throws for
  * a single bad chunk; rethrows only when every leg of the chain failed.
+ *
+ * Cancellation is reported, not thrown (#417). A shutdown abort is an expected
+ * outcome the caller asked for, so it comes back as `{ ok: false, aborted: true }`
+ * the way Slack and Discord already report theirs. Vendor failures still throw:
+ * collapsing the two would make a real delivery fault look like a clean stop.
  */
 export async function sendTelegramMarkdown(
     api: MaybeRichApi,
     chatId: string | number,
     rawMarkdown: string,
     opts?: RichSendOpts,
-): Promise<void> {
+): Promise<TelegramSendResult> {
     // Last mile for every Telegram text send: this helper is the single entry
     // point, so masking here cannot be bypassed by a caller that forgot.
     const markdown = redactOutboundText(rawMarkdown);
     const prefix = effectivePrefix(opts?.prefix ?? '', RICH_MESSAGE_LIMIT, markdown);
     if (!supportsRichMessage(api)) {
-        await sendHtmlFallback(api, chatId, markdown, opts, prefix);
-        return;
+        return sendHtmlFallback(api, chatId, markdown, opts, prefix);
     }
     // The prefix rides on the first chunk, so it has to come out of that
     // chunk's budget. Chunking at the full limit and prepending afterwards
@@ -289,16 +313,27 @@ export async function sendTelegramMarkdown(
     // fallback.
     const chunks = chunkWithPrefixBudget(markdown, prefix, RICH_MESSAGE_LIMIT);
     for (let i = 0; i < chunks.length; i += 1) {
-        if (opts?.signal?.aborted) throw new Error('telegram_send_aborted');
+        if (opts?.signal?.aborted) return ABORTED;
         const withPrefix = i === 0 ? `${prefix}${chunks[i]}` : chunks[i]!;
-        const needsFallback = await attemptSend(() =>
-            // grammY's declared AbortSignal is the abort-controller shim type;
-            // the reaction path (reactions.ts) uses the same `as never` cast.
-            api.sendRichMessage!(chatId, { markdown: withPrefix }, richOpts(opts), opts?.signal as never), opts?.signal);
+        let needsFallback: boolean;
+        try {
+            needsFallback = await attemptSend(() =>
+                // grammY's declared AbortSignal is the abort-controller shim type;
+                // the reaction path (reactions.ts) uses the same `as never` cast.
+                api.sendRichMessage!(chatId, { markdown: withPrefix }, richOpts(opts), opts?.signal as never), opts?.signal);
+        } catch (err: unknown) {
+            // attemptSend rethrows the vendor error as-is when the signal fired
+            // mid-flight. The transport error is incidental there — what the
+            // caller needs to know is that this turn was cancelled.
+            if (opts?.signal?.aborted) return ABORTED;
+            throw err;
+        }
         if (needsFallback) {
-            await sendHtmlFallback(api, chatId, chunks[i]!, opts, i === 0 ? prefix : '');
+            const fallback = await sendHtmlFallback(api, chatId, chunks[i]!, opts, i === 0 ? prefix : '');
+            if (!fallback.ok) return fallback;
         }
     }
+    return OK;
 }
 
 async function sendHtmlFallback(
@@ -307,7 +342,7 @@ async function sendHtmlFallback(
     mdChunk: string,
     opts: RichSendOpts | undefined,
     prefix: string,
-): Promise<void> {
+): Promise<TelegramSendResult> {
     const base = richOpts(opts);
     const htmlOpts = { ...base, parse_mode: 'HTML' as const };
     // Plaintext leg: omit the options object entirely when empty (legacy wire shape).
@@ -318,13 +353,19 @@ async function sendHtmlFallback(
         ? chunkTelegramMessage(html, HTML_MESSAGE_LIMIT - safePrefix.length)
         : chunkTelegramMessage(html, HTML_MESSAGE_LIMIT);
     for (let i = 0; i < chunks.length; i += 1) {
-        if (opts?.signal?.aborted) throw new Error('telegram_send_aborted');
+        if (opts?.signal?.aborted) return ABORTED;
         const withPrefix = i === 0 ? `${safePrefix}${chunks[i]}` : chunks[i]!;
-        const needsPlain = await attemptSend(
-            () => api.sendMessage(chatId, withPrefix, htmlOpts, opts?.signal as never), opts?.signal);
-        if (needsPlain) {
-            await attemptSend(() =>
-                api.sendMessage(chatId, withPrefix.replace(/<[^>]+>/g, ''), plainOpts, opts?.signal as never), opts?.signal);
+        try {
+            const needsPlain = await attemptSend(
+                () => api.sendMessage(chatId, withPrefix, htmlOpts, opts?.signal as never), opts?.signal);
+            if (needsPlain) {
+                await attemptSend(() =>
+                    api.sendMessage(chatId, withPrefix.replace(/<[^>]+>/g, ''), plainOpts, opts?.signal as never), opts?.signal);
+            }
+        } catch (err: unknown) {
+            if (opts?.signal?.aborted) return ABORTED;
+            throw err;
         }
     }
+    return OK;
 }

--- a/tests/unit/outbound-lifecycle.test.ts
+++ b/tests/unit/outbound-lifecycle.test.ts
@@ -75,11 +75,12 @@ test('OSR-006: sendTelegramMarkdown aborts between chunks and skips fallback leg
     };
     // Long enough to need multiple chunks so the loop guard matters too.
     const text = 'x'.repeat(9000);
-    await assert.rejects(
-        () => sendTelegramMarkdown(api as never, 1, text, { signal: controller.signal }),
-        /socket destroyed/,
-        'a cancelled send surfaces the abort error',
-    );
+    // The cancellation is REPORTED, not thrown (#417): the transport error that
+    // happened to surface it is incidental, and a caller must be able to tell a
+    // cancelled turn from a Telegram rejection without matching Error text.
+    const result = await sendTelegramMarkdown(api as never, 1, text, { signal: controller.signal });
+    assert.equal(result.ok, false, 'a cancelled send must not claim it delivered');
+    assert.equal(result.aborted, true, 'and it must be identifiable as a cancellation');
     assert.deepEqual(calls, ['rich'], 'no fallback or retry leg after the abort');
 });
 

--- a/tests/unit/telegram-outbound-cancel.test.ts
+++ b/tests/unit/telegram-outbound-cancel.test.ts
@@ -1,0 +1,88 @@
+// Telegram outbound cancellation (#417, L2).
+//
+// createIpv4Fetch already honours init.signal and DESTROYS the request on abort.
+// What was missing is a caller that supplies one: sendTelegramMarkdown took no
+// signal, so every send below it was unbounded no matter how good the adapter was.
+//
+// grammY takes the signal as its LAST positional argument, which is why these
+// assertions read it off the call record rather than an options object.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendTelegramMarkdown } from '../../src/telegram/rich-message.ts';
+
+type Call = { chunk: string; signal: unknown };
+
+function richApi(onSend?: (chunk: string, signal: AbortSignal | undefined) => void) {
+    const calls: Call[] = [];
+    const api = {
+        sendRichMessage: async (_chatId: unknown, payload: { markdown: string }, _opts: unknown, signal?: AbortSignal) => {
+            calls.push({ chunk: payload.markdown, signal });
+            onSend?.(payload.markdown, signal);
+            return {};
+        },
+        sendMessage: async (_chatId: unknown, text: string, _opts: unknown, signal?: AbortSignal) => {
+            calls.push({ chunk: text, signal });
+            onSend?.(text, signal);
+            return {};
+        },
+    } as unknown as Parameters<typeof sendTelegramMarkdown>[0];
+    return { api, calls };
+}
+
+test('the caller signal reaches the rich send', async () => {
+    const controller = new AbortController();
+    const { api, calls } = richApi();
+
+    await sendTelegramMarkdown(api, 1, 'hello', { signal: controller.signal });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.signal, controller.signal,
+        'grammy takes the signal positionally; dropping it makes every bound below a lie');
+});
+
+test('an already-aborted signal sends nothing at all', async () => {
+    const { api, calls } = richApi();
+
+    await sendTelegramMarkdown(api, 1, 'hello', { signal: AbortSignal.abort() });
+
+    assert.equal(calls.length, 0, 'a turn that is already cancelled must not reach the vendor');
+});
+
+test('a multi-chunk answer stops at the chunk boundary once aborted', async () => {
+    const controller = new AbortController();
+    // Two chunks: abort during the first, so the second must never be sent.
+    const { api, calls } = richApi((_chunk, _signal) => { controller.abort(); });
+    const long = 'x'.repeat(40_000);
+
+    await sendTelegramMarkdown(api, 1, long, { signal: controller.signal });
+
+    assert.equal(calls.length, 1,
+        'the chunk loop must re-check the signal; otherwise shutdown still posts the rest');
+});
+
+test('no signal keeps the previous behaviour', async () => {
+    const { api, calls } = richApi();
+    await sendTelegramMarkdown(api, 1, 'hello');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.signal, undefined);
+});
+
+test('the signal also reaches the HTML fallback leg', async () => {
+    const controller = new AbortController();
+    const calls: Call[] = [];
+    // No sendRichMessage: an older grammy build falls straight to sendMessage.
+    const api = {
+        sendMessage: async (_chatId: unknown, text: string, _opts: unknown, signal?: AbortSignal) => {
+            calls.push({ chunk: text, signal });
+            return {};
+        },
+    } as unknown as Parameters<typeof sendTelegramMarkdown>[0];
+
+    await sendTelegramMarkdown(api, 1, 'hello', { signal: controller.signal });
+
+    assert.ok(calls.length >= 1);
+    assert.equal(calls[0]?.signal, controller.signal,
+        'the fallback path is the one older deployments actually use');
+});
+


### PR DESCRIPTION
## 왜

`sendTelegramMarkdown` 은 셧다운 취소를 `throw new Error('telegram_send_aborted')` 로 알렸다. 같은 사건에 대해 `sendSlackText` 와 `sendDiscordTextRest` 는 `ok: false` 를 **반환**한다. 텔레그램만 달랐다.

비용은 취향 문제가 아니었다. 호출부의 `catch` 블록은 **취소와 실제 텔레그램 거부를 함께 받는다.** 둘을 구분할 방법은 Error 메시지 문자열 매칭뿐인데, 그 문자열이 보장되지 않는다 — `attemptSend` 는 신호가 전송 도중 발화하면 하부 전송 오류(`socket destroyed`)를 그대로 rethrow 하기 때문이다.

즉 큐 안내 경로가 의존하는 단 하나의 구분(**취소된 답변은 절대 notice 를 'answered' 로 닫으면 안 된다**)이, 거기 있으리라 보장되지 않는 문자열 위에 놓여 있었다.

## 무엇

`TelegramSendResult` 반환: `{ ok: true }` 또는 `{ ok: false, aborted: true }`.

**벤더 실패는 여전히 던진다.** 그것까지 결과로 접으면 실제 전송 장애가 깨끗한 중단처럼 보이게 되는데, 이건 정반대 방향의 실수다.

## 호출부 3곳 — 전부 조용히 틀려 있었다

이 변경의 실질은 여기다. 계약을 바꾸니 각 호출부가 명시적 분기를 갖게 됐고, 그 과정에서 기존 결함이 드러났다:

| 위치 | 기존 동작 | 수정 후 |
|---|---|---|
| `telegramSendHandler` | throw 가 `return` 을 지나쳐 탈출 → 보내지지 않은 전송에 **`{ ok: true }` 응답** | `ok: false` + 499 |
| 메시지 핸들러 최종 전달 | `ackOutcome='success'` 설정하고 **전달된 적 없는 답변의 이미지를 릴레이** | failure 로 settle, 릴레이 건너뜀 |
| 큐 응답 경로 | catch 가 notice 를 'expired' 로 닫아주길 의존 | 분기에서 직접 처리 |

## OSR-006

기존 계약(던지기)을 검증하던 테스트라 실패했다. 기대 문자열만 바꾸는 대신 **보고 계약을 검증하도록 재작성**했다.

## 검증

```
npx tsc --noEmit                            exit 0
telegram/channel/delivery/ack 스위트         1104 pass, 0 fail
npm test                                    8031 pass, 25 fail
```

25건은 전부 **기존 실패**다. 변경 전 baseline 과 `comm -13` 비교 결과 **신규 실패 0건**. (`pending-replay-drain`, `clone`, `sidecar-prune-safety` 등 공유 `CLI_JAW_HOME`/SQLite 잠금 계열로, AGENTS.md 가 경고한 그 부류다. 변경 전에는 32건이었다.)

Refs #417
