### PR TITLE
릴리스 체인이 스스로 깨지지 않게: 승격 후 자동 재정렬 (#466)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,16 +73,33 @@ bash scripts/promote-to-main.sh             # preview CI 인증 확인 → main 
 현재 브랜치에 커밋하고 `HEAD:preview` 로 푸시한다. 그 커밋을 `dev` 에도 올리지
 않으면 origin/dev 만 뒤처진 채 남는다.
 
-승격이 끝나면 `main` 에 승격 커밋이 하나 더 생기므로 `dev`/`preview` 를 그 위로
-다시 맞춘다. 내용은 같고 버전 장부만 다르므로 리셋이 안전하다:
+승격이 끝나면 `main` 에 squash 승격 커밋이 하나 생기고, 그 순간 main 은 preview 의
+조상이 아니게 된다 — 그런데 `promote-to-main.sh` 는 다음 사이클 시작에서 바로 그
+조상 관계를 요구한다. **`promote-to-main.sh` 가 승격 직후 `dev`/`preview` 를
+자동으로 재정렬하므로 보통은 손댈 일이 없다** (#466). 로그에 `realign: preview now
+has main as an ancestor` 가 찍혔는지 확인하면 된다.
+
+자동 재정렬이 경고를 남기고 실패했다면 수동으로 맞춘다. **`git reset --hard` 는
+쓰지 않는다** — dev 가 main 보다 앞서 있으면 그 앞선 커밋이 사라진다. 실제로 그
+레시피를 따른 수동 복구가 #418 의 durable queue-notice store 를 통째로 삼켰고,
+그 상태로 `cli-jaw@2.17.13` 이 npm 에 발행됐다:
 
 ```bash
 git fetch origin
 git branch -f backup/dev-pre-align-$(date +%y%m%d) dev
-git reset --hard origin/main
-git push --force-with-lease origin dev
-git push --force-with-lease origin HEAD:preview
+git checkout dev
+# 트리는 그대로 두고 main 을 부모로만 기록한다.
+git merge origin/main -s ours -m "chore: record the promotion as an ancestor"
+git diff --stat backup/dev-pre-align-$(date +%y%m%d) HEAD   # 반드시 비어 있어야 한다
+git merge-base --is-ancestor origin/main HEAD && echo ff-able
+git push origin dev
+git push origin HEAD:preview
 ```
+
+`git diff` 가 비어 있는지 **푸시 전에** 확인할 것. `-s ours` 는 "현재 브랜치의
+트리를 유지" 라는 뜻이라 방향을 헷갈리면 반대쪽 트리가 살아남는다. 2.17.13 사고가
+정확히 그것이었다 — 커밋 메시지는 preview 트리를 취한다고 적혀 있었지만 실제
+결과 트리는 main 쪽과 동일했다.
 
 #### 게이트가 막을 때
 

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -224,3 +224,28 @@ gh workflow run publish.yml \
   -f create-github-release=true
 
 echo "stable publish dispatched: cli-jaw@$STABLE_VERSION from $MERGED_MAIN_SHA"
+
+# ─── Realign dev/preview onto the new main (#466) ───────────────────────────
+# The squash above folds preview's commits into one NEW commit, so main stops
+# being an ancestor of preview the instant this script succeeds — and the guard
+# at the top of this same script requires exactly that ancestry on the next
+# cycle. Left to prose in AGENTS.md, that realignment gets skipped, and the
+# manual recovery it forces is what silently dropped #418's code from the
+# published 2.17.13 tarball.
+#
+# realign_branch_onto_main lives in promotion-checkout.sh and builds the commit
+# from plumbing, so the published tree is an input rather than a merge result.
+# A failure here is a warning, not a release failure: the publish above already
+# went out, and the only cost is that the NEXT promotion needs a manual repair
+# (AGENTS.md carries that recipe).
+realign_branch_onto_main preview "$MERGED_MAIN_SHA" \
+  "chore: record the v$STABLE_VERSION promotion as an ancestor" \
+  || echo "WARN: preview realignment failed; the next promotion will need a manual realign" >&2
+realign_branch_onto_main dev "$MERGED_MAIN_SHA" \
+  "chore: record the v$STABLE_VERSION promotion as an ancestor" \
+  || echo "WARN: dev realignment failed; realign it before the next release" >&2
+
+POST_PREVIEW="$(git ls-remote origin refs/heads/preview | cut -f1)"
+if [ -n "$POST_PREVIEW" ] && ! git merge-base --is-ancestor "$MERGED_MAIN_SHA" "$POST_PREVIEW"; then
+  echo "WARN: origin/main is still not an ancestor of origin/preview — the next promotion will be blocked" >&2
+fi

--- a/scripts/promotion-checkout.sh
+++ b/scripts/promotion-checkout.sh
@@ -128,3 +128,52 @@ assert_promotion_checkout_ready_to_push() {
     return 1
   fi
 }
+
+# ─── Post-promotion realignment (#466) ─────────────────────────────────────
+#
+# A squash promotion folds preview's commits into one NEW commit on main, so
+# main stops being an ancestor of preview the moment the promotion succeeds —
+# and promote-to-main.sh demands exactly that ancestry on the next cycle. The
+# script breaks its own precondition every release. Leaving the repair to prose
+# is what produced the 2.17.13 incident: a hand-made merge claimed to take the
+# preview tree, took main's, and shipped a tarball missing #418's code.
+#
+# Built from plumbing (commit-tree) rather than a worktree on purpose: the tree
+# is an INPUT here, not a merge result, so the published content cannot change
+# no matter which side is which. The caller re-checks it anyway.
+realign_branch_onto_main() {
+  local branch="$1" main_sha="$2" message="$3"
+  local head tree new_commit
+  head="$(git ls-remote origin "refs/heads/$branch" | cut -f1)"
+  if [ -z "$head" ]; then
+    echo "realign: no origin/$branch to realign" >&2
+    return 0
+  fi
+  if git merge-base --is-ancestor "$main_sha" "$head" 2>/dev/null; then
+    echo "realign: $branch already has main as an ancestor"
+    return 0
+  fi
+  git fetch origin "$branch" >/dev/null 2>&1 || true
+  tree="$(git rev-parse "$head^{tree}")" || {
+    promotion_error "realign: cannot read $branch tree"
+    return 1
+  }
+  new_commit="$(git commit-tree "$tree" -p "$head" -p "$main_sha" -m "$message")" || {
+    promotion_error "realign: could not create the realignment commit for $branch"
+    return 1
+  }
+  if [ "$(git rev-parse "$new_commit^{tree}")" != "$tree" ]; then
+    promotion_error "realign: $branch tree changed; refusing to push"
+    return 1
+  fi
+  if ! git merge-base --is-ancestor "$main_sha" "$new_commit"; then
+    promotion_error "realign: $main_sha is still not an ancestor of $branch; refusing to push"
+    return 1
+  fi
+  if git push origin "$new_commit:refs/heads/$branch" >/dev/null 2>&1; then
+    echo "realign: $branch now has main as an ancestor, tree unchanged"
+  else
+    echo "realign: could not push $branch (did it move?)" >&2
+    return 1
+  fi
+}

--- a/tests/integration/promotion-realign.test.ts
+++ b/tests/integration/promotion-realign.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// #466: promote-to-main.sh squash-merges preview into main, which makes main stop
+// being an ancestor of preview — and the guard at the top of that same script
+// demands exactly that ancestry on the next cycle. The script therefore breaks its
+// own precondition every release, and the manual recovery that gap forced is what
+// dropped #418's code from the published 2.17.13 tarball.
+//
+// These run the realignment against a REAL git repository rather than reading the
+// script's text, because the failure being guarded is a wrong merge DIRECTION —
+// something only a tree comparison can catch.
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function git(cwd: string, ...args: string[]): string {
+    const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+    assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+    return r.stdout.trim();
+}
+
+/** upstream + a clone, shaped like the repo right after a squash promotion. */
+function makeRepo(): { work: string; upstream: string; mainSha: string; previewSha: string } {
+    const root = mkdtempSync(join(tmpdir(), 'jaw-promote-'));
+    const upstream = join(root, 'upstream.git');
+    const work = join(root, 'work');
+    mkdirSync(upstream);
+    git(upstream, 'init', '--bare', '--initial-branch=main');
+    git(root, 'clone', upstream, 'work');
+    git(work, 'config', 'user.email', 'test@example.com');
+    git(work, 'config', 'user.name', 'test');
+
+    writeFileSync(join(work, 'shipped.txt'), 'base\n');
+    git(work, 'add', '-A');
+    git(work, 'commit', '-m', 'base');
+    git(work, 'push', 'origin', 'main');
+
+    // preview gains the release work.
+    git(work, 'checkout', '-b', 'preview');
+    writeFileSync(join(work, 'shipped.txt'), 'base\nfeature\n');
+    writeFileSync(join(work, 'only-on-preview.txt'), 'this must survive\n');
+    git(work, 'add', '-A');
+    git(work, 'commit', '-m', 'the release work');
+    git(work, 'push', 'origin', 'preview');
+    const previewSha = git(work, 'rev-parse', 'HEAD');
+
+    // main gets it as a SQUASH — same tree, unrelated commit. This is what
+    // gh pr merge --squash produces, and why the ancestry breaks.
+    git(work, 'checkout', 'main');
+    git(work, 'merge', '--squash', 'preview');
+    git(work, 'commit', '-m', 'chore: promote v9.9.9');
+    git(work, 'push', 'origin', 'main');
+    const mainSha = git(work, 'rev-parse', 'HEAD');
+
+    return { work, upstream, mainSha, previewSha };
+}
+
+test('PRA-001: after a squash promotion, main is NOT an ancestor of preview', () => {
+    const { work, mainSha, previewSha } = makeRepo();
+    const r = spawnSync('git', ['merge-base', '--is-ancestor', mainSha, previewSha], { cwd: work });
+    assert.notEqual(r.status, 0,
+        'this is the precondition the guard rejects; if it ever passes, the premise of #466 changed');
+});
+
+test('PRA-002: the realignment records main as an ancestor without touching the tree', () => {
+    const { work, mainSha } = makeRepo();
+    git(work, 'checkout', 'preview');
+    const treeBefore = git(work, 'rev-parse', 'HEAD^{tree}');
+
+    // The realignment promote-to-main.sh performs.
+    git(work, 'merge', mainSha, '-s', 'ours', '-m', 'chore: record the promotion as an ancestor');
+
+    const treeAfter = git(work, 'rev-parse', 'HEAD^{tree}');
+    assert.equal(treeAfter, treeBefore, 'realignment must not change what ships');
+    assert.equal(
+        spawnSync('git', ['merge-base', '--is-ancestor', mainSha, 'HEAD'], { cwd: work }).status,
+        0,
+        'main must now be an ancestor so the next promotion is not blocked',
+    );
+    assert.equal(readFileSync(join(work, 'only-on-preview.txt'), 'utf8'), 'this must survive\n');
+});
+
+test('PRA-003: the reverse merge direction silently takes the wrong tree — the 2.17.13 failure', () => {
+    // Recorded so the danger stays visible: -s ours keeps the CURRENT branch's
+    // tree, so running it from main discards preview's work while reporting
+    // success. fbefa754 did exactly this and shipped a tarball missing #418.
+    const { work } = makeRepo();
+    git(work, 'checkout', 'preview');
+    writeFileSync(join(work, 'only-on-preview.txt'), 'newer preview content\n');
+    git(work, 'add', '-A');
+    git(work, 'commit', '-m', 'later preview work');
+    const previewTree = git(work, 'rev-parse', 'HEAD^{tree}');
+
+    git(work, 'checkout', 'main');
+    const mainTree = git(work, 'rev-parse', 'HEAD^{tree}');
+    git(work, 'merge', 'preview', '-s', 'ours', '-m', 'take preview tree');
+
+    assert.equal(git(work, 'rev-parse', 'HEAD^{tree}'), mainTree,
+        'from main, -s ours keeps MAIN — the commit message claiming otherwise is not enforcement');
+    assert.notEqual(git(work, 'rev-parse', 'HEAD^{tree}'), previewTree,
+        'this is the silent data loss: a clean merge that contributed nothing from preview');
+});
+
+test('PRA-004: the shipped helper realigns a squash-broken branch, tree untouched', () => {
+    // Runs the REAL helper against a real repository. The script-text checks that
+    // used to live here proved wording, not behavior.
+    const { work, upstream, mainSha } = makeRepo();
+    const helper = join(projectRoot, 'scripts/promotion-checkout.sh');
+    const before = git(work, 'rev-parse', 'origin/preview^{tree}');
+
+    const r = spawnSync('bash', ['-c',
+        `set -euo pipefail; source "${helper}"; realign_branch_onto_main preview "${mainSha}" "chore: test realign"`,
+    ], { cwd: work, encoding: 'utf8' });
+    assert.equal(r.status, 0, `helper failed: ${r.stdout}${r.stderr}`);
+
+    const head = git(work, 'ls-remote', upstream, 'refs/heads/preview').split(/\s+/)[0]!;
+    assert.equal(git(work, 'rev-parse', `${head}^{tree}`), before,
+        'the realignment must not change what ships');
+    assert.equal(spawnSync('git', ['merge-base', '--is-ancestor', mainSha, head], { cwd: work }).status, 0,
+        'main must be an ancestor afterwards, or the next promotion is blocked again');
+});
+
+test('PRA-005: promote-to-main.sh actually calls the helper for both branches', () => {
+    const src = readFileSync(join(projectRoot, 'scripts/promote-to-main.sh'), 'utf8');
+    for (const branch of ['preview', 'dev']) {
+        assert.ok(src.includes(`realign_branch_onto_main ${branch}`),
+            `${branch} must be realigned; skipping either one re-breaks the next cycle`);
+    }
+});


### PR DESCRIPTION
#466 의 제안 1(근본 해결)과 2(스크립트 편입)를 합친 방향으로 고쳤다. `--squash` 자체는 유지하고, 승격 직후 재정렬을 스크립트가 직접 수행한다.

## 왜 이 방향인가

squash 를 merge-commit 이나 fast-forward 로 바꾸는 것도 문제를 없애지만, 그건 main 히스토리의 모양과 tree-identity fast path(`:160-209`) 를 동시에 건드린다. 재정렬은 승격이 끝난 **뒤** 의 동작이라 승격 경로 자체는 그대로 두고 결함만 없앤다.

## 무엇

`realign_branch_onto_main` 을 `promotion-checkout.sh` 에 추가하고 publish dispatch 직후 preview/dev 양쪽에 건다.

핵심은 **plumbing 으로 만든다**는 점이다:

```bash
tree="$(git rev-parse "$head^{tree}")"
new_commit="$(git commit-tree "$tree" -p "$head" -p "$main_sha" -m "$message")"
```

게시될 트리가 머지 **결과**가 아니라 **입력**이다. 어느 브랜치가 체크아웃돼 있든 반대쪽 트리가 살아남을 수 없다 — 2.17.13 사고가 정확히 그 실수였다. 그래도 푸시 전에 트리 왕복과 조상 관계를 다시 확인한다.

worktree 를 쓰지 않은 것은 `release-scripts-contract` 의 기존 계약(`!script.includes('git worktree add')`) 때문이다. 그 계약의 이유가 유효하므로 헬퍼로 옮겼다.

재정렬 실패는 릴리스 실패가 아니라 경고다. publish 는 이미 나간 뒤이고, 대가는 다음 승격에 수동 복구가 필요하다는 것뿐이다.

## AGENTS.md

이슈가 지적한 `git reset --hard origin/main` 을 교체했다. 이번 사이클에서 그대로 따랐다면 #457 의 mermaid/dompurify 보안 상향을 포함해 dev 의 앞선 커밋 전부가 사라졌을 것이다. 대체 레시피는 트리를 유지하고 부모만 기록하며, **푸시 전 `git diff` 확인을 필수**로 적었다. `-s ours` 의 방향 함정도 명시했다.

## 테스트

스크립트 텍스트가 아니라 **실제 git 저장소** 를 상대로 돈다. 잡으려는 결함이 머지 **방향** 이라 트리 비교만이 볼 수 있기 때문이다.

- `PRA-001` squash 승격 후 main 이 preview 의 조상이 아님을 고정 — 이슈의 전제가 바뀌면 여기서 깨진다
- `PRA-002` 재정렬이 조상 관계를 만들고 트리는 그대로
- `PRA-003` **2.17.13 실패를 그대로 재현** — main 에서 `-s ours` 를 돌리면 성공을 보고하면서 preview 작업을 버린다
- `PRA-004` 배포되는 헬퍼를 실제로 실행해 검증
- `PRA-005` 두 브랜치 모두 호출되는지

## 확인 요청 답변

`b34d89a8`(`codex/430-path-length-clean`)은 dev/main/preview 어디에도 없는 게 맞다. 다만 **기능은 이미 들어가 있다** — `scripts/check-path-length.mjs` 와 `check:path-length` 가 현재 dev 에 존재하고 `gate:all` 에 물려 있으며, 상한은 그 브랜치의 200 이 아니라 **150** 으로 더 조여져 있다(#432 에서 74자 접두사 + 186자 경로가 다시 260 에 걸린 뒤). 즉 폐기가 아니라 후속 작업에 흡수된 브랜치다.

```
$ npm run check:path-length
[path-length] OK - 12485 tracked path(s), longest 142, limit 150
```

## 검증

```
npm run test:all   8283 pass / 0 fail
npm run gate:all   23/23
```
