### PR TITLE
fix(slack): optional 스코프 누락을 전송 불능과 구분해 알린다 (#478)

### DIFF
--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -42,7 +42,7 @@ import { OutboundSendRegistry } from '../messaging/outbound-lifecycle.js';
 import {
     recordSlackScopeObservation,
     getSlackScopeStatus,
-    describeSlackScopeGap,
+    describeSlackScopeGaps,
     resetSlackScopeStatus,
 } from './scope-status.js';
 import { SlackSocketClient, type SlackEnvelope, type SlackPreflightResult } from './socket.js';
@@ -1189,8 +1189,13 @@ async function runSlackInit(): Promise<TransportStartOutcome> {
     // that return would make an unconfigured channel hit the network on every
     // start. Documented as a known limitation rather than silently ignored.
     recordSlackScopeObservation(auth.grantedScopes, null);
-    const scopeGap = describeSlackScopeGap(getSlackScopeStatus());
-    if (scopeGap) log.warn(`[slack:scopes] ${scopeGap}`);
+    for (const gap of describeSlackScopeGaps(getSlackScopeStatus())) {
+        // Each group logs at its own level: a missing required scope is a real
+        // break, a missing optional one is not, and one shared WARN made them
+        // indistinguishable (#478).
+        const emit = gap.level === 'warn' ? log.warn : log.info;
+        emit(`[slack:scopes] ${gap.text}`);
+    }
     if (auth.data?.team_id && !sc.teamId) sc.teamId = auth.data.team_id;
     // The team id namespaces every ingress dedup key, and `slackEventKey`
     // degrades an empty one to the literal 'unknown' — so two workspaces,

--- a/src/slack/scope-status.ts
+++ b/src/slack/scope-status.ts
@@ -98,24 +98,51 @@ function slackReinstallUrl(appId?: string | null): string | null {
     return `https://api.slack.com/apps/${id}/install-on-team`;
 }
 
+/** One reportable group of missing scopes, carrying its own severity. */
+export type SlackScopeGapLine = {
+    /** `warn` only when the transport actually cannot do its job. */
+    level: 'warn' | 'info';
+    text: string;
+};
+
 /**
- * One operator-facing line naming every missing scope at once, or null when
- * there is nothing to say. Returning null for the unknown case is deliberate:
+ * Operator-facing lines for the missing scopes, one per severity, or an empty
+ * array when there is nothing to say. Empty for the unknown case is deliberate:
  * a warning that fires when we did not measure anything trains people to
  * ignore warnings.
+ *
+ * Required and optional are reported SEPARATELY because they are different
+ * claims. Concatenating them let one severity word govern both lists, so a
+ * single missing `chat:write` promoted every optional scope to "the transport
+ * needs", and an app missing only optional ones announced a `missing 4
+ * scope(s)` count at WARN while the socket was connected and answering (#478).
+ * A count that mixes an outage with a degradation is not a count anyone can act
+ * on.
  */
-export function describeSlackScopeGap(status: SlackScopeStatus): string | null {
-    if (status.unknown) return null;
-    const missing = [...status.missingRequired, ...status.missingCapabilities];
-    if (missing.length === 0) return null;
+export function describeSlackScopeGaps(status: SlackScopeStatus): SlackScopeGapLine[] {
+    if (status.unknown) return [];
     const where = status.reinstallUrl
         ? `reinstall: ${status.reinstallUrl}`
         : 'add them under OAuth & Permissions, then reinstall the app to your workspace';
-    const severity = status.missingRequired.length > 0
-        ? 'the transport needs'
-        : 'features degrade without';
-    return `Slack app grant is missing ${missing.length} scope(s) — `
-        + `${severity}: ${missing.join(', ')} — ${where}`;
+    const lines: SlackScopeGapLine[] = [];
+    if (status.missingRequired.length > 0) {
+        lines.push({
+            level: 'warn',
+            text: `the transport needs ${status.missingRequired.length} scope(s): `
+                + `${status.missingRequired.join(', ')} — ${where}`,
+        });
+    }
+    if (status.missingCapabilities.length > 0) {
+        // info, not warn: messaging works without these. The operator who read
+        // the old WARN had no way to tell that from a broken transport, and
+        // reinstalled the app to find out.
+        lines.push({
+            level: 'info',
+            text: `${status.missingCapabilities.length} optional scope(s) not granted: `
+                + `${status.missingCapabilities.join(', ')} — messaging is unaffected; ${where}`,
+        });
+    }
+    return lines;
 }
 
 // ─── Inbound conversation scope ─────────────────────

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -263,7 +263,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (21 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (407L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1345L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1350L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (408L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (66L)
 │   │   ├── events.ts         ← inbound gating (self-echo/bot/subtype/allowlist/mention) + Block Kit 텍스트 추출 (283L)
@@ -282,7 +282,7 @@ cli-jaw/
 │   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (72L)
 │   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 (65L)
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (161L)
-│   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (152L) ✨
+│   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (179L) ✨
 │   │   ├── allowlist-audit.ts ← channelIds 변경 방향 분류 + 축소 감사 기록 (게이트 리더 기준 정규화, route·settings watcher 양쪽이 공유) (125L) ✨
 │   │   ├── hot-notify.ts     ← CLI 설정 변경 후 실행 중 서버 hot-reload 통지 (loopback PUT /api/settings → transport 재시작, version skew 감지) (35L)
 │   │   ├── progress.ts       ← 실행 중 진행상황 릴레이 ("정보 수집 중…" placeholder → agent_tool 이벤트로 chat.update rate-limited 편집 → 답변 시 chat.delete, post/edit 모두 자격증명 마스킹) (187L) ✨

--- a/tests/unit/slack-scope-drift.test.ts
+++ b/tests/unit/slack-scope-drift.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import {
     recordSlackScopeObservation,
     getSlackScopeStatus,
-    describeSlackScopeGap,
+    describeSlackScopeGaps,
     resetSlackScopeStatus,
 } from '../../src/slack/scope-status.ts';
 import {
@@ -44,9 +44,10 @@ test('the six scopes from the bug report are reported by name', () => {
     assert.deepEqual(status.missingCapabilities, IDENTITY_SCOPES);
 
     // The whole point: ONE line naming ALL of them, not one per failed call.
-    const line = describeSlackScopeGap(status)!;
+    const lines = describeSlackScopeGaps(status);
+    assert.equal(lines.length, 1, 'nothing required is missing, so there is nothing to warn about');
     for (const scope of status.missingCapabilities) {
-        assert.ok(line.includes(scope), scope + ' missing from the operator line');
+        assert.ok(lines[0]!.text.includes(scope), scope + ' missing from the operator line');
     }
 });
 
@@ -58,7 +59,7 @@ test('a full grant produces no warning at all', () => {
     assert.equal(status.ok, true);
     assert.equal(status.unknown, false);
     // A warning that always fires is a warning nobody reads.
-    assert.equal(describeSlackScopeGap(status), null);
+    assert.deepEqual(describeSlackScopeGaps(status), []);
 });
 
 test('an unobserved header is "cannot check", not "nothing missing"', () => {
@@ -70,7 +71,7 @@ test('an unobserved header is "cannot check", not "nothing missing"', () => {
     assert.equal(status.checkedAt, null);
     // ok stays true so a header-stripping proxy cannot manufacture a false
     // alarm, but the unknown flag is what consumers must branch on.
-    assert.equal(describeSlackScopeGap(status), null, 'no measurement means no claim');
+    assert.deepEqual(describeSlackScopeGaps(status), [], 'no measurement means no claim');
 });
 
 test('a missing required scope is reported as a real break', () => {
@@ -80,17 +81,18 @@ test('a missing required scope is reported as a real break', () => {
 
     assert.deepEqual(status.missingRequired, ['chat:write']);
     assert.equal(status.ok, false);
-    assert.match(describeSlackScopeGap(status)!, /the transport needs/);
+    const required = describeSlackScopeGaps(status).find(l => l.level === 'warn')!;
+    assert.match(required.text, /the transport needs/);
 });
 
 test('the reinstall URL appears only when the app id is known', () => {
     resetSlackScopeStatus();
     recordSlackScopeObservation(OLD_INSTALL_GRANT, 'A123');
-    assert.match(describeSlackScopeGap(getSlackScopeStatus())!, /apps\/A123\/install-on-team/);
+    assert.match(describeSlackScopeGaps(getSlackScopeStatus())[0]!.text, /apps\/A123\/install-on-team/);
 
     resetSlackScopeStatus();
     recordSlackScopeObservation(OLD_INSTALL_GRANT, null);
-    const line = describeSlackScopeGap(getSlackScopeStatus())!;
+    const line = describeSlackScopeGaps(getSlackScopeStatus())[0]!.text;
     // Never guess an app id: a wrong one sends the operator to someone else's app.
     assert.doesNotMatch(line, /api\.slack\.com\/apps/);
     assert.match(line, /OAuth & Permissions/);
@@ -137,3 +139,47 @@ test('a failed call still reports the grant it observed', async () => {
     assert.equal(result.grantedScopes, OLD_INSTALL_GRANT);
 });
 
+// #478: an app installed before v2.17.10 lacks four optional scopes. The single
+// combined line announced `missing 4 scope(s)` at WARN while the socket was
+// connected and answering, so the operator could not tell a degradation from an
+// outage and reinstalled the app to find out. These pin that the two severities
+// stay apart.
+
+const V217_10_SCOPES = ['channels:join', 'chat:write.public', 'team:read', 'mpim:read'];
+
+test('#478: an optional-only gap reports at info, never warn', () => {
+    resetSlackScopeStatus();
+    recordSlackScopeObservation(ALL.filter(s => !V217_10_SCOPES.includes(s)).join(','), null);
+    const status = getSlackScopeStatus();
+
+    assert.deepEqual(status.missingRequired, [], 'the transport itself is intact');
+    const lines = describeSlackScopeGaps(status);
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0]!.level, 'info', 'messaging works — this must not read as a break');
+    // The operator's actual question was "is the bot broken?". Answer it.
+    assert.match(lines[0]!.text, /messaging is unaffected/);
+});
+
+test('#478: a required gap does not drag optional scopes into its severity', () => {
+    resetSlackScopeStatus();
+    // Both kinds missing at once — the case the old single-line output flattened.
+    recordSlackScopeObservation(
+        ALL.filter(s => s !== 'chat:write' && !V217_10_SCOPES.includes(s)).join(','),
+        null,
+    );
+    const lines = describeSlackScopeGaps(getSlackScopeStatus());
+
+    assert.equal(lines.length, 2, 'two severities, two lines');
+    const warn = lines.find(l => l.level === 'warn')!;
+    const info = lines.find(l => l.level === 'info')!;
+
+    assert.match(warn.text, /chat:write/);
+    for (const scope of V217_10_SCOPES) {
+        assert.ok(!warn.text.includes(scope), scope + ' is optional and must stay out of the warning');
+        assert.ok(info.text.includes(scope), scope + ' missing from the optional line');
+    }
+    // The old output said "missing 5 scope(s)" — a count spanning an outage and
+    // a degradation, which no operator can act on.
+    assert.match(warn.text, /needs 1 scope\(s\)/);
+    assert.match(info.text, /4 optional scope\(s\)/);
+});


### PR DESCRIPTION
## 무엇이 문제였나

v2.17.10 이전에 설치된 Slack 앱은 `channels:join`, `chat:write.public`, `team:read`, `mpim:read` 4개가 빠져 있다. 기동 시 점검이 이걸 찾아내고 **`missing 4 scope(s)` 를 WARN 으로** 알렸는데, 그 시점에 소켓은 연결돼 있었고 봇은 정상 응답 중이었다. 제보자는 이게 "고장" 인지 "기능 일부 없음" 인지 판단할 근거가 없어서, 확인을 위해 앱을 재설치했다 (#478).

## 원인

판정 데이터는 처음부터 나뉘어 있었다 — `missingRequired` 와 `missingCapabilities` 는 별개 배열이다. 납작해진 건 **보고 단계뿐**이다.

```js
const missing = [...status.missingRequired, ...status.missingCapabilities];
const severity = status.missingRequired.length > 0 ? 'the transport needs' : 'features degrade without';
```

두 배열을 이어붙인 뒤 severity 를 **전체에 하나만** 골랐다. 그래서 두 실패가 운영자가 읽는 표면에서 구분되지 않았다.

- `chat:write` 하나만 빠져도 optional 스코프까지 전부 `the transport needs` 로 승격됐다
- optional 만 빠진 경우엔 일어나지도 않은 break 에서 WARN 을 빌려왔다
- 개수가 둘에 걸쳐 있어서 어느 쪽이 몇 개인지 알 수 없었다

## 수정

severity 당 한 줄씩 반환하고, 각자 자기 레벨로 로깅한다.

```
[WARN] [slack:scopes] the transport needs 1 scope(s): chat:write — reinstall: ...
[INFO] [slack:scopes] 4 optional scope(s) not granted: channels:join, chat:write.public,
       team:read, mpim:read — messaging is unaffected; reinstall: ...
```

optional 줄에 `messaging is unaffected` 를 명시한 건 그게 제보자의 실제 질문이었기 때문이다.

**매니페스트는 건드리지 않았다.** 이슈의 세 번째 제안(4개를 매니페스트에 추가)은 이미 반영돼 있다 — `channels:join`/`chat:write.public` 은 v2.17.10, `team:read`/`mpim:read` 는 v2.14.0 부터 들어 있다. Slack 은 설치 시점에 grant 를 고정하므로 구버전 매니페스트로 만든 앱은 재설치 전까지 이 상태가 유지된다. 보고할 가치가 있는 상태이되, 고장은 아니다.

## 범위

로그 문구와 레벨만 바뀐다. 스코프 필수/선택 분류(`REQUIRED_SLACK_BOT_SCOPES` / `SLACK_CAPABILITY_SCOPES`), `/api/health` 의 `slackScopes` 응답, `SlackScopeStatus` 필드는 그대로다. 소비자는 `bot.ts` 한 곳뿐이었다.

## 테스트 (2건 신규)

| 고정한 계약 |
|---|
| optional 만 빠지면 info 로만 보고한다 — WARN 이 아니다 |
| required 가 있어도 optional 을 그 severity 로 끌고 오지 않는다 (2줄, 개수 분리) |

기존 5건은 새 시그니처로 갱신했다.

## 증거

- `npx tsx --test tests/unit/slack-scope-drift.test.ts` — 10 passed / 0 failed
- `npx tsc --noEmit` exit 0
- `describeSlackScopeGap` 잔여 참조 0건
- `structure/verify-counts.sh` 443/443 일치

---

미검증으로 남긴 것: 전체 스위트(`npm test`)와 `npm run build` 는 아직 돌리지 않았다. draft 인 이유다.
