### PR TITLE
feat(doctor): detect when jaw is unreachable from a non-interactive shell (#479)

### DIFF
--- a/bin/commands/doctor.ts
+++ b/bin/commands/doctor.ts
@@ -18,6 +18,7 @@ import { migrateAllJawHomes, hasPendingLegacySkillDirs, discoverJawHomes } from 
 import { isDiscoverableSkillDirName } from '../../lib/mcp/skills-utils.js';
 import { classifyClaudeInstall } from '../../src/core/claude-install.js';
 import { isWsl, isWindowsNative, resolvePlatformKind } from '../../src/core/platform-kind.js';
+import { checkNonInteractivePath, nonInteractivePathRemedy } from '../../src/core/noninteractive-path.js';
 import { readClaudeCreds } from '../../src/routes/quota.js';
 import { CLI_KEYS } from '../../src/cli/registry.js';
 import { shouldShowHelp, printAndExit } from '../helpers/help.js';
@@ -675,6 +676,47 @@ check('uv (Python)', () => {
         throw new Error(`WARN: not installed — run: ${installHint}`);
     }
 });
+
+// 9b. Non-interactive shell reachability (#479)
+//
+// Remote one-shot commands (`ssh host 'jaw serve ...'`) run a shell that
+// reads none of the profile files the installer writes to, so `jaw` can be
+// fine here and unresolvable there. doctor itself runs in the shell that
+// works, so it has to ask the question against `getconf PATH` instead of
+// process.env.PATH.
+if (process.platform !== 'win32') {
+    check('Non-interactive PATH (ssh)', () => {
+        // Where jaw actually lives on THIS host. A version-managed Node
+        // (nvm/fnm/Homebrew) installs global bins under a prefix no static
+        // list can predict.
+        const npmPrefix = getNpmPrefix();
+        const knownBinDirs = [
+            npmPrefix ? path.join(npmPrefix, 'bin') : '',
+            findBinaryPath('jaw') ? path.dirname(findBinaryPath('jaw')!) : '',
+        ].filter(Boolean);
+
+        const result = checkNonInteractivePath('jaw', os.homedir(), {
+            baselinePath: () => {
+                try { return execFileSync('getconf', ['PATH'], { encoding: 'utf8', stdio: 'pipe' }).trim() || null; }
+                catch { return null; }
+            },
+            isExecutableFile: (candidate) => {
+                try { return fs.statSync(candidate).isFile() && (fs.statSync(candidate).mode & 0o111) !== 0; }
+                catch { return false; }
+            },
+        }, knownBinDirs);
+
+        if (result.status === 'unknown') return 'skipped (no baseline PATH)';
+        if (result.status === 'reachable') return `jaw resolves in a non-interactive shell (${result.foundIn})`;
+        if (result.status === 'not-installed') return 'jaw not found in any known install dir — skipping';
+
+        throw new Error(
+            `WARN: jaw is in ${result.foundIn} but not on the non-interactive PATH — `
+            + "remote `ssh host 'jaw ...'` will fail with \"No such file or directory\"\n"
+            + nonInteractivePathRemedy('jaw', result.foundIn!).map(line => `     ${line}`).join('\n')
+        );
+    });
+}
 
 if (isWindowsNative()) {
     check('Windows (native)', () => {

--- a/src/core/noninteractive-path.ts
+++ b/src/core/noninteractive-path.ts
@@ -1,0 +1,116 @@
+/**
+ * Non-interactive shell PATH reachability (#479).
+ *
+ * `ssh host 'jaw serve ...'` runs a non-login, non-interactive shell. That
+ * shell reads none of the files the installer writes to: bash skips
+ * `.bash_profile`/`.profile` (login-only) and Debian's stock `.bashrc`
+ * returns at its first line when non-interactive; zsh reads only `.zshenv`,
+ * which the installer never touches. So a host where `jaw` works
+ * interactively can still fail to resolve it over SSH, and the failure
+ * surfaces as `nohup: failed to run command 'jaw'` — no PATH in sight.
+ *
+ * doctor cannot observe this by inspecting its own environment: it runs in
+ * the shell that already works. The reachability question has to be asked
+ * against the PATH a non-interactive shell would actually get, which is what
+ * `getconf PATH` reports.
+ */
+import { delimiter, join } from 'node:path';
+
+export interface NonInteractivePathProbes {
+    /** The PATH a non-interactive shell starts from, or null when unavailable. */
+    baselinePath(): string | null;
+    /** True when the path names an executable file. */
+    isExecutableFile(path: string): boolean;
+}
+
+export type NonInteractivePathStatus =
+    /** Resolvable from the baseline PATH — remote one-shot commands work. */
+    | 'reachable'
+    /** Not on the baseline PATH, but found in a known install dir. */
+    | 'unreachable'
+    /** Not found anywhere; a PATH fix would not help. */
+    | 'not-installed'
+    /** No baseline PATH to test against (non-POSIX host). */
+    | 'unknown';
+
+export interface NonInteractivePathResult {
+    status: NonInteractivePathStatus;
+    /** The directory holding the binary, when one was found. */
+    foundIn: string | null;
+    /** The baseline PATH the check ran against. */
+    baseline: string | null;
+}
+
+/**
+ * Install directories to search after the baseline PATH misses.
+ *
+ * `~/.local/bin` is what `scripts/install.sh` configures and what #479
+ * reported. The static list alone is not enough: a Node installed by nvm,
+ * fnm, or Homebrew puts global bins under a version-specific prefix that no
+ * fixed list can enumerate, and treating those as "not installed" would
+ * silently drop exactly the hosts this check exists for. So the caller's own
+ * resolved directories (npm prefix, the running binary's dir) are searched
+ * first — they are facts about this install, not guesses.
+ */
+export function candidateInstallDirs(homeDir: string, knownBinDirs: string[] = []): string[] {
+    return [
+        ...knownBinDirs.filter(Boolean),
+        join(homeDir, '.local', 'bin'),
+        join(homeDir, '.npm-global', 'bin'),
+        join(homeDir, 'bin'),
+        join(homeDir, '.volta', 'bin'),
+        join(homeDir, '.bun', 'bin'),
+    ];
+}
+
+function findIn(dirs: string[], binary: string, probes: NonInteractivePathProbes): string | null {
+    for (const dir of dirs) {
+        if (!dir) continue;
+        if (probes.isExecutableFile(join(dir, binary))) return dir;
+    }
+    return null;
+}
+
+/**
+ * Decide whether `binary` resolves in a non-interactive shell.
+ *
+ * Pure over its probes so the whole matrix is testable without an SSH host.
+ */
+export function checkNonInteractivePath(
+    binary: string,
+    homeDir: string,
+    probes: NonInteractivePathProbes,
+    knownBinDirs: string[] = [],
+): NonInteractivePathResult {
+    const baseline = probes.baselinePath();
+    if (!baseline) return { status: 'unknown', foundIn: null, baseline: null };
+
+    const baselineDirs = baseline.split(delimiter).map(s => s.trim()).filter(Boolean);
+    const onBaseline = findIn(baselineDirs, binary, probes);
+    if (onBaseline) return { status: 'reachable', foundIn: onBaseline, baseline };
+
+    // Only search install dirs the baseline did not already cover, so a hit
+    // here always means "installed but unreachable" rather than a re-report.
+    const extraDirs = candidateInstallDirs(homeDir, knownBinDirs).filter(dir => !baselineDirs.includes(dir));
+    const installed = findIn(extraDirs, binary, probes);
+    if (installed) return { status: 'unreachable', foundIn: installed, baseline };
+
+    return { status: 'not-installed', foundIn: null, baseline };
+}
+
+/**
+ * Operator-facing remedy for an unreachable binary.
+ *
+ * `~/.zshenv` is named for zsh because it is the only startup file a
+ * non-interactive zsh reads; bash has no equivalent (`BASH_ENV` is honored
+ * only for non-interactive shells and is not set by default), so bash users
+ * get the absolute-path form, which always works.
+ */
+export function nonInteractivePathRemedy(binary: string, foundIn: string): string[] {
+    const absolute = join(foundIn, binary);
+    return [
+        `call it by absolute path: ${absolute}`,
+        `or export PATH in the remote command: ssh host 'export PATH="${foundIn}:$PATH"; ${binary} ...'`,
+        `or (zsh) add to ~/.zshenv: export PATH="${foundIn}:$PATH"`,
+    ];
+}

--- a/tests/unit/noninteractive-path.test.ts
+++ b/tests/unit/noninteractive-path.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #479 regression: `ssh host 'jaw serve ...'` failed with
+ * "nohup: failed to run command 'jaw'" because ~/.local/bin is added to PATH
+ * only by files a non-interactive shell never reads. doctor had no check for
+ * it, and could not have had a naive one: doctor runs in the interactive
+ * shell where PATH already works.
+ *
+ * The probes are injected, so the whole matrix runs without an SSH host.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    checkNonInteractivePath,
+    candidateInstallDirs,
+    nonInteractivePathRemedy,
+    type NonInteractivePathProbes,
+} from '../../src/core/noninteractive-path.ts';
+
+const HOME = '/home/box';
+const POSIX_BASELINE = '/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games';
+
+/** Probes where exactly `present` resolve as executables. */
+function probes(baseline: string | null, present: string[]): NonInteractivePathProbes {
+    return {
+        baselinePath: () => baseline,
+        isExecutableFile: (path) => present.includes(path),
+    };
+}
+
+test('NIP-001: the #479 shape is reported unreachable, not missing', () => {
+    // Exactly the reporter's host: installed in ~/.local/bin, which the
+    // non-interactive baseline PATH does not contain.
+    const result = checkNonInteractivePath('jaw', HOME, probes(POSIX_BASELINE, [join(HOME, '.local/bin/jaw')]));
+    assert.equal(result.status, 'unreachable');
+    assert.equal(result.foundIn, join(HOME, '.local/bin'));
+});
+
+test('NIP-002: a binary on the baseline PATH is reachable', () => {
+    const result = checkNonInteractivePath('jaw', HOME, probes(POSIX_BASELINE, ['/usr/local/bin/jaw']));
+    assert.equal(result.status, 'reachable');
+    assert.equal(result.foundIn, '/usr/local/bin');
+});
+
+test('NIP-003: a binary installed nowhere is not-installed, so no PATH advice is given', () => {
+    // Distinct from unreachable: telling this user to fix PATH would be wrong.
+    const result = checkNonInteractivePath('jaw', HOME, probes(POSIX_BASELINE, []));
+    assert.equal(result.status, 'not-installed');
+    assert.equal(result.foundIn, null);
+});
+
+test('NIP-004: no baseline PATH yields unknown rather than a false alarm', () => {
+    const result = checkNonInteractivePath('jaw', HOME, probes(null, [join(HOME, '.local/bin/jaw')]));
+    assert.equal(result.status, 'unknown');
+});
+
+test('NIP-005: the check ignores the caller PATH entirely', () => {
+    // The bug is invisible from an interactive shell; a check that consulted
+    // process.env.PATH would report reachable on the reporter's host.
+    const original = process.env['PATH'];
+    process.env['PATH'] = `${join(HOME, '.local/bin')}:${POSIX_BASELINE}`;
+    try {
+        const result = checkNonInteractivePath('jaw', HOME, probes(POSIX_BASELINE, [join(HOME, '.local/bin/jaw')]));
+        assert.equal(result.status, 'unreachable');
+    } finally {
+        if (original === undefined) delete process.env['PATH']; else process.env['PATH'] = original;
+    }
+});
+
+test('NIP-006: a candidate dir already on the baseline is not double-reported', () => {
+    const baseline = `${join(HOME, '.local/bin')}:${POSIX_BASELINE}`;
+    const result = checkNonInteractivePath('jaw', HOME, probes(baseline, [join(HOME, '.local/bin/jaw')]));
+    assert.equal(result.status, 'reachable');
+});
+
+test('NIP-007: candidate dirs cover the installer default', () => {
+    // scripts/install.sh configures ~/.local/bin; if that moves, this check
+    // stops seeing the very case #479 reported.
+    assert.ok(candidateInstallDirs(HOME).includes(join(HOME, '.local', 'bin')));
+});
+
+test('NIP-010: a version-managed prefix is found via caller-supplied dirs', () => {
+    // Observed on the dev host: nvm puts jaw in a version-specific prefix that
+    // no static list can enumerate. Without this, the check reports
+    // "not-installed" and stays silent on a host that IS broken over ssh.
+    const nvmBin = join(HOME, '.nvm/versions/node/v22.19.0/bin');
+    const result = checkNonInteractivePath(
+        'jaw', HOME, probes(POSIX_BASELINE, [join(nvmBin, 'jaw')]), [nvmBin],
+    );
+    assert.equal(result.status, 'unreachable');
+    assert.equal(result.foundIn, nvmBin);
+});
+
+test('NIP-011: caller-supplied dirs are searched before the static list', () => {
+    const nvmBin = join(HOME, '.nvm/versions/node/v22.19.0/bin');
+    assert.equal(candidateInstallDirs(HOME, [nvmBin])[0], nvmBin);
+});
+
+test('NIP-008: the remedy is runnable in a non-interactive shell', () => {
+    const lines = nonInteractivePathRemedy('jaw', join(HOME, '.local/bin'));
+    const text = lines.join('\n');
+    assert.match(text, /\/home\/box\/\.local\/bin\/jaw/, 'must offer the absolute path');
+    assert.match(text, /\.zshenv/, 'zsh needs the one file a non-interactive shell reads');
+    // tmux/screen cannot be driven from a one-shot ssh command.
+    assert.doesNotMatch(text, /tmux|screen/, 'interactive multiplexers are not a remote-one-shot remedy');
+});
+
+test('NIP-009: doctor wires the check in and skips it on win32', () => {
+    const src = readFileSync(new URL('../../bin/commands/doctor.ts', import.meta.url), 'utf8');
+    assert.match(src, /checkNonInteractivePath/, 'doctor must run the check');
+    assert.match(src, /getconf/, 'the baseline must come from getconf PATH, not process.env');
+    const guard = src.indexOf("process.platform !== 'win32'");
+    const call = src.indexOf('checkNonInteractivePath(');
+    assert.ok(guard !== -1 && guard < call, 'the POSIX guard must precede the check');
+});


### PR DESCRIPTION
## What

`jaw doctor` now reports when `jaw` cannot be resolved from a non-interactive shell — the condition behind #479, which is invisible from the shell doctor itself runs in.

## Why this was invisible

`ssh host 'jaw serve ...'` runs a non-login, non-interactive shell that reads none of the files `scripts/install.sh` writes to:

| Shell | Installer writes to | Read by `ssh host 'cmd'` |
|---|---|---|
| bash | `.bashrc`, `.bash_profile` | ✗ — `.bash_profile` is login-only, and Debian's stock `.bashrc` returns on its first line when non-interactive |
| zsh | `.zshrc`, `.zprofile` | ✗ — non-interactive zsh reads only `.zshenv` |
| other | `.profile` | ✗ — login-only |

So `~/.local/bin` never reaches PATH, `nohup` fails to resolve `jaw`, and the only evidence is `No such file or directory` — a message that never mentions PATH.

A naive check could not catch this either: doctor runs in the interactive shell where PATH already works. The check therefore asks the question against `getconf PATH`.

## Verification

```
$ jaw doctor
⚠️  Non-interactive PATH (ssh): jaw is in /Users/syon/.nvm/versions/node/v22.19.0/bin but not on the
   non-interactive PATH — remote `ssh host 'jaw ...'` will fail with "No such file or directory"
     call it by absolute path: …/bin/jaw
     or export PATH in the remote command: …
     or (zsh) add to ~/.zshenv: …

$ env -i PATH="$(getconf PATH)" sh -c 'command -v jaw'
(nothing — the warning is accurate)

$ env -i PATH="$(getconf PATH)" sh -c 'export PATH="…/bin:$PATH"; command -v jaw'
…/bin/jaw          # the printed remedy works
```

Running it live also caught a real defect before merge: the first version searched only a static list of install dirs, so a version-managed Node (nvm/fnm/Homebrew) read as "not installed" and the check stayed silent on a host that *is* broken. Candidate dirs now include the caller's resolved npm prefix and binary dir.

11 unit tests (`tests/unit/noninteractive-path.test.ts`), `tsc --noEmit` clean, full suite shows **0 new failures** vs an origin/dev baseline.

Refs #479

**Stack** (merge bottom-up):

| # | Layer | Review focus |
|---|-------|--------------|
| 4 | docs — remote/headless guide | docs only |
| 3 | supervisor backend | generated sh + liveness contract |
| 2 | service guidance | operator message correctness |
| 1 | doctor detection ← you are here | detection logic + probe seam |

Review this PR's diff only; its base is the layer below.
