### PR TITLE
fix(service): replace unusable tmux advice on hosts with no service manager (#479)

### DIFF
--- a/bin/commands/service.ts
+++ b/bin/commands/service.ts
@@ -16,6 +16,7 @@ import { parseArgs } from 'node:util';
 import { JAW_HOME } from '../../src/core/config.js';
 import { instanceId, getNodePath, getJawPath, sanitizeUnitName, buildServicePath } from '../../src/core/instance.js';
 import { defaultLifecycleDeps, verifyOwnership, type OwnershipVerdict } from '../../src/core/instance-lifecycle.js';
+import { manualSupervisionGuidance } from '../../src/manager/manual-supervision.js';
 import type { DashboardLifecycleResult, DashboardServiceState } from '../../src/manager/types.js';
 import { detectServiceState, permInstance, restartServiceInstance, stopServiceInstance, unpermInstance } from '../../src/manager/platform-service.js';
 
@@ -202,9 +203,17 @@ function detectBackend(): Backend {
         return 'systemd';
     } catch { /* no systemctl */ }
 
-    console.error('❌ 지원되지 않는 환경입니다.');
-    console.error('   지원: macOS (launchd), Linux (systemd), Docker');
-    console.error('   수동 설정은 jaw serve를 tmux/screen에서 실행하세요.');
+    // No service manager (#479). tmux/screen used to be suggested here, but a
+    // multiplexer needs an interactive session to attach to and inherits the
+    // same non-interactive PATH that already failed to resolve `jaw` — so it
+    // is unusable from the one-shot ssh command that lands operators here.
+    console.error('❌ ' + manualSupervisionGuidance({
+        nodePath: getNodePath(),
+        jawPath: getJawPath(),
+        home: JAW_HOME,
+        port: PORT,
+        logPath: join(JAW_HOME, 'logs', 'jaw-serve.log'),
+    }).join('\n'));
     process.exit(1);
 }
 
@@ -247,6 +256,21 @@ if (backend === 'docker') {
     console.log('   docker-compose.yml의 restart: unless-stopped 설정을 확인하세요.\n');
     console.log('   상태 확인: docker ps | grep cli-jaw');
     console.log('   로그 확인: docker logs -f cli-jaw');
+
+    // A restart policy only restarts the container, and only when jaw is its
+    // entrypoint. Someone who ran `jaw service` inside an already-running
+    // container (#479's shape: PID 1 = tini, no systemd) is not in that case,
+    // and exiting 0 here told them a daemon existed when none had started.
+    if (!existsSync('/run/systemd/system')) {
+        console.log('\n   If jaw is NOT this container\'s entrypoint, nothing is supervising it.');
+        console.log('   ' + manualSupervisionGuidance({
+            nodePath: getNodePath(),
+            jawPath: getJawPath(),
+            home: JAW_HOME,
+            port: PORT,
+            logPath: join(JAW_HOME, 'logs', 'jaw-serve.log'),
+        }).slice(2).join('\n   '));
+    }
     process.exit(0);
 }
 

--- a/src/manager/manual-supervision.ts
+++ b/src/manager/manual-supervision.ts
@@ -1,0 +1,67 @@
+/**
+ * Guidance for hosts with no service manager (#479).
+ *
+ * `jaw service` can only register autostart where a service manager exists.
+ * On a systemd-less container (PID 1 = tini, a common shape) there is nothing
+ * to register with, so the command has to hand the operator a working manual
+ * recipe instead.
+ *
+ * The recipe it used to print — "run jaw serve under tmux/screen" — is not one.
+ * The reporter's failing command was a one-shot `ssh host '...'`, and a
+ * terminal multiplexer cannot be driven from that: it needs an interactive
+ * session to attach to, which is what a one-shot SSH command does not have.
+ * Worse, tmux inherits the same non-interactive PATH, so the multiplexer would
+ * fail to find `jaw` for exactly the reason the operator is already stuck on.
+ *
+ * What does work is what the reporter arrived at by hand: absolute paths (no
+ * PATH lookup to fail), `setsid` to detach from the SSH session so the
+ * process outlives the connection, and stdin from /dev/null so it never
+ * blocks on a terminal that is about to disappear.
+ */
+import { dirname } from 'node:path';
+
+export interface ManualSupervisionContext {
+    nodePath: string;
+    jawPath: string;
+    home: string;
+    port: string;
+    logPath: string;
+}
+
+/** Shell-quote a path only when it needs it, to keep the recipe readable. */
+function q(value: string): string {
+    return /[\s"'$`\\]/.test(value) ? `'${value.replace(/'/g, "'\\''")}'` : value;
+}
+
+/**
+ * A copy-pasteable start command that survives a one-shot SSH connection.
+ *
+ * Absolute node + jaw paths are deliberate: on the hosts that reach this
+ * message, a bare `jaw` is precisely what does not resolve.
+ */
+export function manualStartCommand(ctx: ManualSupervisionContext): string {
+    return `setsid nohup ${q(ctx.nodePath)} ${q(ctx.jawPath)} --home ${q(ctx.home)} `
+        + `serve --port ${ctx.port} --no-open >> ${q(ctx.logPath)} 2>&1 < /dev/null &`;
+}
+
+/**
+ * The full operator message for a host with no service manager.
+ */
+export function manualSupervisionGuidance(ctx: ManualSupervisionContext): string[] {
+    return [
+        'No service manager available on this host.',
+        '   Supported: macOS (launchd), Linux (systemd), Windows (startup), Docker',
+        '',
+        '   This host has neither, so start it manually. Use absolute paths — a',
+        `   non-interactive shell (ssh host '...') does not have ${dirname(ctx.jawPath)} on PATH:`,
+        '',
+        `     ${manualStartCommand(ctx)}`,
+        '',
+        `   Verify it started (an empty result means it died):  jaw --home ${q(ctx.home)} service status`,
+        `   Read the log on failure:                            tail -n 50 ${q(ctx.logPath)}`,
+        '',
+        '   To keep it running across crashes, re-run that command from a',
+        '   supervisor loop (cron @reboot, a container entrypoint, or a 60s',
+        '   while-loop that checks the port before restarting).',
+    ];
+}

--- a/tests/unit/manual-supervision.test.ts
+++ b/tests/unit/manual-supervision.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #479 regression: on a host with no service manager (PID 1 = tini, no
+ * systemd), `jaw service` told the operator to run `jaw serve` under
+ * tmux/screen. That advice cannot be followed from the one-shot
+ * `ssh host '...'` command that lands people there, and a multiplexer would
+ * inherit the same non-interactive PATH that already failed to resolve `jaw`.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { manualStartCommand, manualSupervisionGuidance } from '../../src/manager/manual-supervision.ts';
+
+// The reporter's host, verbatim from the issue.
+const CTX = {
+    nodePath: '/home/box/.local/lib/nodejs/node-v24.19.0-linux-x64/bin/node',
+    jawPath: '/home/box/.local/bin/jaw',
+    home: '/home/box/.cli-jaw',
+    port: '3457',
+    logPath: '/home/box/.cli-jaw/logs/jaw-serve.log',
+};
+
+test('MS-001: the start command uses absolute paths, never a bare jaw', () => {
+    const cmd = manualStartCommand(CTX);
+    assert.ok(cmd.includes(CTX.nodePath), 'node must be absolute');
+    assert.ok(cmd.includes(CTX.jawPath), 'jaw must be absolute');
+    // A bare `jaw` is the exact token that fails on these hosts.
+    assert.doesNotMatch(cmd, /(^|\s)jaw\s/, 'a PATH-resolved jaw would reproduce the bug');
+});
+
+test('MS-002: the command survives the ssh session that launched it', () => {
+    const cmd = manualStartCommand(CTX);
+    assert.match(cmd, /setsid/, 'must detach from the session leader');
+    assert.match(cmd, /< \/dev\/null/, 'must not block on a disappearing terminal');
+    assert.match(cmd, /&$/, 'must background');
+    assert.match(cmd, />> /, 'must keep a log to diagnose a silent death');
+});
+
+test('MS-003: guidance never suggests an interactive multiplexer', () => {
+    const text = manualSupervisionGuidance(CTX).join('\n');
+    assert.doesNotMatch(text, /tmux|screen/, 'unusable from a one-shot ssh command');
+});
+
+test('MS-004: guidance tells the operator how to confirm it actually started', () => {
+    // The #479 failure mode is silence: the process dies and a pid file or a
+    // clean exit code implies health. Guidance must point at a real check.
+    const text = manualSupervisionGuidance(CTX).join('\n');
+    assert.match(text, /service status/, 'must offer a liveness check');
+    assert.match(text, /tail -n 50/, 'must point at the log on failure');
+    assert.match(text, /supervisor loop/, 'systemd-less hosts need a restart story');
+});
+
+test('MS-005: paths containing spaces are quoted', () => {
+    const cmd = manualStartCommand({ ...CTX, home: '/home/box/my jaw home' });
+    assert.match(cmd, /'\/home\/box\/my jaw home'/);
+});
+
+test('MS-006: service.ts no longer prints the tmux advice', () => {
+    const src = readFileSync(new URL('../../bin/commands/service.ts', import.meta.url), 'utf8');
+    // Comments may still explain WHY the advice was removed; what must not
+    // survive is a console line that prints it.
+    const printed = src.split(/\r?\n/).filter(line => /console\.(log|error|warn)/.test(line)).join('\n');
+    assert.doesNotMatch(printed, /tmux|screen/, '#479: tmux/screen advice was unusable from a one-shot ssh command');
+    assert.match(src, /manualSupervisionGuidance/, 'the no-backend path must print real guidance');
+});
+
+test('MS-007: the docker branch warns when jaw is not the entrypoint', () => {
+    // Exiting 0 with "restart policy handles it" implied a daemon existed
+    // when `jaw service` had started nothing.
+    const src = readFileSync(new URL('../../bin/commands/service.ts', import.meta.url), 'utf8');
+    const dockerBranch = src.slice(src.indexOf("if (backend === 'docker')"), src.indexOf("if (backend === 'windows')"));
+    assert.match(dockerBranch, /nothing is supervising it/);
+    assert.match(dockerBranch, /manualSupervisionGuidance/);
+});


### PR DESCRIPTION
## What

The message `jaw service` printed on a host with no service manager told the operator to run `jaw serve` under tmux/screen. This replaces it with a recipe that works, and fixes the same class of problem in the docker branch.

## Why the old advice could not be followed

Operators reach that message from a one-shot `ssh host '...'` command. A terminal multiplexer needs an interactive session to attach to, which is exactly what that does not have — and tmux would inherit the same non-interactive PATH that just failed to resolve `jaw`, so it would fail for the original reason.

## What replaces it

What the #479 reporter had to work out by hand:

| Token | Why |
|---|---|
| absolute node + jaw paths | nothing to resolve; a bare `jaw` is what fails here |
| `setsid` | the server outlives the SSH connection |
| `< /dev/null` | never blocks on a terminal that is about to vanish |
| `>> …log` | something to read when it dies silently |

It also names the liveness check and the log path, because the #479 failure mode is silence rather than an error.

## Docker branch

Same shape of problem: it printed "the container's restart policy manages this" and exited **0** even when jaw was not the container's entrypoint — so `jaw service` reported success having started nothing. It now says so and prints the same recipe.

## Verification

Rendered with the reporter's exact paths; output matches the workaround they arrived at independently. 7 unit tests (`tests/unit/manual-supervision.test.ts`), `tsc --noEmit` clean.

One test is deliberately narrow: it scans only `console.*` lines for tmux/screen, so a comment may still explain *why* the advice was removed.

Refs #479

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 4 | #488 | docs — remote/headless guide | docs only |
| 3 | #487 | supervisor backend | generated sh + liveness contract |
| 2 | #486 | service guidance ← you are here | operator message correctness |
| 1 | #485 | doctor detection | detection logic + probe seam |

Review this PR's diff only; its base is the layer below.
