### PR TITLE
docs: add a remote and headless residency guide (#479)

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,18 @@ jaw --home C:\jaw\worker-a service restart --port 3458
 jaw --home "$HOME/jaw/worker-a" service stop --port 3458
 ```
 
+### Remote and headless hosts
+
+`ssh host 'jaw serve ...'` runs a non-login, non-interactive shell that reads none of the
+files the installer adds `~/.local/bin` to, so `jaw` can work when you log in and still fail
+over SSH with `nohup: failed to run command 'jaw'`. Run `jaw doctor` and check the
+**Non-interactive PATH (ssh)** row, then call jaw by absolute path or export PATH inside the
+remote command.
+
+On a host with no service manager (a container whose PID 1 is tini, for example),
+`jaw service --backend supervisor` generates a keep-alive loop to wire into your container
+entrypoint or cron. Full guide: [structure/remote-headless.md](structure/remote-headless.md).
+
 ---
 
 ## Development

--- a/structure/INDEX.md
+++ b/structure/INDEX.md
@@ -87,6 +87,7 @@ graph LR
 | [type-safety-status.md](type-safety-status.md) | tsconfig strict flags + type escape hatch inventory | TypeScript, strict, @ts-nocheck, as any |
 | [CAPABILITY_TRUTH_TABLE.md](CAPABILITY_TRUTH_TABLE.md) | agbrowse/cli-jaw parity claim source of truth | parity, capability, support label |
 | [tui-scrollback.md](tui-scrollback.md) | TUI native scrollback commit architecture (Ghostty 1.3+) | scrollback, DECSTBM, CommitFrontier, fillRows |
+| [remote-headless.md](remote-headless.md) | 원격·무인 상주: 비대화형 SSH 셸의 PATH 부재(#479), systemd 없는 호스트의 supervisor 백엔드, pid 파일 검증 | 원격, ssh, 비대화형, PATH, supervisor, 상주 |
 
 ---
 

--- a/structure/remote-headless.md
+++ b/structure/remote-headless.md
@@ -1,0 +1,152 @@
+---
+created: 2026-08-26
+status: done
+tags: [cli-jaw, remote, ssh, headless, supervisor, issue-479]
+---
+# 원격·무인 상주 가이드 (#479)
+
+SSH로 붙는 원격 호스트, 그중에서도 systemd가 없는 컨테이너에 `jaw`를 상주시키는
+방법. 로컬 개발 머신에는 해당하지 않는다 — `jaw service` 한 줄이면 끝난다.
+
+## 결론부터: 왜 조용히 실패했나
+
+```
+$ ssh box 'nohup jaw serve --port 3457 --no-open > serve.log 2>&1 &'
+$ cat serve.log
+nohup: failed to run command 'jaw': No such file or directory
+```
+
+로그인해서 치면 잘 되는데 위처럼 하면 안 된다. **PATH 문제인데 PATH라는 말이
+어디에도 안 나오는 것**이 이 실패의 성질이다. `nohup`이 `jaw`를 찾지 못해 먼저
+죽으므로 서버 코드는 한 줄도 실행되지 않고, pid 파일만 보고 상태를 판단하는
+스크립트는 "서비스가 떠 있다"고 오판한다.
+
+## 원인: 비대화형 셸은 그 파일들을 읽지 않는다
+
+`npm i -g`가 설치하는 `~/.local/bin`은 셸 시작 파일에서 PATH에 추가된다. 그런데
+`ssh host 'command'`는 **비로그인·비대화형** 셸이라 그 파일들 중 어느 것도 읽지
+않는다.
+
+| 셸 | 설치 스크립트가 기록하는 곳 | `ssh host 'cmd'`가 읽나 |
+|---|---|---|
+| bash | `.bashrc`, `.bash_profile` | ✗ — `.bash_profile`은 로그인 전용이고, 데비안 기본 `.bashrc`는 첫 줄에서 비대화형이면 `return` |
+| zsh | `.zshrc`, `.zprofile` | ✗ — 비대화형 zsh는 `.zshenv`만 읽는다 |
+| 그 외 | `.profile` | ✗ — 로그인 전용 |
+
+즉 대화형 셸에서 `jaw`가 되는 것과 원격 원샷 명령에서 되는 것은 **별개의 사실**이다.
+
+### 자가 진단
+
+```bash
+jaw doctor            # "Non-interactive PATH (ssh)" 항목을 본다
+```
+
+직접 확인하려면 비대화형 셸의 기본 PATH를 그대로 재현한다:
+
+```bash
+env -i PATH="$(getconf PATH)" sh -c 'command -v jaw'   # 아무것도 안 나오면 재현된 것
+```
+
+## 해결: 셋 중 하나
+
+### 1. 절대 경로 (항상 통함, 설정 불필요)
+
+```bash
+ssh box '/home/box/.local/bin/jaw --version'
+```
+
+### 2. 원격 명령에서 PATH를 직접 준다
+
+```bash
+ssh box 'export PATH="$HOME/.local/bin:$PATH"; jaw service restart'
+```
+
+### 3. `~/.zshenv` (zsh 한정, 영구적)
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshenv
+```
+
+bash에는 대응물이 없다. `BASH_ENV`가 비대화형 셸용이지만 기본값이 없어 `ssh`가
+설정해 주지 않으므로, bash 호스트에서는 1번이나 2번을 쓴다.
+
+> `/usr/local/bin` 심볼릭 링크는 권하지 않는다. sudo가 필요하고, npm 전역 경로가
+> 바뀌면 링크가 끊기며, 다중 Node 버전 환경에서 잘못된 바이너리를 가리키기 쉽다.
+
+## 상주시키기
+
+### systemd가 있으면
+
+```bash
+jaw service                 # 유닛 생성 + enable --now
+jaw service status
+```
+
+생성된 유닛은 `Environment="PATH=..."`를 직접 박으므로 위 PATH 문제와 무관하다.
+
+### systemd가 없으면 (컨테이너, PID1=tini)
+
+```bash
+jaw service --backend supervisor --port 3457
+```
+
+`<JAW_HOME>/jaw-supervisor.sh`를 생성한다. **이것은 autostart 등록이 아니다** —
+그런 호스트에는 등록할 대상이 없다. 부팅을 소유한 무언가에 직접 연결해야 한다:
+
+```bash
+# 컨테이너 entrypoint / CMD
+/home/box/.cli-jaw/jaw-supervisor.sh
+
+# cron
+@reboot /home/box/.cli-jaw/jaw-supervisor.sh &
+
+# ssh로 지금 당장
+ssh box 'setsid nohup /home/box/.cli-jaw/jaw-supervisor.sh >> /home/box/.cli-jaw/logs/jaw-serve.log 2>&1 < /dev/null &'
+```
+
+루프는 60초마다 `jaw service status --port N`으로 생존을 확인하고 죽었을 때만
+재기동한다. `pgrep jaw` 같은 이름 매칭을 쓰지 않는 이유는 **PID 재사용** 때문이다 —
+pid 파일의 PID를 무관한 프로세스가 물려받으면 이름 매칭은 영원히 "살아 있음"으로
+읽고, 그게 #479가 겪은 오판과 같은 종류의 침묵이다. `service status`는 pid 파일을
+OS의 프로세스 시작 시각과 대조하므로 재사용된 PID를 죽은 것으로 판정한다.
+
+### 수동 기동 (일회성)
+
+```bash
+ssh box 'setsid nohup /home/box/.local/lib/nodejs/node-v24.19.0-linux-x64/bin/node \
+  /home/box/.local/bin/jaw --home /home/box/.cli-jaw serve --port 3457 --no-open \
+  >> /home/box/.cli-jaw/logs/jaw-serve.log 2>&1 < /dev/null &'
+```
+
+각 요소가 하는 일:
+
+| 요소 | 이유 |
+|---|---|
+| 절대 경로 | 비대화형 PATH에서 이름 해석이 안 된다 (이 문서의 주제) |
+| `setsid` | SSH 세션이 끊겨도 프로세스가 살아남는다. util-linux라서 macOS·일부 최소 이미지에는 없다 — 없으면 생략하고 `nohup`만 쓴다 |
+| `nohup` | SIGHUP을 무시한다 |
+| `< /dev/null` | 곧 사라질 터미널에 stdin이 물려 블록되는 것을 막는다 |
+| `>> …log` | 조용히 죽었을 때 읽을 것이 남는다 |
+| `&` | 백그라운드 |
+
+## 상주 확인은 pid 파일만으로 부족하다
+
+```bash
+ssh box 'export PATH=$HOME/.local/bin:$PATH; jaw --home ~/.cli-jaw service status'
+```
+
+`jaw serve`는 `<JAW_HOME>/jaw.pid.json`에 PID와 **OS 프로세스 시작 시각**을 함께
+기록하고, `service status`/`stop`/`restart`는 그 둘을 대조해 stale·foreign·검증불가
+레코드를 거부한다. pid 파일의 존재만 보는 자작 스크립트는 이 검증을 건너뛰므로
+죽은 서버를 살아 있다고 보고한다.
+
+배포 후에는 **실행 중인 프로세스가 새 `dist/`를 로드했는지**까지 본다. `npm i -g`는
+파일만 교체하고 서비스는 옛 코드를 계속 돌린다 — 절차는 루트 `AGENTS.md`의
+"배포 확인은 npm 버전만으로 부족하다" 절에 있다.
+
+## 관련 문서
+
+- `structure/windows-ssh.md` — Windows OpenSSH의 ConPTY 제어 시퀀스 (#326)
+- `structure/infra.md` — 릴리스 파이프라인과 부분 실패 복구
+- 루트 `AGENTS.md` — Build & Deploy Contract
+

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -9,7 +9,7 @@ aliases: [CLI-JAW Source Structure, str_func, source structure reference]
 # CLI-JAW — Source Structure & Function Reference
 
 > 마지막 검증: 2026-07-10 (image inlay/channel relay SoT sync)
-> `server.ts` 640L / `src/routes/` 36 TS files (238 route handlers including `/`; 237 API endpoints; `src/routes/` subtotal 199 handlers) / `src/cli/handlers*.ts` 460L + 507L + 103L + search 34L + project 73L + workflow 494L / `src/cli/api-auth.ts` 45L / `src/workflows/` 20 root files + 3 subdirs / `src/agent/` 48 TS files (spawn.ts 2544L + events/ submodules + cursor/claude-e/agy/jwc runtimes + AGY capability probe) / `src/goal/` 5 files (+`pause-gate.ts`) / `src/goal-run/` 5 files / `src/trace/` 3 files / `src/team/` 5 files / `src/jaw-ceo/` 16 files / `src/shared/` 6 files + reminders helper / `src/manager/` 94 TS/TSX files (+`telegram-hub/` 3 files) / `src/browser/web-ai/` 96 TS files / `adaptive-fetch/` 34 files / `src/telegram/` 9 files (+`hub-callback.ts`) / `src/messaging/` 13 files (+`thread-target.ts`, `extract-images.ts`) / `bin/commands/` 30 top-level + `hooks.ts` / `electron/` sidecar packaging / `native/claude-e/` canonical embedded crate
+> `server.ts` 640L / `src/routes/` 36 TS files (238 route handlers including `/`; 237 API endpoints; `src/routes/` subtotal 199 handlers) / `src/cli/handlers*.ts` 460L + 507L + 103L + search 34L + project 73L + workflow 494L / `src/cli/api-auth.ts` 45L / `src/workflows/` 20 root files + 3 subdirs / `src/agent/` 48 TS files (spawn.ts 2544L + events/ submodules + cursor/claude-e/agy/jwc runtimes + AGY capability probe) / `src/goal/` 5 files (+`pause-gate.ts`) / `src/goal-run/` 5 files / `src/trace/` 3 files / `src/team/` 5 files / `src/jaw-ceo/` 16 files / `src/shared/` 6 files + reminders helper / `src/manager/` 100 TS/TSX files (+`telegram-hub/` 3 files) / `src/browser/web-ai/` 96 TS files / `adaptive-fetch/` 34 files / `src/telegram/` 9 files (+`hub-callback.ts`) / `src/messaging/` 13 files (+`thread-target.ts`, `extract-images.ts`) / `bin/commands/` 30 top-level + `hooks.ts` / `electron/` sidecar packaging / `native/claude-e/` canonical embedded crate
 >
 > 상세 모듈 문서는 [서브 문서](#서브-문서)를 참조하세요.
 
@@ -57,6 +57,7 @@ cli-jaw/
 │   │   ├── runtime-settings-gate.ts ← settings mutation in-flight gate (41L)
 │   │   ├── codex-config.ts   ← Codex config.toml context window sync (96L)
 │   │   ├── runtime-path.ts   ← buildServicePath() PATH 보강 (nvm/fnm/homebrew/volta/asdf/cargo/bun/yarn/pnpm 14+ dirs) (182L)
+│   │   ├── noninteractive-path.ts ← 비대화형 셸(ssh 원샷)에서 jaw 해석 가능 여부 판정 + 처방 (#479) (116L)
 │   │   ├── cli-detect.ts     ← PATH 후보 spawnability 검사 + rejected candidate reason 수집 (445L)
 │   │   ├── browser-open.ts   ← 브라우저 open 정책/명령 실행 helper (68L)
 │   │   ├── browser-open-default.ts ← OS/headless 기본 open 여부 판별 (21L)
@@ -375,7 +376,7 @@ cli-jaw/
 │   │   ├── tool-log-sanitize.ts ← tool log sanitization helpers (247L)
 │   │   └── reminders/tray-triage.ts ← tray reminder badge/count triage helper (30L)
 │   │   └── shell-command-display.ts ← shell command display formatter (48L)
-│   ├── manager/              ← Multi-instance 대시보드 매니저 (94 TS/TSX files; +telegram-hub/ forum topic routing; design workspace routes; embedded-browser routes; project pick; git scm-snapshot/scm-operation)
+│   ├── manager/              ← Multi-instance 대시보드 매니저 (100 TS/TSX files; +telegram-hub/ forum topic routing; design workspace routes; embedded-browser routes; project pick; git scm-snapshot/scm-operation)
 │   ├── team/                 ← Team dispatch planner (5 files, 323L) ✨
 │   │   ├── planner.ts        ← team task planning logic (75L)
 │   │   ├── collector.ts      ← team result collector (66L)
@@ -457,7 +458,7 @@ cli-jaw/
 │       ├── history.ts        ← 채팅 히스토리 검색 CLI (65L)
 │       ├── init.ts           ← 초기화 마법사 + --safe/--dry-run + --help (516L)
 │       ├── slack.ts          ← `jaw slack manifest|setup` — 앱 매니페스트 출력 + 가이드 설정 (토큰 prefix 가드 + auth.test/apps.connections.open 라이브 검증 + settings 병합, channel 미변경) (394L)
-│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1131L)
+│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1173L)
 │       ├── jwc.ts            ← optional external-only JWC runtime install/clean/doctor helper (234L)
 │       ├── status.ts         ← 서버 상태 (--json) (115L)
 │       ├── mcp.ts            ← MCP 관리 (install/sync/list/reset) (230L)


### PR DESCRIPTION
## What

`structure/remote-headless.md` — the guide #479 actually asked for. The three layers below make the failure detectable and give systemd-less hosts a supervisor, but nobody reads a doctor row they never ran.

## Contents

- **Why it looks like anything but PATH** — `nohup` dies before jaw runs, so the log says `No such file or directory` and never mentions PATH.
- **Which startup file each shell actually reads** in a non-interactive session, as a table.
- **One-line reproduction**: `env -i PATH="$(getconf PATH)" sh -c 'command -v jaw'`.
- **Three fixes** in order of preference (absolute path → PATH in the remote command → `~/.zshenv`), with the note that bash has no `.zshenv` equivalent since `BASH_ENV` is unset by default.
- **Residency**: systemd path, the supervisor backend, and what each token of the manual `setsid`/`nohup` command buys.
- **Why pidfile presence is not liveness** — start-time verification, and the `dist/` reload caveat already in AGENTS.md.

## One issue suggestion deliberately not adopted

The `/usr/local/bin` symlink is documented as **not recommended**: it needs sudo, breaks when the npm prefix moves, and points at the wrong binary under multiple Node versions. `~/.zshenv` and absolute paths have none of those failure modes.

## Verification

`bash structure/check-doc-drift.sh` passes (4/4). `str_func.md` counts refreshed for the new modules per AGENTS.md; linked from `structure/INDEX.md` and README.

Pre-existing count drift unrelated to this work (`src/manager` was already 98 vs a documented 94) was left alone apart from the delta my own files introduce.

Refs #479

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 4 | #488 | docs — remote/headless guide ← you are here | docs only |
| 3 | #487 | supervisor backend | generated sh + liveness contract |
| 2 | #486 | service guidance | operator message correctness |
| 1 | #485 | doctor detection | detection logic + probe seam |

Review this PR's diff only; its base is the layer below.
