### PR TITLE
fix(slack): 빈 allowlist를 '전송 불가'가 아니라 '모든 대화 허용'으로 읽는다 (#476)

### DIFF
--- a/src/messaging/channel-health.ts
+++ b/src/messaging/channel-health.ts
@@ -98,7 +98,22 @@ function slackHasSendTarget(): boolean {
             && slackPeerKind(lastSlack.targetId) === 'direct';
     }
     if (ids.length) return true;
-    return Boolean(lastSlack?.targetId);
+    // An EMPTY allowlist is "every conversation", not "no destination". That is
+    // the shipped default, and `validateTarget` implements it literally: with no
+    // ids configured it admits every Slack target it is handed. Requiring a
+    // last-active slot on top of that made health disagree with the send path it
+    // reports on — a fresh install reported `missing_channel_id` while every
+    // send would in fact have been permitted, so `jaw slack setup` and
+    // `jaw doctor` called the state "all conversations allowed" while health
+    // called it broken (#476).
+    //
+    // doctor stopped degrading on this in #406 and `slackChannelScope()` names
+    // it `all_conversations`; this is health catching up to that reading.
+    //
+    // The malformed branch above still fails closed, and it must stay above this
+    // line: that sentinel is an unmatchable id, so it denies every channel
+    // target instead of widening to all of them.
+    return true;
 }
 
 export function getTransportCapability(channel: MessengerChannel): TransportCapability {

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -130,7 +130,7 @@ cli-jaw/
 │   │   ├── fold.ts           ← 정규화 폴딩 엔진 (escape 디코드 + invisible 제거 + NFKC, 오프셋 맵 추적) (276L) ✨
 │   │   ├── redact.ts         ← 채널 크리덴셜 마스킹 (Slack/TG/Discord 토큰 + URL 경로 capability) (600L) ✨
 │   │   ├── chunk.ts          ← 공유 메시지 분할 (무손실 + 서로게이트 안전 + 펜스/언어태그 보존, 단 delimiter가 한도 이내일 때) (389L) ✨
-│   │   ├── channel-health.ts ← 채널 헬스 체크 helper + additive ingress/metrics snapshot (187L) ✨
+│   │   ├── channel-health.ts ← 채널 헬스 체크 helper + additive ingress/metrics snapshot (202L) ✨
 │   │   ├── channel-validate.ts ← 온보딩 마법사 라이브 크리덴셜 검증 (telegram getMe / discord users@me / slack auth.test+connections.open, 토큰 비로깅) (139L) ✨
 │   │   ├── send-result.ts    ← send result type helper (14L) ✨
 │   │   ├── session-key.ts    ← 세션 키 헬퍼 (49L)

--- a/tests/unit/slack-contracts.test.ts
+++ b/tests/unit/slack-contracts.test.ts
@@ -208,11 +208,32 @@ test('slack health reports missing_app_token for outbound-only setups', () => {
     });
 });
 
-test('slack health reports missing_channel_id with both tokens and no target', () => {
+// #476: this used to assert the opposite. An empty allowlist is the SHIPPED
+// DEFAULT meaning "every conversation" — `jaw slack setup` prints "all
+// conversations allowed", `slackChannelScope()` names it `all_conversations`,
+// and doctor stopped degrading on it in #406. Health was the last surface still
+// calling it `missing_channel_id`, so a correctly configured install read as
+// broken on three surfaces that agreed and one that did not.
+//
+// It also disagreed with the send path it reports on: `validateTarget` admits
+// every Slack target when no ids are configured, so the sends health called
+// impossible would all have gone through.
+test('an empty slack allowlist is every conversation, not a missing target', () => {
     withSlackSettings({ enabled: true, botToken: 'xoxb-x', appToken: 'xapp-x', channelIds: [] }, () => {
         const cap = getTransportCapability('slack');
-        assert.equal(cap.sendCapable, false);
-        assert.equal(cap.reason, 'missing_channel_id');
+        assert.equal(cap.sendCapable, true, 'an empty allowlist allows every conversation');
+        assert.equal(cap.reason, undefined, 'the shipped default is not a degraded reason');
+        // The claim health makes must be the one the send path honours.
+        assert.equal(validateTarget(slackTargetFromId('C_ANY'), 'slack'), true);
+    });
+});
+
+// The narrowing case is the one that must NOT widen: a list that names
+// conversations still denies the ones it leaves out.
+test('a narrowed slack allowlist still denies the channels it omits', () => {
+    withSlackSettings({ enabled: true, botToken: 'xoxb-x', appToken: 'xapp-x', channelIds: ['C123'] }, () => {
+        assert.equal(getTransportCapability('slack').sendCapable, true);
+        assert.equal(validateTarget(slackTargetFromId('C999'), 'slack'), false);
     });
 });
 


### PR DESCRIPTION
## What was wrong

`jaw slack setup` finishes and prints `Channels: all conversations allowed`. `jaw doctor` agrees. `/api/health`, on the same settings, says the transport cannot send:

```json
"slack": { "configured": true, "sendCapable": false, "reason": "missing_channel_id" }
```

Three surfaces call the state configured, one calls it broken. The only way to find out why the bot was silent was to curl health directly.

## Why health was the one that was wrong

An empty `channelIds` is the **shipped default**, not an unfinished setting. `slackChannelScope()` in `scope-status.ts` already names it `all_conversations` and documents it as "the shipped default and a normal way to run", and doctor stopped degrading on it in #406.

More concretely, health disagreed with the send path it reports on. `validateTarget` reads an empty allowlist literally:

```ts
const { ids: allowed } = slackAllowlist();
if (allowed.length && !allowed.includes(target.targetId)) return false;
```

With no ids configured that check does nothing — every Slack target is admitted. So the sends health called impossible would all have succeeded.

`slackHasSendTarget()` was asking for a last-active slot **on top of** a gate that asks for nothing. On a fresh install nobody has spoken yet, so the slot is empty and a correctly configured workspace reads as broken.

## The fix

```diff
 if (ids.length) return true;
-return Boolean(lastSlack?.targetId);
+return true;
```

**The malformed branch above is untouched and still fails closed.** That sentinel is an unmatchable id, so it has to deny every channel target rather than widen to all of them — which is exactly why it must be read *before* an empty list can mean "all". `lastSlack` is still used there.

## Evidence

`getTransportCapability('slack')` with both tokens present:

| `channelIds` | before | after |
|---|---|---|
| `[]` | `sendCapable:false, missing_channel_id` | **`sendCapable:true`** |
| `['C123']` | `sendCapable:true` | `sendCapable:true` |
| `'C_BAD'` (malformed) | `sendCapable:false` | `sendCapable:false` |

Only the empty case moves.

### Tests

One existing test asserted the bug as a contract (`slack health reports missing_channel_id with both tokens and no target`) and is replaced by two:

- an empty allowlist is send-capable with no degraded reason, **and `validateTarget` agrees** — the two claims are pinned together so they cannot drift apart again
- a narrowed allowlist still denies the channels it omits, so this does not read as widening

The #406 malformed contracts in `messaging-transport-capability.test.ts` all still pass (57/57 across the four Slack suites).

### Checks

- **`npm test`** — no new failures. Five `clone P3-*` tests fail, and they fail **identically on unmodified `origin/dev`** (both runs: `pass 67 / fail 5` on the same four files). Unrelated to Slack.
- **`npx tsc --noEmit`** — clean.
- **`npm run build`** — compiled and swapped; `dist/src/messaging/channel-health.js` carries the change. (The postbuild global-symlink step fails in this sandbox for an unrelated reason: an existing non-symlink at the nvm path.)
- **`structure/verify-counts.sh`** — 445/445 after updating `channel-health.ts` to 202L.

## Scope

**#476 only.** Not touched, filed separately:

- **#477** — `jaw slack setup` does not add `slack` to `messaging.enabledChannels`, so the socket never opens. A user hitting both sees one symptom ("the bot is silent") with two causes; this PR removes one of them.

Fixes #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty Slack allowlists now permit sending to any conversation without requiring a previously active target.
  - Restricted allowlists continue to reject targets that are not explicitly permitted.
  - Malformed allowlists remain safely restricted to valid direct-message targets.

- **Tests**
  - Updated Slack health checks to cover empty and narrowed allowlist behavior.

- **Documentation**
  - Updated internal documentation to reflect current source line counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->