### PR TITLE
fix(slack): setup이 messaging.enabledChannels 를 갱신해 인바운드가 실제로 켜지게 한다 (#477)

### DIFF
--- a/bin/commands/doctor.ts
+++ b/bin/commands/doctor.ts
@@ -486,6 +486,29 @@ check('Slack', () => {
 // 6e. Channel consistency
 check('Channel consistency', () => {
     const enabled = getEnabledChannels(settings || {});
+    // The reverse gap, and the one that actually bit: a channel can be fully
+    // configured — tokens validated, `enabled: true` — and still be absent from
+    // `enabledChannels`, which is the set the transport loop reads. Nothing ran,
+    // and every other surface said the setup was complete (#477).
+    //
+    // Slack additionally needs the app token: without it there is no socket to
+    // open, so being out of the set is correct rather than a gap.
+    const stranded: string[] = [];
+    if (settings?.telegram?.enabled && !enabled.includes('telegram')) {
+        stranded.push('Telegram');
+    }
+    if (settings?.discord?.enabled && !enabled.includes('discord')) {
+        stranded.push('Discord');
+    }
+    if (settings?.slack?.enabled && settings?.slack?.appToken && !enabled.includes('slack')) {
+        stranded.push('Slack');
+    }
+    if (stranded.length > 0) {
+        throw new Error(
+            `WARN: ${stranded.join(', ')} 설정은 끝났지만 messaging.enabledChannels 에 없어 인바운드가 뜨지 않습니다 `
+            + `— jaw slack setup 을 다시 실행하거나 settings.json 의 enabledChannels 에 추가하세요`,
+        );
+    }
     if (enabled.length === 0) return 'no enabled channels';
     const issues: string[] = [];
     for (const ch of enabled) {

--- a/bin/commands/slack.ts
+++ b/bin/commands/slack.ts
@@ -22,6 +22,7 @@ import { cliFetch, getCliAuthToken } from '../../src/cli/api-auth.js';
 import { slackApi } from '../../src/slack/api.js';
 import { slackManifestYaml, slackManifestCreateUrl } from '../../src/slack/manifest.js';
 import { notifyRunningServer, type HotReload } from '../../src/slack/hot-notify.js';
+import { getHomeChannel } from '../../src/messaging/runtime.js';
 import { shouldShowHelp, printAndExit } from '../helpers/help.js';
 
 // Mirror of the Slack settings shape (see doctor.ts): unlike the other
@@ -282,9 +283,7 @@ async function runSetup(): Promise<void> {
         const channelIds = channelIdsRaw.split(',').map(s => s.trim()).filter(Boolean);
 
         // Merge: preserve every slack field the wizard does not own
-        // (mentionOnly, replyInThread, forwardAll, allowBots) and never touch
-        // `channel` — a two-token channel must not hijack the active channel
-        // by accident, same rule as the SLACK_BOT_TOKEN env import.
+        // (mentionOnly, replyInThread, forwardAll, allowBots).
         s["slack"] = {
             ...existing,
             enabled: true,
@@ -296,13 +295,47 @@ async function runSetup(): Promise<void> {
             // connection. Clones sharing these tokens will not open a socket.
             attachPort: String((s["port"] as string) || existing.attachPort || '3457'),
         } satisfies SlackSettings;
+        // `slack.enabled` says the channel is configured; `enabledChannels` says
+        // it should RUN. Both are required, and the wizard used to write only the
+        // first — so a correct setup ended with the socket still closed and
+        // `activeInbound` naming some other, disabled channel. Nothing in the
+        // output said a step was left (#477).
+        //
+        // Only inbound-capable setups are enrolled. Without an app token there
+        // is no socket to open, so adding it here would enable a transport that
+        // cannot start and report a fault instead of "outbound only".
+        //
+        // `homeChannel` is deliberately NOT taken. It decides where UNADDRESSED
+        // messages go, so moving it would silently redirect heartbeats and
+        // reminders away from the channel the user already chose — the same
+        // hijack the SLACK_BOT_TOKEN import refuses to do. It is only set when
+        // nothing else is enabled, where there is no other channel to steal from.
+        const enrolledSlack = Boolean(appToken);
+        if (enrolledSlack) {
+            const messaging = (s["messaging"] && typeof s["messaging"] === 'object' && !Array.isArray(s["messaging"]))
+                ? s["messaging"] as Record<string, unknown>
+                : {};
+            const enabled = Array.isArray(messaging["enabledChannels"])
+                ? messaging["enabledChannels"].filter((c): c is string => typeof c === 'string')
+                : [];
+            const others = enabled.filter(c => c !== 'slack');
+            s["messaging"] = {
+                ...messaging,
+                enabledChannels: [...new Set([...enabled, 'slack'])],
+                homeChannel: others.length ? messaging["homeChannel"] : 'slack',
+            };
+        }
         saveSettings(s);
 
         // A file write alone never starts the transport — hot-notify the
         // running server so the Slack socket opens now, not after a restart.
         const hotReload: HotReload = values['no-notify']
             ? 'server-off'
-            : await notifyRunningServer(s["slack"] as Record<string, unknown>);
+            : await notifyRunningServer(
+                s["slack"] as Record<string, unknown>,
+                undefined,
+                enrolledSlack ? s["messaging"] as Record<string, unknown> : undefined,
+            );
         const serverLine =
             hotReload === 'reloaded' ? '    2. (done) the running server picked up the settings — no restart needed' :
             hotReload === 'old-server' ? `    2. Restart the server — it is running an OLDER build without the new Slack code (jaw serve)` :
@@ -316,6 +349,9 @@ async function runSetup(): Promise<void> {
     App token   : ${appToken ? appToken.slice(0, 10) + '…' : '(outbound only)'}
     Team        : ${(s["slack"] as SlackSettings).teamId || '(unknown)'}
     Channels    : ${channelIds.length ? channelIds.join(', ') : 'all conversations allowed'}
+    Inbound     : ${enrolledSlack
+        ? `enabled${getHomeChannel(s) === 'slack' ? ' (home channel)' : ''}`
+        : 'off — no app token, so this instance can post but not receive'}
 
   Next steps:
     1. /invite @cli-jaw in each channel the bot should read

--- a/src/slack/hot-notify.ts
+++ b/src/slack/hot-notify.ts
@@ -13,6 +13,7 @@ export type HotReload = 'reloaded' | 'server-off' | 'needs-restart' | 'old-serve
 export async function notifyRunningServer(
     slackBlock: Record<string, unknown>,
     fetchImpl: typeof fetch = fetch,
+    messagingBlock?: Record<string, unknown>,
 ): Promise<HotReload> {
     const base = getServerUrl();
     try {
@@ -25,7 +26,12 @@ export async function notifyRunningServer(
         const put = await fetchImpl(`${base}/api/settings`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ slack: slackBlock }),
+            // The messaging block rides along when the caller changed it. The
+            // transport restart is keyed on `enabledChannels`
+            // (`restartMessagingRuntime`), so sending only the slack block wrote
+            // credentials the server accepted while leaving the socket closed —
+            // the hot path reproducing the same gap as the file write (#477).
+            body: JSON.stringify(messagingBlock ? { slack: slackBlock, messaging: messagingBlock } : { slack: slackBlock }),
             signal: AbortSignal.timeout(5000),
         });
         return put.ok ? 'reloaded' : 'needs-restart';

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -286,7 +286,7 @@ cli-jaw/
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (161L)
 │   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (179L) ✨
 │   │   ├── allowlist-audit.ts ← channelIds 변경 방향 분류 + 축소 감사 기록 (게이트 리더 기준 정규화, route·settings watcher 양쪽이 공유) (125L) ✨
-│   │   ├── hot-notify.ts     ← CLI 설정 변경 후 실행 중 서버 hot-reload 통지 (loopback PUT /api/settings → transport 재시작, version skew 감지) (35L)
+│   │   ├── hot-notify.ts     ← CLI 설정 변경 후 실행 중 서버 hot-reload 통지 (loopback PUT /api/settings → transport 재시작, version skew 감지) (41L)
 │   │   ├── progress.ts       ← 실행 중 진행상황 릴레이 ("정보 수집 중…" placeholder → agent_tool 이벤트로 chat.update rate-limited 편집 → 답변 시 chat.delete, post/edit 모두 자격증명 마스킹) (187L) ✨
 │   │   └── register.ts       ← lazy transport 등록 (inbound + send) (16L)
 │   ├── browser/              ← Chrome CDP 제어 + web-ai 자동화 + adaptive-fetch
@@ -458,8 +458,8 @@ cli-jaw/
 │       ├── lock.ts           ← instance lock/unlock for process protection (96L)
 │       ├── history.ts        ← 채팅 히스토리 검색 CLI (65L)
 │       ├── init.ts           ← 초기화 마법사 + --safe/--dry-run + --help (516L)
-│       ├── slack.ts          ← `jaw slack manifest|setup` — 앱 매니페스트 출력 + 가이드 설정 (토큰 prefix 가드 + auth.test/apps.connections.open 라이브 검증 + settings 병합, channel 미변경) (404L)
-│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1173L)
+│       ├── slack.ts          ← `jaw slack manifest|setup` — 앱 매니페스트 출력 + 가이드 설정 (토큰 prefix 가드 + auth.test/apps.connections.open 라이브 검증 + settings 병합, channel 미변경) (440L)
+│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1196L)
 │       ├── jwc.ts            ← optional external-only JWC runtime install/clean/doctor helper (234L)
 │       ├── status.ts         ← 서버 상태 (--json) (115L)
 │       ├── mcp.ts            ← MCP 관리 (install/sync/list/reset) (230L)

--- a/tests/unit/slack-hot-notify.test.ts
+++ b/tests/unit/slack-hot-notify.test.ts
@@ -42,6 +42,40 @@ test('old-server: version skew means no PUT — the old build has no transport t
     assert.equal(calls.some(c => c.method === 'PUT'), false, 'must not merge settings into an old build');
 });
 
+// #477: the transport restart is keyed on `messaging.enabledChannels`
+// (`restartMessagingRuntime`), so a PUT carrying only the slack block wrote
+// credentials the server accepted while the socket stayed closed — the hot path
+// reproducing the same gap as the file write.
+test('the messaging block rides along so the transport actually restarts (#477)', async () => {
+    const { calls, fn } = fakeFetch({
+        '/api/health': { ok: true, json: { version: APP_VERSION } },
+        '/api/settings': { ok: true, json: {} },
+    });
+    const result = await notifyRunningServer(
+        { enabled: true, botToken: 'xoxb-1' },
+        fn,
+        { enabledChannels: ['slack'], homeChannel: 'slack' },
+    );
+    assert.equal(result, 'reloaded');
+    const put = calls.find(c => c.method === 'PUT');
+    assert.deepEqual(put?.body, {
+        slack: { enabled: true, botToken: 'xoxb-1' },
+        messaging: { enabledChannels: ['slack'], homeChannel: 'slack' },
+    });
+});
+
+// An outbound-only setup changes no channel enrolment, so it must not send a
+// messaging patch at all.
+test('no messaging block is sent when the caller did not change one (#477)', async () => {
+    const { calls, fn } = fakeFetch({
+        '/api/health': { ok: true, json: { version: APP_VERSION } },
+        '/api/settings': { ok: true, json: {} },
+    });
+    await notifyRunningServer({ enabled: true }, fn, undefined);
+    const put = calls.find(c => c.method === 'PUT');
+    assert.deepEqual(put?.body, { slack: { enabled: true } });
+});
+
 test('server-off: connection failure is silent, never throws', async () => {
     const { fn } = fakeFetch({});
     const result = await notifyRunningServer({ enabled: true }, fn);

--- a/tests/unit/slack-setup.test.ts
+++ b/tests/unit/slack-setup.test.ts
@@ -132,9 +132,55 @@ test('setup writes slack settings, preserves unrelated fields, never touches cha
     // Fields the wizard does not own survive the merge.
     assert.equal(s.slack.mentionOnly, false);
     assert.equal(s.slack.replyInThread, false);
-    // A two-token channel must never hijack the active channel.
+    // The home channel is still never hijacked: it decides where UNADDRESSED
+    // output goes, so taking it would redirect heartbeats and reminders away
+    // from the channel the user already chose.
     assert.equal(s.messaging.homeChannel, 'telegram');
-    assert.deepEqual(s.messaging.enabledChannels, ['telegram']);
+    // But being enabled is a different claim from being home, and the wizard
+    // used to write neither — leaving `slack.enabled: true` with the socket
+    // closed, which is #477. Slack joins the enabled set alongside telegram.
+    assert.deepEqual(s.messaging.enabledChannels, ['telegram', 'slack']);
+});
+
+// #477: setup wrote only the `slack` block, so a correct, fully validated
+// configuration ended with `enabledChannels: []` and the socket never opened.
+// `/api/health` then reported `activeInbound` as some other, DISABLED channel
+// while the wizard printed "settings saved" with no sign a step was missing.
+test('setup enrolls slack in the enabled channel set (#477)', (t) => {
+    const { status, output, home } = runSlack([
+        'setup', '--non-interactive', '--skip-validate', '--no-notify',
+        '--bot-token', 'xoxb-1-testbot', '--app-token', SAMPLE_APP_TOKEN,
+    ]);
+    t.after(() => rmSync(home, { recursive: true, force: true }));
+    assert.equal(status, 0, output);
+
+    const s = readSettings(home);
+    assert.deepEqual(s.messaging.enabledChannels, ['slack'],
+        'a configured slack must be in the set the transport loop reads');
+    // Nothing else was enabled, so there is no channel to steal home from.
+    assert.equal(s.messaging.homeChannel, 'slack');
+    assert.match(output, /Inbound\s+: enabled/, 'the summary must say inbound is on');
+});
+
+// Without an app token there is no socket to open. Enrolling anyway would put a
+// transport in the enabled set that cannot start, turning "outbound only" into a
+// startup fault.
+test('an outbound-only setup is not enrolled for inbound (#477)', (t) => {
+    const seed = {
+        messaging: { enabledChannels: ['telegram'], homeChannel: 'telegram' },
+    };
+    const { status, output, home } = runSlack([
+        'setup', '--non-interactive', '--skip-validate', '--no-notify',
+        '--bot-token', 'xoxb-1-testbot',
+    ], seed);
+    t.after(() => rmSync(home, { recursive: true, force: true }));
+    assert.equal(status, 0, output);
+
+    const s = readSettings(home);
+    assert.deepEqual(s.messaging.enabledChannels, ['telegram'],
+        'no app token means no socket, so slack must not join the enabled set');
+    assert.equal(s.messaging.homeChannel, 'telegram');
+    assert.match(output, /Inbound\s+: off/, 'the summary must say why inbound is off');
 });
 
 test('setup without an app token writes outbound-only with a warning', (t) => {


### PR DESCRIPTION
## What was wrong

`jaw slack setup` passed both live token checks, wrote settings, and printed "settings saved". The bot stayed silent. `/api/health`:

```json
"channels": {
  "activeInbound": "telegram",
  "telegram": {"configured": false, "activeInbound": false, "reason": "disabled"},
  "slack":    {"configured": true,  "activeInbound": false, "sendCapable": true}
}
```

A channel that is `configured:false, reason:"disabled"` was holding the `activeInbound` slot.

## Two fields have to agree, and the wizard wrote one

| field | claim | who reads it |
|---|---|---|
| `slack.enabled` | the channel is **configured** | credential paths |
| `messaging.enabledChannels` | the channel should **run** | `initEnabledMessagingRuntimes` |

The wizard predates schema v4 and still wrote only the `slack` block, so a correct setup ended with `enabledChannels: []` and no socket. Its output gave no hint a step was left.

The hot path had the same hole from the other side: `notifyRunningServer` PUT only `{slack}`, but `restartMessagingRuntime` decides what to (re)start by **diffing `enabledChannels`**. The server accepted the credentials and started nothing. The messaging block now rides along when the wizard changed it.

## What is deliberately *not* done

**`homeChannel` is not taken when another channel is already enabled.** Home decides where *unaddressed* output goes, so moving it would silently redirect heartbeats and reminders away from the channel the user chose — the same hijack `applyEnvOverrides` already refuses to do for `SLACK_BOT_TOKEN`. Slack claims home only when nothing else is enabled, where there is no other channel to take it from.

**Outbound-only setups are not enrolled.** With no app token there is no socket to open; adding slack to the set would enable a transport that cannot start and report a fault instead of "outbound only".

## doctor gains the check it was missing

It verified that everything *in* `enabledChannels` is configured — never that a configured channel made it *into* the set. That is why it printed `OK Channel consistency` on the broken install. On the incident state now:

```
⚠️  Channel consistency: Slack 설정은 끝났지만 messaging.enabledChannels 에 없어
    인바운드가 뜨지 않습니다 — jaw slack setup 을 다시 실행하거나 …
```

## Evidence

Real CLI runs, `--skip-validate --no-notify`, throwaway `CLI_JAW_HOME`:

| scenario | `enabledChannels` | `homeChannel` | summary line |
|---|---|---|---|
| fresh install | `[]` → **`["slack"]`** | → `slack` | `Inbound: enabled (home channel)` |
| telegram already home | `["telegram"]` → **`["telegram","slack"]`** | **`telegram` (kept)** | `Inbound: enabled` |
| no app token | `["telegram"]` (untouched) | `telegram` | `Inbound: off — no app token…` |

Before this change the first row stayed `[]` with `homeChannel: "telegram"`, exactly as reported.

### Tests

One existing assertion (`enabledChannels` stays `['telegram']`) encoded the bug and is split into the two claims it was conflating: home is still never hijacked, but slack now joins the enabled set. Added:

- setup enrols slack and claims home only when nothing else is enabled
- an outbound-only setup is **not** enrolled
- the hot-notify PUT carries the messaging block, and omits it when nothing changed

### Checks

- **Affected suites** — 123 pass / 1 fail; that one failure (`slack-connection-reset-route`, needs `CLI_JAW_HOME` from the shared setup when run standalone) **reproduces identically on `origin/dev`** — baseline 119/1, same test.
- **doctor suites** — 55/55.
- **`npx tsc --noEmit`** — clean.
- **`npm run build`** — `dist/bin/commands/slack.js` and `dist/src/slack/hot-notify.js` carry the change. (The postbuild global-symlink step fails in this sandbox for an unrelated pre-existing reason.)
- **`structure/verify-counts.sh`** — 445/445.

## Related

Stacked conceptually on #491 (#476). Both produce the same user-visible symptom — "setup succeeded, the bot is silent" — from different causes, and the reporter hit them back to back. With both merged, `jaw slack setup` on a headless remote host finishes in one pass.

Fixes #477
