### PR TITLE
fix(cli-detect): keep the exit status, stderr, and PATH shape of a failed lookup (#471)

### DIFF
--- a/src/core/cli-detect.ts
+++ b/src/core/cli-detect.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { buildServicePath } from './runtime-path.js';
+import { buildServicePath, splitPathList } from './runtime-path.js';
 import { classifyClaudeInstall } from './claude-install.js';
 
 // This seam has exactly one call site and it always passes encoding:'utf8',
@@ -63,6 +63,40 @@ function uniqueLines(raw: string): string[] {
         out.push(candidate);
     }
     return out;
+}
+
+/**
+ * Summarise the PATH a lookup ran against, without printing it.
+ *
+ * #471 reported `Command failed: where.exe codex` and the report could go no
+ * further: the message names neither the exit status nor the PATH the lookup
+ * used, so "the tool refused this environment" and "the tool is broken" read
+ * identically. A full PATH is too long for an error line and can carry user
+ * directory names, so report its SHAPE — entry count, and whether it holds
+ * POSIX-style entries a win32 lookup tool cannot resolve.
+ */
+export function describePathShape(
+    pathValue: string,
+    platform: NodeJS.Platform = process.platform,
+): string {
+    const entries = splitPathList(pathValue, platform);
+    if (entries.length === 0) return 'PATH empty';
+    // A win32 process can inherit a POSIX-delimited PATH from MSYS/git-bash
+    // (#273). splitPathList already separates those entries; what it cannot do
+    // is make `where.exe` understand '/c/Users/...'. Say so when it happens.
+    const posixLike = platform === 'win32'
+        ? entries.filter((entry) => entry.startsWith('/')).length
+        : 0;
+    const shape = `PATH ${entries.length} entries`;
+    return posixLike > 0 ? `${shape}, ${posixLike} POSIX-style` : shape;
+}
+
+/** First line of a lookup tool's stderr, bounded so an error line stays readable. */
+function firstStderrLine(raw: string | Buffer | null | undefined): string {
+    const text = String(raw ?? '').trim();
+    if (!text) return '';
+    const line = text.split(/\r?\n/, 1)[0]?.trim() ?? '';
+    return line.length > 160 ? `${line.slice(0, 160)}…` : line;
 }
 
 const BUN_DEPRIO_CLIS = new Set(['claude', 'codex', 'copilot', 'opencode']);
@@ -396,13 +430,14 @@ export function listCliBinaryCandidates(name: string, seedPath = readProcessPath
         // a timeout, and a malformed PATH all produced. Keep the distinction
         // so the reported message names what actually happened.
         //
-        // execFileSync errors carry status/stdout/signal at runtime, but
+        // execFileSync errors carry status/stdout/stderr/signal at runtime, but
         // NodeJS.ErrnoException declares none of them — describe the real shape.
         const err = error as Error & {
             code?: string | number;
             status?: number | null;
             signal?: NodeJS.Signals | null;
             stdout?: string | Buffer | null;
+            stderr?: string | Buffer | null;
         };
 
         // `where.exe`/`which` exits 1 with empty stdout when the name simply is
@@ -411,12 +446,25 @@ export function listCliBinaryCandidates(name: string, seedPath = readProcessPath
             return { candidates: [] };
         }
 
-        const scanError = err.code === 'ENOENT'
-            ? `lookup tool '${cmd}' not found`
-            : err.signal === 'SIGTERM'
-                ? `lookup timed out after 3000ms`
-                : (err.message || 'lookup failed');
-        return { candidates: [], scanError };
+        // ETIMEDOUT is the code Node sets on a timeout kill; the SIGTERM signal
+        // check alone also matches a tool killed by something else.
+        if (err.code === 'ENOENT') {
+            return { candidates: [], scanError: `lookup tool '${cmd}' not found` };
+        }
+        if (err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM') {
+            return { candidates: [], scanError: 'lookup timed out after 3000ms' };
+        }
+
+        // Everything else is a tool that RAN and refused. That is the #471
+        // branch, and the three facts below are what its report was missing:
+        // what the tool said, how it exited, and what PATH it was asked about.
+        const detail = [
+            firstStderrLine(err.stderr),
+            typeof err.status === 'number' ? `exit ${err.status}` : '',
+            describePathShape(readProcessPath(buildCliDetectionEnv(seedPath))),
+        ].filter(Boolean).join('; ');
+        const base = err.message || 'lookup failed';
+        return { candidates: [], scanError: detail ? `${base} (${detail})` : base };
     }
 }
 

--- a/tests/unit/cli-detect.test.ts
+++ b/tests/unit/cli-detect.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import {
     __setLookupExecForTests,
     buildCliDetectionEnv,
+    describePathShape,
     formatCliUnavailableMessage,
     isSpawnableCliFile,
     listCliBinaryCandidates,
@@ -127,6 +128,111 @@ test('CD-SCAN-003: the unavailable message names the scan error', () => {
     });
 
     assert.match(message, /could not be resolved: lookup timed out after 3000ms/);
+});
+
+// ─── #471: a lookup tool that RAN and refused ───
+//
+// The reported failure was 'Command failed: where.exe codex' and nothing else.
+// Exit status, the tool's own stderr, and the PATH it was asked about were all
+// discarded, so the incident could not be narrowed past "resolution failed".
+
+test('CD-SCAN-004: a tool that ran and refused reports status, stderr, and PATH shape', () => {
+    __setLookupExecForTests(() => {
+        const error = new Error('Command failed: where.exe codex') as Error & {
+            status: number; stdout: string; stderr: string;
+        };
+        error.status = 2;
+        error.stdout = '';
+        error.stderr = 'ERROR: The system cannot find the path specified.\r\n';
+        throw error;
+    });
+    try {
+        const scan = listCliBinaryCandidates('codex', '/usr/bin:/bin');
+        const scanError = scan.scanError || '';
+
+        // The original message survives — existing consumers still match on it.
+        assert.match(scanError, /Command failed: where\.exe codex/);
+        // and the three facts #471 could not recover are now attached.
+        assert.match(scanError, /The system cannot find the path specified/);
+        assert.match(scanError, /exit 2/);
+        assert.match(scanError, /PATH \d+ entries/);
+    } finally {
+        __setLookupExecForTests(null);
+    }
+});
+
+test('CD-SCAN-005: a timeout is still reported as a timeout, not as a refusal', () => {
+    // Node sets code ETIMEDOUT and signal SIGTERM when it kills on timeout.
+    __setLookupExecForTests(() => {
+        const error = new Error('spawnSync where.exe ETIMEDOUT') as Error & {
+            code: string; signal: NodeJS.Signals; status: null;
+        };
+        error.code = 'ETIMEDOUT';
+        error.signal = 'SIGTERM';
+        error.status = null;
+        throw error;
+    });
+    try {
+        const scan = listCliBinaryCandidates('codex', '/usr/bin:/bin');
+        assert.equal(scan.scanError, 'lookup timed out after 3000ms');
+    } finally {
+        __setLookupExecForTests(null);
+    }
+});
+
+test('CD-SCAN-006: a refusal with no stderr still names its exit status', () => {
+    __setLookupExecForTests(() => {
+        const error = new Error('Command failed: which -a codex') as Error & {
+            status: number; stdout: string; stderr: string;
+        };
+        error.status = 3;
+        error.stdout = '';
+        error.stderr = '';
+        throw error;
+    });
+    try {
+        const scan = listCliBinaryCandidates('codex', '/usr/bin:/bin');
+        assert.match(scan.scanError || '', /exit 3/);
+    } finally {
+        __setLookupExecForTests(null);
+    }
+});
+
+test('CD-SCAN-007: an exit-1 empty scan is still not a discovery failure', () => {
+    // Guards the ordinary "not installed" path against the new detail branch.
+    __setLookupExecForTests(() => {
+        const error = new Error('Command failed: which -a codex') as Error & {
+            status: number; stdout: string; stderr: string;
+        };
+        error.status = 1;
+        error.stdout = '';
+        error.stderr = '';
+        throw error;
+    });
+    try {
+        const scan = listCliBinaryCandidates('codex', '/usr/bin:/bin');
+        assert.deepEqual(scan.candidates, []);
+        assert.equal(scan.scanError, undefined);
+    } finally {
+        __setLookupExecForTests(null);
+    }
+});
+
+test('describePathShape counts entries and flags POSIX-style ones on win32', () => {
+    // The MSYS shape #471's process tree points at: a win32 lookup tool cannot
+    // resolve '/c/...' or '/mingw64/bin', and the count alone would not say so.
+    const msys = describePathShape('/mingw64/bin:/usr/bin:C:\\Users\\u\\AppData\\Roaming\\npm', 'win32');
+    assert.match(msys, /3 entries/);
+    assert.match(msys, /2 POSIX-style/);
+
+    // A native win32 PATH carries no such warning.
+    const native = describePathShape('C:\\WINDOWS\\System32;C:\\Users\\u\\AppData\\Roaming\\npm', 'win32');
+    assert.match(native, /2 entries/);
+    assert.doesNotMatch(native, /POSIX-style/);
+
+    // POSIX paths are not "POSIX-style entries on a win32 PATH" — no flag there.
+    assert.doesNotMatch(describePathShape('/usr/bin:/bin', 'darwin'), /POSIX-style/);
+    assert.equal(describePathShape('', 'darwin'), 'PATH empty');
 });
 
 test('prioritizeCliCandidates moves bun shims behind managed node bins for claude', () => {


### PR DESCRIPTION
## What

A failed CLI lookup now reports **what the tool said, how it exited, and what PATH it was asked about**. Before this, all three were discarded.

## Why this layer exists

#471 was reported with exactly one line of evidence:

```
CLI 'codex-app' could not be resolved: Command failed: where.exe codex.
```

and the investigation could go no further — the reporter wrote that they could not claim the same root cause as #273 because the failing process's environment was never captured.

That message is the catch block's **last fallback**. It keeps `err.message` and drops the rest, so "where.exe is broken" and "where.exe refused this environment" read identically.

## The branch is narrower than it looks

Which is what makes the discarded detail worth recovering:

| Real failure | Branch | Message today |
|---|---|---|
| Not on PATH (exit 1, empty stdout) | early return | `not found in PATH` |
| `where.exe` itself missing | `code === 'ENOENT'` | `lookup tool not found` |
| Over 3s | timeout | `lookup timed out` |
| **Ran and refused with another status** | `err.message` | **the reported string** |

Node reports a timeout kill as `code: 'ETIMEDOUT'`, `signal: 'SIGTERM'` — verified by running it. So reaching this branch means the tool **ran and refused**, which is precisely the case whose cause the message cannot name.

Timeout detection now also accepts `ETIMEDOUT`; the previous SIGTERM-only check classified any other SIGTERM kill as a timeout.

## Why PATH *shape* and not the PATH

`describePathShape()` reports entry count plus how many entries are POSIX-spelled. An error line is the wrong place for a full PATH and it carries user directory names. The one distinction that matters for diagnosis — an MSYS PATH a win32 tool cannot read vs an ordinary one — survives.

## Verification

```
CLI 'codex-app' could not be resolved: Command failed: where.exe codex
  (ERROR: The system cannot find the path specified.; exit 2; PATH 14 entries, 3 POSIX-style)
```

5 new cases. **Verified red**: reverting just the detail branch fails CD-SCAN-004 and CD-SCAN-006, so these tests are load-bearing rather than decorative. `tsc --noEmit` clean; full suite shows 0 new failures against an `origin/dev` baseline (30 pre-existing).

Refs #471

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 3 | #495 | MSYS path normalization (draft) | win32 conversion, pure function |
| 2 | #494 | readiness contract | API shape, cache, 503 semantics |
| 1 | #493 | scan-error detail ← you are here | what the error line preserves |

Review this PR's diff only; its base is `dev`.
