### PR TITLE
feat(health): answer readiness separately from liveness (#471)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -174,7 +174,7 @@ Use `structure/server_api.md` for the full table. Major route groups:
 
 | Group | Examples |
 | --- | --- |
-| Core/system | `/api/health`, `/api/session`, `/api/runtime`, `/api/auth/token` |
+| Core/system | `/api/health` (liveness), `/api/ready` (readiness, 503), `/api/session`, `/api/runtime`, `/api/auth/token` |
 | Messages/sessions | `/api/messages`, `/api/messages/count`, `/api/chat-sessions` |
 | Events | `/api/events` SSE |
 | Commands | `/api/command`, `/api/commands`, `/api/message` |

--- a/src/core/agent-readiness.ts
+++ b/src/core/agent-readiness.ts
@@ -1,0 +1,165 @@
+/**
+ * Agent-runtime readiness for the configured CLI (#471).
+ *
+ * `/api/health` answers LIVENESS: its `ok` has been a constant since the
+ * endpoint was added for Docker HEALTHCHECK, and Docker restarts the container
+ * and the manager drops the instance when it turns false. So a server whose
+ * configured CLI could not be resolved still reported healthy for 16 hours
+ * while every prompt failed before spawn. This module answers the OTHER
+ * question — can the configured agent actually be launched — and leaves the
+ * liveness contract alone.
+ *
+ * Why a cache: `detectCli` shells out to `where.exe`/`which` with a 3s
+ * timeout, synchronously. `/api/health` is a polling route, so calling it
+ * inline would block the event loop on every poll. Reads are served from the
+ * last result and refreshes run off the request path, the same shape
+ * `CliStatusCache` uses for the full multi-CLI probe.
+ */
+import { detectCli, settings } from './config.js';
+import { formatCliUnavailableMessage } from './cli-detect.js';
+
+export type AgentReadinessState = 'ready' | 'unavailable' | 'unknown';
+
+export interface AgentReadinessSnapshot {
+    /** Configured CLI, or null when none is set. */
+    cli: string | null;
+    ready: boolean;
+    state: AgentReadinessState;
+    /** Resolved binary path when ready. */
+    path?: string;
+    /** User-facing reason when not ready. */
+    error?: string;
+    /** Epoch ms of the probe this snapshot came from; null before the first. */
+    checkedAt: number | null;
+}
+
+export interface AgentReadinessOptions {
+    now?: () => number;
+    ttlMs?: number;
+    /** Injected probe. Returns the snapshot fields a detection can determine. */
+    probe?: (cli: string) => { ready: boolean; path?: string; error?: string };
+}
+
+const TTL_MS = 15_000;
+
+function defaultProbe(cli: string): { ready: boolean; path?: string; error?: string } {
+    const detected = detectCli(cli);
+    if (detected.available) {
+        return detected.path ? { ready: true, path: detected.path } : { ready: true };
+    }
+    return { ready: false, error: formatCliUnavailableMessage(cli, detected) };
+}
+
+/**
+ * Readiness of one CLI, refreshed off the request path.
+ *
+ * Deliberately NOT reusing CliStatusCache: that one forks a worker to probe
+ * every registered CLI plus auth and capability. Readiness needs one binary
+ * lookup for the configured CLI, and putting a fork on the health path would
+ * trade a blocked event loop for a process spawn per poll.
+ */
+export class AgentReadinessCache {
+    private readonly now: () => number;
+    private readonly ttlMs: number;
+    private readonly probe: (cli: string) => { ready: boolean; path?: string; error?: string };
+    private last: AgentReadinessSnapshot | null = null;
+    private lastCli: string | null = null;
+    private refreshingCli: string | null = null;
+
+    constructor(options: AgentReadinessOptions = {}) {
+        this.now = options.now ?? Date.now;
+        this.ttlMs = options.ttlMs ?? TTL_MS;
+        this.probe = options.probe ?? defaultProbe;
+    }
+
+    /** Never blocks. Returns the last known snapshot and schedules a refresh when stale. */
+    getSnapshot(): AgentReadinessSnapshot {
+        const cli = (settings['cli'] as string | undefined) || null;
+        if (!cli) {
+            // No configured CLI is a configuration state, not a broken runtime.
+            // Reporting it as `unavailable` would make a fresh install look
+            // failed; `unknown` keeps liveness and readiness both honest.
+            return { cli: null, ready: false, state: 'unknown', checkedAt: null };
+        }
+
+        // A CLI switch invalidates immediately: serving the previous CLI's
+        // verdict under the new name would be a wrong answer, not a stale one.
+        if (this.lastCli !== cli) {
+            this.last = null;
+            this.lastCli = cli;
+        }
+
+        const age = this.last?.checkedAt == null
+            ? Number.POSITIVE_INFINITY
+            : this.now() - this.last.checkedAt;
+        if (age > this.ttlMs) this.scheduleRefresh(cli);
+
+        return this.last ?? { cli, ready: false, state: 'unknown', checkedAt: null };
+    }
+
+    /** Probe now and wait for the result. For CLI/doctor paths, never for polling routes. */
+    async refreshNow(): Promise<AgentReadinessSnapshot> {
+        const cli = (settings['cli'] as string | undefined) || null;
+        if (!cli) return { cli: null, ready: false, state: 'unknown', checkedAt: null };
+        this.lastCli = cli;
+        this.runProbe(cli);
+        return this.last ?? { cli, ready: false, state: 'unknown', checkedAt: null };
+    }
+
+    private scheduleRefresh(cli: string): void {
+        // Keyed by CLI, not a bare boolean. A bare flag set by a probe for the
+        // PREVIOUS cli stays true across a switch and every later refresh is
+        // skipped, freezing the cache on 'unknown' for good. Found by AR-005,
+        // and live-reachable: settings.cli is editable at runtime via
+        // PUT /api/settings.
+        if (this.refreshingCli === cli) return;
+        this.refreshingCli = cli;
+        // setImmediate, not await: the caller is a request handler and must not
+        // wait on a synchronous 3s-timeout lookup.
+        setImmediate(() => {
+            try { this.runProbe(cli); } finally {
+                if (this.refreshingCli === cli) this.refreshingCli = null;
+            }
+        });
+    }
+
+    private runProbe(cli: string): void {
+        try {
+            const result = this.probe(cli);
+            this.last = {
+                cli,
+                ready: result.ready,
+                state: result.ready ? 'ready' : 'unavailable',
+                ...(result.path ? { path: result.path } : {}),
+                ...(result.error ? { error: result.error } : {}),
+                checkedAt: this.now(),
+            };
+        } catch (error) {
+            // A probe that throws is not evidence the CLI is missing, so this
+            // must not read as `unavailable` — that would let a probe bug
+            // trigger an operator's restart policy.
+            this.last = {
+                cli,
+                ready: false,
+                state: 'unknown',
+                error: error instanceof Error ? error.message : String(error),
+                checkedAt: this.now(),
+            };
+        }
+    }
+}
+
+const defaultCache = new AgentReadinessCache();
+
+export function getAgentReadiness(): AgentReadinessSnapshot {
+    return defaultCache.getSnapshot();
+}
+
+export function refreshAgentReadiness(): Promise<AgentReadinessSnapshot> {
+    return defaultCache.refreshNow();
+}
+
+/** @internal exported for deterministic tests. */
+export function createAgentReadinessCacheForTest(options: AgentReadinessOptions): AgentReadinessCache {
+    return new AgentReadinessCache(options);
+}

--- a/src/core/rate-limit.ts
+++ b/src/core/rate-limit.ts
@@ -74,6 +74,10 @@ export function classifyPath(method: string, path: string): RatePathClass {
     if (normalizedMethod !== 'GET' && normalizedMethod !== 'HEAD') return 'mutate';
     if (path === '/api/status'
         || path === '/api/health'
+        // Readiness is polled on the same cadence as health — by watchdogs and
+        // container probes rather than by a browser (#471). Leaving it in the
+        // 'general' bucket would rate-limit the very check meant to run often.
+        || path === '/api/ready'
         || path === '/api/messages/latest'
         || path === '/api/goal') return 'poll';
     return 'general';

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -10,6 +10,7 @@ import { APP_VERSION, settings } from '../core/config.js';
 import { drainLogRing } from '../core/logger.js';
 import { getSession } from '../core/db.js';
 import { buildChannelHealthSnapshot } from '../messaging/channel-health.js';
+import { getAgentReadiness } from '../core/agent-readiness.js';
 import { getCliModelAndEffort } from '../core/main-session.js';
 import { isAgentBusy, messageQueue } from '../agent/spawn.js';
 import {
@@ -33,12 +34,38 @@ function getRuntimeSnapshot() {
 }
 
 export function registerSystemRoutes(app: Router, deps: { jawAuthToken: string }): void {
+    // LIVENESS. `ok` stays a constant on purpose (#471): it was added for
+    // Docker HEALTHCHECK, and Docker restarts the container and the manager
+    // drops the instance when it goes false. A CLI that cannot be resolved is
+    // not "this server does not exist", so it is reported in an ADDITIVE
+    // `agentRuntime` block and enforced by /api/ready below.
     app.get('/api/health', (_req, res) => res.json({
         ok: true,
         version: APP_VERSION,
         uptime: process.uptime(),
         channels: buildChannelHealthSnapshot(),
+        agentRuntime: getAgentReadiness(),
     }));
+
+    // READINESS. Separate from liveness so a watchdog or probe can act on
+    // "the configured agent cannot be launched" without conflating it with a
+    // dead process. 503 is the part that matters: curl, Docker, and k8s-style
+    // probes consume it without parsing a body.
+    //
+    // `unknown` (no CLI configured, or a probe that threw) does NOT return
+    // 503. A fresh install has no CLI yet, and a probe bug is not evidence the
+    // runtime is broken — either would otherwise drive a restart loop that
+    // fixes nothing.
+    app.get('/api/ready', (_req, res) => {
+        const agentRuntime = getAgentReadiness();
+        const status = agentRuntime.state === 'unavailable' ? 503 : 200;
+        res.status(status).json({
+            ok: agentRuntime.ready,
+            version: APP_VERSION,
+            uptime: process.uptime(),
+            agentRuntime,
+        });
+    });
 
     // Canonical Slack app manifest for the settings-page copy button. No
     // secrets — scopes and event names only, same exposure class as

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -9,7 +9,7 @@ aliases: [CLI-JAW Server API, server.ts reference, server_api]
 # server.ts — Glue + Route Registration (640L)
 
 > Express/SSE bootstrap + localhost/LAN opt-in 보안 가드 + `src/routes/*` registrar + mounted sub-router 등록.
-> 현재 라이브 surface는 총 253개 route handler이며, 이 중 `/`를 제외한 API 엔드포인트는 252개다.
+> 현재 라이브 surface는 총 254개 route handler이며, 이 중 `/`를 제외한 API 엔드포인트는 253개다.
 > mutation route(`POST`/`PUT`/`DELETE`)는 모두 `requireAuth`를 거친다. 단, `requireAuth()`는 loopback 요청을 토큰 없이 통과시키고, `lanAllowed()`가 true일 때 private IP도 LAN bypass로 통과시킨다.
 > `GET /api/auth/token`은 Bearer bootstrap 전용이며 `Sec-Fetch-Site`가 `same-origin` 또는 `none`이 아닐 때 `403`을 반환한다.
 
@@ -80,7 +80,8 @@ static → employees → heartbeat → skills → jaw-memory → orchestrate
 | Method | Path | 설명 |
 | --- | --- | --- |
 | `GET` | `/` | `public/dist/index.html`이 있으면 Vite build를 서빙, 없으면 static fallback |
-| `GET` | `/api/health` | `{ ok, version, uptime }` |
+| `GET` | `/api/health` | **liveness.** `{ ok, version, uptime, channels, agentRuntime }`. `ok`는 상수다 — Docker HEALTHCHECK가 컨테이너를 재시작하고 manager scan이 인스턴스를 목록에서 제거하는 신호이므로 CLI 미해석을 여기서 표현하지 않는다. 에이전트 런타임 준비 상태는 가산 필드 `agentRuntime: { cli, ready, state, path?, error?, checkedAt }`로만 노출한다 (#471) |
+| `GET` | `/api/ready` | **readiness.** 설정된 CLI가 spawn 가능한지 답한다. `state:"unavailable"`일 때만 **503**, 그 외 200. `unknown`(CLI 미설정 또는 probe 예외)은 503이 아니다 — 신규 설치와 probe 버그가 무의미한 재시작을 유발하면 안 된다. 워치독은 본문 파싱 없이 상태 코드만 소비할 수 있다 (#471) |
 | `GET` | `/api/slack/manifest` | 설정 페이지 "매니페스트 복사"용 canonical Slack 앱 매니페스트. 선택 `?name=`은 1~35자 앱 표시명을 받고 봇 표시명은 자동 파생한다. `{ ok, data: { yaml, json, botDisplayName } }` (비밀값 없음, unauthenticated) |
 | `POST` | `/api/channels/validate` | 온보딩 마법사 라이브 크리덴셜 검증 `{ channel, botToken, appToken?, guildId? }` → `{ ok, identity?, teamId? }` 또는 `{ ok:false, error }`. 저장하지 않고 검증만 수행 |
 | `GET` | `/api/session` | 현재 main session row 반환 |
@@ -117,7 +118,7 @@ static → employees → heartbeat → skills → jaw-memory → orchestrate
 
 | Category | Endpoints |
 | --- | --- |
-| Core/Auth | `GET /api/health` `GET /api/slack/manifest` `GET /api/session` `GET /api/messages` `GET /api/messages/count` `GET /api/messages/search` `GET /api/messages/latest` `GET /api/runtime` `GET /api/auth/token` `GET /media/:filename` `GET /api/image` `GET /api/widgets/:chatId/:widgetId` `POST /api/message` `POST /api/stop` `POST /api/clear` `POST /api/session/reset` |
+| Core/Auth | `GET /api/health` `GET /api/ready` `GET /api/slack/manifest` `GET /api/session` `GET /api/messages` `GET /api/messages/count` `GET /api/messages/search` `GET /api/messages/latest` `GET /api/runtime` `GET /api/auth/token` `GET /media/:filename` `GET /api/image` `GET /api/widgets/:chatId/:widgetId` `POST /api/message` `POST /api/stop` `POST /api/clear` `POST /api/session/reset` |
 | Commands | `POST /api/command` `GET /api/commands?interface=` `POST /api/elicitation/callback` |
 | Events | `GET /api/events` |
 | Chat Sessions | `GET /api/chat-sessions` `POST /api/chat-sessions` `POST /api/chat-sessions/:id/switch` `DELETE /api/chat-sessions/:id` |
@@ -150,7 +151,7 @@ static → employees → heartbeat → skills → jaw-memory → orchestrate
 | Dashboard Schedule | `GET /api/dashboard/schedule/work` `POST /api/dashboard/schedule/work` `PATCH /api/dashboard/schedule/work/:id` `DELETE /api/dashboard/schedule/work/:id` `POST /api/dashboard/schedule/work/:id/dispatch` |
 | i18n | `GET /api/i18n/languages` `GET /api/i18n/:lang` |
 
-> 실제 코드(`server.ts` + `src/routes/*.ts` + mounted runtime/security/Jaw CEO/dashboard sub-router)에서 추출한 총 253개 route handler 기준이다. 이 중 API 엔드포인트는 252개이고, 나머지 1개는 `/` 엔트리이다. Browser API 43개는 `src/routes/browser.ts`에서 등록된다. Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 sub-router로 등록된다.
+> 실제 코드(`server.ts` + `src/routes/*.ts` + mounted runtime/security/Jaw CEO/dashboard sub-router)에서 추출한 총 254개 route handler 기준이다. 이 중 API 엔드포인트는 253개이고, 나머지 1개는 `/` 엔트리이다. Browser API 43개는 `src/routes/browser.ts`에서 등록된다. Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 sub-router로 등록된다.
 
 `POST /api/channel/send`에서 `channel`은 `telegram|discord|slack|active` transport다. 대화 ID는 `chat_id` 또는 `target.targetId`에 넣는다. Slack thread를 명시할 때 `target.threadId`는 reply ts가 아닌 parent message ts다. target을 생략하면 검증된 현재 대화와 thread를 사용한다. 빈 `slack.channelIds`는 임의 explicit channel을 열지 않으며, 이미 저장·검증된 `lastActive/latestSeen`과 같은 conversation/thread만 명시적으로 재사용할 수 있다.
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -45,7 +45,7 @@ cli-jaw/
 │   │   ├── session-generation.ts ← persistent chat_sessions.generation (not process-local spawn tokens) (94L)
 │   │   ├── db.ts             ← SQLite 스키마 + prepared statements + trace + tool_log + working_dir migration + closeDb() WAL checkpoint + checkOrphanedWal + busy_timeout + clearMessagesScoped + queued_messages table + model-aware clearEmployeeSession + getRecentMessagesLite + searchMessages(days+recent scope) + getMessageContext(±N range) (812L)
 │   │   ├── chat-sessions.ts  ← 채팅 세션 CRUD + 활성 세션 전환 (233L)
-│   │   ├── rate-limit.ts     ← 클라이언트 클래스별(cli/manager/browser/lan/remote) 슬라이딩 윈도 리미터 + atomic peek/commit + Retry-After 미들웨어 팩토리 (213L)
+│   │   ├── rate-limit.ts     ← 클라이언트 클래스별(cli/manager/browser/lan/remote) 슬라이딩 윈도 리미터 + atomic peek/commit + Retry-After 미들웨어 팩토리 (217L)
 │   │   ├── bus.ts            ← public SSE publish + 내부 리스너 fan-out (65L)
 │   │   ├── logger.ts         ← 로거 유틸 + structured log.event (100L)
 │   │   ├── i18n.ts           ← 서버사이드 번역 (90L)

--- a/tests/unit/agent-readiness.test.ts
+++ b/tests/unit/agent-readiness.test.ts
@@ -1,0 +1,172 @@
+// ─── Agent-runtime readiness (#471) ───
+//
+// The incident: /api/health reported healthy for 16 hours while every prompt
+// failed before spawn, because health never asked whether the configured CLI
+// could be resolved. These tests pin the contract that answers it, and the
+// boundaries that keep it from driving a useless restart.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { createAgentReadinessCacheForTest } from '../../src/core/agent-readiness.ts';
+import { settings } from '../../src/core/config.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const systemSrc = fs.readFileSync(join(__dirname, '../../src/routes/system.ts'), 'utf8');
+
+// Async-aware: an earlier sync-only version restored settings.cli before the
+// awaited body finished, so the cache read a CLI the test had already put back.
+async function withCli<T>(cli: string | undefined, fn: () => Promise<T> | T): Promise<T> {
+    const previous = settings['cli'];
+    (settings as Record<string, unknown>)['cli'] = cli;
+    try { return await fn(); } finally { (settings as Record<string, unknown>)['cli'] = previous; }
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test('AR-001: a resolvable CLI reports ready with its path', async () => {
+    await withCli('codex-app', async () => {
+        const cache = createAgentReadinessCacheForTest({
+            probe: () => ({ ready: true, path: '/usr/local/bin/codex' }),
+        });
+
+        // First read never blocks, so it cannot already know the answer.
+        assert.equal(cache.getSnapshot().state, 'unknown');
+        await tick();
+
+        const snapshot = cache.getSnapshot();
+        assert.equal(snapshot.ready, true);
+        assert.equal(snapshot.state, 'ready');
+        assert.equal(snapshot.path, '/usr/local/bin/codex');
+        assert.equal(snapshot.cli, 'codex-app');
+    });
+});
+
+test('AR-002: an unresolvable CLI reports unavailable and carries the reason', async () => {
+    await withCli('codex-app', async () => {
+        const cache = createAgentReadinessCacheForTest({
+            probe: () => ({ ready: false, error: "CLI 'codex-app' could not be resolved: Command failed: where.exe codex" }),
+        });
+        cache.getSnapshot();
+        await tick();
+
+        const snapshot = cache.getSnapshot();
+        assert.equal(snapshot.ready, false);
+        assert.equal(snapshot.state, 'unavailable');
+        assert.match(snapshot.error || '', /where\.exe codex/);
+    });
+});
+
+test('AR-003: reads are served from cache — the probe does not run per request', async () => {
+    await withCli('codex-app', async () => {
+        let probes = 0;
+        const cache = createAgentReadinessCacheForTest({
+            ttlMs: 15_000,
+            now: () => 1_000,
+            probe: () => { probes += 1; return { ready: true }; },
+        });
+        cache.getSnapshot();
+        await tick();
+        for (let i = 0; i < 50; i += 1) cache.getSnapshot();
+        await tick();
+
+        // /api/health is a polling route and the real probe is a synchronous
+        // 3s-timeout lookup; one probe per poll would block the event loop.
+        assert.equal(probes, 1);
+    });
+});
+
+test('AR-004: a stale snapshot refreshes after the TTL', async () => {
+    await withCli('codex-app', async () => {
+        let probes = 0;
+        let clock = 1_000;
+        const cache = createAgentReadinessCacheForTest({
+            ttlMs: 15_000,
+            now: () => clock,
+            probe: () => { probes += 1; return { ready: true }; },
+        });
+        cache.getSnapshot();
+        await tick();
+        assert.equal(probes, 1);
+
+        clock += 20_000;
+        cache.getSnapshot();
+        await tick();
+        assert.equal(probes, 2);
+    });
+});
+
+test('AR-005: switching CLI invalidates immediately rather than serving the old verdict', async () => {
+    const cache = createAgentReadinessCacheForTest({
+        now: () => 1_000,
+        probe: (cli) => (cli === 'codex-app' ? { ready: true } : { ready: false, error: 'nope' }),
+    });
+
+    await withCli('codex-app', async () => {
+        cache.getSnapshot();
+        await tick();
+        assert.equal(cache.getSnapshot().ready, true);
+    });
+
+    await withCli('claude', async () => {
+        // Stale-by-TTL would still be fresh here; answering 'ready' under the
+        // new CLI's name would be a wrong answer, not a stale one.
+        const immediate = cache.getSnapshot();
+        assert.equal(immediate.cli, 'claude');
+        assert.equal(immediate.state, 'unknown');
+        await tick();
+        assert.equal(cache.getSnapshot().state, 'unavailable');
+    });
+});
+
+test('AR-006: no configured CLI is unknown, not unavailable', async () => {
+    await withCli(undefined, () => {
+        const cache = createAgentReadinessCacheForTest({ probe: () => ({ ready: true }) });
+        const snapshot = cache.getSnapshot();
+
+        // A fresh install has no CLI yet. Reporting 'unavailable' would make
+        // /api/ready return 503 and drive a restart that fixes nothing.
+        assert.equal(snapshot.state, 'unknown');
+        assert.equal(snapshot.cli, null);
+        assert.equal(snapshot.ready, false);
+    });
+});
+
+test('AR-007: a probe that throws is unknown, not unavailable', async () => {
+    await withCli('codex-app', async () => {
+        const cache = createAgentReadinessCacheForTest({
+            probe: () => { throw new Error('probe exploded'); },
+        });
+        cache.getSnapshot();
+        await tick();
+
+        const snapshot = cache.getSnapshot();
+        assert.equal(snapshot.state, 'unknown');
+        assert.equal(snapshot.ready, false);
+        assert.match(snapshot.error || '', /probe exploded/);
+    });
+});
+
+// ─── Route contract ───
+
+test('AR-010: /api/health keeps ok as a constant and adds agentRuntime', () => {
+    const healthBlock = systemSrc.slice(
+        systemSrc.indexOf("app.get('/api/health'"),
+        systemSrc.indexOf("app.get('/api/ready'"),
+    );
+
+    // Docker HEALTHCHECK restarts the container and the manager scan drops the
+    // instance when this flips. Readiness must not be expressed here.
+    assert.match(healthBlock, /ok:\s*true/);
+    assert.ok(healthBlock.includes('agentRuntime: getAgentReadiness()'));
+});
+
+test('AR-011: /api/ready returns 503 only for a proven-unavailable runtime', () => {
+    const readyBlock = systemSrc.slice(systemSrc.indexOf("app.get('/api/ready'"));
+
+    // The 503 is the machine-consumable part of the contract: a watchdog reads
+    // the status code without parsing a body.
+    assert.match(readyBlock, /agentRuntime\.state === 'unavailable' \? 503 : 200/);
+});


### PR DESCRIPTION
## What

Readiness gets its own answer, beside liveness rather than inside it:

- `/api/health` gains an **additive** `agentRuntime` block; `ok` stays constant.
- `/api/ready` is new and returns **503** when the configured CLI is proven unresolvable.

## The bug is an absence, not a false positive

`/api/health` returned `ok: true` for 16 hours while every prompt failed before spawn. It has **no field that looks at the agent runtime**, so the response is byte-identical whether the CLI resolves or not.

That is by construction. The endpoint arrived in `ffb45364` — *"server.ts: /api/health endpoint for Docker HEALTHCHECK"* — and its first implementation was `{ ok: true, version, uptime }` with `ok` as a literal. `Dockerfile` consumes it with `if(!r.ok)throw 1`, i.e. status code only. It answers liveness. Nothing answered readiness.

## Why `ok` is not flipped

The issue suggested `{ ok: false, agentRuntime: {...} }`. That is the one change this must not make:

| Consumer | If `ok` goes false |
|---|---|
| Docker HEALTHCHECK | restarts the container |
| manager `scanPort` | drops the instance from the list |
| `hot-notify` | reports `needs-restart` |
| `doctor` | stops reading Slack scope drift |

"One CLI does not resolve" would become "this server does not exist." The additive shape matches what `activeInboundChannels` and `slackScopes` already do here — neither flips the top-level `ok`.

## `unknown` is deliberately not 503

A fresh install has no CLI configured, and a probe that throws is not evidence the runtime is broken. Returning 503 for either would drive a restart loop that fixes nothing — the failure mode that makes a diagnosable fault undiagnosable.

| State | `/api/ready` |
|---|---|
| `ready` | 200 |
| `unavailable` (probe says no) | **503** |
| `unknown` (no CLI / probe threw) | 200 |

## Cost, and why not `CliStatusCache`

`detectCli` is a synchronous `execFileSync` with a 3s timeout; `/api/health` is a polling route. Inline probing would block the event loop on every poll, so reads come from a 15s TTL cache refreshed off the request path.

`CliStatusCache` was not reused: it forks a worker covering every registered CLI plus auth and capability. Putting that on the health path trades a blocked event loop for a process spawn per poll. `/api/ready` joins the `poll` rate-limit class for the same reason — rate-limiting the check meant to run often defeats it.

## A real defect the tests caught

A bare `refreshing` boolean stayed `true` across a CLI switch, so **every later refresh was skipped and the cache froze on `unknown` permanently**. `settings.cli` is editable at runtime via `PUT /api/settings`, so that state is reachable in production. Now keyed by CLI.

## Verification

Mounted the real routes and exercised both endpoints with an unresolvable CLI:

```
HEALTH status: 200 | ok: true
HEALTH agentRuntime: {"cli":"...","ready":false,"state":"unavailable","error":"CLI '...' not found in PATH. Run \`jaw doctor --json\`.","checkedAt":...}
READY  status: 503 | ok: false
```

9 new cases, including one asserting the probe runs **once** across 50 reads. `tsc --noEmit` clean; `docs:check` passes (route count 253 → 254). Full suite: 0 new failures vs an `origin/dev` baseline.

Refs #471

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 3 | #495 | MSYS path normalization (draft) | win32 conversion, pure function |
| 2 | #494 | readiness contract ← you are here | API shape, cache, 503 semantics |
| 1 | #493 | scan-error detail | what the error line preserves |

Review this PR's diff only; its base is the layer below.
