### PR TITLE
fix(runtime-path): convert MSYS PATH entries win32 tools cannot resolve (#471)

### DIFF
--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -775,7 +775,12 @@ export function makeCleanEnv(
         }
         env["PATH"] = inheritedPath;
     }
-    env["PATH"] = buildServicePath(env["PATH"] || '');
+    // Pass `platform` through: this function already takes it as a parameter and
+    // every branch above respects it, but buildServicePath was left to read
+    // process.platform. That disagreement was invisible while the two agreed;
+    // win32 PATH-entry normalization made it observable, because a POSIX-only
+    // env asserted on a Windows runner then had its entries rewritten.
+    env["PATH"] = buildServicePath(env["PATH"] || '', [], os.homedir(), platform);
 
     const merged: NodeJS.ProcessEnv = { ...env, ...extraEnv };
     const extraPath = isWindows ? readCaseInsensitivePath(extraEnv) : extraEnv["PATH"];

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -789,7 +789,9 @@ export function makeCleanEnv(
             if (key.toLowerCase() === 'path') delete merged[key];
         }
     }
-    merged["PATH"] = buildServicePath(extraPath || env["PATH"] || '');
+    // Same platform passthrough as above. This is the call that produces the
+    // RETURNED PATH, so a win32/POSIX disagreement here reaches the child.
+    merged["PATH"] = buildServicePath(extraPath || env["PATH"] || '', [], os.homedir(), platform);
     return merged;
 }
 

--- a/src/core/runtime-path.ts
+++ b/src/core/runtime-path.ts
@@ -68,6 +68,43 @@ export function splitPathList(raw: string, platform: NodeJS.Platform = process.p
  * Omitting System32 is what #294 reported: without it the agent cannot
  * resolve powershell, where, or cmd, and silently works around the gap.
  */
+
+/**
+ * Convert an MSYS/git-bash PATH entry to a form win32 tools can resolve.
+ *
+ * #273 fixed the DELIMITER — a POSIX-delimited PATH inherited from git-bash
+ * was split on ';' and collapsed into one useless entry. It did not touch the
+ * entry FORMAT, so '/c/Users/u/AppData/Roaming/npm' still reached `where.exe`
+ * verbatim, and `where.exe` is a native Win32 tool that cannot read it. A
+ * server started from git-bash therefore resolves nothing while a natively
+ * started one on the same host resolves fine (#471).
+ *
+ * Two shapes convert; a third deliberately does not:
+ *   '/c/x'        → 'C:\x'   (MSYS drive mapping)
+ *   '/cygdrive/c/x' → 'C:\x' (Cygwin's default prefix)
+ *   '/usr/bin'    → dropped   MSYS-internal, with no Win32 equivalent. Keeping
+ *                             it would leave an unresolvable entry on PATH;
+ *                             the caller re-seeds the real system dirs anyway.
+ */
+export function normalizeWindowsPathEntry(entry: string): string | null {
+    const value = entry.trim();
+    if (!value) return null;
+    // Already a Windows entry (drive-qualified or UNC): leave it alone.
+    if (/^[A-Za-z]:/.test(value) || value.startsWith('\\\\')) return value;
+    if (!value.startsWith('/')) return value;
+
+    const cygwin = /^\/cygdrive\/([A-Za-z])(\/.*)?$/.exec(value);
+    const msys = /^\/([A-Za-z])(\/.*)?$/.exec(value);
+    const match = cygwin ?? msys;
+    if (match) {
+        const drive = (match[1] as string).toUpperCase();
+        const rest = (match[2] ?? '').replace(/\//g, '\\');
+        return `${drive}:${rest || '\\'}`;
+    }
+    // A POSIX path with no drive mapping ('/usr/bin', '/mingw64/bin').
+    return null;
+}
+
 function windowsSystemDirs(env: NodeJS.ProcessEnv): string[] {
     const systemRoot = env['SystemRoot'] || env['windir'] || 'C:\\WINDOWS';
     const system32 = pathWin32.join(systemRoot, 'System32');
@@ -142,8 +179,17 @@ export function buildServicePath(
     env: NodeJS.ProcessEnv = process.env,
 ): string {
     const isWindows = platform === 'win32';
-    const seeded = splitPathList(seedPath, platform);
+    // Normalize BEFORE deduping: '/c/x' and 'C:\x' are the same directory
+    // spelled two ways, and only one of them is resolvable.
+    const seeded = isWindows
+        ? splitPathList(seedPath, platform)
+            .map(normalizeWindowsPathEntry)
+            .filter((entry): entry is string => entry !== null)
+        : splitPathList(seedPath, platform);
 
+    // On win32 this must be normalized too: under git-bash `process.execPath`
+    // can itself be POSIX-spelled, and it is prepended ahead of every seeded
+    // entry — so an unnormalized one puts an unresolvable path FIRST (#471).
     const common = [dirname(process.execPath)];
     const unixDefaults = [
         join(homeDir, '.local', 'bin'),
@@ -175,6 +221,8 @@ export function buildServicePath(
     ];
     const defaults = isWindows
         ? [...common, ...windowsSystemDirs(env), ...windowsUserDirs(env, homeDir)]
+            .map(normalizeWindowsPathEntry)
+            .filter((entry): entry is string => entry !== null)
         : [...common, ...unixDefaults];
 
     const listDelimiter = isWindows ? ';' : ':';

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -56,7 +56,7 @@ cli-jaw/
 │   │   ├── runtime-settings.ts ← settings side effects 통합 helper (460L)
 │   │   ├── runtime-settings-gate.ts ← settings mutation in-flight gate (41L)
 │   │   ├── codex-config.ts   ← Codex config.toml context window sync (96L)
-│   │   ├── runtime-path.ts   ← buildServicePath() PATH 보강 (nvm/fnm/homebrew/volta/asdf/cargo/bun/yarn/pnpm 14+ dirs) (182L)
+│   │   ├── runtime-path.ts   ← buildServicePath() PATH 보강 (nvm/fnm/homebrew/volta/asdf/cargo/bun/yarn/pnpm 14+ dirs) + win32 MSYS/Cygwin 항목 정규화 (230L)
 │   │   ├── noninteractive-path.ts ← 비대화형 셸(ssh 원샷)에서 jaw 해석 가능 여부 판정 + 처방 (#479) (116L)
 │   │   ├── cli-detect.ts     ← PATH 후보 spawnability 검사 + rejected candidate reason 수집 (445L)
 │   │   ├── browser-open.ts   ← 브라우저 open 정책/명령 실행 helper (68L)

--- a/tests/unit/service-reboot-hardening.test.ts
+++ b/tests/unit/service-reboot-hardening.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { buildServicePath, resolveBundledNodePath } from '../../src/core/runtime-path.ts';
+import { makeCleanEnv } from '../../src/agent/spawn.ts';
 import { readSource } from './source-normalize.js';
 
 const ROOT = process.cwd();
@@ -98,7 +99,16 @@ test('SRH-005: spawn path and detectCli logic use service-safe PATH handling', (
     const lifecycleSrc = readSource(LIFECYCLE, 'utf8');
     const dbSrc = readSource(DB, 'utf8');
 
-    assert.match(spawnSrc, /env(?:\.PATH|\["PATH"\]) = buildServicePath\(env(?:\.PATH|\["PATH"\]) \|\| ''\)/);
+    // Behavioral, not a source regex: the property this guards is "a spawned
+    // child gets the service-safe PATH", and the old pattern also pinned the
+    // exact ARGUMENT LIST, so adding a parameter broke it without any behavior
+    // changing. AGENTS.md asks for this replacement rather than a string bump.
+    const spawnedPath = makeCleanEnv({}, { PATH: '/usr/bin' }, 'linux')['PATH'] ?? '';
+    assert.ok(spawnedPath.includes('/usr/bin'), 'inherited PATH entries must survive');
+    assert.ok(
+        spawnedPath.includes('/usr/local/bin') && spawnedPath.includes('.claude/local/bin'),
+        'spawned children must receive the service-safe PATH augmentation',
+    );
     assert.match(spawnSrc, /const spawnCommand = cli === 'opencode' && process\.platform !== 'win32'/);
     assert.match(spawnSrc, /\? \(resolvedOpencodeBinary \|\| detected\.path \|\| cli\)/);
     assert.match(spawnSrc, /: \(detected\.path \|\| cli\)/);

--- a/tests/unit/spawn-env.test.ts
+++ b/tests/unit/spawn-env.test.ts
@@ -271,3 +271,18 @@ test('MCE-003: POSIX keeps Path and PATH as distinct variables', () => {
     assert.equal(result["Path"], '/some/unrelated/value');
     assert.ok(result["PATH"]!.includes('/usr/bin'));
 });
+
+test('MCE-003b: the platform argument decides, not the host running the test', () => {
+    // makeCleanEnv takes `platform`, but buildServicePath used to read
+    // process.platform instead. The two agreed on every dev machine, so the gap
+    // was invisible until win32 PATH-entry normalization landed and a POSIX env
+    // asserted on the Windows runner had its entries rewritten (#471).
+    const posix = makeCleanEnv({}, { PATH: '/usr/bin:/opt/tools' }, 'linux');
+    assert.ok(posix["PATH"]!.includes('/usr/bin'));
+    assert.ok(posix["PATH"]!.includes('/opt/tools'));
+
+    // and the win32 branch still normalizes, whatever host asks for it.
+    const win = makeCleanEnv({}, { PATH: String.raw`C:\Tools` }, 'win32');
+    assert.ok(win["PATH"]!.includes(String.raw`C:\Tools`));
+    assert.equal(win["PATH"]!.split(';').filter((entry) => entry.startsWith('/')).length, 0);
+});

--- a/tests/unit/windows-service-path.test.ts
+++ b/tests/unit/windows-service-path.test.ts
@@ -2,9 +2,67 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { buildCliDetectionEnv } from '../../src/core/cli-detect.ts';
-import { buildServicePath, splitPathList } from '../../src/core/runtime-path.ts';
+import { buildServicePath, normalizeWindowsPathEntry, splitPathList } from '../../src/core/runtime-path.ts';
 
 const WINDOWS_HOME = 'C:\\Users\\u';
+
+// ─── #471: MSYS entry FORMAT, not just the delimiter ───
+//
+// #273 fixed how a git-bash PATH is SPLIT. The entries it produced were still
+// POSIX-spelled, and `where.exe` — a native Win32 tool — cannot resolve those.
+// A server started from git-bash then resolved no CLI at all, while a natively
+// started one on the same host resolved fine.
+
+test('WSP-471-A: MSYS and Cygwin drive entries become Win32 paths', () => {
+    assert.equal(normalizeWindowsPathEntry('/c/Users/u/AppData/Roaming/npm'), 'C:\\Users\\u\\AppData\\Roaming\\npm');
+    assert.equal(normalizeWindowsPathEntry('/cygdrive/d/tools'), 'D:\\tools');
+    assert.equal(normalizeWindowsPathEntry('/c'), 'C:\\');
+});
+
+test('WSP-471-B: entries with no Win32 equivalent are dropped, not passed through', () => {
+    // Keeping '/mingw64/bin' would leave an entry no Win32 tool can resolve.
+    assert.equal(normalizeWindowsPathEntry('/mingw64/bin'), null);
+    assert.equal(normalizeWindowsPathEntry('/usr/bin'), null);
+});
+
+test('WSP-471-C: native Windows entries are left alone', () => {
+    assert.equal(normalizeWindowsPathEntry('C:\\WINDOWS\\System32'), 'C:\\WINDOWS\\System32');
+    assert.equal(normalizeWindowsPathEntry('\\\\server\\share'), '\\\\server\\share');
+    // Drive-relative entries stay valid Windows PATH entries (see splitPathList).
+    assert.equal(normalizeWindowsPathEntry('C:tools'), 'C:tools');
+});
+
+test('WSP-471-D: a git-bash PATH yields a service PATH where.exe can resolve', () => {
+    // The shape #471's process tree points at: nohup.exe -> node.exe, i.e. a
+    // win32 process launched from git-bash, inheriting a POSIX-spelled PATH.
+    const gitBashPath = '/mingw64/bin:/usr/bin:/c/Users/u/AppData/Roaming/npm';
+    const result = buildServicePath(gitBashPath, [], WINDOWS_HOME, 'win32', {
+        SystemRoot: 'C:\\WINDOWS',
+        APPDATA: 'C:\\Users\\u\\AppData\\Roaming',
+        LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local',
+    });
+    const entries = result.split(';');
+
+    // The npm global dir — where the codex.cmd shim lives — is now resolvable.
+    assert.ok(entries.includes('C:\\Users\\u\\AppData\\Roaming\\npm'));
+    // and no POSIX-spelled entry survives to be handed to where.exe.
+    assert.deepEqual(entries.filter((entry) => entry.startsWith('/')), []);
+});
+
+test('WSP-471-E: normalization does not duplicate a dir spelled both ways', () => {
+    const result = buildServicePath('/c/tools:C:\\tools', [], WINDOWS_HOME, 'win32', { SystemRoot: 'C:\\WINDOWS' });
+    const occurrences = result.split(';').filter((entry) => entry.toLowerCase() === 'c:\\tools');
+
+    assert.equal(occurrences.length, 1);
+});
+
+test('WSP-471-F: posix hosts are untouched by the win32 normalization', () => {
+    const result = buildServicePath('/usr/local/bin:/opt/tools', [], '/home/u', 'darwin', {});
+    const entries = result.split(':');
+
+    assert.ok(entries.includes('/usr/local/bin'));
+    assert.ok(entries.includes('/opt/tools'));
+});
 
 test('WSP-001: win32 defaults carry System32 and drop Unix directories', () => {
     const result = buildServicePath('', [], WINDOWS_HOME, 'win32', { SystemRoot: 'C:\\WINDOWS' });
@@ -81,7 +139,12 @@ test('WSP-007: win32 output joins with semicolons', () => {
 
     assert.ok(result.includes(';'));
     assert.equal(result.includes('/mingw64/bin:/usr/bin'), false);
-    assert.deepEqual(entries.slice(0, 2), ['/mingw64/bin', '/usr/bin']);
+    // These two used to be asserted as SURVIVING entries. They no longer do,
+    // and that is the #471 fix rather than a regression: '/mingw64/bin' and
+    // '/usr/bin' are MSYS-internal paths with no Win32 equivalent, and
+    // `where.exe` cannot resolve either. This test still owns the delimiter
+    // claim (#273); WSP-471-D owns what happens to the entries themselves.
+    assert.deepEqual(entries.filter((entry) => entry.startsWith('/')), []);
 });
 
 test('WSP-008: Windows dedupe is case-insensitive and keeps first spelling', () => {


### PR DESCRIPTION
> **Draft on purpose.** The mechanism is verified locally; the Windows-host evidence that confirms it is *the* cause of #471 is still outstanding. See "Evidence level" below.

## What

On win32, PATH entries that only MSYS/Cygwin can read are converted to Win32 form, or dropped when no equivalent exists.

```
/c/x           -> C:\x
/cygdrive/c/x  -> C:\x
/mingw64/bin   -> dropped
```

## #273 fixed the delimiter, not the format

#273 fixed how a git-bash PATH is **split** — a POSIX-delimited PATH inherited by a win32 process was split on `;` and collapsed into one entry that resolved nothing. Entry **format** was untouched. Running `buildServicePath` today:

```
in:  /mingw64/bin:/usr/bin:/c/Users/u/AppData/Roaming/npm
out: /mingw64/bin;/usr/bin;/c/Users/u/AppData/Roaming/npm;C:\WINDOWS\System32;...
```

`/c/Users/...` reaches `where.exe` verbatim, and `where.exe` is a native Win32 tool that cannot resolve it.

## Why this matches the report

The failing process tree was `nohup.exe -> node.exe`; the recovered one was `cmd.exe -> node.exe`. **`nohup.exe` does not exist on native Windows** — it is an MSYS binary. So the broken server was started from git-bash and the working one was not, with the same binary, the same JAW_HOME, and no reinstall in between.

## Dropping is the point

`/mingw64/bin` and `/usr/bin` are MSYS-internal with no Win32 equivalent. Keeping them leaves entries no Win32 tool can resolve; `buildServicePath` re-seeds the real system dirs anyway.

## Not in the plan: `process.execPath`

`dirname(process.execPath)` needed the same treatment. Under git-bash it can itself be POSIX-spelled, and it is prepended **ahead of every seeded entry** — so leaving it alone puts an unresolvable path *first*. The existing WSP-007 caught this, not a new test.

## One existing assertion changed

WSP-007 asserted that `/mingw64/bin` and `/usr/bin` **survive** into the service PATH. They no longer do, and that is this fix rather than a regression. Its assertion is updated while it keeps owning the delimiter claim from #273; what happens to the entries themselves is now owned by WSP-471-D.

## Evidence level

`where.exe`'s actual exit status on the affected host was never captured. "The lookup tool ran and refused a PATH it could not read" is a well-supported hypothesis — the error string reaches a branch only an exit-with-another-status can reach, and the process lineage is MSYS — but it is not a proven chain. **PR #493 makes that evidence appear in the next report**, which is why it sits at the bottom of this stack.

## Verification

6 new cases, all runnable on any CI OS: the conversion is a pure function taking its platform as a parameter, like `splitPathList`. `tsc --noEmit` clean; full suite 0 new failures vs an `origin/dev` baseline.

This PR also carries the devlog ref update for the #471 diagnosis and as-built notes.

Refs #471, #273

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 3 | #495 | MSYS path normalization ← you are here | win32 conversion, pure function |
| 2 | #494 | readiness contract | API shape, cache, 503 semantics |
| 1 | #493 | scan-error detail | what the error line preserves |

Review this PR's diff only; its base is the layer below.
