### PR TITLE
fix(agy): the AGY default model pointed at a retired Flash generation

### DIFF
--- a/public/js/constants.ts
+++ b/public/js/constants.ts
@@ -46,8 +46,8 @@ const FALLBACK_CLI_REGISTRY: CliRegistry = {
         // renderCliSettings appends an absent selected value as a custom option
         // (public/js/features/settings-core.ts).
         models: [
+            'Gemini 3.7 Flash (Medium)',
             'Gemini 3.6 Flash (Medium)',
-            'Gemini 3.5 Flash (Medium)',
         ],
     },
     'ai-e': {

--- a/public/manager/src/settings/pages/components/agent/agent-meta.ts
+++ b/public/manager/src/settings/pages/components/agent/agent-meta.ts
@@ -55,11 +55,11 @@ export const CLI_META: Record<string, CliMeta> = {
         // A persisted legacy value still renders: optionList() prepends the
         // current value even when it is absent from this catalog.
         models: [
+            'Gemini 3.7 Flash (Medium)',
             'Gemini 3.6 Flash (Medium)',
-            'Gemini 3.5 Flash (Medium)',
         ],
         efforts: [],
-        modelNote: 'AGY model override is version-dependent. Observed AGY 1.1.4 supports --model; cli-jaw probes the installed binary and emits this field only when supported. Leave empty to use native AGY selection.',
+        modelNote: 'AGY model override is version-dependent. Observed AGY 1.1.13 supports --model; cli-jaw probes the installed binary and emits this field only when supported. Leave empty to use native AGY selection.',
         effortNote: 'AGY has no separate effort flag.',
     },
     pi: {

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -17,24 +17,33 @@ export const CLI_REGISTRY = {
         label: 'Antigravity',
         binary: 'agy',
         experimental: true,
-        defaultModel: 'Gemini 3.5 Flash (Medium)',
+        defaultModel: 'Gemini 3.7 Flash (Medium)',
         defaultEffort: '',
         efforts: [],
         // Tier-bearing label form, which is what `agy --model` accepts on its
         // own. cli-jaw never sends --effort for AGY, and a tier-less slug is
-        // rejected in that shape ("requires --effort"). `agy models` prints a
-        // DIFFERENT, effort-suffixed slug form (gemini-3.6-flash-medium) — do
-        // not paste that output here. Refreshed 2026-07-25 against AGY 1.1.4,
-        // which added the Gemini 3.6 Flash tier. `defaultModel` intentionally
-        // stays on 3.5 Flash: promoting a default changes every new session's
-        // model, which is a policy decision, not a catalog sync.
+        // rejected in that shape ("requires --effort"). `agy models` prints two
+        // columns; the SECOND is this form. Do not paste the first (the
+        // effort-suffixed slug `gemini-3.7-flash-medium`) here.
+        //
+        // Refreshed 2026-09-02 against AGY 1.1.13 by reading `agy models`.
+        // Google pulls the previous Flash generation from Antigravity soon
+        // after the next ships, so this list is checked against the binary
+        // rather than derived: 1.1.13 offers 3.7 and 3.6 and no longer offers
+        // 3.5 at all.
+        //
+        // `defaultModel` moved off 3.5 Flash because the earlier note here --
+        // "promoting a default is a policy decision, not a catalog sync" --
+        // stopped applying once 3.5 disappeared from the binary. Keeping it
+        // was no longer a conservative choice; it pointed every new AGY
+        // session at a model AGY cannot serve.
         models: [
+            'Gemini 3.7 Flash (High)',
+            'Gemini 3.7 Flash (Medium)',
+            'Gemini 3.7 Flash (Low)',
             'Gemini 3.6 Flash (High)',
             'Gemini 3.6 Flash (Medium)',
             'Gemini 3.6 Flash (Low)',
-            'Gemini 3.5 Flash (Medium)',
-            'Gemini 3.5 Flash (High)',
-            'Gemini 3.5 Flash (Low)',
             'Gemini 3.1 Pro (High)',
             'Gemini 3.1 Pro (Low)',
             'Claude Sonnet 4.6 (Thinking)',

--- a/tests/unit/cli-registry.test.ts
+++ b/tests/unit/cli-registry.test.ts
@@ -163,10 +163,16 @@ test('ai-e per-model efforts are provider-scoped, never a flat colliding map', a
 test('Antigravity registry exposes AGY as a top-level runtime, not an ai-e provider', () => {
     assert.equal(CLI_REGISTRY.agy.label, 'Antigravity');
     assert.equal(CLI_REGISTRY.agy.binary, 'agy');
-    assert.equal(CLI_REGISTRY.agy.defaultModel, 'Gemini 3.5 Flash (Medium)');
+    assert.equal(CLI_REGISTRY.agy.defaultModel, 'Gemini 3.7 Flash (Medium)');
     assert.deepEqual(CLI_REGISTRY.agy.efforts, []);
     assert.ok(CLI_REGISTRY.agy.models.length >= 8);
-    assert.ok(CLI_REGISTRY.agy.models.includes('Gemini 3.5 Flash (Medium)'));
+    assert.ok(CLI_REGISTRY.agy.models.includes('Gemini 3.7 Flash (Medium)'));
+    // The default must be selectable, which is the invariant that broke: AGY
+    // 1.1.13 no longer lists any 3.5 Flash tier, so the previous default was
+    // unreachable. Asserting membership rather than only the string keeps a
+    // future generation bump from re-introducing that gap silently.
+    assert.ok(CLI_REGISTRY.agy.models.includes(CLI_REGISTRY.agy.defaultModel));
+    assert.equal(CLI_REGISTRY.agy.models.some((m) => m.includes('3.5 Flash')), false);
     assert.equal(CLI_REGISTRY['ai-e'].providers.includes('agy'), false);
 });
 


### PR DESCRIPTION
## Summary

cli-jaw's AGY catalog defaulted to `Gemini 3.5 Flash (Medium)`, a tier the installed AGY no longer serves. `agy models` on AGY 1.1.13 offers Gemini 3.7 and 3.6 Flash and **no 3.5 tier at all**, so every new AGY session opened on an unusable model.

This is not masked at runtime: `buildLiveCliRegistry` deliberately never overwrites `defaultModel` (`src/cli/registry-live.ts`), because `buildDefaultPerCli` seeds persisted user settings from it. A stale default stays stale even with the proxy running.

Three catalogs carry AGY models and all three were stale, so all three move together:

| Catalog | Surface | Change |
|---|---|---|
| `src/cli/registry.ts` | backend, authoritative | +3.7 trio, −3.5 trio, default → `Gemini 3.7 Flash (Medium)` |
| `public/js/constants.ts` | legacy web offline fallback | `Gemini 3.5 Flash (Medium)` → `Gemini 3.7 Flash (Medium)` |
| `public/manager/.../agent-meta.ts` | Electron Manager fallback | same, plus observed-version note 1.1.4 → 1.1.13 |

The offline fallbacks matter most here: they are what the picker shows *when the live catalog is unavailable*, so a dead entry there was handed to the user exactly when nothing else could correct it.

### 3.6 deliberately stays

`opencodex` lists the 3.6 tiers under `RETIRED_FLASH_TIERS` and aliases them to the 3.7 wire id (`src/providers/antigravity-models.ts:38-49`), which reads as "remove them". The installed binary still offers all three 3.6 rungs. For a label-form catalog the binary is the authority, so removing rows a user can still select would be a regression dressed as a cleanup. Only 3.5 — absent from the binary — is dropped.

### Why the previous pin no longer applied

The comment being replaced justified holding the default with "promoting a default is a policy decision, not a catalog sync". That was right while 3.5 worked. Once 3.5 left the binary, holding it stopped being the conservative option and became the defect.

### Model-id provenance

Ids are read from the **second** column of `agy models` — the tier-bearing label form `agy --model` accepts without `--effort` — not slugged from wire ids. Slugging the display label is the regression `opencodex` documents at `antigravity-models.ts:113-119` (#1897): it re-splits a collapsed base model into three suffix rows and strips effort control. The default's `medium` rung matches opencodex's own default for `gemini-3.7-flash` (`antigravity-models.ts:189`).

## Verification

Run on this exact head (`e4ce07eb`).

- `npm run build` — pass. `dist/src/cli/registry.js` carries the new ids (4 matches).
- `npm run build:frontend` — pass. Both fallbacks present in `public/dist/assets/constants-*.js` and `agent-meta-*.js`.
- Runtime proof from the built output, not the source: `CLI_REGISTRY.agy.defaultModel` → `Gemini 3.7 Flash (Medium)`, and `models.includes(defaultModel)` → `true`. That second check is the invariant that was broken.
- `tests/unit/{cli-registry,frontend-constants,manager-settings-model,quota-reverse-agy}.test.ts` — **zero new failures.**

Two failures appear in `cli-registry.test.ts` and are **pre-existing baseline**, not regressions: `live CLI registry preserves JWC runtime metadata` and `live CLI registry carries per-model Codex efforts including max and ultra`. Both require a running opencodex proxy and a JWC install. Proven by baseline rather than asserted — the four files were stashed and the suite re-run against pristine `origin/dev` content, which reproduced both failures identically.

`tests/unit/frontend-constants.test.ts` label-form invariant still passes: every offered value ends in a `(Low|Medium|High)` tier, and `Gemini 3.6 Flash (Medium)` is still present as the pinned known-good entry.

`quota-reverse-agy` was re-run because `classifyAgyQuotaFamily` buckets by substring on `gemini`/`claude`/`opus`/`sonnet`/`gpt-oss` (`src/routes/quota-agy-reverse.ts:39-52`); a label missing all of those is silently dropped from the quota pool. `Gemini 3.7 Flash (…)` matches `gemini`, and the tests confirm it.

## Checklist

- [x] Targets `dev`
- [x] `npm run build` run (backend `src/**` changed)
- [x] `npm run build:frontend` run (`public/js/**` and `public/manager/src/**` changed)
- [x] Focused unit tests run; new failures: none; baseline failures identified with evidence
- [x] No credential, auth, or quota-logic change. The Pi credential surface (`src/agent/pi-runtime.ts`) and the JWC auth-discovery path (`src/code-mode/model-options.ts` below line 360) are untouched.
- [x] Every model id traceable to a source: the installed `agy` binary plus `opencodex/src/providers/antigravity-models.ts`. No id invented.
- [ ] No screenshot — the change is a dropdown's option list, with no layout or styling change. The Manager surface is `agent-meta.ts` metadata only.

## Notes for the reviewer

The default change is user-visible: existing sessions keep their persisted value (settings render an absent selected value as a custom option), but **new** AGY sessions will open on 3.7 Flash instead of 3.5. That is the point of the fix, and it is the one line worth a second opinion.

This PR is one runtime out of a broader catalog audit. Still outstanding and deliberately not bundled here: OpenCode Go is missing 13 ids and its default is stale, Copilot is missing the `gpt-5.6` sol/terra/luna trio, Cursor is missing `glm-5.3` and `gpt-5.5-extra`, and the `ai-e` kiro mirror has drifted between the backend and both frontends. Each is its own runtime and its own commit.

Made with [Cursor](https://cursor.com)