### PR TITLE
feat(orchestrate): stop dropping the audit keys, and refuse a declared failed audit

### DIFF
--- a/src/orchestrator/attestation.ts
+++ b/src/orchestrator/attestation.ts
@@ -27,6 +27,24 @@ export interface PhaseAttestation {
   checkOutput?: string;
   /** Optional exit code; if present and non-zero, C→D is rejected. */
   exitCode?: number;
+  /**
+   * P→A: the plan unit this cycle is working out of, e.g. `devlog/_plan/260902_slug`.
+   * Advisory-only — a missing unit does not block, but it is no longer discarded.
+   */
+  planUnit?: string;
+  /** Optional work-phase id, for multi-cycle work under one objective. */
+  workPhaseId?: string;
+  /** A→B: pasted tail of the reviewer's verdict. */
+  auditOutput?: string;
+  /**
+   * A→B: the MAIN agent's judgement of the audit round (AUDIT-LOOP-01). A declared
+   * `fail` BLOCKS the transition; the other values pass. Unrecognized strings are
+   * dropped rather than guessed at, so a typo cannot smuggle a fail past the gate as
+   * an unknown value — it is simply absent, and absence is advisory.
+   */
+  auditVerdict?: 'pass' | 'near-pass' | 'fail';
+  /** A→B, near-pass only: each residual blocker and its disposition. */
+  auditResidual?: string;
   /** The raw source the attestation was parsed from (block text or JSON string). */
   raw: string;
 }
@@ -52,6 +70,18 @@ function coerce(obj: Record<string, unknown>, raw: string): PhaseAttestation | n
   if (typeof obj['checkOutput'] === 'string') att.checkOutput = obj['checkOutput'].trim();
   if (typeof obj['exitCode'] === 'number' && Number.isFinite(obj['exitCode'])) {
     att.exitCode = obj['exitCode'] as number;
+  }
+  // Audit and plan-unit fields. These used to be dropped here with no error and no
+  // warning, which meant a caller could write `auditVerdict: "fail"` and watch the
+  // transition succeed — the field vanished before any gate saw it. Parsing them does
+  // not by itself make them required; see checkAttestationGate for what each one does.
+  for (const key of ['planUnit', 'workPhaseId', 'auditOutput', 'auditResidual'] as const) {
+    const v = obj[key];
+    if (typeof v === 'string' && v.trim()) att[key] = v.trim();
+  }
+  const verdict = obj['auditVerdict'];
+  if (verdict === 'pass' || verdict === 'near-pass' || verdict === 'fail') {
+    att.auditVerdict = verdict;
   }
   return att;
 }
@@ -136,6 +166,42 @@ export function checkAttestationGate(
       reason: `${from} → ${to} attestation needs a specific "did" narrative (not empty or a placeholder) describing what you actually did.`,
     };
   }
+  if (key === 'A>B') {
+    // AUDIT-LOOP-01: a FAIL round never exits A. This is the one audit rule a form-only
+    // gate can actually enforce — it needs no cross-check against runtime state, only
+    // the agent's own recorded judgement. Blocking here cannot break an existing caller
+    // because nothing sent this field until now; the field's absence stays advisory.
+    if (att.auditVerdict === 'fail') {
+      return {
+        ok: false,
+        reason:
+          `A → B is refused: the attestation declares auditVerdict "fail". A failed audit round ` +
+          `never exits A (AUDIT-LOOP-01). Record the synthesis (per-blocker root cause, conflicts, ` +
+          `accept/rebut per point), amend the plan, and re-audit with the SAME reviewer. After 3 ` +
+          `failed rounds, return to P with a changed plan instead.`,
+      };
+    }
+    if (att.auditVerdict === 'near-pass' && !att.auditResidual) {
+      return {
+        ok: false,
+        reason:
+          `A → B declares auditVerdict "near-pass" but carries no "auditResidual". Near-pass means ` +
+          `every High/Critical blocker was folded in as a concrete amendment or explicitly rebutted ` +
+          `with recorded rationale — name each residual and its disposition, or declare "pass".`,
+      };
+    }
+    const advisory = checkAuditEvidenceAdvisory(att);
+    if (advisory) return { ok: true, advisory };
+  }
+  if (key === 'P>A' && !att.planUnit) {
+    return {
+      ok: true,
+      advisory:
+        `[UNIT-RESIDENCE-01 advisory] P → A carries no "planUnit". The diff-level plan should ` +
+        `live in a real devlog/_plan/YYMMDD_slug/ unit rather than only in this narrative. ` +
+        `Pass it as "planUnit" so a later reader can find the plan this cycle was built from.`,
+    };
+  }
   if (key === 'C>D') {
     if (!att.checkOutput) {
       return {
@@ -158,6 +224,28 @@ export function checkAttestationGate(
     }
   }
   return { ok: true };
+}
+
+// ─── Audit-evidence soft warning (AUDIT-LOOP-01) ────────────────
+// A→B is where a plan audit is supposed to have happened. The gate cannot verify that a
+// reviewer really ran — that is the faithful-execution obligation the form-only gate
+// explicitly does not cover — but it CAN notice that the attestation offers no evidence
+// either way, and say so instead of passing in silence.
+
+/**
+ * Returns advisory text when an A→B attestation records no audit evidence at all: no
+ * verdict, and no pasted reviewer output. Returns null once either is present, since a
+ * `pass` with output is a complete claim and a bare `pass` is at least an explicit one.
+ */
+export function checkAuditEvidenceAdvisory(att: PhaseAttestation): string | null {
+  if (att.auditVerdict || att.auditOutput) return null;
+  return (
+    '[AUDIT-LOOP-01 advisory] A → B carries no "auditVerdict" and no "auditOutput". ' +
+    'A is a loop — audit, synthesize, amend, re-audit — and it exits only on a ' +
+    'main-agent-judged pass or near-pass. Record the judgement as "auditVerdict" ' +
+    '("pass" | "near-pass" | "fail") and paste the reviewer\'s verdict tail as ' +
+    '"auditOutput", so the round is re-readable later. A declared "fail" is refused.'
+  );
 }
 
 // ─── Render-grounding soft warning (C-RENDER-GROUNDING-01) ──────

--- a/tests/unit/phase-attestation.test.ts
+++ b/tests/unit/phase-attestation.test.ts
@@ -6,6 +6,7 @@ import {
   stripPhaseAttestation,
   checkAttestationGate,
   checkRenderGroundingAdvisory,
+  checkAuditEvidenceAdvisory,
   detectNoStateNarration,
 } from '../../src/orchestrator/attestation.ts';
 
@@ -202,4 +203,98 @@ test('ATT-RENDER-008: C→D gate result has no advisory for non-render work', ()
   const result = checkAttestationGate('C', 'D', att);
   assert.equal(result.ok, true);
   assert.equal(result.advisory, undefined, 'no advisory for non-render work');
+});
+
+// ─── audit and plan-unit keys (AUDIT-LOOP-01) ────────
+// Before this, coerce() dropped every one of these with no error and no warning, so a
+// caller could declare a failed audit and watch A→B succeed. The first test is the
+// regression that used to pass silently.
+
+test('ATT-AUDIT-001: a declared auditVerdict "fail" is REFUSED on A→B', () => {
+  const att = parsePhaseAttestationObject({
+    from: 'A', to: 'B',
+    did: 'reviewer found 2 High blockers in the migration plan',
+    auditVerdict: 'fail',
+    auditOutput: 'VERDICT: FAIL\n1. rollback path missing\n2. caller list incomplete',
+  })!;
+  assert.equal(att.auditVerdict, 'fail', 'the field must survive parsing');
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, false, 'a failed audit round never exits A');
+  assert.match(result.reason!, /AUDIT-LOOP-01/);
+  assert.match(result.reason!, /SAME reviewer/);
+});
+
+test('ATT-AUDIT-002: "near-pass" without auditResidual is refused', () => {
+  const att = parsePhaseAttestationObject({
+    from: 'A', to: 'B', did: 'audited; folded 2 blockers', auditVerdict: 'near-pass',
+  })!;
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, false);
+  assert.match(result.reason!, /auditResidual/);
+});
+
+test('ATT-AUDIT-003: "near-pass" WITH auditResidual passes', () => {
+  const att = parsePhaseAttestationObject({
+    from: 'A', to: 'B', did: 'audited; folded 2 blockers', auditVerdict: 'near-pass',
+    auditResidual: 'B1 folded as amendment 3; B2 rebutted — the caller is generated, not hand-written',
+  })!;
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, true);
+  assert.equal(result.advisory, undefined);
+});
+
+test('ATT-AUDIT-004: an unrecognized auditVerdict is dropped, not guessed at', () => {
+  // A typo must not smuggle a fail past the gate as an unknown value, and must not be
+  // coerced into a pass either. It is simply absent, and absence is advisory.
+  const att = parsePhaseAttestationObject({
+    from: 'A', to: 'B', did: 'audited the plan', auditVerdict: 'FAILED',
+  })!;
+  assert.equal(att.auditVerdict, undefined);
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, true);
+  assert.match(result.advisory!, /AUDIT-LOOP-01 advisory/);
+});
+
+test('ATT-AUDIT-005: A→B with no audit evidence passes with an advisory', () => {
+  const att = parsePhaseAttestationObject({ from: 'A', to: 'B', did: 'audited the plan against the tree' })!;
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, true, 'absence advises, it does not block');
+  assert.match(result.advisory!, /auditVerdict/);
+});
+
+test('ATT-AUDIT-006: a bare "pass" is explicit enough to silence the advisory', () => {
+  const att = parsePhaseAttestationObject({ from: 'A', to: 'B', did: 'audited', auditVerdict: 'pass' })!;
+  const result = checkAttestationGate('A', 'B', att);
+  assert.equal(result.ok, true);
+  assert.equal(result.advisory, undefined);
+});
+
+test('ATT-AUDIT-007: planUnit and workPhaseId survive parsing', () => {
+  const att = parsePhaseAttestationObject({
+    from: 'P', to: 'A', did: 'wrote the diff-level plan',
+    planUnit: 'devlog/_plan/260902_slug', workPhaseId: 'wp3',
+  })!;
+  assert.equal(att.planUnit, 'devlog/_plan/260902_slug');
+  assert.equal(att.workPhaseId, 'wp3');
+  assert.equal(checkAttestationGate('P', 'A', att).advisory, undefined);
+});
+
+test('ATT-AUDIT-008: P→A without planUnit advises but does not block', () => {
+  const att = parsePhaseAttestationObject({ from: 'P', to: 'A', did: 'wrote the plan in this reply' })!;
+  const result = checkAttestationGate('P', 'A', att);
+  assert.equal(result.ok, true);
+  assert.match(result.advisory!, /UNIT-RESIDENCE-01 advisory/);
+});
+
+test('ATT-AUDIT-009: checkAuditEvidenceAdvisory is silent once either field is present', () => {
+  const withOutput = parsePhaseAttestationObject({ from: 'A', to: 'B', did: 'x', auditOutput: 'VERDICT: PASS' })!;
+  assert.equal(checkAuditEvidenceAdvisory(withOutput), null);
+  const bare = parsePhaseAttestationObject({ from: 'A', to: 'B', did: 'x' })!;
+  assert.ok(checkAuditEvidenceAdvisory(bare));
+});
+
+test('ATT-AUDIT-010: the new keys do not affect ungated or other edges', () => {
+  // A fail declared on the wrong edge must not block it — the rule is about A→B.
+  const att = parsePhaseAttestationObject({ from: 'B', to: 'C', did: 'implemented', auditVerdict: 'fail' })!;
+  assert.equal(checkAttestationGate('B', 'C', att).ok, true);
 });


### PR DESCRIPTION
## Summary

The attest parser accepted five keys and **silently discarded everything else** — no error, no warning. A caller could write `auditVerdict: "fail"` into the JSON and watch `A→B` succeed, because the field vanished in `coerce()` before any gate saw it. Six keys were affected: `planUnit`, `workPhaseId`, `auditOutput`, `auditVerdict`, `auditResidual`, `testReceiptPath`.

This is the **code half of a two-part decision**. The skills half landed in [cli-jaw-skills #2](https://github.com/lidge-jun/cli-jaw-skills/pull/2): `jaw-dev-pabcd`'s `ATTEST-SHAPE-01` tells agents to carry the plan-unit pointer *inside* `did` **because** the keys were dropped. That instruction was honest about the runtime as it was; this PR changes the runtime so the keys mean something.

## Three strengths, pre-declared

`DEVOPS-GATE-WEAKEN-01` cuts against tightening a gate after the fact, so each level is chosen deliberately rather than retrofitted:

| Behavior | Edge | Why this strength |
|---|---|---|
| **BLOCK** — `auditVerdict: "fail"` | `A→B` | `AUDIT-LOOP-01` says a failed round never exits A. This is the one audit rule a form-only gate can enforce: it needs no cross-check against runtime state, only the agent's own recorded judgement. Blocking cannot break an existing caller, because nothing sent this field until now. |
| **BLOCK** — `near-pass` with no `auditResidual` | `A→B` | Near-pass means every High/Critical blocker was folded in or explicitly rebutted. Claiming it without naming the residuals is the claim without its content. |
| **ADVISE** — no audit evidence at all | `A→B` | Absence advises rather than blocks, so every existing attest form keeps working. |
| **ADVISE** — no `planUnit` | `P→A` | Same reason. `UNIT-RESIDENCE-01` wants the plan in a real unit, but a narrative-only plan is not a gate failure. |

An unrecognized `auditVerdict` is **dropped rather than guessed at**, and that matters in both directions: a typo must not smuggle a fail past the gate as an unknown value, and must not be coerced into a pass either. It becomes absent, and absence is advisory.

`testReceiptPath` is intentionally **still not accepted** — cli-jaw has no receipt command for it to point at, so parsing it would create a field with no producer.

The advisory path reuses the existing `GateResult.advisory` seam that `C-RENDER-GROUNDING-01` already uses, so nothing new was invented for the soft cases.

## Tests

10 new cases in `tests/unit/phase-attestation.test.ts`.

**`ATT-AUDIT-001` is the regression that used to pass silently.** It asserts both halves: that a declared `fail` survives parsing, *and* that the gate then refuses the transition. Either assertion alone would have passed before this change for the wrong reason.

`ATT-AUDIT-010` pins the scope — a `fail` declared on `B→C` must not block it, since the rule is about the A gate specifically. `ATT-AUDIT-004` covers the typo case in both directions.

## Verification

- `npx tsc --noEmit -p tsconfig.build.json` — clean.
- `npm run build` — pass.
- `tests/unit/phase-attestation.test.ts` — **38/38**.
- The five orchestrate contract tests (`phase-attestation-wiring`, `orchestrate-cli-contract`, `orchestrate-phase-command-contract`, `orchestrate-plan-guard`, `orchestrate-route-gate-e2e`) — **31/31**.

No frontend change, so no `build:frontend` needed. Two files, no dependency or config changes.

## Relationship to the other open PRs

Independent of the model-catalog stack ([#496](https://github.com/lidge-jun/cli-jaw/pull/496) → [#497](https://github.com/lidge-jun/cli-jaw/pull/497) → [#499](https://github.com/lidge-jun/cli-jaw/pull/499)) and of the submodule pointer ([#498](https://github.com/lidge-jun/cli-jaw/pull/498)), so it targets `dev` directly rather than stacking. Merge order is free.

Worth reading alongside cli-jaw-skills #2: that PR documents the gate as it was, this one changes it. If both land, `ATTEST-SHAPE-01`'s wording is worth a follow-up pass — the keys it says are dropped are no longer all dropped, though the guidance to keep the pointer in `did` stays valid for readability.

Made with [Cursor](https://cursor.com)

## Checklist

- [x] Targets `dev`
- [x] `npm run build` run (backend `src/**` changed)
- [x] No `build:frontend` needed — no frontend surface touched
- [x] `npx tsc --noEmit -p tsconfig.build.json` clean
- [x] Focused tests run: `phase-attestation` 38/38, plus the five orchestrate contract tests 31/31; new failures: none
- [x] Regression test included that fails without the fix (`ATT-AUDIT-001`)
- [x] No credential, auth, or quota-logic change — orchestrator transition gate only
- [ ] No screenshot — no UI surface
