### PR TITLE
fix(deps): patch browserslist to 4.28.8 to clear the HIGH advisory blocking every PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3600,9 +3600,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.22",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
-      "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3677,9 +3677,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -3697,11 +3697,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3749,9 +3749,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -4806,9 +4806,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7706,11 +7706,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "3.1.0",
@@ -9471,9 +9474,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

The dependency advisory gate has been failing on **every** open pull request on this repository — including [#498](https://github.com/lidge-jun/cli-jaw/pull/498), which changes only two submodule gitlinks, and pre-existing [#473](https://github.com/lidge-jun/cli-jaw/pull/473). Two HIGH advisories against `browserslist` had no allowlist entry:

| Advisory | Vector |
|---|---|
| [GHSA-c83g-rgw3-j3cx](https://github.com/advisories/GHSA-c83g-rgw3-j3cx) | Unbounded memory growth (no cache eviction) via distinct query results, leading to eventual OOM |
| [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) | Uncaught crash / prototype write via untrusted `browserslist-stats.json` custom stats (`normalizeStats`) |

## This was not caused by any open PR

Three independent lines of evidence, because "CI went red" invites the assumption that someone's change did it:

1. **#498 fails identically**, and it changes only two submodule SHAs. A pointer commit cannot introduce a dependency advisory.
2. Every affected branch has a `package-lock.json` **byte-identical to `dev`'s** (`git diff --quiet origin/dev HEAD -- package-lock.json`).
3. **`dev`'s last green run is 2026-08-22; these runs are 2026-09-02.** Same dependency tree, opposite result, eleven days apart. The gate queries a live advisory database, so the advisories were published in that window.

## Why upgrade rather than an allowlist entry

The gate offers both remedies: *"Either upgrade the package, or add an entry to `scripts/audit-allowlist.json` stating why the vulnerable path is unreachable."*

Upgrade is the right one. The vulnerable range is `<=4.28.6` and **4.28.8 is published**, so this is a patch bump inside the same minor — not a tolerated exposure.

The reachability argument would have been easy to write: `browserslist` resolves through exactly one path, `@vitejs/plugin-react` → `@babel/core` → `@babel/helper-compilation-targets`, which `npm explain` marks `dev`, and neither advisory is reachable without attacker-controlled input to a build tool. **That is precisely why an entry would have been the wrong call** — `audit-allowlist.json` says an entry "is a decision, not a mute," and it is for advisories we choose to *carry*. There is no reason to carry one that has a published patch.

`package.json` is untouched; only the lockfile resolution moved. The footprint is `browserslist` plus its own data packages:

```
browserslist            4.28.2       -> 4.28.8
caniuse-lite            1.0.30001790 -> 1.0.30001810
electron-to-chromium    1.5.344      -> 1.5.420
node-releases           2.0.38       -> 2.0.54
update-browserslist-db  1.2.3        -> 1.3.2
```

## Verification

| Check | Result |
|---|---|
| `npx tsx scripts/check-deps-audit.ts` | **PASS** — "11 advisory package(s); 11 allowlisted, 0 unexpected" |
| `npm run build` | pass |
| `npm run build:frontend` | pass — this is the build that actually consumes `browserslist` (autoprefixer targets), so the data-package bumps are exercised rather than merely installed |
| `npm test` | **8410 tests, 8384 pass, 0 fail, 26 skipped** |

**Attribution note for anyone reproducing the test run.** A first pass showed 10 failures, all of them skill-file tests reading `skills_ref` (`WAIS-001..004`, `EMP-008`, `P37-CU-010`, and others). The submodule was checked out on a stale local branch predating the `jaw-` rename, so those tests were looking for `jaw-*` paths absent from that tree. Aligning `skills_ref` to the SHA `dev` records turns the same two files from 0/6 to 6/6, and the full suite to 0 fail. Unrelated to this change, but worth recording so the number is not mistaken for a regression later.

## Security review requested

`AGENTS.md` reserves dependency changes for explicit security review, so this is deliberately a **separate PR** rather than folded into the skill or model-catalog stacks. It touches no credential, auth, or quota path — lockfile only.

## Checklist

- [x] Targets `dev`
- [x] `npm run build` run
- [x] `npm run build:frontend` run
- [x] Full `npm test` run (a lockfile change is repo-wide, so the scoped default does not apply): 0 failures
- [x] Advisory gate verified green locally on this exact head
- [x] `package.json` unchanged — no new or removed dependency declaration
- [x] No credential, auth, or quota-logic change
- [ ] Security review pending per `AGENTS.md` (dependency change)
- [ ] No screenshot — no UI surface

Made with [Cursor](https://cursor.com)