### PR TITLE
fix(jwc): derive the unconfigured default model from the provider list, not a literal

### DIFF
--- a/src/core/runtime-settings.ts
+++ b/src/core/runtime-settings.ts
@@ -3,6 +3,7 @@ import {
     ensureWorkingDirSkillsLinks, initMcpConfig,
 } from '../../lib/mcp-sync.js';
 import { syncCodexContextWindow } from './codex-config.js';
+import { JWC_PROVIDER_MODEL_DEFAULTS } from '../code-mode/model-options.js';
 import {
     settings, persistAndCommit, snapshotSettingsState, migrateSettings, normalizeProjectDirs,
     RUNTIME_DEFAULT_MIGRATION_ID, type RuntimeDefaultMigration,
@@ -136,14 +137,21 @@ export async function withMultiSessionDefaultMigrationLock<T>(work: () => Promis
     }
 }
 
-function syncJwcConfigDefault(currentSettings: Record<string, any>): void {
+export function syncJwcConfigDefault(currentSettings: Record<string, any>): void {
     try {
         const cli = currentSettings["cli"];
         if (cli !== 'jwc') return;
         const ao = currentSettings["activeOverrides"]?.['jwc'] as Record<string, string> | undefined;
         const pc = currentSettings["perCli"]?.['jwc'] as Record<string, string> | undefined;
-        const model = ao?.['model'] || pc?.['model'] || 'claude-sonnet-4-6';
         const provider = ao?.['provider'] || pc?.['provider'] || 'anthropic';
+        // Derive the unconfigured fallback from the provider's own default list instead of
+        // repeating a literal here. The literal had drifted to claude-sonnet-4-6, seventh
+        // in the anthropic list and a generation behind its head, and a catalog refresh
+        // could not carry it: nothing links the two. Taking the head means a user who
+        // never picked a model gets what the rest of the system already calls that
+        // provider's default, and the next refresh moves this with it.
+        const model = ao?.['model'] || pc?.['model'] || JWC_PROVIDER_MODEL_DEFAULTS[provider]?.[0];
+        if (!model) return;
         const modelRole = provider !== 'anthropic' ? `${provider}/${model}` : `${provider}/${model}`;
         const agentDir = process.env['CLI_JAW_JWC_AGENT_DIR'] || join(homedir(), '.jwc', 'agent');
         const configPath = join(agentDir, 'config.yml');

--- a/tests/unit/code-model-default-contract.test.ts
+++ b/tests/unit/code-model-default-contract.test.ts
@@ -91,3 +91,67 @@ test('model popup exposes session-independent Set default path', () => {
     assert.ok(client.includes("'/api/code/model-default'"), 'client must expose model-default route');
     assert.ok(routes.includes("app.post('/api/code/model-default'"), 'server must expose model-default route');
 });
+
+// ─── JWC unconfigured fallback derives from the provider list ─────
+// The fallback used to be a literal, claude-sonnet-4-6, which had drifted to seventh in
+// the anthropic default list and a generation behind its head. Nothing linked the two, so
+// a catalog refresh could not carry it. These tests pin the derivation, not a version
+// string, so they keep passing when the catalog moves and fail if the link is cut.
+
+async function runJwcSync(settings: Record<string, unknown>): Promise<string | null> {
+    const { syncJwcConfigDefault } = await import('../../src/core/runtime-settings.ts');
+    const dir = await mkdtemp(join(tmpdir(), 'jaw-jwc-default-'));
+    const prev = process.env['CLI_JAW_JWC_AGENT_DIR'];
+    process.env['CLI_JAW_JWC_AGENT_DIR'] = dir;
+    try {
+        syncJwcConfigDefault(settings as Record<string, any>);
+        return await readFile(join(dir, 'config.yml'), 'utf8').catch(() => null);
+    } finally {
+        if (prev === undefined) delete process.env['CLI_JAW_JWC_AGENT_DIR'];
+        else process.env['CLI_JAW_JWC_AGENT_DIR'] = prev;
+        await rm(dir, { recursive: true, force: true });
+    }
+}
+
+test('CMDC-JWC-001: an unconfigured jwc writes the head of the provider default list', async () => {
+    const { JWC_PROVIDER_MODEL_DEFAULTS } = await import('../../src/code-mode/model-options.ts');
+    const expected = JWC_PROVIDER_MODEL_DEFAULTS['anthropic']?.[0];
+    assert.ok(expected, 'anthropic must have a default list to derive from');
+    const written = await runJwcSync({ cli: 'jwc' });
+    assert.ok(written, 'config.yml should be written');
+    assert.match(written!, /modelRoles:/);
+    assert.match(written!, new RegExp(`default: anthropic/${expected!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`));
+});
+
+test('CMDC-JWC-002: the fallback is not the stale literal', async () => {
+    const written = await runJwcSync({ cli: 'jwc' });
+    const { JWC_PROVIDER_MODEL_DEFAULTS } = await import('../../src/code-mode/model-options.ts');
+    // Only meaningful while sonnet-4-6 is NOT the head; if a future refresh makes it the
+    // head again this assertion correctly stops applying rather than failing wrongly.
+    if (JWC_PROVIDER_MODEL_DEFAULTS['anthropic']?.[0] !== 'claude-sonnet-4-6') {
+        assert.doesNotMatch(written!, /claude-sonnet-4-6/);
+    }
+});
+
+test('CMDC-JWC-003: an explicit model still wins over the derived default', async () => {
+    const written = await runJwcSync({ cli: 'jwc', perCli: { jwc: { model: 'claude-opus-5', provider: 'anthropic' } } });
+    assert.match(written!, /default: anthropic\/claude-opus-5\b/);
+    const overridden = await runJwcSync({
+        cli: 'jwc',
+        perCli: { jwc: { model: 'claude-opus-5' } },
+        activeOverrides: { jwc: { model: 'claude-sonnet-5' } },
+    });
+    assert.match(overridden!, /default: anthropic\/claude-sonnet-5\b/);
+});
+
+test('CMDC-JWC-004: an unknown provider writes nothing rather than a model it lacks', async () => {
+    // The old literal was written for ANY provider, so an unknown one got
+    // `<provider>/claude-sonnet-4-6` -- a model that provider does not have. Writing
+    // nothing is the better failure.
+    const written = await runJwcSync({ cli: 'jwc', perCli: { jwc: { provider: 'no-such-provider' } } });
+    assert.equal(written, null);
+});
+
+test('CMDC-JWC-005: a non-jwc cli is untouched', async () => {
+    assert.equal(await runJwcSync({ cli: 'claude' }), null);
+});


### PR DESCRIPTION
## Summary

`src/core/runtime-settings.ts` is one of the nine files this work's model-catalog objective named, and it was the **last one still holding a stale hardcoded id**. `syncJwcConfigDefault` fell back to `'claude-sonnet-4-6'` when neither `activeOverrides` nor `perCli` specified a model — seventh in `JWC_PROVIDER_MODEL_DEFAULTS.anthropic`, and a generation behind its head.

Bumping the literal would have been the smaller change and the wrong one: **nothing linked it to the list**, so the next catalog refresh would have left it behind again exactly as this one did. It now takes the head of the provider's own default list, so a user who never picked a model gets what the rest of the system already calls that provider's default, and a refresh moves this with it.

```
anthropic    -> claude-fable-5   (head of the list, was claude-sonnet-4-6)
xai          -> grok-4.5
cursor       -> auto
unknown      -> nothing written
```

## A second bug the derivation removes

The literal was written for **any** provider. An unknown or non-anthropic provider therefore got `<provider>/claude-sonnet-4-6` — a model that provider does not have — written into JWC's `config.yml`. With no list to derive from, the function now returns early and writes nothing. That is the better failure: a missing model role is recoverable, a confidently wrong one is not.

## Tests

5 behavior tests, driven through the `CLI_JAW_JWC_AGENT_DIR` env var the function already honors, so they assert the written `config.yml` rather than matching source text.

They pin the **derivation**, not a version string. `CMDC-JWC-001` reads the expected value from `JWC_PROVIDER_MODEL_DEFAULTS` at runtime, so it keeps passing when the catalog moves and fails if the link is cut. `CMDC-JWC-002` guards the specific stale literal but skips itself if a future refresh legitimately makes `sonnet-4-6` the head again.

**Proven non-vacuous.** Reverting the source to its pre-fix shape fails `CMDC-JWC-001`, `-002` and `-004`; restoring it passes 11/11.

`syncJwcConfigDefault` is now exported for that test. It was module-private, and the alternative was another source-regex test — which `AGENTS.md` discourages, and which would not have caught this anyway, since the stale literal was present in the source either way.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit -p tsconfig.build.json` | clean |
| `npm run build` | pass |
| `code-model-default-contract`, `code-model-assignment-contract`, `runtime-settings*` | **24/24** |
| Pre-fix revert | 3 of the 5 new tests fail, as intended |

No import cycle: `model-options.ts` does not import `runtime-settings.ts`, and `registry-live.ts` already imports from that module.

## Relationship to the other PRs

Independent of the model-catalog stack ([#496](https://github.com/lidge-jun/cli-jaw/pull/496) → [#497](https://github.com/lidge-jun/cli-jaw/pull/497) → [#499](https://github.com/lidge-jun/cli-jaw/pull/499)), so it targets `dev`. It works either way: with #499 merged the derived anthropic head becomes `claude-fable-5-1`, and this change picks that up automatically rather than needing an edit — which is the point.

## Checklist

- [x] Targets `dev`
- [x] `npm run build` run (backend `src/**` changed)
- [x] No `build:frontend` needed — no frontend surface touched
- [x] Focused tests run: 24/24, new failures 0
- [x] Regression tests included, proven to fail without the fix
- [x] No invented model ids — the change removes a literal rather than adding one
- [x] No credential, auth, or quota-logic change. This writes a `modelRoles.default` line; the JWC auth-discovery path is untouched.
- [ ] No screenshot — no UI surface

Made with [Cursor](https://cursor.com)