### PR TITLE
feat(manager): t3-style design-token foundation (wp1)

### DIFF
--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -115,7 +115,7 @@ h2 { font-size: 13px; }
     width: 100%;
     min-height: 30px;
     border: 1px solid var(--border-strong);
-    border-radius: 7px;
+    border-radius: var(--control-radius);
     background: var(--canvas-deep);
     color: var(--text-primary);
     padding: 6px 9px;
@@ -125,14 +125,14 @@ h2 { font-size: 13px; }
 .command-mini-stat {
     border: 1px solid var(--border-subtle);
     background: var(--canvas-soft);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     color: var(--text-secondary);
     font-size: 11px;
     padding: 5px 7px;
     white-space: nowrap;
 }
 .command-mini-stat {
-    font-family: "Geist Mono", "JetBrains Mono", monospace;
+    font-family: var(--font-mono);
     color: var(--text-primary);
 }
 .state {
@@ -225,7 +225,7 @@ h2 { font-size: 13px; }
 }
 .instance-row {
     position: relative; display: grid; gap: 8px; margin-bottom: 7px;
-    border: 1px solid transparent; border-radius: 8px; background: transparent; padding: 10px;
+    border: 1px solid transparent; border-radius: var(--radius-md); background: transparent; padding: 10px;
 }
 .instance-row.density-compact {
     gap: 6px;
@@ -233,12 +233,12 @@ h2 { font-size: 13px; }
 }
 .instance-row.priority-active {
     border-color: var(--border-strong);
-    background: var(--row-bg);
+    background: var(--sidebar-row-active);
 }
-.instance-row:hover, .instance-row:focus-within { border-color: transparent; background: var(--row-bg-hover); }
+.instance-row:hover, .instance-row:focus-within { border-color: transparent; background: var(--sidebar-row-hover); }
 .instance-row-select {
     width: 100%; min-height: 0; min-width: 0; display: grid; gap: 8px; border: 0;
-    background: transparent; color: inherit; border-radius: 6px; padding: 0;
+    background: transparent; color: inherit; border-radius: var(--radius-sm); padding: 0;
     grid-template-columns: minmax(0, 1fr);
     justify-self: stretch; justify-content: start; justify-items: stretch;
     align-content: start; align-items: start;
@@ -250,10 +250,10 @@ h2 { font-size: 13px; }
     transform: none;
 }
 .instance-row-select:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: var(--focus-ring);
     outline-offset: 2px;
 }
-.instance-row.priority-active.is-selected { border-color: transparent; background: var(--surface-raised); }
+.instance-row.priority-active.is-selected { border-color: transparent; background: var(--sidebar-row-selected); }
 .instance-row:not(.priority-active).is-selected {
     border-color: color-mix(in srgb, var(--accent) 42%, transparent);
     background: color-mix(in srgb, var(--accent) 6%, transparent);
@@ -290,11 +290,11 @@ h2 { font-size: 13px; }
     min-height: 24px;
     padding: 0;
     border: 1px solid var(--border-subtle);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     background: transparent;
     color: var(--text-secondary);
     cursor: pointer;
-    transition: color 0.12s, border-color 0.12s, background 0.12s;
+    transition: color var(--motion-fast), border-color var(--motion-fast), background var(--motion-fast);
 }
 .quick-btn:hover { color: var(--text-primary); background: var(--surface-raised); }
 .quick-btn.action-stop { border-color: color-mix(in srgb, var(--status-error) 30%, var(--border-subtle)); color: var(--status-error); }

--- a/public/manager/src/manager-polish.css
+++ b/public/manager/src/manager-polish.css
@@ -28,7 +28,7 @@
 
 .rail-button-short {
     display: none;
-    font-family: "Geist Mono", "JetBrains Mono", monospace;
+    font-family: var(--font-mono);
     font-weight: 700;
 }
 
@@ -189,7 +189,7 @@
 .manager-sidebar .instance-row {
     gap: 4px;
     margin-bottom: 4px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     padding: 7px 8px;
 }
 
@@ -273,6 +273,7 @@
 .manager-sidebar .instance-actions button,
 .manager-sidebar .instance-actions .open-link {
     min-height: 24px;
+    border-radius: var(--control-radius);
     padding-inline: 5px;
     font-size: 10.5px;
 }

--- a/public/manager/src/manager-tokens.css
+++ b/public/manager/src/manager-tokens.css
@@ -1,32 +1,33 @@
 /* ──────────────────────────────────────────────────────────────────────────
- * 10.6.9a — Theme tokens for the manager dashboard.
+ * Theme tokens for the manager dashboard (260902 t3 shell polish, wp1).
  *
  * Three-tier hierarchy:
- *   primitive  raw color values (referenced only inside this file)
+ *   primitive  raw scale values (referenced only inside this file)
  *   semantic   intent-based aliases (consumed by all other CSS)
  *   component  declared in component CSS only when truly divergent
  *
- * The semantic layer keeps the legacy variable names so existing CSS files
- * (styles, layout, components, persistence, polish) keep rendering without
- * being rewritten in this slice. New `--surface-*` and `--ink-*` aliases are
- * exposed for future code; they map to the same legacy values.
+ * Every legacy variable name is preserved; only values moved to the
+ * zinc/neutral oklch scale with a single oklch primary accent
+ * (devlog/_plan/260902_t3_shell_polish/010_design_tokens.md).
+ * `--accent` is the CTA primary, not a surface tint.
  *
  * Theme resolution lives on <html data-theme="dark|light|auto">. The inline
  * boot script in index.html sets this attribute before paint to prevent FOUC.
  * ────────────────────────────────────────────────────────────────────────── */
 
-/* Primitive scale ─ never consumed outside this file. */
+/* Primitive scale — never consumed outside this file (radius/font/motion are
+ * theme-independent semantics that also live here). */
 :root {
-    --jp-gray-50:  #f7f8fa;
-    --jp-gray-100: #eef0f3;
-    --jp-gray-200: #e2e6ec;
-    --jp-gray-300: #cdd3dc;
-    --jp-gray-400: #a8b0bc;
-    --jp-gray-500: #6b7382;
-    --jp-gray-600: #4d5662;
-    --jp-gray-700: #2f3742;
-    --jp-gray-800: #1a2027;
-    --jp-gray-900: #111418;
+    --jp-gray-50:  oklch(98.5% 0 0);
+    --jp-gray-100: oklch(96.7% 0.001 286.375);
+    --jp-gray-200: oklch(92% 0.004 286.32);
+    --jp-gray-300: oklch(87.1% 0.006 286.286);
+    --jp-gray-400: oklch(70.5% 0.015 286.067);
+    --jp-gray-500: oklch(55.2% 0.016 285.938);
+    --jp-gray-600: oklch(44.2% 0.017 285.786);
+    --jp-gray-700: oklch(37% 0.013 285.805);
+    --jp-gray-800: oklch(27.4% 0.006 286.033);
+    --jp-gray-900: oklch(21% 0.006 285.885);
 
     --jp-blue-100: #dbe7ff;
     --jp-blue-300: #8fb8f7;
@@ -35,44 +36,59 @@
     --jp-blue-600: #1f6feb;
     --jp-blue-700: #155bbb;
 
-    --jp-green-400: #34d399;
-    --jp-green-600: #15803d;
-    --jp-amber-400: #f5a524;
-    --jp-amber-600: #b45309;
-    --jp-red-400:   #f87171;
-    --jp-red-600:   #b91c1c;
-    --jp-slate-400: #7b8797;
-    --jp-slate-500: #6b7382;
+    --jp-green-400: oklch(76.5% 0.177 163.223);
+    --jp-green-600: oklch(59.6% 0.145 163.225);
+    --jp-amber-400: oklch(82.8% 0.189 84.429);
+    --jp-amber-600: oklch(66.6% 0.179 58.318);
+    --jp-red-400:   oklch(70.4% 0.191 22.216);
+    --jp-red-600:   oklch(57.7% 0.245 27.325);
+    --jp-slate-400: oklch(70.5% 0.015 286.067);
+    --jp-slate-500: oklch(55.2% 0.016 285.938);
+
+    --radius-sm: 0.375rem;
+    --radius-md: 0.5rem;
+    --radius-lg: 0.625rem;
+    --radius-xl: 0.875rem;
+    --control-radius: 0.5rem;
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+        "Pretendard", "Noto Sans CJK SC", "Noto Sans CJK JP", "Noto Sans KR", sans-serif;
+    --font-mono: "Geist Mono", ui-monospace, "SF Mono", "SFMono-Regular", Menlo,
+        Consolas, "Liberation Mono", monospace;
+    --motion-fast: 120ms;
+    --motion-base: 180ms;
+    --workspace-topbar-height: 44px;
+    --scrollbar-size: 6px;
+    --scrollbar-radius: 3px;
 }
 
-/* Default = dark (matches the previous behavior). */
+/* Default = dark. */
 :root,
 :root[data-theme="dark"] {
     color-scheme: dark;
 
     /* legacy variable names — keep so existing CSS still renders */
-    --bg-base:        #080b0f;
-    --bg-panel:       #10161d;
-    --bg-raised:      #151c25;
-    --bg-elevated:    #1a2430;
-    --border-subtle:  #202a35;
-    --border-strong:  #2d3b4c;
-    --text-primary:   #e7edf5;
-    --text-secondary: #9aa6b5;
-    --text-dim:       #657283;
-    --accent:         #62a8f5;
-    --accent-soft:    #1e2b3d;
+    --bg-base:        #0a0a0a;
+    --bg-panel:       color-mix(in srgb, #0a0a0a 97%, white);
+    --bg-raised:      color-mix(in srgb, white 4%, transparent);
+    --bg-elevated:    color-mix(in srgb, #0a0a0a 97%, white);
+    --border-subtle:  color-mix(in srgb, white 8%, transparent);
+    --border-strong:  color-mix(in srgb, white 10%, transparent);
+    --text-primary:   #f1f3f7;
+    --text-secondary: #a3a3a3;
+    --text-dim:       color-mix(in srgb, oklch(55.6% 0 0) 90%, white);
+    --accent:         oklch(0.571 0.21 264);
+    --accent-soft:    color-mix(in srgb, var(--accent) 12%, transparent);
     --selection-bg:   color-mix(in srgb, var(--accent) 40%, transparent);
-    --status-running: #34d399;
-    --status-success: #4caf50;
-    --status-warn:    #f5a524;
-    --status-error:   #f87171;
-    --status-idle:    #7b8797;
-    --shadow-panel:    0 22px 70px rgba(0, 0, 0, 0.28);
-    --shadow-elevated: 0 1px 3px rgba(0, 0, 0, 0.18);
-    --scrim-overlay:   rgba(5, 8, 12, 0.68);
+    --status-running: oklch(69.6% 0.17 162.48);
+    --status-success: oklch(69.6% 0.17 162.48);
+    --status-warn:    oklch(76.9% 0.188 70.08);
+    --status-error:   color-mix(in srgb, oklch(63.7% 0.237 25.331) 90%, white);
+    --status-idle:    color-mix(in srgb, oklch(55.2% 0.016 285.938) 90%, white);
+    --shadow-panel:    inset 0 1px rgb(255 255 255 / 4%), 0 24px 72px -20px rgb(0 0 0 / 90%);
+    --shadow-elevated: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
+    --scrim-overlay:   color-mix(in srgb, var(--bg-base) 64%, transparent);
 
-    /* new semantic aliases — used by 10.6.9 components and onward */
+    /* semantic aliases */
     --surface-base:    var(--bg-base);
     --surface-panel:   var(--bg-panel);
     --surface-raised:  var(--bg-raised);
@@ -84,69 +100,84 @@
     --ink-on-accent:   #ffffff;
     --ring:            var(--accent);
 
-    /* common composite values previously inlined as raw hex */
-    --button-bg:       #142133;
-    --button-bg-hover: #1a2b42;
-    --button-border-hover: #3a5470;
-    --row-bg:          #111b26;
-    --row-bg-hover:    rgba(21, 28, 37, 0.62);
-    --canvas-deep:     #0b1016;
-    --canvas-mid:      #0c1218;
-    --canvas-soft:     #0d141c;
-    --shell-tint:      rgba(98, 168, 245, 0.12);
-    --error-border:    #70303a;
-    --error-text:      #ffc0c6;
-    --lifecycle-border:#315a82;
-    --lifecycle-text:  #cfe8ff;
-    --highlight-bg:    #20344e;
-    --highlight-border:#426483;
-    --placeholder-ink: #728093;
-    --segment-track:   rgba(255, 255, 255, 0.03);
-    --segment-border:  rgba(255, 255, 255, 0.05);
-    --segment-hover:   rgba(255, 255, 255, 0.05);
-    --segment-active:  #232c38;
-    --segment-active-ink: #e2e8f0;
-    --link-border:     rgba(255, 255, 255, 0.12);
-    --link-bg-hover:   rgba(255, 255, 255, 0.06);
-    --link-border-hover: rgba(255, 255, 255, 0.2);
-    --link-ink:        #a1b0c0;
-    --inset-glow:      rgba(255, 255, 255, 0.03);
-    --rail-top:        #0d141c;
-    --rail-bottom:     #0a1017;
+    /* common composite values */
+    --button-bg:       color-mix(in srgb, #0a0a0a 97%, white);
+    --button-bg-hover: color-mix(in srgb, white 4%, transparent);
+    --button-border-hover: color-mix(in srgb, white 10%, transparent);
+    --row-bg:          #000000;
+    --row-bg-hover:    color-mix(in srgb, white 4%, transparent);
+    --canvas-deep:     #000000;
+    --canvas-mid:      color-mix(in srgb, #0a0a0a 97%, white);
+    --canvas-soft:     color-mix(in srgb, white 4%, transparent);
+    --shell-tint:      color-mix(in srgb, var(--accent) 6%, transparent);
+    --error-border:    color-mix(in srgb, var(--status-error) 16%, transparent);
+    --error-text:      var(--jp-red-400);
+    --lifecycle-border:color-mix(in srgb, var(--accent) 30%, transparent);
+    --lifecycle-text:  color-mix(in srgb, var(--accent) 60%, white);
+    --highlight-bg:    color-mix(in srgb, var(--accent) 12%, transparent);
+    --highlight-border:color-mix(in srgb, white 10%, transparent);
+    --placeholder-ink: var(--text-dim);
+    --segment-track:   color-mix(in srgb, white 3%, transparent);
+    --segment-border:  color-mix(in srgb, white 8%, transparent);
+    --segment-hover:   color-mix(in srgb, white 4%, transparent);
+    --segment-active:  #000000;
+    --segment-active-ink: #f1f3f7;
+    --link-border:     color-mix(in srgb, white 8%, transparent);
+    --link-bg-hover:   color-mix(in srgb, white 4%, transparent);
+    --link-border-hover: color-mix(in srgb, white 10%, transparent);
+    --link-ink:        #a3a3a3;
+    --inset-glow:      color-mix(in srgb, white 3%, transparent);
+    --rail-top:        #000000;
+    --rail-bottom:     #000000;
 
-    /* alias tokens for notes/panels (previously undeclared) */
-    --canvas-panel:       oklch(16% 0.01 260);
-    --canvas-base:        oklch(13% 0.005 260);
-    --danger-soft:        color-mix(in srgb, var(--status-error) 12%, transparent);
+    /* alias tokens for notes/panels */
+    --canvas-panel:       color-mix(in srgb, #0a0a0a 97%, white);
+    --canvas-base:        #000000;
+    --danger-soft:        color-mix(in srgb, var(--status-error) 16%, transparent);
     --accent-primary:     var(--accent);
     --surface-secondary:  var(--surface-raised);
     --text-tertiary:      var(--text-dim);
+    --text-danger:        var(--error-text);
+
+    /* sidebar surface + status tokens (260902 t3 shell, consumed from wp2/wp3) */
+    --sidebar-row-hover:    color-mix(in srgb, #f1f3f7 8%, transparent);
+    --sidebar-row-active:   color-mix(in srgb, #f1f3f7 11%, transparent);
+    --sidebar-row-selected: color-mix(in srgb, #f1f3f7 7%, transparent);
+    --sidebar-row-working:   #38bdf8;
+    --sidebar-row-attention: var(--jp-amber-400);
+    --sidebar-row-error:     var(--jp-red-400);
+    --sidebar-row-ready:     var(--text-dim);
+    --sidebar-border:        color-mix(in srgb, white 8%, transparent);
+    --sidebar-control-surface: #0a0a0a;
+    --focus-ring:            2px solid color-mix(in srgb, var(--ring) 50%, transparent);
+    --scrollbar-thumb:       rgb(255 255 255 / 8%);
+    --scrollbar-thumb-hover: rgb(255 255 255 / 12%);
 }
 
 /* Light palette. */
 :root[data-theme="light"] {
     color-scheme: light;
 
-    --bg-base:        var(--jp-gray-50);
+    --bg-base:        oklch(99.2% 0 0);
     --bg-panel:       #ffffff;
-    --bg-raised:      var(--jp-gray-100);
+    --bg-raised:      var(--jp-gray-50);
     --bg-elevated:    #ffffff;
     --border-subtle:  var(--jp-gray-200);
     --border-strong:  var(--jp-gray-300);
-    --text-primary:   var(--jp-gray-900);
+    --text-primary:   var(--jp-gray-800);
     --text-secondary: var(--jp-gray-600);
     --text-dim:       var(--jp-gray-500);
-    --accent:         var(--jp-blue-600);
-    --accent-soft:    var(--jp-blue-100);
+    --accent:         oklch(0.488 0.217 264);
+    --accent-soft:    color-mix(in srgb, var(--accent) 8%, transparent);
     --selection-bg:   color-mix(in srgb, var(--accent) 30%, transparent);
     --status-running: var(--jp-green-600);
     --status-success: var(--jp-green-600);
     --status-warn:    var(--jp-amber-600);
     --status-error:   var(--jp-red-600);
     --status-idle:    var(--jp-slate-500);
-    --shadow-panel:    0 18px 50px rgba(17, 20, 24, 0.08);
-    --shadow-elevated: 0 1px 3px rgba(17, 20, 24, 0.08);
-    --scrim-overlay:   rgba(17, 20, 24, 0.32);
+    --shadow-panel:    0 24px 64px -24px rgb(0 0 0 / 18%);
+    --shadow-elevated: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
+    --scrim-overlay:   color-mix(in srgb, var(--bg-base) 60%, transparent);
 
     --surface-base:    var(--bg-base);
     --surface-panel:   var(--bg-panel);
@@ -157,43 +188,57 @@
     --ink-secondary:   var(--text-secondary);
     --ink-muted:       var(--text-dim);
     --ink-on-accent:   #ffffff;
-    --ring:            var(--jp-blue-500);
+    --ring:            var(--accent);
 
     --button-bg:       #ffffff;
     --button-bg-hover: var(--jp-gray-100);
     --button-border-hover: var(--jp-gray-400);
     --row-bg:          #ffffff;
-    --row-bg-hover:    rgba(31, 111, 235, 0.06);
+    --row-bg-hover:    oklch(99.2% 0 0);
     --canvas-deep:     var(--jp-gray-50);
     --canvas-mid:      #ffffff;
     --canvas-soft:     var(--jp-gray-100);
-    --shell-tint:      rgba(31, 111, 235, 0.05);
-    --error-border:    #f5b7bd;
-    --error-text:      #8a1f2a;
-    --lifecycle-border:#b3d2f5;
-    --lifecycle-text:  #1f4e84;
-    --highlight-bg:    var(--jp-blue-100);
-    --highlight-border: var(--jp-blue-300);
+    --shell-tint:      color-mix(in srgb, var(--accent) 6%, transparent);
+    --error-border:    color-mix(in srgb, var(--status-error) 8%, transparent);
+    --error-text:      oklch(50.5% 0.213 27.518);
+    --lifecycle-border:color-mix(in srgb, var(--accent) 25%, transparent);
+    --lifecycle-text:  var(--accent);
+    --highlight-bg:    var(--jp-gray-100);
+    --highlight-border: var(--jp-gray-300);
     --placeholder-ink: var(--jp-gray-500);
-    --segment-track:   var(--jp-gray-100);
+    --segment-track:   var(--jp-gray-50);
     --segment-border:  var(--jp-gray-200);
-    --segment-hover:   rgba(17, 20, 24, 0.04);
+    --segment-hover:   oklch(99.2% 0 0);
     --segment-active:  #ffffff;
-    --segment-active-ink: var(--jp-gray-900);
+    --segment-active-ink: var(--jp-gray-800);
     --link-border:     var(--jp-gray-200);
-    --link-bg-hover:   var(--jp-gray-100);
+    --link-bg-hover:   oklch(99.2% 0 0);
     --link-border-hover: var(--jp-gray-300);
     --link-ink:        var(--jp-gray-600);
     --inset-glow:      rgba(0, 0, 0, 0.02);
     --rail-top:        #ffffff;
-    --rail-bottom:     var(--jp-gray-50);
+    --rail-bottom:     oklch(99.2% 0 0);
 
-    --canvas-panel:       oklch(97% 0.005 260);
-    --canvas-base:        oklch(99% 0.002 260);
+    --canvas-panel:       #ffffff;
+    --canvas-base:        oklch(99.2% 0 0);
     --danger-soft:        color-mix(in srgb, var(--status-error) 8%, transparent);
     --accent-primary:     var(--accent);
     --surface-secondary:  var(--surface-raised);
     --text-tertiary:      var(--text-dim);
+    --text-danger:        var(--error-text);
+
+    --sidebar-row-hover:    oklch(99.2% 0 0);
+    --sidebar-row-active:   #ffffff;
+    --sidebar-row-selected: #ffffff;
+    --sidebar-row-working:   #0284c7;
+    --sidebar-row-attention: var(--jp-amber-600);
+    --sidebar-row-error:     var(--jp-red-600);
+    --sidebar-row-ready:     var(--text-dim);
+    --sidebar-border:        var(--border-subtle);
+    --sidebar-control-surface: var(--jp-gray-100);
+    --focus-ring:            2px solid color-mix(in srgb, var(--ring) 50%, transparent);
+    --scrollbar-thumb:       rgb(217 217 217);
+    --scrollbar-thumb-hover: rgb(191 191 191);
 }
 
 /* Auto: follow OS, default to dark when query is unsupported. */
@@ -201,26 +246,26 @@
     :root[data-theme="auto"] {
         color-scheme: light;
 
-        --bg-base:        var(--jp-gray-50);
+        --bg-base:        oklch(99.2% 0 0);
         --bg-panel:       #ffffff;
-        --bg-raised:      var(--jp-gray-100);
+        --bg-raised:      var(--jp-gray-50);
         --bg-elevated:    #ffffff;
         --border-subtle:  var(--jp-gray-200);
         --border-strong:  var(--jp-gray-300);
-        --text-primary:   var(--jp-gray-900);
+        --text-primary:   var(--jp-gray-800);
         --text-secondary: var(--jp-gray-600);
         --text-dim:       var(--jp-gray-500);
-        --accent:         var(--jp-blue-600);
-        --accent-soft:    var(--jp-blue-100);
+        --accent:         oklch(0.488 0.217 264);
+        --accent-soft:    color-mix(in srgb, var(--accent) 8%, transparent);
         --selection-bg:   color-mix(in srgb, var(--accent) 30%, transparent);
         --status-running: var(--jp-green-600);
         --status-success: var(--jp-green-600);
         --status-warn:    var(--jp-amber-600);
         --status-error:   var(--jp-red-600);
         --status-idle:    var(--jp-slate-500);
-        --shadow-panel:    0 18px 50px rgba(17, 20, 24, 0.08);
-        --shadow-elevated: 0 1px 3px rgba(17, 20, 24, 0.08);
-        --scrim-overlay:   rgba(17, 20, 24, 0.32);
+        --shadow-panel:    0 24px 64px -24px rgb(0 0 0 / 18%);
+        --shadow-elevated: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
+        --scrim-overlay:   color-mix(in srgb, var(--bg-base) 60%, transparent);
 
         --surface-base:    var(--bg-base);
         --surface-panel:   var(--bg-panel);
@@ -231,42 +276,57 @@
         --ink-secondary:   var(--text-secondary);
         --ink-muted:       var(--text-dim);
         --ink-on-accent:   #ffffff;
-        --ring:            var(--jp-blue-500);
+        --ring:            var(--accent);
 
         --button-bg:       #ffffff;
         --button-bg-hover: var(--jp-gray-100);
         --button-border-hover: var(--jp-gray-400);
         --row-bg:          #ffffff;
-        --row-bg-hover:    rgba(31, 111, 235, 0.06);
+        --row-bg-hover:    oklch(99.2% 0 0);
         --canvas-deep:     var(--jp-gray-50);
         --canvas-mid:      #ffffff;
         --canvas-soft:     var(--jp-gray-100);
-        --shell-tint:      rgba(31, 111, 235, 0.05);
-        --error-border:    #f5b7bd;
-        --error-text:      #8a1f2a;
-        --lifecycle-border:#b3d2f5;
-        --lifecycle-text:  #1f4e84;
-        --highlight-bg:    var(--jp-blue-100);
-        --highlight-border: var(--jp-blue-300);
+        --shell-tint:      color-mix(in srgb, var(--accent) 6%, transparent);
+        --error-border:    color-mix(in srgb, var(--status-error) 8%, transparent);
+        --error-text:      oklch(50.5% 0.213 27.518);
+        --lifecycle-border:color-mix(in srgb, var(--accent) 25%, transparent);
+        --lifecycle-text:  var(--accent);
+        --highlight-bg:    var(--jp-gray-100);
+        --highlight-border: var(--jp-gray-300);
         --placeholder-ink: var(--jp-gray-500);
-        --segment-track:   var(--jp-gray-100);
+        --segment-track:   var(--jp-gray-50);
         --segment-border:  var(--jp-gray-200);
-        --segment-hover:   rgba(17, 20, 24, 0.04);
+        --segment-hover:   oklch(99.2% 0 0);
         --segment-active:  #ffffff;
-        --segment-active-ink: var(--jp-gray-900);
+        --segment-active-ink: var(--jp-gray-800);
         --link-border:     var(--jp-gray-200);
-        --link-bg-hover:   var(--jp-gray-100);
+        --link-bg-hover:   oklch(99.2% 0 0);
         --link-border-hover: var(--jp-gray-300);
         --link-ink:        var(--jp-gray-600);
         --inset-glow:      rgba(0, 0, 0, 0.02);
         --rail-top:        #ffffff;
-        --rail-bottom:     var(--jp-gray-50);
+        --rail-bottom:     oklch(99.2% 0 0);
 
-        --canvas-panel:       oklch(97% 0.005 260);
-        --canvas-base:        oklch(99% 0.002 260);
+        --canvas-panel:       #ffffff;
+        --canvas-base:        oklch(99.2% 0 0);
         --danger-soft:        color-mix(in srgb, var(--status-error) 8%, transparent);
         --accent-primary:     var(--accent);
         --surface-secondary:  var(--surface-raised);
         --text-tertiary:      var(--text-dim);
+        --text-danger:        var(--error-text);
+
+        --sidebar-row-hover:    oklch(99.2% 0 0);
+        --sidebar-row-active:   #ffffff;
+        --sidebar-row-selected: #ffffff;
+        --sidebar-row-working:   #0284c7;
+        --sidebar-row-attention: var(--jp-amber-600);
+        --sidebar-row-error:     var(--jp-red-600);
+        --sidebar-row-ready:     var(--text-dim);
+        --sidebar-border:        var(--border-subtle);
+        --sidebar-control-surface: var(--jp-gray-100);
+        --focus-ring:            2px solid color-mix(in srgb, var(--ring) 50%, transparent);
+        --scrollbar-thumb:       rgb(217 217 217);
+        --scrollbar-thumb-hover: rgb(191 191 191);
     }
 }
+

--- a/public/manager/src/styles.css
+++ b/public/manager/src/styles.css
@@ -2,12 +2,20 @@
  * defaults and base control reset. */
 
 :root {
-    font-family: 'Outfit', 'Geist', 'Satoshi', 'Inter', 'Pretendard',
-        'Noto Sans CJK SC', 'Noto Sans CJK JP', 'Noto Sans KR',
-        system-ui, sans-serif;
+    font-family: var(--font-sans);
     background: var(--bg-base);
     color: var(--text-primary);
 }
+html {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
+}
+html::-webkit-scrollbar { width: var(--scrollbar-size); height: var(--scrollbar-size); }
+html::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: var(--scrollbar-radius);
+}
+html::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
 * { box-sizing: border-box; }
 
@@ -20,7 +28,7 @@ body {
         radial-gradient(circle at 12% 0%, var(--shell-tint), transparent 32rem),
         var(--bg-base);
     color: var(--text-primary);
-    transition: background-color 200ms ease, color 200ms ease;
+    transition: background-color var(--motion-base) ease, color var(--motion-base) ease;
 }
 
 #manager-root { height: 100dvh; overflow: hidden; }
@@ -32,14 +40,14 @@ button, .open-link {
     border: 1px solid var(--border-strong);
     background: var(--button-bg);
     color: var(--text-primary);
-    border-radius: 7px;
+    border-radius: var(--control-radius);
     padding: 5px 10px;
     font-size: 12px;
     text-decoration: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+    transition: background var(--motion-base) ease, border-color var(--motion-base) ease, transform var(--motion-fast) ease;
 }
 
 button:hover:not(:disabled),
@@ -58,7 +66,7 @@ button:focus-visible,
 a:focus-visible,
 input:focus-visible,
 select:focus-visible {
-    outline: 2px solid var(--ring);
+    outline: var(--focus-ring);
     outline-offset: 2px;
 }
 

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -217,6 +217,14 @@ settings.ts (barrel)
 
 `public/manager/`는 메인 채팅 UI와 별개의 React 19 앱이다. `vite.config.ts`의 `manager` entry가 `public/manager/index.html`을 빌드한다.
 
+### Manager design tokens (260902 t3 shell polish, wp1)
+
+`public/manager/src/manager-tokens.css`는 primitive → semantic 2계층으로, t3code(pingdotgg/t3code `apps/web/src/index.css`) zinc/neutral oklch 스케일을 값으로 쓴다. 다크 기본은 캔버스 `#0a0a0a` / 사이드바·레일 `#000`, 라이트는 zinc-25(`oklch(99.2% 0 0)`) 캔버스에 흰 카드. `--accent`는 표면 틴트가 아니라 CTA primary(`oklch(0.571 0.21 264)` 다크 / `oklch(0.488 0.217 264)` 라이트)이고 `--ring`도 같은 값이다. 다크 보더는 `color-mix(in srgb, white 8%, transparent)`부터 시작한다(contrast 슬라이더가 없으므로 t3의 6%보다 한 단계 진하게). Tailwind 전용 `--alpha()`는 쓰지 않는다.
+
+레거시 변수 이름 88개(`--bg-base`, `--text-primary`, `--accent`, `--surface-*`, `--ink-*` 등)는 전부 보존되며 값만 바뀌었다. 추가된 semantic 토큰: `--radius-sm/md/lg/xl`(0.375/0.5/0.625/0.875rem), `--control-radius`(0.5rem), `--font-sans`(시스템 스택 + CJK 폴백), `--font-mono`(Geist Mono 우선), `--focus-ring`, `--motion-fast`(120ms) / `--motion-base`(180ms), `--workspace-topbar-height`(44px), `--sidebar-row-hover/active/selected`, `--sidebar-row-working/attention/error/ready`(행 상태 색, wp3 소비), `--sidebar-border`, `--sidebar-control-surface`, `--text-danger`, `--scrollbar-*`. 라이트 블록은 `:root[data-theme="light"]`와 `@media (prefers-color-scheme: light) :root[data-theme="auto"]`에 동일하게 복제되어야 한다.
+
+로드맵: `devlog/_plan/260902_t3_shell_polish/` (000 SoT, 010 토큰, 020 사이드바 셸, 030 행, 040 검색/키보드, 050 커맨드바, 060 브라우저 크롬, 070 Electron, 080 하드닝).
+
 ### Manager preview memory note
 
 2026-06-14 점검 기준, Chrome에서 manager Web UI를 열었을 때 1GB 근처까지 올라갔다가 약 10분 뒤 300MB대 근처로 안정화되는 패턴은 `jaw dashboard serve` manager 서버 누수보다 preview iframe의 cold-load peak로 해석한다. 실제 관찰에서는 manager 서버 `dist/src/manager/server.js` RSS가 약 170~220MB 수준이었고, 큰 RSS는 Chrome renderer와 각 `jaw serve` worker(`dist/server.js`) 쪽에 있었다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -53,7 +53,7 @@ cli-jaw/
 │   │   ├── main-session.ts   ← 메인 세션 authoritative CLI/clear-state helper + clearBossSessionOnly (232L)
 │   │   ├── message-summary.ts ← message preview/summary helper (55L)
 │   │   ├── path-expand.ts    ← shell-style path expansion helper (12L)
-│   │   ├── runtime-settings.ts ← settings side effects 통합 helper (460L)
+│   │   ├── runtime-settings.ts ← settings side effects 통합 helper (468L)
 │   │   ├── runtime-settings-gate.ts ← settings mutation in-flight gate (41L)
 │   │   ├── codex-config.ts   ← Codex config.toml context window sync (96L)
 │   │   ├── runtime-path.ts   ← buildServicePath() PATH 보강 (nvm/fnm/homebrew/volta/asdf/cargo/bun/yarn/pnpm 14+ dirs) + win32 MSYS/Cygwin 항목 정규화 (230L)
@@ -99,7 +99,7 @@ cli-jaw/
 │   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (253L)
 │   │   ├── kiro-models.ts    ← Kiro live model inventory (KiroModelEntry, KiroModelInventory, parseKiroModelListJson, fetchKiroModelInventory) (98L)
 │   │   ├── kiro-runtime.ts   ← Kiro plain-text stdout parser + session capture (isKiroPlainTextCli, processKiroStdoutChunk, flushKiroStdoutContext, appendKiroStdoutChunk, captureKiroSessionIdAfterExit, stripKiroAnsi, parseKiroAssistantText, isKiroStaleSessionOutput, isKiroResumeDegradedOutput, KiroStreamEvent, KiroStdoutContext) (460L)
-│   │   ├── cursor-runtime.ts ← Cursor CLI event adapter + session management (386L) ✨
+│   │   ├── cursor-runtime.ts ← Cursor CLI event adapter + session management (395L) ✨
 │   │   ├── agy-runtime.ts    ← AGY timeout stdout/close-text 판별 + 최종 planner 기준 timeout suffix 정규화 + stdout/log conversation id 추출 + quiet completion/replay/prompt-echo stripping helper (321L)
 │   │   ├── claude-e-runtime.ts ← `jaw_runtime` helper event를 internal `agent:claude-e:*` broadcast로 변환 (46L)
 │   │   ├── alert-escalation.ts ← alert escalation event helper (88L)
@@ -175,7 +175,7 @@ cli-jaw/
 │   │   ├── friction.ts       ← Interview friction/stagnation detector (76L)
 │   │   ├── seed.ts           ← Interview seed/ontology builder (107L)
 │   │   ├── sanitize.ts       ← Interview tracker strip helper + stripPhaseAttestation re-export (79L)
-│   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> (tagged block + --attest object) + form-only checkAttestationGate (gates P→A/A→B/B→C/C→D; narrative did required, C→D needs checkOutput) + stripPhaseAttestation + warn-only no-state narration detector (217L)
+│   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> (tagged block + --attest object) + form-only checkAttestationGate (gates P→A/A→B/B→C/C→D; narrative did required, C→D needs checkOutput) + stripPhaseAttestation + warn-only no-state narration detector (305L)
 │   ├── prompt/               ← 프롬프트 조립 (4 files + templates/ 10 files)
 │   │   ├── builder.ts        ← A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1211L)
 │   │   ├── runtime-context.ts ← 런타임 컨텍스트 주입 (RuntimeContextEntry, loadEntries, getActiveEntries, addEntry, removeEntry, clearAll, buildInjectionBlock) (80L)
@@ -193,9 +193,9 @@ cli-jaw/
 │   │   ├── handlers-skill-invoke.ts ← `/skill:<id>` handler — SKILL.md 전문을 steerPrompt로 주입, submitMessage 라우팅 (41L)
 │   │   ├── handlers-project.ts ← `/project` 커맨드 핸들러 (projectDirs 관리) (73L) ✨
 │   │   ├── api-auth.ts       ← CLI→server Bearer token bootstrap (`getCliAuthToken`, `authHeaders`, `cliFetch`) (45L)
-│   │   ├── claude-models.ts  ← Claude 정규 모델셋 (CLAUDE_CANONICAL_MODELS, CLAUDE_LEGACY_VALUE_MAP) + migration/validation helpers (95L)
+│   │   ├── claude-models.ts  ← Claude 정규 모델셋 (CLAUDE_CANONICAL_MODELS, CLAUDE_LEGACY_VALUE_MAP) + migration/validation helpers (101L)
 │   │   ├── compact.ts        ← /compact 슬래시 커맨드 핸들러 (Claude native + managed 경로 분기) + working_dir scoped (185L)
-│   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (290L)
+│   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (331L)
 │   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (136L)
 │   │   ├── readiness.ts      ← CLI별 인증/설치 상태 점검 + Pi npm-exec readiness + AGY runtime auth hint + `claude-e` underlying Claude auth/readiness bridge (CliReadiness[]) (174L)
 │   │   ├── acp-client.ts     ← Copilot ACP JSON-RPC 클라이언트 (394L)


### PR DESCRIPTION
## wp1 — Manager design-token foundation (t3code zinc/neutral + oklch primary)

public/manager/src/manager-tokens.css 를 zinc/neutral oklch 스케일로 재작성. 레거시 변수 이름 88개 전부 보존(값만 변경), 추가 토큰 25개(radius 스케일, control radius, 시스템 폰트 스택, focus ring, motion, sidebar row/status, scrollbar, text-danger).

- 다크: 캔버스 #0a0a0a, 사이드바 #000, 보더 white 8% color-mix, accent oklch(0.571 0.21 264)
- 라이트: zinc-25 캔버스, 흰 카드, accent oklch(0.488 0.217 264)
- --accent 는 CTA primary(t3 --primary)이며 표면 틴트가 아님
- styles.css: --font-sans, scrollbar, --focus-ring, motion 토큰 소비
- components/polish CSS: 사이드바·커맨드바 경로 리터럴 13곳 토큰화
- structure/frontend.md 토큰 절 추가, str_func counts 갱신

검증: typecheck:frontend 0, build:frontend 0, check:frontend-build-output 0, 88 legacy names missing=0, --alpha() 0, verify-counts ALL PASS. text-dim 대비 다크 5.09 / 라이트 4.72 (AA 통과, 기존은 둘 다 4.5 미만).

스크린샷 (vite dev 5199 → 24576 API, 1280x720): devlog evidence wp1-dark-1280x720.png, wp1-light-1280x720.png.

Plan: devlog/_plan/260902_t3_shell_polish/010_design_tokens.md
