### PR TITLE
feat(manager): t3-style instance rows and collapsible groups (wp3)

### DIFF
--- a/public/manager/src/components/InstanceGroups.tsx
+++ b/public/manager/src/components/InstanceGroups.tsx
@@ -6,6 +6,8 @@ import type {
     DashboardLifecycleAction,
     DashboardProfile,
 } from '../types';
+import { comparePinnedThenLabel } from './instance-row-status';
+import { useSidebarGroupCollapse } from '../hooks/useSidebarGroupCollapse';
 
 type InstanceGroupsProps = {
     instances: DashboardInstance[];
@@ -21,6 +23,7 @@ type InstanceGroupsProps = {
     showInlineLabelEditor?: boolean;
     showSidebarRuntimeLine?: boolean;
     showSelectedRowActions?: boolean;
+    density?: 'compact' | 'comfortable' | 'rail';
     /** Session disclosure for the Active row (devlog 260806 D2). */
     activeSessionCount?: number;
     activeSessionsOpen?: boolean;
@@ -33,6 +36,14 @@ type InstanceGroupsProps = {
     onMarkActivitySeen: (port: number) => void;
     onInstanceLabelSave: (port: number, label: string | null) => Promise<void>;
     onLifecycle: (action: DashboardLifecycleAction, instance: DashboardInstance) => void;
+};
+
+type InstanceGroupSectionProps = {
+    group: DashboardInstanceGroup;
+    props: InstanceGroupsProps;
+    profileMap: Map<string, DashboardProfile>;
+    collapsed: boolean;
+    onToggle: () => void;
 };
 
 function withoutPorts(instances: DashboardInstance[], used: Set<number>): DashboardInstance[] {
@@ -59,6 +70,12 @@ function groupInstances(instances: DashboardInstance[], selectedPort: number | n
     const running = remaining.filter(instance => instance.status === 'online');
     const attention = remaining.filter(instance => ['timeout', 'error', 'unknown'].includes(instance.status));
     const offline = remaining.filter(instance => instance.status === 'offline');
+    const labelOf = (instance: Pick<DashboardInstance, 'label' | 'port'>) => instance.label || String(instance.port);
+    favorites.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
+    running.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
+    attention.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
+    offline.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
+    for (const group of userGroups.values()) group.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
 
     const groups: DashboardInstanceGroup[] = [
         { id: 'active', label: 'Active', instances: selected },
@@ -97,6 +114,7 @@ function renderInstanceRow(
             {...(props.showInlineLabelEditor !== undefined ? { showInlineLabelEditor: props.showInlineLabelEditor } : {})}
             {...(props.showSidebarRuntimeLine !== undefined ? { showRuntimeLine: props.showSidebarRuntimeLine } : {})}
             {...(props.showSelectedRowActions !== undefined ? { showSelectedActions: props.showSelectedRowActions } : {})}
+            {...(props.density !== undefined ? { density: props.density } : {})}
             {...(priority === 'active' && props.activeSessionCount !== undefined ? { sessionCount: props.activeSessionCount } : {})}
             {...(priority === 'active' && props.activeSessionsOpen !== undefined ? { sessionsOpen: props.activeSessionsOpen } : {})}
             {...(priority === 'active' && props.onToggleActiveSessions ? { onToggleSessions: props.onToggleActiveSessions } : {})}
@@ -112,31 +130,53 @@ function renderInstanceRow(
     );
 }
 
-function renderRows(
-    props: InstanceGroupsProps,
-    instances: DashboardInstance[],
-    profileMap: Map<string, DashboardProfile> = new Map(),
-) {
-    return groupInstances(instances, props.selectedPort).map(group => (
+function InstanceGroupSection(section: InstanceGroupSectionProps) {
+    const { group, props, profileMap, collapsed, onToggle } = section;
+    const selected = group.instances.find(instance => instance.port === props.selectedPort);
+    const visible = group.id === 'active' || !collapsed
+        ? group.instances
+        : selected ? [selected] : [];
+    const header = group.id === 'active' ? (
+        <div className="instance-group-header">
+            <span>{group.label}</span>
+            <strong>{group.instances.length}</strong>
+        </div>
+    ) : (
+        <button
+            type="button"
+            className="instance-group-header instance-group-toggle"
+            aria-expanded={!collapsed}
+            aria-controls={`instance-group-body-${group.id}`}
+            onClick={onToggle}
+        >
+            <span>
+                <svg className="instance-group-chevron" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M3.5 6l4.5 4.5L12.5 6" /></svg>
+                {' '}{group.label}
+            </span>
+            <strong>{group.instances.length}</strong>
+        </button>
+    );
+
+    return (
         <section className="instance-group" key={group.id} aria-label={`${group.label} instances`}>
-            <div className="instance-group-header">
-                <span>{group.label}</span>
-                <strong>{group.instances.length}</strong>
+            {header}
+            <div id={`instance-group-body-${group.id}`} hidden={collapsed && visible.length === 0}>
+                {visible.map(instance => renderInstanceRow(
+                    props,
+                    instance,
+                    instance.profileId ? profileMap.get(instance.profileId) : undefined,
+                    group.id === 'active' ? 'active' : 'normal',
+                ))}
+                {group.id === 'active' && visible[0] ? props.renderActiveSessionList?.(visible[0].port) : null}
             </div>
-            {group.instances.map(instance => renderInstanceRow(
-                props,
-                instance,
-                instance.profileId ? profileMap.get(instance.profileId) : undefined,
-                group.id === 'active' ? 'active' : 'normal',
-            ))}
-            {group.id === 'active' && group.instances[0] ? props.renderActiveSessionList?.(group.instances[0].port) : null}
         </section>
-    ));
+    );
 }
 
 export function InstanceGroups(props: InstanceGroupsProps) {
     const groups = groupInstances(props.instances, props.selectedPort);
     const profileMap = new Map((props.profiles || []).map(profile => [profile.profileId, profile]));
+    const { isCollapsed, toggle: toggleGroup } = useSidebarGroupCollapse();
 
     if (groups.length === 0 && profileMap.size === 0) {
         return <section className="state">No matching instances found.</section>;
@@ -145,14 +185,32 @@ export function InstanceGroups(props: InstanceGroupsProps) {
     if (profileMap.size > 0) {
         return (
             <div className="instance-groups profile-instance-groups is-profile-merged">
-                {renderRows(props, props.instances, profileMap)}
+                {groups.map(group => (
+                    <InstanceGroupSection
+                        key={group.id}
+                        group={group}
+                        props={props}
+                        profileMap={profileMap}
+                        collapsed={group.id === 'active' ? false : isCollapsed(group.id)}
+                        onToggle={() => toggleGroup(group.id)}
+                    />
+                ))}
             </div>
         );
     }
 
     return (
         <div className="instance-groups">
-            {renderRows(props, props.instances)}
+            {groups.map(group => (
+                <InstanceGroupSection
+                    key={group.id}
+                    group={group}
+                    props={props}
+                    profileMap={profileMap}
+                    collapsed={group.id === 'active' ? false : isCollapsed(group.id)}
+                    onToggle={() => toggleGroup(group.id)}
+                />
+            ))}
         </div>
     );
 }

--- a/public/manager/src/components/InstanceRow.tsx
+++ b/public/manager/src/components/InstanceRow.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { FormEvent, MouseEvent } from 'react';
 import type { DashboardInstance, DashboardLifecycleAction, DashboardProfile } from '../types';
+import { composeInstanceRowTitle, formatWorkingDurationLabel, resolveInstanceRowStatus } from './instance-row-status';
 
 type InstanceRowProps = {
     instance: DashboardInstance;
@@ -63,6 +64,21 @@ const ChevronIcon = ({ open }: { open: boolean }) => (
     </svg>
 );
 
+function WorkingDuration(props: { startedAtMs: number | null }) {
+    const [, setTick] = useState(0);
+    useEffect(() => {
+        if (props.startedAtMs == null) return undefined;
+        const id = window.setInterval(() => setTick(tick => tick + 1), 1000);
+        return () => window.clearInterval(id);
+    }, [props.startedAtMs]);
+    if (props.startedAtMs == null) return null;
+    return (
+        <span className="instance-row-working-duration">
+            {formatWorkingDurationLabel(Date.now() - props.startedAtMs)}
+        </span>
+    );
+}
+
 export function InstanceRow(props: InstanceRowProps) {
     const lifecycle = props.instance.lifecycle;
     const reason = lifecycle?.reason || props.instance.healthReason || 'ok';
@@ -76,7 +92,24 @@ export function InstanceRow(props: InstanceRowProps) {
     }
 
     const transitionLabel = props.transitioning ? TRANSITION_LABELS[props.transitioning] : null;
-    const dotClass = `${statusClass(props.instance.status)}${transitionLabel ? ' is-transitioning' : ''}${props.agentBusy ? ' is-busy' : ''}`;
+    const rowStatus = resolveInstanceRowStatus(props.instance, {
+        busy: Boolean(props.agentBusy),
+        transitioning: props.transitioning || null,
+    });
+    const startedAtRef = useRef<number | null>(null);
+    if (rowStatus === 'working') {
+        if (startedAtRef.current == null) startedAtRef.current = Date.now();
+    } else {
+        startedAtRef.current = null;
+    }
+    const statusLabel = rowStatus === 'transitioning' && transitionLabel
+        ? transitionLabel
+        : rowStatus === 'working' ? 'Working'
+            : rowStatus === 'offline' ? 'Offline'
+                : rowStatus === 'attention' ? 'Attention'
+                    : 'Online';
+    const hideStatusLine = props.density === 'compact' || props.density === 'rail';
+    const dotClass = `${statusClass(props.instance.status)}${transitionLabel ? ' is-transitioning' : ''}${props.agentBusy ? ' is-busy' : ''} is-${rowStatus}`;
     const primaryLabel = props.instance.label || props.profile?.label || props.label;
     async function submitLabel(event: FormEvent<HTMLFormElement>): Promise<void> {
         event.preventDefault();
@@ -94,7 +127,10 @@ export function InstanceRow(props: InstanceRowProps) {
     }
 
     return (
-        <article className={`instance-row density-${props.density || 'comfortable'} priority-${props.priority || 'normal'} ${props.selected ? 'is-selected' : ''}${transitionLabel ? ' is-transitioning-row' : ''}`}>
+        <article
+            className={`instance-row density-${props.density || 'comfortable'} priority-${props.priority || 'normal'} ${props.selected ? 'is-selected' : ''}${transitionLabel ? ' is-transitioning-row' : ''} is-${rowStatus}`}
+            title={composeInstanceRowTitle(props.instance)}
+        >
             <button
                 className="instance-row-select"
                 type="button"
@@ -106,6 +142,14 @@ export function InstanceRow(props: InstanceRowProps) {
                 <div className="instance-row-main">
                     <span className={dotClass} aria-label={props.instance.status} />
                     <div className="instance-row-title">
+                        {!hideStatusLine ? (
+                            <div className="instance-row-status-line" data-status={rowStatus}>
+                                <span className={`instance-row-status-pill is-${rowStatus} health-${props.instance.status}`}>
+                                    {statusLabel}
+                                </span>
+                                {rowStatus === 'working' ? <WorkingDuration startedAtMs={startedAtRef.current} /> : null}
+                            </div>
+                        ) : null}
                         <div className="instance-row-title-line">
                             <strong>{props.instance.favorite ? `Pinned ${primaryLabel}` : primaryLabel}</strong>
                             {props.activityUnreadCount ? (

--- a/public/manager/src/components/instance-row-status.ts
+++ b/public/manager/src/components/instance-row-status.ts
@@ -1,0 +1,48 @@
+import type { DashboardInstance, DashboardLifecycleAction } from '../types';
+
+export type InstanceRowStatus =
+    | 'working'
+    | 'online'
+    | 'offline'
+    | 'attention'
+    | 'transitioning';
+
+export function resolveInstanceRowStatus(
+    instance: Pick<DashboardInstance, 'status'>,
+    flags: { busy?: boolean; transitioning?: DashboardLifecycleAction | null } = {},
+): InstanceRowStatus {
+    if (flags.transitioning) return 'transitioning';
+    if (flags.busy) return 'working';
+    if (instance.status === 'offline') return 'offline';
+    if (instance.status === 'online') return 'online';
+    return 'attention';
+}
+
+export function formatWorkingDurationLabel(elapsedMs: number): string {
+    const seconds = Number.isFinite(elapsedMs) ? Math.max(0, Math.floor(elapsedMs / 1000)) : 0;
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m`;
+    return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+export function composeInstanceRowTitle(instance: Pick<DashboardInstance, 'port' | 'homeDisplay' | 'currentCli' | 'currentModel' | 'version'>): string {
+    return [
+        `:${instance.port}`,
+        instance.homeDisplay || 'home n/a',
+        instance.currentCli || 'cli n/a',
+        instance.currentModel || 'model n/a',
+        `v${instance.version || 'n/a'}`,
+    ].join(' · ');
+}
+
+export function comparePinnedThenLabel<T extends Pick<DashboardInstance, 'favorite' | 'label' | 'port'>>(
+    a: T,
+    b: T,
+    labelOf: (instance: T) => string,
+): number {
+    const fav = Number(Boolean(b.favorite)) - Number(Boolean(a.favorite));
+    if (fav !== 0) return fav;
+    const byLabel = labelOf(a).localeCompare(labelOf(b), undefined, { sensitivity: 'base' });
+    return byLabel !== 0 ? byLabel : a.port - b.port;
+}

--- a/public/manager/src/hooks/useSidebarGroupCollapse.ts
+++ b/public/manager/src/hooks/useSidebarGroupCollapse.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+export const SIDEBAR_GROUP_COLLAPSED_KEY = 'jaw.sidebarGroupCollapsed';
+
+function readMap(): Record<string, boolean> {
+    try {
+        if (typeof localStorage === 'undefined') return {};
+        const raw = localStorage.getItem(SIDEBAR_GROUP_COLLAPSED_KEY);
+        if (!raw) return {};
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+        const next: Record<string, boolean> = {};
+        for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (typeof value === 'boolean') next[key] = value;
+        }
+        return next;
+    } catch {
+        return {};
+    }
+}
+
+function writeMap(value: Record<string, boolean>): void {
+    try {
+        if (typeof localStorage === 'undefined') return;
+        localStorage.setItem(SIDEBAR_GROUP_COLLAPSED_KEY, JSON.stringify(value));
+    } catch {
+        // private mode
+    }
+}
+
+export function useSidebarGroupCollapse(): {
+    isCollapsed: (groupKey: string) => boolean;
+    toggle: (groupKey: string) => void;
+    toggleGroup: (groupKey: string) => void;
+} {
+    const [collapsedByKey, setCollapsedByKey] = useState<Record<string, boolean>>(readMap);
+    const isCollapsed = useCallback((groupKey: string) => collapsedByKey[groupKey] === true, [collapsedByKey]);
+    const toggle = useCallback((groupKey: string) => {
+        setCollapsedByKey(prev => {
+            const next = { ...prev, [groupKey]: !prev[groupKey] };
+            writeMap(next);
+            return next;
+        });
+    }, []);
+    return { isCollapsed, toggle, toggleGroup: toggle };
+}

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -229,19 +229,120 @@ h2 { font-size: 13px; }
     font-weight: 700;
     padding: 7px 4px 6px;
 }
+.instance-group-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 7px 4px 6px;
+}
+.instance-group-toggle,
+button.instance-group-header,
+button.instance-group-toggle {
+    width: 100%;
+    min-height: 0;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 7px 4px 6px;
+    justify-content: space-between;
+    cursor: pointer;
+    text-align: left;
+}
+button.instance-group-header:hover:not(:disabled),
+button.instance-group-toggle:hover:not(:disabled) {
+    background: var(--sidebar-row-hover);
+    border-color: transparent;
+    color: var(--text-secondary);
+}
+button.instance-group-header:active:not(:disabled) { transform: none; }
+.instance-group-toggle > span { display: inline-flex; align-items: center; gap: 4px; min-width: 0; }
+.instance-group-toggle:focus-visible,
+button.instance-group-header:focus-visible,
+button.instance-group-toggle:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+}
+.instance-group-chevron {
+    display: inline-block;
+    flex-shrink: 0;
+    transition: transform var(--motion-fast);
+}
+.instance-group-toggle[aria-expanded="false"] .instance-group-chevron,
+button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
+    transform: rotate(-90deg);
+}
 .instance-row {
-    position: relative; display: grid; gap: 8px; margin-bottom: 7px;
-    border: 1px solid transparent; border-radius: var(--radius-md); background: transparent; padding: 10px;
+    position: relative;
+    display: grid;
+    gap: 8px;
+    margin-bottom: 7px;
+    min-height: 56px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    padding: 10px;
 }
 .instance-row.density-compact {
+    min-height: 36px;
     gap: 6px;
     padding: 8px;
+}
+.instance-row.density-rail {
+    min-height: 36px;
 }
 .instance-row.priority-active {
     border-color: var(--border-strong);
     background: var(--sidebar-row-active);
 }
 .instance-row:hover, .instance-row:focus-within { border-color: transparent; background: var(--sidebar-row-hover); }
+.instance-row-status-line {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    color: var(--sidebar-row-ready);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+}
+.instance-row.density-compact .instance-row-status-line,
+.instance-row.density-rail .instance-row-status-line {
+    display: none;
+}
+.instance-row-status-line[data-status="working"] {
+    color: var(--sidebar-row-working);
+}
+.instance-row-status-line[data-status="attention"] {
+    color: var(--sidebar-row-attention);
+}
+.instance-row-status-line[data-status="error"] {
+    color: var(--sidebar-row-error);
+}
+.instance-row-status-line[data-status="ready"],
+.instance-row-status-line[data-status="online"],
+.instance-row-status-line[data-status="offline"] {
+    color: var(--sidebar-row-ready);
+}
+.instance-row-status-pill,
+.instance-row-working-duration {
+    color: inherit;
+    font: inherit;
+    background: transparent;
+}
+/* The compact sidebar polish hides every span inside .instance-row-title
+   (secondary metadata); the status line is primary and must stay visible. */
+.manager-sidebar .instance-row-title .instance-row-status-line span {
+    display: inline;
+    color: inherit;
+    font-size: 10px;
+}
 .instance-row-select {
     width: 100%; min-height: 0; min-width: 0; display: grid; gap: 8px; border: 0;
     background: transparent; color: inherit; border-radius: var(--radius-sm); padding: 0;
@@ -287,6 +388,17 @@ h2 { font-size: 13px; }
     gap: 4px;
     flex-shrink: 0;
 }
+.instance-row .instance-row-quick .quick-btn {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--motion-fast), color var(--motion-fast), border-color var(--motion-fast), background var(--motion-fast);
+}
+.instance-row:hover .instance-row-quick .quick-btn:not(:disabled),
+.instance-row:focus-within .instance-row-quick .quick-btn:not(:disabled),
+.instance-row.is-selected .instance-row-quick .quick-btn:not(:disabled) {
+    opacity: 1;
+    pointer-events: auto;
+}
 .quick-btn {
     display: inline-grid;
     place-items: center;
@@ -330,6 +442,11 @@ h2 { font-size: 13px; }
 }
 @media (prefers-reduced-motion: reduce) {
     .instance-session-list { animation: none; }
+    .instance-group-chevron,
+    .instance-row .instance-row-quick .quick-btn,
+    .quick-btn {
+        transition: none;
+    }
 }
 .instance-session-row {
     display: flex;

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -231,6 +231,10 @@ settings.ts (barrel)
 
 `AppChrome`이 capture-phase window keydown(`createManagerCaptureKeydownHandler`)으로 `toggleLeftSidebar` / `toggleRightPanel` / `resetSidebarWidth`를 포커스된 에디터보다 먼저 처리한다. `[data-keybinding-capture]` 조상이 있으면 건너뛴다. keymap 기본값(`Meta+B` 우측, `Meta+Shift+B` 좌측)은 바뀌지 않았다. 레일 버튼은 32px, 아이콘 18px stroke 1.5, active는 `--sidebar-row-active` + 왼쪽 2px `--accent`.
 
+### Manager sidebar rows (260902 t3 shell polish, wp3)
+
+`components/instance-row-status.ts`가 행 상태를 정한다: `transitioning`(라이프사이클 진행) > `working`(`busyPorts`) > `attention`(timeout/error/unknown) > `offline` > `online`. `InstanceRow`는 제목 위에 `.instance-row-status-line[data-status]`(pill + working일 때만 행 국소 1s `WorkingDuration`, `Ns`/`Nm`/`Xh Ym`)를 두고, compact/rail density에서는 숨긴다. 툴팁은 `composeInstanceRowTitle`의 native `title`. 퀵 액션(`.instance-row-quick .quick-btn`)은 hover/focus-within/선택 행에서만, 그리고 `:not(:disabled)`만 드러난다. `InstanceGroups` 헤더는 `button.instance-group-header.instance-group-toggle[aria-expanded]`로 접히며(`Active` 그룹은 예외), 접힘 맵은 `hooks/useSidebarGroupCollapse.ts`가 localStorage `jaw.sidebarGroupCollapsed`(`Record<groupId, boolean>`)에 저장한다. 접힌 그룹에서도 선택 인스턴스는 한 줄로 남는다. Pinned는 favorite 우선 후 label 정렬이며 서버 order key가 없어 DnD는 없다. 제네릭 `.instance-row.is-selected {` 선택자는 contract 테스트가 금지한다.
+
 ### Manager preview memory note
 
 2026-06-14 점검 기준, Chrome에서 manager Web UI를 열었을 때 1GB 근처까지 올라갔다가 약 10분 뒤 300MB대 근처로 안정화되는 패턴은 `jaw dashboard serve` manager 서버 누수보다 preview iframe의 cold-load peak로 해석한다. 실제 관찰에서는 manager 서버 `dist/src/manager/server.js` RSS가 약 170~220MB 수준이었고, 큰 RSS는 Chrome renderer와 각 `jaw serve` worker(`dist/server.js`) 쪽에 있었다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -425,7 +425,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 563 files source/assets, ~99800L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 565 files source/assets, ~100100L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (1223L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시

--- a/tests/unit/manager-instance-row-status.test.ts
+++ b/tests/unit/manager-instance-row-status.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    comparePinnedThenLabel,
+    composeInstanceRowTitle,
+    formatWorkingDurationLabel,
+    resolveInstanceRowStatus,
+} from '../../public/manager/src/components/instance-row-status.js';
+
+test('resolveInstanceRowStatus prefers transitioning then working then health', () => {
+    assert.equal(resolveInstanceRowStatus({ status: 'error' }, { busy: true, transitioning: 'restart' }), 'transitioning');
+    assert.equal(resolveInstanceRowStatus({ status: 'timeout' }, { busy: true }), 'working');
+    assert.equal(resolveInstanceRowStatus({ status: 'online' }, { busy: false }), 'online');
+    assert.equal(resolveInstanceRowStatus({ status: 'offline' }), 'offline');
+    assert.equal(resolveInstanceRowStatus({ status: 'timeout' }), 'attention');
+    assert.equal(resolveInstanceRowStatus({ status: 'error' }), 'attention');
+    assert.equal(resolveInstanceRowStatus({ status: 'unknown' }), 'attention');
+});
+
+test('formatWorkingDurationLabel matches t3 Sidebar.logic L723-728', () => {
+    assert.equal(formatWorkingDurationLabel(0), '0s');
+    assert.equal(formatWorkingDurationLabel(42_000), '42s');
+    assert.equal(formatWorkingDurationLabel(5 * 60_000), '5m');
+    assert.equal(formatWorkingDurationLabel(90 * 60_000), '1h 30m');
+    assert.equal(formatWorkingDurationLabel(-5_000), '0s');
+    assert.equal(formatWorkingDurationLabel(Number.NaN), '0s');
+});
+
+test('composeInstanceRowTitle is native tooltip copy', () => {
+    assert.equal(
+        composeInstanceRowTitle({ port: 3457, homeDisplay: '~/.cli-jaw', currentCli: 'pi', currentModel: 'opus', version: '2.17.30' }),
+        ':3457 · ~/.cli-jaw · pi · opus · v2.17.30',
+    );
+});
+
+test('comparePinnedThenLabel is favorite then label then port', () => {
+    const labelOf = (row: { label?: string | null; port: number }) => row.label || String(row.port);
+    const pinnedB = { favorite: true, label: 'beta', port: 2 };
+    const pinnedA = { favorite: true, label: 'alpha', port: 1 };
+    const plain = { favorite: false, label: 'aaa', port: 3 };
+    assert.ok(comparePinnedThenLabel(pinnedA, plain, labelOf) < 0);
+    assert.ok(comparePinnedThenLabel(pinnedA, pinnedB, labelOf) < 0);
+});


### PR DESCRIPTION
## wp3 — t3-style instance rows, collapsible groups, pinned ordering

- instance-row-status.ts: resolveInstanceRowStatus (transitioning > working > attention > offline > online), formatWorkingDurationLabel (Ns/Nm/Xh Ym), composeInstanceRowTitle, comparePinnedThenLabel.
- InstanceRow: status line (pill + row-local 1s WorkingDuration only while working), native title, hover/focus-within/selected reveal of enabled quick actions; hidden on compact/rail density.
- InstanceGroups: aria-expanded header buttons with chevron (Active group exempt), collapse persisted via useSidebarGroupCollapse (localStorage jaw.sidebarGroupCollapsed); selected instance stays visible in a collapsed group; Pinned favorite-first then label.
- CSS on wp1 tokens: min-height 56/36, status colors from --sidebar-row-working/attention/error/ready, group toggle styles, reduced-motion guard. No generic .instance-row.is-selected selector (contract test).

Verification: typecheck:frontend 0, build:frontend 0, check:frontend-build-output 0; manager/electron/dashboard unit set 1156/1156 locally; manager-instance-row-status 4/4; verify-counts ALL PASS.

Rendered (headless Chrome 1280x720): status pill per row, hover reveals action row (opacity 0 -> 1), Offline group collapse persists {"offline":true} and keeps the selected row. Screenshots wp3-{rows,hover,group-collapsed}-1280x720.png in devlog evidence.

Plan: devlog/_plan/260902_t3_shell_polish/030_sidebar_rows.md
