### PR TITLE
feat(manager): sidebar search, keyboard traversal, jump hints, settled shelf (wp4)

### DIFF
--- a/public/manager/src/AppChrome.tsx
+++ b/public/manager/src/AppChrome.tsx
@@ -151,7 +151,8 @@ export function AppChrome(props: AppChromeProps) {
                         onSelectTab={props.handleTabChange} onToggleActivityFromMobile={props.activityUnreadOpenAndMarkSeen} drawerProfileFilters={props.drawerProfileFilters}
                         dashboardSettingsUi={props.dashboardSettingsUi} titleSupport={props.titleSupport} onDashboardSettingsPatch={props.handleDashboardSettingsPatch}
                         viewMode={props.view.viewMode} onViewModeChange={props.view.setViewMode}
-                        port={Number(window.location.port) || 3457} workingDir={props.view.rightFolderRootPath || ''} />
+                        port={Number(window.location.port) || 3457} workingDir={props.view.rightFolderRootPath || ''}
+                        query={props.query} onQueryChange={props.setQuery} onSelectInstance={props.handleSelectInstance} />
                 )}
                 activityHeight={props.view.activityDockCollapsed ? 48 : props.view.activityDockHeight}
             />

--- a/public/manager/src/SidebarRailRouter.tsx
+++ b/public/manager/src/SidebarRailRouter.tsx
@@ -70,6 +70,7 @@ import type { JawCeoVoiceController } from './jaw-ceo/useJawCeoVoice';
 import { ModeSwitch } from './code/ModeSwitch';
 const CodeCanvas = lazy(() => import('./code/CodeCanvas').then(m => ({ default: m.CodeCanvas })));
 import './code/code.css';
+import { registerInstanceJumpSelector } from './components/sidebar-keyboard';
 
 type WorkspaceSurfaceProps = {
     active: boolean;
@@ -172,6 +173,9 @@ type Props = {
     onViewModeChange: (mode: DashboardViewMode) => void;
     port: number;
     workingDir: string;
+    query: string;
+    onQueryChange: (value: string) => void;
+    onSelectInstance: (instance: DashboardInstance) => void;
 };
 
 type RightPanelRenderContext = {
@@ -348,6 +352,17 @@ export function SidebarRailRouter(props: Props) {
         && props.notesSelectedNote
         && !props.notesSelectedNote.tags?.includes(props.notesModel.tagFilter),
     );
+
+    useEffect(() => {
+        registerInstanceJumpSelector(port => {
+            const instance = props.instances.find(row => row.port === port)
+                ?? (props.selectedInstance?.port === port ? props.selectedInstance : null);
+            if (instance) props.onSelectInstance(instance);
+        });
+        return () => {
+            registerInstanceJumpSelector(null);
+        };
+    }, [props.instances, props.selectedInstance, props.onSelectInstance]);
     // External file open: focus/create a Files tab and assign the file to it.
     // Stable identity matters: this is passed as `onLocalFileOpen` into
     // MarkdownRenderer (via CodeCanvas/DocPanel), and a fresh function each
@@ -519,7 +534,18 @@ export function SidebarRailRouter(props: Props) {
                                 <div id="code-session-sidebar-host" className="code-session-sidebar-host" />
                             </section>
                         ) : (
-                            <InstanceNavigator active={props.selectedInstance} hiddenCount={props.instances.filter(instance => instance.hidden).length} collapsed={props.sidebarCollapsed}>
+                            <InstanceNavigator
+                                active={props.selectedInstance}
+                                hiddenCount={props.instances.filter(instance => instance.hidden).length}
+                                collapsed={props.sidebarCollapsed}
+                                query={props.query}
+                                onQueryChange={props.onQueryChange}
+                                onSelectPort={port => {
+                                    const instance = props.instances.find(row => row.port === port)
+                                        ?? (props.selectedInstance?.port === port ? props.selectedInstance : null);
+                                    if (instance) props.onSelectInstance(instance);
+                                }}
+                            >
                                 {props.instanceListContent}
                             </InstanceNavigator>
                         )}

--- a/public/manager/src/components/InstanceGroups.tsx
+++ b/public/manager/src/components/InstanceGroups.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, useSyncExternalStore, type ReactNode } from 'react';
 import { InstanceRow } from './InstanceRow';
 import type {
     DashboardInstance,
@@ -8,6 +8,14 @@ import type {
 } from '../types';
 import { comparePinnedThenLabel } from './instance-row-status';
 import { useSidebarGroupCollapse } from '../hooks/useSidebarGroupCollapse';
+import {
+    SETTLED_TAIL_INITIAL_COUNT,
+    SETTLED_TAIL_PAGE_COUNT,
+    getJumpHintsVisible,
+    isSettledStatus,
+    pageSettledPorts,
+    subscribeJumpHints,
+} from './sidebar-keyboard';
 
 type InstanceGroupsProps = {
     instances: DashboardInstance[];
@@ -44,6 +52,10 @@ type InstanceGroupSectionProps = {
     profileMap: Map<string, DashboardProfile>;
     collapsed: boolean;
     onToggle: () => void;
+    jumpStartIndex: number;
+    showJumpHints: boolean;
+    settledVisibleCount: number;
+    onShowMoreSettled: () => void;
 };
 
 function withoutPorts(instances: DashboardInstance[], used: Set<number>): DashboardInstance[] {
@@ -68,13 +80,13 @@ function groupInstances(instances: DashboardInstance[], selectedPort: number | n
 
     const remaining = withoutPorts(instances, used);
     const running = remaining.filter(instance => instance.status === 'online');
-    const attention = remaining.filter(instance => ['timeout', 'error', 'unknown'].includes(instance.status));
-    const offline = remaining.filter(instance => instance.status === 'offline');
+    const attention = remaining.filter(instance => instance.status === 'error');
+    const settled = remaining.filter(instance => isSettledStatus(instance.status));
     const labelOf = (instance: Pick<DashboardInstance, 'label' | 'port'>) => instance.label || String(instance.port);
     favorites.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
     running.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
     attention.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
-    offline.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
+    settled.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
     for (const group of userGroups.values()) group.sort((a, b) => comparePinnedThenLabel(a, b, labelOf));
 
     const groups: DashboardInstanceGroup[] = [
@@ -87,7 +99,7 @@ function groupInstances(instances: DashboardInstance[], selectedPort: number | n
         })),
         { id: 'running', label: 'Running', instances: running },
         { id: 'attention', label: 'Attention', instances: attention },
-        { id: 'offline', label: 'Offline', instances: offline },
+        { id: 'settled', label: 'Settled', instances: settled },
     ];
 
     return groups.filter(group => group.instances.length > 0);
@@ -98,6 +110,7 @@ function renderInstanceRow(
     instance: DashboardInstance,
     profile?: DashboardProfile,
     priority: 'active' | 'normal' = 'normal',
+    jumpHint?: string | null,
 ) {
     return (
         <InstanceRow
@@ -126,16 +139,41 @@ function renderInstanceRow(
             onMarkActivitySeen={props.onMarkActivitySeen}
             onInstanceLabelSave={props.onInstanceLabelSave}
             onLifecycle={props.onLifecycle}
+            jumpHint={jumpHint ?? null}
         />
     );
 }
 
-function InstanceGroupSection(section: InstanceGroupSectionProps) {
-    const { group, props, profileMap, collapsed, onToggle } = section;
-    const selected = group.instances.find(instance => instance.port === props.selectedPort);
-    const visible = group.id === 'active' || !collapsed
-        ? group.instances
+function visibleGroupInstances(
+    group: DashboardInstanceGroup,
+    selectedPort: number | null,
+    collapsed: boolean,
+    settledVisibleCount: number,
+): DashboardInstance[] {
+    const selected = group.instances.find(instance => instance.port === selectedPort);
+    const pagedSettled = group.id === 'settled'
+        ? pageSettledPorts(
+            group.instances.map(instance => instance.port),
+            settledVisibleCount,
+            selectedPort,
+        )
+        : [];
+    const settledByPort = new Map(group.instances.map(instance => [instance.port, instance]));
+    const expandedInstances = group.id === 'settled'
+        ? pagedSettled.map(port => settledByPort.get(port)).filter((instance): instance is DashboardInstance => instance != null)
+        : group.instances;
+    return group.id === 'active' || !collapsed
+        ? expandedInstances
         : selected ? [selected] : [];
+}
+
+function InstanceGroupSection(section: InstanceGroupSectionProps) {
+    const { group, props, profileMap, collapsed, onToggle, jumpStartIndex, showJumpHints, settledVisibleCount, onShowMoreSettled } = section;
+    const settledExpanded = group.id !== 'settled' || !collapsed;
+    const visible = visibleGroupInstances(group, props.selectedPort, collapsed, settledVisibleCount);
+    const hiddenSettled = group.id === 'settled' && settledExpanded
+        ? Math.max(0, group.instances.length - settledVisibleCount)
+        : 0;
     const header = group.id === 'active' ? (
         <div className="instance-group-header">
             <span>{group.label}</span>
@@ -161,13 +199,27 @@ function InstanceGroupSection(section: InstanceGroupSectionProps) {
         <section className="instance-group" key={group.id} aria-label={`${group.label} instances`}>
             {header}
             <div id={`instance-group-body-${group.id}`} hidden={collapsed && visible.length === 0}>
-                {visible.map(instance => renderInstanceRow(
-                    props,
-                    instance,
-                    instance.profileId ? profileMap.get(instance.profileId) : undefined,
-                    group.id === 'active' ? 'active' : 'normal',
-                ))}
+                {visible.map((instance, rowIndex) => {
+                    const jumpIndex = jumpStartIndex + rowIndex;
+                    const jumpHint = showJumpHints && jumpIndex < 9 ? String(jumpIndex + 1) : null;
+                    return renderInstanceRow(
+                        props,
+                        instance,
+                        instance.profileId ? profileMap.get(instance.profileId) : undefined,
+                        group.id === 'active' ? 'active' : 'normal',
+                        jumpHint,
+                    );
+                })}
                 {group.id === 'active' && visible[0] ? props.renderActiveSessionList?.(visible[0].port) : null}
+                {group.id === 'settled' && settledExpanded && hiddenSettled > 0 ? (
+                    <button
+                        type="button"
+                        className="instance-settled-more"
+                        onClick={onShowMoreSettled}
+                    >
+                        Show {Math.min(hiddenSettled, SETTLED_TAIL_PAGE_COUNT)} more
+                    </button>
+                ) : null}
             </div>
         </section>
     );
@@ -177,40 +229,50 @@ export function InstanceGroups(props: InstanceGroupsProps) {
     const groups = groupInstances(props.instances, props.selectedPort);
     const profileMap = new Map((props.profiles || []).map(profile => [profile.profileId, profile]));
     const { isCollapsed, toggle: toggleGroup } = useSidebarGroupCollapse();
+    const showJumpHints = useSyncExternalStore(subscribeJumpHints, getJumpHintsVisible);
+    const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
+
+    useEffect(() => {
+        setSettledVisibleCount(SETTLED_TAIL_INITIAL_COUNT);
+    }, [props.instances]);
 
     if (groups.length === 0 && profileMap.size === 0) {
         return <section className="state">No matching instances found.</section>;
     }
 
+    let jumpCursor = 0;
+    const sections = groups.map(group => {
+        const collapsed = group.id === 'active' ? false : isCollapsed(group.id);
+        const visibleCount = visibleGroupInstances(group, props.selectedPort, collapsed, settledVisibleCount).length;
+        const jumpStartIndex = jumpCursor;
+        jumpCursor += visibleCount;
+        return (
+            <InstanceGroupSection
+                key={group.id}
+                group={group}
+                props={props}
+                profileMap={profileMap}
+                collapsed={collapsed}
+                onToggle={() => toggleGroup(group.id)}
+                jumpStartIndex={jumpStartIndex}
+                showJumpHints={showJumpHints}
+                settledVisibleCount={settledVisibleCount}
+                onShowMoreSettled={() => setSettledVisibleCount(count => count + SETTLED_TAIL_PAGE_COUNT)}
+            />
+        );
+    });
+
     if (profileMap.size > 0) {
         return (
             <div className="instance-groups profile-instance-groups is-profile-merged">
-                {groups.map(group => (
-                    <InstanceGroupSection
-                        key={group.id}
-                        group={group}
-                        props={props}
-                        profileMap={profileMap}
-                        collapsed={group.id === 'active' ? false : isCollapsed(group.id)}
-                        onToggle={() => toggleGroup(group.id)}
-                    />
-                ))}
+                {sections}
             </div>
         );
     }
 
     return (
         <div className="instance-groups">
-            {groups.map(group => (
-                <InstanceGroupSection
-                    key={group.id}
-                    group={group}
-                    props={props}
-                    profileMap={profileMap}
-                    collapsed={group.id === 'active' ? false : isCollapsed(group.id)}
-                    onToggle={() => toggleGroup(group.id)}
-                />
-            ))}
+            {sections}
         </div>
     );
 }

--- a/public/manager/src/components/InstanceNavigator.tsx
+++ b/public/manager/src/components/InstanceNavigator.tsx
@@ -1,14 +1,45 @@
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import type { DashboardInstance } from '../types';
+import {
+    INSTANCE_JUMP_HINT_SHOW_DELAY_MS,
+    createJumpHintVisibilityController,
+    handleInstanceListKeyDown,
+    setJumpHintsVisible,
+    shouldArmJumpHint,
+} from './sidebar-keyboard';
 
 type InstanceNavigatorProps = {
     active: DashboardInstance | null;
     hiddenCount: number;
     collapsed: boolean;
     children: ReactNode;
+    query: string;
+    onQueryChange: (value: string) => void;
+    onSelectPort: (port: number) => void;
 };
 
 export function InstanceNavigator(props: InstanceNavigatorProps) {
+    useEffect(() => {
+        const controller = createJumpHintVisibilityController({
+            delayMs: INSTANCE_JUMP_HINT_SHOW_DELAY_MS,
+            onVisibilityChange: setJumpHintsVisible,
+        });
+        const onKeyDown = (event: KeyboardEvent) => {
+            controller.sync(shouldArmJumpHint(event));
+        };
+        const onKeyUp = (event: KeyboardEvent) => {
+            controller.sync(shouldArmJumpHint(event));
+        };
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('keyup', onKeyUp);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+            window.removeEventListener('keyup', onKeyUp);
+            controller.dispose();
+            setJumpHintsVisible(false);
+        };
+    }, []);
+
     if (props.collapsed) {
         return <div className="instance-navigator is-collapsed">{props.children}</div>;
     }
@@ -21,8 +52,30 @@ export function InstanceNavigator(props: InstanceNavigatorProps) {
                     <strong>{props.active ? `:${props.active.port}` : 'No active target'}</strong>
                 </div>
                 <span>{props.hiddenCount} hidden</span>
+                <label className="instance-navigator-search">
+                    <span className="visually-hidden">Search instances</span>
+                    <input
+                        id="manager-sidebar-search"
+                        value={props.query}
+                        placeholder="Search instances"
+                        aria-label="Search instances"
+                        onChange={event => props.onQueryChange(event.currentTarget.value)}
+                        onKeyDown={event => {
+                            if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+                            if (event.key === 'Escape') {
+                                event.preventDefault();
+                                props.onQueryChange('');
+                            }
+                        }}
+                    />
+                </label>
             </header>
-            <div className="instance-navigator-scroll">{props.children}</div>
+            <div
+                className="instance-navigator-scroll"
+                onKeyDown={event => handleInstanceListKeyDown(event.nativeEvent, event.currentTarget, props.onSelectPort)}
+            >
+                {props.children}
+            </div>
         </section>
     );
 }

--- a/public/manager/src/components/InstanceRow.tsx
+++ b/public/manager/src/components/InstanceRow.tsx
@@ -29,6 +29,7 @@ type InstanceRowProps = {
     onMarkActivitySeen: (port: number) => void;
     onInstanceLabelSave: (port: number, label: string | null) => Promise<void>;
     onLifecycle: (action: DashboardLifecycleAction, instance: DashboardInstance) => void;
+    jumpHint?: string | null;
 };
 
 const TRANSITION_LABELS: Record<DashboardLifecycleAction, string> = {
@@ -134,6 +135,7 @@ export function InstanceRow(props: InstanceRowProps) {
             <button
                 className="instance-row-select"
                 type="button"
+                data-instance-port={props.instance.port}
                 aria-pressed={props.selected}
                 onClick={() => {
                     props.onSelect(props.instance);
@@ -263,6 +265,7 @@ export function InstanceRow(props: InstanceRowProps) {
                     </svg>
                 </button>
             ) : null}
+            {props.jumpHint ? <span className="instance-jump-hint" aria-hidden="true">{props.jumpHint}</span> : null}
             {props.showSelectedActions !== false && (
             <div className="instance-actions">
                 <button

--- a/public/manager/src/components/sidebar-keyboard.ts
+++ b/public/manager/src/components/sidebar-keyboard.ts
@@ -1,0 +1,129 @@
+export const INSTANCE_JUMP_HINT_SHOW_DELAY_MS = 200;
+export const SETTLED_TAIL_INITIAL_COUNT = 10;
+export const SETTLED_TAIL_PAGE_COUNT = 25;
+
+export type TraverseDir = 'previous' | 'next';
+export type InstanceJumpSelector = (port: number) => void;
+
+export function resolveAdjacentPort(list: readonly number[], current: number | null, dir: TraverseDir): number | null {
+    if (list.length === 0) return null;
+    if (current == null) return dir === 'previous' ? (list[list.length - 1] ?? null) : (list[0] ?? null);
+    const idx = list.indexOf(current);
+    if (idx === -1) return null;
+    if (dir === 'previous') return idx > 0 ? (list[idx - 1] ?? null) : null;
+    return idx < list.length - 1 ? (list[idx + 1] ?? null) : null;
+}
+
+export function jumpInstanceIndexFromAction(action: string): number | null {
+    const match = /^jumpInstance([1-9])$/.exec(action);
+    return match ? Number(match[1]!) - 1 : null;
+}
+
+export function isSettledStatus(status: string): boolean {
+    return status === 'offline' || status === 'unknown' || status === 'timeout';
+}
+
+export function pageSettledPorts(settledPorts: readonly number[], visibleCount: number, selectedPort: number | null): number[] {
+    const visible = settledPorts.slice(0, Math.max(0, visibleCount));
+    if (selectedPort != null && settledPorts.includes(selectedPort) && !visible.includes(selectedPort)) {
+        return [...visible, selectedPort];
+    }
+    return visible;
+}
+
+export function createJumpHintVisibilityController(input: {
+    delayMs: number;
+    onVisibilityChange: (visible: boolean) => void;
+    setTimeoutFn?: typeof setTimeout;
+    clearTimeoutFn?: typeof clearTimeout;
+}): { sync: (shouldShow: boolean) => void; dispose: () => void } {
+    const setTimeoutFn = input.setTimeoutFn ?? setTimeout;
+    const clearTimeoutFn = input.clearTimeoutFn ?? clearTimeout;
+    let isVisible = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const clearPending = (): void => {
+        if (timeoutId == null) return;
+        clearTimeoutFn(timeoutId);
+        timeoutId = null;
+    };
+    return {
+        sync(shouldShow: boolean): void {
+            if (!shouldShow) {
+                clearPending();
+                if (isVisible) {
+                    isVisible = false;
+                    input.onVisibilityChange(false);
+                }
+                return;
+            }
+            if (isVisible || timeoutId != null) return;
+            timeoutId = setTimeoutFn(() => {
+                timeoutId = null;
+                isVisible = true;
+                input.onVisibilityChange(true);
+            }, input.delayMs);
+        },
+        dispose(): void { clearPending(); },
+    };
+}
+
+let jumpHintsVisible = false;
+const jumpHintListeners = new Set<() => void>();
+
+export function subscribeJumpHints(cb: () => void): () => void {
+    jumpHintListeners.add(cb);
+    return () => { jumpHintListeners.delete(cb); };
+}
+
+export function getJumpHintsVisible(): boolean {
+    return jumpHintsVisible;
+}
+
+export function setJumpHintsVisible(next: boolean): void {
+    if (jumpHintsVisible === next) return;
+    jumpHintsVisible = next;
+    jumpHintListeners.forEach(listener => listener());
+}
+
+export function shouldArmJumpHint(event: Pick<KeyboardEvent, 'altKey' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'key'>): boolean {
+    return event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey;
+}
+
+export function readRenderedInstancePorts(root: ParentNode): number[] {
+    return Array.from(root.querySelectorAll<HTMLElement>('[data-instance-port]'))
+        .map(el => Number(el.dataset['instancePort']))
+        .filter(port => Number.isInteger(port));
+}
+
+export function handleInstanceListKeyDown(event: KeyboardEvent, root: ParentNode, onSelectPort: (port: number) => void): void {
+    if (event.isComposing || event.keyCode === 229) return;
+    const buttons = Array.from(root.querySelectorAll<HTMLElement>('[data-instance-port]'));
+    if (buttons.length === 0) return;
+    const ports = buttons.map(el => Number(el.dataset['instancePort']));
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const currentEl = active?.closest('[data-instance-port]');
+    const currentPort = currentEl instanceof HTMLElement ? Number(currentEl.dataset['instancePort']) : null;
+    let next: number | null = null;
+    if (event.key === 'ArrowDown') next = resolveAdjacentPort(ports, currentPort, 'next');
+    else if (event.key === 'ArrowUp') next = resolveAdjacentPort(ports, currentPort, 'previous');
+    else if (event.key === 'Home') next = ports[0] ?? null;
+    else if (event.key === 'End') next = ports[ports.length - 1] ?? null;
+    else if (event.key === 'Enter' && currentPort != null) {
+        event.preventDefault();
+        onSelectPort(currentPort);
+        return;
+    }
+    if (next == null) return;
+    event.preventDefault();
+    buttons.find(el => Number(el.dataset['instancePort']) === next)?.focus();
+}
+
+let instanceJumpSelector: InstanceJumpSelector | null = null;
+
+export function registerInstanceJumpSelector(fn: InstanceJumpSelector | null): void {
+    instanceJumpSelector = fn;
+}
+
+export function getInstanceJumpSelector(): InstanceJumpSelector | null {
+    return instanceJumpSelector;
+}

--- a/public/manager/src/dashboard-settings/DashboardSettingsWorkspace.tsx
+++ b/public/manager/src/dashboard-settings/DashboardSettingsWorkspace.tsx
@@ -105,6 +105,11 @@ const COPY = {
                 scope: '단축키',
                 description: '기본 300으로 되돌리고 \'jaw.sidebarWidth\' 키를 지운다.',
             },
+            shortcutJumpInstance: {
+                label: '인스턴스 점프',
+                scope: '단축키',
+                description: '렌더된 사이드바 행 1–9로 이동합니다. Meta+1–4는 탭 전환에 남아 있어 Alt를 씁니다.',
+            },
         },
         support: {
             ariaLabel: '작업 제목 출처 준비 상태',
@@ -185,6 +190,11 @@ const COPY = {
                 label: 'Reset sidebar width',
                 scope: 'Shortcut',
                 description: 'Restore the default 300px width and delete the \'jaw.sidebarWidth\' key.',
+            },
+            shortcutJumpInstance: {
+                label: 'Jump to instance',
+                scope: 'Shortcut',
+                description: 'Jump to rendered sidebar rows 1–9. Meta+1–4 stay on tab switching, so these use Alt.',
             },
         },
         support: {
@@ -267,6 +277,11 @@ const COPY = {
                 scope: '快捷键',
                 description: '恢复默认 300px 宽度并删除 \'jaw.sidebarWidth\' 键。',
             },
+            shortcutJumpInstance: {
+                label: '跳转到实例',
+                scope: '快捷键',
+                description: '跳转到已渲染的侧边栏第 1–9 行。Meta+1–4 仍用于切换标签，因此这里使用 Alt。',
+            },
         },
         support: {
             ariaLabel: '活动标题来源就绪状态',
@@ -347,6 +362,11 @@ const COPY = {
                 label: 'サイドバー幅をリセット',
                 scope: 'ショートカット',
                 description: '既定の 300px に戻し、\'jaw.sidebarWidth\' キーを削除します。',
+            },
+            shortcutJumpInstance: {
+                label: 'インスタンスへジャンプ',
+                scope: 'ショートカット',
+                description: '描画済みサイドバー行 1–9 へ移動します。Meta+1–4 はタブ切替のままなので Alt を使います。',
             },
         },
         support: {
@@ -466,6 +486,7 @@ function shortcutCopyKey(action: DashboardShortcutAction): keyof typeof COPY.ko.
     if (action === 'focusNotes') return 'shortcutFocusNotes';
     if (action === 'previousInstance') return 'shortcutPreviousInstance';
     if (action === 'resetSidebarWidth') return 'shortcutResetSidebarWidth';
+    if (action.startsWith('jumpInstance')) return 'shortcutJumpInstance';
     return 'shortcutNextInstance';
 }
 

--- a/public/manager/src/help/helpContent.tsx
+++ b/public/manager/src/help/helpContent.tsx
@@ -148,6 +148,7 @@ const ShortcutsHelp = (
             <li><kbd>{formatShortcut(DEFAULT_MANAGER_SHORTCUT_KEYMAP.focusActiveSession)}</kbd>는 선택된 인스턴스의 Preview 탭으로 이동해요.</li>
             <li><kbd>{formatShortcut(DEFAULT_MANAGER_SHORTCUT_KEYMAP.focusNotes)}</kbd>는 Notes workspace로 이동해요.</li>
             <li><kbd>{formatShortcut(DEFAULT_MANAGER_SHORTCUT_KEYMAP.previousInstance)}</kbd> / <kbd>{formatShortcut(DEFAULT_MANAGER_SHORTCUT_KEYMAP.nextInstance)}</kbd>는 현재 필터된 인스턴스 목록에서 이전/다음 행을 선택해요.</li>
+            <li><kbd>Alt+1</kbd> … <kbd>Alt+9</kbd>는 렌더된 사이드바 행으로 점프하고, Alt를 200ms 누르면 행 오른쪽에 점프 힌트가 떠요.</li>
             <li><kbd>⌘/Ctrl + S</kbd>는 Notes와 Settings처럼 저장 가능한 화면에서 현재 편집 내용을 저장해요.</li>
             <li><kbd>⌘/Ctrl + E</kbd>는 Notes 편집 모드를 순환해요.</li>
             <li>Manager 단축키는 Dashboard settings에서 켜고 끄거나 keymap을 바꿀 수 있어요.</li>

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -201,6 +201,7 @@ h2 { font-size: 13px; }
     border-bottom: 1px solid var(--border-subtle);
     background: var(--canvas-deep);
     padding: 10px;
+    flex-wrap: wrap;
 }
 .instance-navigator-header strong {
     display: block;
@@ -218,6 +219,57 @@ h2 { font-size: 13px; }
     flex: 1;
     min-height: 0;
     overflow: auto;
+}
+.instance-navigator-search { flex: 1 1 100%; }
+.instance-navigator-search input {
+    width: 100%;
+    border: 1px solid var(--border-subtle);
+    background: var(--canvas-deep);
+    color: var(--text-primary);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font: inherit;
+}
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+.instance-jump-hint {
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    height: 16px;
+    min-width: 16px;
+    padding: 0 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text-secondary);
+    background: var(--surface-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    pointer-events: none;
+    z-index: 2;
+}
+.instance-settled-more {
+    width: 100%;
+    margin-top: 4px;
+    border: 0;
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+    padding: 6px 4px;
 }
 .instance-group { margin-bottom: 12px; }
 .instance-group-header {

--- a/public/manager/src/manager-shortcut-runner.ts
+++ b/public/manager/src/manager-shortcut-runner.ts
@@ -2,6 +2,7 @@ import type { DashboardDetailTab, DashboardInstance, DashboardShortcutAction, Da
 import { actionForShortcutEvent } from './manager-shortcuts';
 import { panelShortcutBus } from './panels/panel-shortcut-bus';
 import { getDesktop } from './panels/desktop-bridge';
+import { getInstanceJumpSelector, jumpInstanceIndexFromAction, readRenderedInstancePorts } from './components/sidebar-keyboard';
 
 /**
  * Dependencies the manager keyboard-shortcut runner needs from <App>.
@@ -23,6 +24,14 @@ export interface ManagerShortcutRunnerDeps {
 
 export function runManagerShortcut(action: DashboardShortcutAction, deps: ManagerShortcutRunnerDeps): void {
     if (panelShortcutBus.dispatch(action)) return;
+    const jumpIndex = jumpInstanceIndexFromAction(action);
+    if (jumpIndex != null) {
+        const root = document.getElementById('manager-sidebar-list');
+        if (!root) return;
+        const port = readRenderedInstancePorts(root)[jumpIndex];
+        if (port != null) getInstanceJumpSelector()?.(port);
+        return;
+    }
     if (action === 'focusInstances') {
         deps.handleSidebarModeChange('instances');
         deps.setDrawerOpen(false);

--- a/public/manager/src/manager-shortcuts.ts
+++ b/public/manager/src/manager-shortcuts.ts
@@ -28,6 +28,15 @@ export const MANAGER_SHORTCUT_ACTIONS: DashboardShortcutAction[] = [
     'terminalNewTab',
     'toggleLeftSidebar',
     'resetSidebarWidth',
+    'jumpInstance1',
+    'jumpInstance2',
+    'jumpInstance3',
+    'jumpInstance4',
+    'jumpInstance5',
+    'jumpInstance6',
+    'jumpInstance7',
+    'jumpInstance8',
+    'jumpInstance9',
 ];
 
 export const DEFAULT_MANAGER_SHORTCUT_KEYMAP: DashboardShortcutKeymap = {
@@ -58,6 +67,15 @@ export const DEFAULT_MANAGER_SHORTCUT_KEYMAP: DashboardShortcutKeymap = {
     terminalNewTab: 'Meta+T',
     toggleLeftSidebar: 'Meta+Shift+B',
     resetSidebarWidth: 'Alt+Shift+B',
+    jumpInstance1: 'Alt+1',
+    jumpInstance2: 'Alt+2',
+    jumpInstance3: 'Alt+3',
+    jumpInstance4: 'Alt+4',
+    jumpInstance5: 'Alt+5',
+    jumpInstance6: 'Alt+6',
+    jumpInstance7: 'Alt+7',
+    jumpInstance8: 'Alt+8',
+    jumpInstance9: 'Alt+9',
 };
 
 const MANAGER_SHORTCUT_ALIASES: Partial<Record<DashboardShortcutAction, string[]>> = {
@@ -119,6 +137,7 @@ export function normalizeManagerShortcutKeymap(value: unknown): DashboardShortcu
 
 function resolveEventKey(event: KeyboardEvent): string {
     if (event.code === 'Backquote') return '`';
+    if (event.altKey && event.code?.startsWith('Digit')) return event.code.slice(5);
     const k = normalizeKey(event.key);
     if (k.length === 1) return k;
     // macOS Option+letter produces special chars (e.g. ∆ for Alt+J).

--- a/public/manager/src/types.ts
+++ b/public/manager/src/types.ts
@@ -40,7 +40,10 @@ export type DashboardShortcutAction =
     | 'terminalClear'
     | 'terminalNewTab'
     | 'toggleLeftSidebar'
-    | 'resetSidebarWidth';
+    | 'resetSidebarWidth'
+    | 'jumpInstance1' | 'jumpInstance2' | 'jumpInstance3'
+    | 'jumpInstance4' | 'jumpInstance5' | 'jumpInstance6'
+    | 'jumpInstance7' | 'jumpInstance8' | 'jumpInstance9';
 export type DashboardShortcutKeymap = Record<DashboardShortcutAction, string>;
 export type DashboardDiffMode = 'unstaged' | 'staged' | 'head' | 'base';
 export type DashboardDiffRootPolicy = 'project-first' | 'working-dir-first' | 'manual';

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -235,6 +235,11 @@ settings.ts (barrel)
 
 `components/instance-row-status.ts`가 행 상태를 정한다: `transitioning`(라이프사이클 진행) > `working`(`busyPorts`) > `attention`(timeout/error/unknown) > `offline` > `online`. `InstanceRow`는 제목 위에 `.instance-row-status-line[data-status]`(pill + working일 때만 행 국소 1s `WorkingDuration`, `Ns`/`Nm`/`Xh Ym`)를 두고, compact/rail density에서는 숨긴다. 툴팁은 `composeInstanceRowTitle`의 native `title`. 퀵 액션(`.instance-row-quick .quick-btn`)은 hover/focus-within/선택 행에서만, 그리고 `:not(:disabled)`만 드러난다. `InstanceGroups` 헤더는 `button.instance-group-header.instance-group-toggle[aria-expanded]`로 접히며(`Active` 그룹은 예외), 접힘 맵은 `hooks/useSidebarGroupCollapse.ts`가 localStorage `jaw.sidebarGroupCollapsed`(`Record<groupId, boolean>`)에 저장한다. 접힌 그룹에서도 선택 인스턴스는 한 줄로 남는다. Pinned는 favorite 우선 후 label 정렬이며 서버 order key가 없어 DnD는 없다. 제네릭 `.instance-row.is-selected {` 선택자는 contract 테스트가 금지한다.
 
+### Manager sidebar search, keyboard, settled shelf (260902 t3 shell polish, wp4)
+
+`InstanceNavigator` 헤더의 `#manager-sidebar-search`는 CommandBar와 같은 `App.query`를 소비한다(두 번째 필터 없음). Escape는 쿼리를 비우고 IME 조합 중에는 무시한다. `components/sidebar-keyboard.ts`가 순수 헬퍼를 가진다: `resolveAdjacentPort`(wrap 없음), `handleInstanceListKeyDown`(Arrow/Home/End는 `[data-instance-port]` 버튼 포커스만 이동, Enter가 선택), `createJumpHintVisibilityController`(Alt 200ms 유지 시 렌더된 행 1..9 오른쪽 상단 `.instance-jump-hint` 오버레이), `readRenderedInstancePorts(#manager-sidebar-list)`, `registerInstanceJumpSelector`(SidebarRailRouter가 등록). 단축키 `jumpInstance1..9`(기본 `Alt+1..9`)는 `resolveEventKey`의 Digit 코드 폴백으로 macOS Alt+숫자 특수문자에도 매칭되며 서버 keymap whitelist에는 넣지 않는다(switchTab과 동일하게 기본값 복원). offline/unknown/timeout은 `Settled` 그룹(id `settled`, 접힘은 wp3 `useSidebarGroupCollapse`)으로 내려가고 `pageSettledPorts`로 10개 → "Show N more" 25개씩 페이징되며 선택 인스턴스는 항상 렌더된다. Attention은 error만.
+
+
 ### Manager preview memory note
 
 2026-06-14 점검 기준, Chrome에서 manager Web UI를 열었을 때 1GB 근처까지 올라갔다가 약 10분 뒤 300MB대 근처로 안정화되는 패턴은 `jaw dashboard serve` manager 서버 누수보다 preview iframe의 cold-load peak로 해석한다. 실제 관찰에서는 manager 서버 `dist/src/manager/server.js` RSS가 약 170~220MB 수준이었고, 큰 RSS는 Chrome renderer와 각 `jaw serve` worker(`dist/server.js`) 쪽에 있었다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -425,7 +425,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 565 files source/assets, ~100100L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 566 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (1223L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시

--- a/tests/unit/manager-shortcuts.test.ts
+++ b/tests/unit/manager-shortcuts.test.ts
@@ -100,3 +100,14 @@ test('reload shortcuts are owned by the Electron menu and ignored by the rendere
     assert.ok(RENDERER_DISABLED_SHORTCUT_ACTIONS.has('browserReload'));
     assert.ok(RENDERER_DISABLED_SHORTCUT_ACTIONS.has('browserHardReload'));
 });
+
+test('Alt+Digit recovers jumpInstance even when macOS rewrites the key character', () => {
+    assert.equal(
+        actionForShortcutEvent(keyEvent('1', { altKey: true, code: 'Digit1' }), DEFAULT_MANAGER_SHORTCUT_KEYMAP),
+        'jumpInstance1',
+    );
+    assert.equal(
+        actionForShortcutEvent(keyEvent('£', { altKey: true, code: 'Digit3' }), DEFAULT_MANAGER_SHORTCUT_KEYMAP),
+        'jumpInstance3',
+    );
+});

--- a/tests/unit/manager-sidebar-keyboard.test.ts
+++ b/tests/unit/manager-sidebar-keyboard.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createJumpHintVisibilityController,
+    getInstanceJumpSelector,
+    jumpInstanceIndexFromAction,
+    pageSettledPorts,
+    registerInstanceJumpSelector,
+    resolveAdjacentPort,
+    shouldArmJumpHint,
+} from '../../public/manager/src/components/sidebar-keyboard.js';
+
+test('resolveAdjacentPort next/prev/null-current/missing/empty',
+    () => {
+        assert.equal(resolveAdjacentPort([1, 2, 3], 2, 'next'), 3);
+        assert.equal(resolveAdjacentPort([1, 2, 3], 1, 'previous'), null);
+        assert.equal(resolveAdjacentPort([1, 2, 3], null, 'next'), 1);
+        assert.equal(resolveAdjacentPort([1, 2, 3], null, 'previous'), 3);
+        assert.equal(resolveAdjacentPort([1, 2, 3], 9, 'next'), null);
+        assert.equal(resolveAdjacentPort([], 1, 'next'), null);
+        assert.equal(resolveAdjacentPort([1, 2, 3], 3, 'next'), null);
+        assert.equal(resolveAdjacentPort([1, 2, 3], 2, 'previous'), 1);
+    });
+
+test('jumpInstanceIndexFromAction maps jumpInstance1..9 and rejects others',
+    () => {
+        assert.equal(jumpInstanceIndexFromAction('jumpInstance1'), 0);
+        assert.equal(jumpInstanceIndexFromAction('jumpInstance3'), 2);
+        assert.equal(jumpInstanceIndexFromAction('jumpInstance9'), 8);
+        assert.equal(jumpInstanceIndexFromAction('jumpInstance0'), null);
+        assert.equal(jumpInstanceIndexFromAction('jumpInstance10'), null);
+        assert.equal(jumpInstanceIndexFromAction('nextInstance'), null);
+    });
+
+test('createJumpHintVisibilityController 199ms hidden / 200ms visible / hide / re-arm',
+    () => {
+        const timers = new Map<number, { fn: () => void; due: number }>();
+        let nextId = 1;
+        let now = 0;
+        let visible = false;
+        const setTimeoutFn = ((fn: () => void, delay: number) => {
+            const id = nextId++;
+            timers.set(id, { fn, due: now + delay });
+            return id as unknown as ReturnType<typeof setTimeout>;
+        }) as typeof setTimeout;
+        const clearTimeoutFn = ((id: ReturnType<typeof setTimeout>) => {
+            timers.delete(id as unknown as number);
+        }) as typeof clearTimeout;
+        const advance = (ms: number): void => {
+            now += ms;
+            for (const [id, timer] of [...timers.entries()]) {
+                if (timer.due <= now) {
+                    timers.delete(id);
+                    timer.fn();
+                }
+            }
+        };
+
+        const controller = createJumpHintVisibilityController({
+            delayMs: 200,
+            onVisibilityChange: next => { visible = next; },
+            setTimeoutFn,
+            clearTimeoutFn,
+        });
+
+        controller.sync(true);
+        advance(199);
+        assert.equal(visible, false);
+        advance(1);
+        assert.equal(visible, true);
+
+        controller.sync(false);
+        assert.equal(visible, false);
+
+        controller.sync(true);
+        advance(199);
+        assert.equal(visible, false);
+        advance(1);
+        assert.equal(visible, true);
+
+        controller.dispose();
+        controller.sync(true);
+        advance(200);
+        assert.equal(visible, true);
+    });
+
+test('pageSettledPorts keeps the selected port when it is past the visible window',
+    () => {
+        const ports = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        assert.deepEqual(pageSettledPorts(ports, 10, 12), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12]);
+        assert.deepEqual(pageSettledPorts(ports, 10, 3), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert.deepEqual(pageSettledPorts(ports, 10, null), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert.deepEqual(pageSettledPorts(ports, 0, 12), [12]);
+    });
+
+test('shouldArmJumpHint stays armed for Alt plus a follow-up key without extra modifiers',
+    () => {
+        assert.equal(shouldArmJumpHint({ altKey: true, metaKey: false, ctrlKey: false, shiftKey: false, key: 'Alt' }), true);
+        assert.equal(shouldArmJumpHint({ altKey: true, metaKey: false, ctrlKey: false, shiftKey: false, key: '£' }), true);
+        assert.equal(shouldArmJumpHint({ altKey: true, metaKey: true, ctrlKey: false, shiftKey: false, key: '1' }), false);
+        assert.equal(shouldArmJumpHint({ altKey: false, metaKey: false, ctrlKey: false, shiftKey: false, key: 'Alt' }), false);
+    });
+
+test('registerInstanceJumpSelector stores and clears the module-level callback',
+    () => {
+        const original = getInstanceJumpSelector();
+        const fn = (_port: number): void => {};
+        registerInstanceJumpSelector(fn);
+        assert.equal(getInstanceJumpSelector(), fn);
+        registerInstanceJumpSelector(null);
+        assert.equal(getInstanceJumpSelector(), null);
+        registerInstanceJumpSelector(original);
+    });


### PR DESCRIPTION
## wp4 — Sidebar search, keyboard traversal, jump hints, settled shelf

- InstanceNavigator header search (#manager-sidebar-search) shares the command-bar query; Escape clears; IME guarded.
- sidebar-keyboard.ts: no-wrap adjacency, Arrow/Home/End focus traversal + Enter select on rendered [data-instance-port] rows, 200ms Alt jump-hint controller (injectable timers), rendered-port reader, jump selector registry.
- jumpInstance1..9 (Alt+1..9) through types/keymap/runner/settings copy/help; Digit-code fallback in resolveEventKey so macOS Alt+digit symbols match; server keymap whitelist unchanged (defaults restore like switchTab).
- Settled shelf: offline/unknown/timeout under a collapsible Settled group (reuses wp3 group collapse), paged 10 then 25 with Show N more; selected instance always rendered; Attention = error only.
- Jump hint badge overlay on first nine rendered rows while Alt is held. App.tsx untouched (499).

Verification: typecheck/build/check 0; manager-sidebar-keyboard 6/6, manager-shortcuts 6/6 (incl. Alt+£/Digit3 -> jumpInstance3); broad manager/electron/dashboard set 1163/1163; verify-counts ALL PASS.

Rendered (headless Chrome 1280x720): 12 rows -> Show 25 more -> 37 rows; typing 3465 in sidebar mirrors command bar and narrows to 3; Escape restores; ArrowDown x2 moves focus 3457->3468 without changing selection; Alt held 120ms -> 0 hints, 370ms -> 9 hints, release -> 0; Alt+Digit3 selects third rendered row (3468). Screenshots wp4-*.png in devlog evidence.

Plan: devlog/_plan/260902_t3_shell_polish/040_sidebar_search_keyboard.md
