### PR TITLE
feat(manager): t3-style command bar with traffic-light inset (wp5)

### DIFF
--- a/public/manager/src/AppChrome.tsx
+++ b/public/manager/src/AppChrome.tsx
@@ -17,6 +17,7 @@ import type { NotesModelState } from './notes/useNotesModel';
 import type { NotesSidebarMode } from './notes/NotesSidebar';
 import type { CommandPaletteApi } from './hooks/useCommandPalette';
 import type { ThemeApi } from './hooks/useTheme';
+import { useWindowFullscreen } from './hooks/useWindowFullscreen';
 import type { useDashboardView } from './hooks/useDashboardView';
 import type { DashboardDetailTab, DashboardInstance, DashboardNotesAuthoringMode, DashboardNotesGraphSettings, DashboardNotesViewMode, DashboardScanResult, DashboardShortcutAction, ManagerEvent, NoteMetadata } from './types';
 import { createManagerCaptureKeydownHandler } from './manager-shortcut-runner';
@@ -105,6 +106,7 @@ type AppChromeProps = {
 };
 
 export function AppChrome(props: AppChromeProps) {
+    useWindowFullscreen();
     useEffect(() => {
         if (!props.view.dashboardShortcutsEnabled) return undefined;
         const handler = createManagerCaptureKeydownHandler(

--- a/public/manager/src/components/CommandBar.tsx
+++ b/public/manager/src/components/CommandBar.tsx
@@ -19,8 +19,10 @@ export function CommandBar(props: CommandBarProps) {
     return (
         <CommandCenter
             mobileMenuButton={(
-                <button className="drawer-trigger" type="button" onClick={props.onOpenDrawer} aria-label="Open sidebar">
-                    ☰
+                <button className="drawer-trigger command-icon-button" type="button" onClick={props.onOpenDrawer} aria-label="Open sidebar">
+                    <svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden="true" focusable="false">
+                        <path d="M4 6h12M4 10h12M4 14h12" />
+                    </svg>
                 </button>
             )}
             title={(
@@ -30,7 +32,7 @@ export function CommandBar(props: CommandBarProps) {
                 </h1>
             )}
             search={(
-                <div className="search-input-wrapper">
+                <div className="search-input-wrapper is-ghost">
                     <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
                     <input
                         value={props.query}
@@ -54,8 +56,18 @@ export function CommandBar(props: CommandBarProps) {
                         <span aria-hidden="true">⌘K</span>
                     </button>
                     <ThemeSwitch theme={props.theme} onChange={props.onThemeChange} />
-                    <button type="button" onClick={props.onRefresh} disabled={props.loading}>
-                        {props.loading ? 'Scanning' : 'Refresh'}
+                    <button
+                        type="button"
+                        className="command-icon-button"
+                        onClick={props.onRefresh}
+                        disabled={props.loading}
+                        aria-label={props.loading ? 'Scanning' : 'Refresh'}
+                        title={props.loading ? 'Scanning' : 'Refresh'}
+                    >
+                        <svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+                            <path d="M16 10a6 6 0 1 1-2-4.5" />
+                            <path d="M16 4v4h-4" />
+                        </svg>
                     </button>
                 </div>
             )}

--- a/public/manager/src/hooks/useWindowFullscreen.ts
+++ b/public/manager/src/hooks/useWindowFullscreen.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { getDesktop } from '../panels/desktop-bridge';
+
+function readFullscreenState(): boolean {
+    return getDesktop()?.window?.getFullscreenState?.() === true;
+}
+
+export function useWindowFullscreen(): boolean {
+    useEffect(() => {
+        const root = document.documentElement;
+        const apply = (next: boolean): void => {
+            if (next) root.dataset['windowFullscreen'] = 'true';
+            else delete root.dataset['windowFullscreen'];
+        };
+        apply(readFullscreenState());
+        const unsubscribe = getDesktop()?.window?.onFullscreenStateChange?.(apply);
+        return () => {
+            unsubscribe?.();
+            delete root.dataset['windowFullscreen'];
+        };
+    }, []);
+    return readFullscreenState();
+}

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -56,18 +56,19 @@
 .command-bar {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 10px 14px;
+    gap: 0;
+    padding: 0 14px;
+    height: var(--workspace-topbar-height);
+    min-height: var(--workspace-topbar-height);
 }
 .command-primary {
     width: 100%;
     min-width: 0;
+    height: 100%;
     display: grid;
     align-items: center;
-    gap: 10px;
-}
-.command-primary {
-    grid-template-columns: minmax(128px, 190px) max-content minmax(max-content, 1fr);
+    gap: 8px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
 }
 .drawer-trigger { display: none; }
 .eyebrow {
@@ -83,24 +84,23 @@ h1 { font-size: 14px; }
 h2 { font-size: 13px; }
 .command-search {
     min-width: 0;
-    width: clamp(280px, 34vw, 820px);
+    width: 100%;
     max-width: 100%;
-    justify-self: start;
-    display: grid;
-    grid-template-columns: minmax(160px, 1fr);
-    gap: 8px;
+    justify-self: stretch;
 }
 .command-actions { justify-self: end; }
 .is-electron-titlebar {
     -webkit-app-region: drag;
-    padding-left: 132px;
+    padding-left: var(--electron-titlebar-left-reserve, 90px);
 }
 .is-electron-titlebar button,
 .is-electron-titlebar input,
 .is-electron-titlebar select,
 .is-electron-titlebar a,
 .is-electron-titlebar .command-actions,
-.is-electron-titlebar .command-search {
+.is-electron-titlebar .command-search,
+.is-electron-titlebar .drawer-trigger,
+.is-electron-titlebar .theme-switch {
     -webkit-app-region: no-drag;
 }
 .command-filter-strip {

--- a/public/manager/src/manager-layout.css
+++ b/public/manager/src/manager-layout.css
@@ -150,7 +150,6 @@
     .dashboard-shell.manager-shell:not(.is-sidebar-collapsed) .manager-workspace.is-side-panel-open {
         --right-panel-width: 50vw;
     }
-    .command-primary { grid-template-columns: minmax(120px, 180px) max-content minmax(max-content, 1fr); }
     .command-search { width: clamp(260px, 38vw, 620px); }
     .overview-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
@@ -207,11 +206,9 @@
     }
     .command-primary {
         grid-template-columns: auto minmax(0, 1fr) auto;
-        grid-template-areas: "drawer title actions" "search search search";
+        grid-template-areas: "title search actions";
     }
-    .command-actions { grid-area: actions; justify-self: end; }
-    .command-title { grid-area: title; }
-    .command-search { grid-area: search; }
+    .drawer-trigger { display: inline-flex; }
     .command-search { width: 100%; }
     .command-filter-strip .home-input { display: none; }
     .preview-frame { min-height: 300px; }
@@ -243,11 +240,7 @@
         width: min(90vw, var(--right-panel-width, 340px));
         max-width: min(90vw, 360px);
     }
-    .command-bar {
-        gap: 8px;
-        padding: 9px 10px;
-    }
-    .command-primary { grid-template-columns: auto minmax(0, 1fr) auto; grid-template-areas: "drawer search actions"; }
+    .command-primary { grid-template-columns: auto minmax(0, 1fr) auto; grid-template-areas: "title search actions"; }
     .command-title { display: none; }
     .command-actions { grid-area: actions; }
     .command-filter-strip {

--- a/public/manager/src/manager-p0-1-1.css
+++ b/public/manager/src/manager-p0-1-1.css
@@ -1,34 +1,56 @@
 .command-bar {
-    gap: 4px;
-    padding: 6px 10px;
+    box-sizing: border-box;
+    height: var(--workspace-topbar-height);
+    min-height: var(--workspace-topbar-height);
+    gap: 0;
+    padding: 0 10px;
 }
 .command-center.command-bar.is-electron-titlebar,
 :root[data-cli-jaw-desktop="true"] .command-center.command-bar {
-    --electron-titlebar-left-reserve: 132px;
-    padding: 6px 10px 6px var(--electron-titlebar-left-reserve);
+    --electron-titlebar-left-reserve: 90px;
+    padding: 0 10px 0 var(--electron-titlebar-left-reserve);
 }
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar {
-    -webkit-app-region: drag;
+:root[data-window-fullscreen="true"] .command-center.command-bar.is-electron-titlebar,
+:root[data-cli-jaw-desktop="true"][data-window-fullscreen="true"] .command-center.command-bar {
+    --electron-titlebar-left-reserve: 12px;
 }
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar button,
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar input,
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar select,
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar a,
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar .command-actions,
-:root[data-cli-jaw-desktop="true"] .command-center.command-bar .command-search {
+:root[data-cli-jaw-desktop="true"] .command-center.command-bar { -webkit-app-region: drag; }
+:root[data-cli-jaw-desktop="true"] .command-center.command-bar :is(button, input, select, a, .command-actions, .command-search, .drawer-trigger, .theme-switch, .command-panel-controls, .search-input-wrapper, .desktop-open-button, .desktop-status-badge) {
     -webkit-app-region: no-drag;
 }
 
 .command-primary {
+    height: 100%;
     gap: 8px;
-    grid-template-columns: minmax(112px, 148px) max-content minmax(max-content, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas: "title search actions";
 }
+.drawer-trigger { grid-area: title; }
+/* .command-icon-button is more specific than the components display:none;
+   keep the mobile drawer trigger hidden on desktop. */
+.command-primary .drawer-trigger.command-icon-button { display: none; }
+@media (max-width: 1023px) {
+    .command-primary {
+        grid-template-columns: auto auto minmax(0, 1fr) auto;
+        grid-template-areas: "drawer title search actions";
+    }
+    .command-primary .drawer-trigger.command-icon-button { display: inline-grid; grid-area: drawer; }
+}
+@media (max-width: 767px) {
+    .command-primary {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        grid-template-areas: "drawer search actions";
+    }
+}
+.command-title { grid-area: title; }
+.command-search { grid-area: search; width: 100%; max-width: none; }
+.command-actions { grid-area: actions; }
 
 .command-title {
     --manager-brand-cyan: #21e6f3;
     position: relative;
-    display: flex;
-    gap: 0;
+    display: inline-flex;
+    gap: 8px;
     align-content: center;
     align-items: center;
     min-width: 0;
@@ -37,16 +59,16 @@
 
 .command-title h1,
 .command-title .manager-brand-heading {
-    max-width: 136px;
+    max-width: 148px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     color: var(--manager-brand-cyan);
     font-family: "Satoshi", "Geist Mono", "IBM Plex Mono", monospace;
-    font-size: 14px;
-    font-weight: 850;
-    letter-spacing: 0;
-    line-height: 0.95;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    line-height: 1;
     text-shadow: 0 0 16px color-mix(in srgb, var(--manager-brand-cyan) 28%, transparent);
 }
 
@@ -60,6 +82,7 @@
 
 .manager-brand-wordmark {
     flex: 0 0 auto;
+    letter-spacing: 0.02em;
 }
 
 .manager-brand-dash {
@@ -89,18 +112,21 @@
     gap: 4px;
 }
 
+.command-icon-button,
 .command-panel-toggle {
-    width: 30px;
-    min-width: 30px;
-    height: 30px;
-    min-height: 30px;
+    width: 28px;
+    min-width: 28px;
+    height: 28px;
+    min-height: 28px;
     display: inline-grid;
     place-items: center;
+    padding: 0;
+    border-radius: var(--control-radius);
+}
+.command-panel-toggle {
     border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-subtle));
-    border-radius: 8px;
     background: color-mix(in srgb, var(--accent) 7%, transparent);
     color: var(--text-primary);
-    padding: 0;
 }
 
 .command-panel-toggle:hover,
@@ -112,6 +138,21 @@
 .command-panel-toggle.is-active {
     border-color: color-mix(in srgb, var(--accent) 70%, var(--border-strong));
     background: color-mix(in srgb, var(--accent) 18%, var(--bg-raised));
+}
+
+.search-input-wrapper.is-ghost input {
+    height: 28px;
+    min-height: 28px;
+    border: 1px solid transparent;
+    background: var(--sidebar-control-surface);
+    border-radius: var(--control-radius);
+    padding: 0 8px 0 32px;
+    font-size: 12px;
+}
+.command-palette-trigger {
+    height: 28px;
+    min-height: 28px;
+    border-radius: var(--control-radius);
 }
 
 .workbench-preview .workbench-header {

--- a/public/manager/src/manager-polish.css
+++ b/public/manager/src/manager-polish.css
@@ -42,31 +42,8 @@
     display: inline;
 }
 
-.command-bar {
-    gap: 4px;
-    padding: 6px 10px;
-}
-.command-bar.is-electron-titlebar {
-    padding-left: 132px;
-}
-
-.command-primary {
-    gap: 8px;
-    grid-template-columns: minmax(108px, 150px) max-content minmax(max-content, 1fr);
-}
-
 .command-title .eyebrow {
     display: none;
-}
-
-.command-title h1 {
-    max-width: 150px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text-primary);
-    font-size: 14px;
-    font-weight: 700;
 }
 
 .command-filter-strip {

--- a/public/manager/src/manager-tokens.css
+++ b/public/manager/src/manager-tokens.css
@@ -330,3 +330,6 @@
     }
 }
 
+:root[data-cli-jaw-desktop="true"] {
+    --workspace-topbar-height: 52px;
+}

--- a/public/manager/src/panels/desktop-bridge.ts
+++ b/public/manager/src/panels/desktop-bridge.ts
@@ -281,6 +281,11 @@ export type PermissionDiagnosticsBridgeApi = {
     getLastDenials: () => Promise<{ ok: boolean; denials?: PermissionDenial[]; error?: string }>;
 };
 
+export type DesktopWindowBridgeApi = {
+    getFullscreenState?: () => boolean;
+    onFullscreenStateChange?: (cb: (fullscreen: boolean) => void) => () => void;
+};
+
 export type DesktopShellCapability = 'terminal' | 'diff' | 'git' | 'folder' | 'shortcuts' | 'browser' | 'clipboard' | 'permissions';
 
 /**
@@ -306,6 +311,7 @@ export type CliJawDesktopApi = {
     browser?: BrowserBridgeApi | undefined;
     reloadWindow?: (() => void) | undefined;
     hardReloadWindow?: (() => void) | undefined;
+    window?: DesktopWindowBridgeApi | undefined;
 };
 
 export function getDesktop(): CliJawDesktopApi | null {

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -240,6 +240,11 @@ settings.ts (barrel)
 `InstanceNavigator` 헤더의 `#manager-sidebar-search`는 CommandBar와 같은 `App.query`를 소비한다(두 번째 필터 없음). Escape는 쿼리를 비우고 IME 조합 중에는 무시한다. `components/sidebar-keyboard.ts`가 순수 헬퍼를 가진다: `resolveAdjacentPort`(wrap 없음), `handleInstanceListKeyDown`(Arrow/Home/End는 `[data-instance-port]` 버튼 포커스만 이동, Enter가 선택), `createJumpHintVisibilityController`(Alt 200ms 유지 시 렌더된 행 1..9 오른쪽 상단 `.instance-jump-hint` 오버레이), `readRenderedInstancePorts(#manager-sidebar-list)`, `registerInstanceJumpSelector`(SidebarRailRouter가 등록). 단축키 `jumpInstance1..9`(기본 `Alt+1..9`)는 `resolveEventKey`의 Digit 코드 폴백으로 macOS Alt+숫자 특수문자에도 매칭되며 서버 keymap whitelist에는 넣지 않는다(switchTab과 동일하게 기본값 복원). offline/unknown/timeout은 `Settled` 그룹(id `settled`, 접힘은 wp3 `useSidebarGroupCollapse`)으로 내려가고 `pageSettledPorts`로 10개 → "Show N more" 25개씩 페이징되며 선택 인스턴스는 항상 렌더된다. Attention은 error만.
 
 
+### Manager command bar (260902 t3 shell polish, wp5)
+
+탑바는 한 줄 `[brand][search][actions]` 그리드다. 높이는 `--workspace-topbar-height`(브라우저 44px, `:root[data-cli-jaw-desktop="true"]`에서 52px). Electron에서는 `--electron-titlebar-left-reserve`가 90px(t3 값)이고 `html[data-window-fullscreen="true"]`이면 12px로 접힌다; 바 자체는 `-webkit-app-region: drag`, 모든 인터랙티브 자식은 `no-drag`(p0-1-1.css 상단 블록이 권위). 브랜드 13px/600/0.02em(`--manager-brand-cyan` 유지), 검색은 28px ghost(`--sidebar-control-surface`), 액션은 28px `.command-icon-button`. 드로어 트리거는 SVG이며 1024px 이상에서는 숨고 그 아래에서는 `drawer` 열을 따로 가진다. `hooks/useWindowFullscreen.ts`가 `getDesktop()?.window?.getFullscreenState?.()`를 읽어 `data-window-fullscreen` 속성을 생산한다(fullscreen이 아니면 속성 제거); IPC 생산자는 wp7. Mod+B 기본값(`Meta+B` 우측 패널, `Meta+Shift+B` 좌측)은 바꾸지 않았다.
+
+
 ### Manager preview memory note
 
 2026-06-14 점검 기준, Chrome에서 manager Web UI를 열었을 때 1GB 근처까지 올라갔다가 약 10분 뒤 300MB대 근처로 안정화되는 패턴은 `jaw dashboard serve` manager 서버 누수보다 preview iframe의 cold-load peak로 해석한다. 실제 관찰에서는 manager 서버 `dist/src/manager/server.js` RSS가 약 170~220MB 수준이었고, 큰 RSS는 Chrome renderer와 각 `jaw serve` worker(`dist/server.js`) 쪽에 있었다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -425,7 +425,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 566 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 567 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (1223L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시

--- a/tests/unit/manager-electron-desktop-contract.test.ts
+++ b/tests/unit/manager-electron-desktop-contract.test.ts
@@ -255,12 +255,16 @@ test('Electron titlebar spacing survives React timing and CSS cascade', () => {
     assert.ok(preload.includes("document.documentElement.dataset.cliJawDesktop = 'true'"), 'preload must mark the document as cli-jaw Desktop');
     assert.ok(compact.includes(':root[data-cli-jaw-desktop="true"] .command-center.command-bar'), 'desktop titlebar CSS must work from the preload document marker');
     assert.ok(reserveMatch, 'desktop titlebar must define an explicit left reserve for macOS traffic lights');
-    assert.ok(Number(reserveMatch[1]) >= 132, 'desktop titlebar left reserve must clear hiddenInset traffic lights');
+    assert.ok(Number(reserveMatch[1]) >= 90, 'desktop titlebar left reserve must clear hiddenInset traffic lights');
     assert.ok(
-        compact.includes('padding: 6px 10px 6px var(--electron-titlebar-left-reserve)'),
+        compact.includes('padding: 0 10px 0 var(--electron-titlebar-left-reserve)'),
         'desktop titlebar padding must consume the explicit traffic-light reserve',
     );
     assert.ok(compact.includes('-webkit-app-region: no-drag'), 'desktop titlebar controls must remain clickable');
+    assert.ok(compact.includes('data-window-fullscreen="true"'), 'desktop titlebar CSS must collapse the traffic-light reserve in fullscreen');
+    assert.ok(compact.includes('--electron-titlebar-left-reserve: 12px'), 'fullscreen titlebar reserve must collapse to 12px');
+    const fullscreenHook = read('public/manager/src/hooks/useWindowFullscreen.ts');
+    assert.ok(fullscreenHook.includes('getDesktop()?.window?.getFullscreenState?.()'), 'fullscreen hook must read the optional desktop window bridge');
 });
 
 test('Electron preload bridge avoids unsupported sandbox Node builtins', () => {

--- a/tests/unit/manager-frontend-contract.test.ts
+++ b/tests/unit/manager-frontend-contract.test.ts
@@ -102,7 +102,12 @@ test('manager command bar exposes polished dashboard brand', () => {
     assert.equal(command.includes('🦈'), false, 'top dashboard brand must not use emoji');
     assert.ok(compact.includes('manager-brand-heading'), 'brand heading must have explicit polish styling');
     assert.ok(compact.includes('manager-brand-dash'), 'DASH label must be styled as secondary context');
-    assert.ok(compact.includes('font-weight: 850'), 'brand heading must use stronger typography');
+    assert.ok(compact.includes('font-weight: 600'), 'brand heading must use stronger typography');
+    assert.ok(compact.includes('font-size: 13px'), 'brand heading must use compact dashboard type');
+    assert.ok(compact.includes('letter-spacing: 0.02em'), 'brand heading must keep tracked wordmark spacing');
+    assert.equal(command.includes('☰'), false, 'drawer trigger must not use a hamburger text glyph');
+    assert.ok(command.includes('drawer-trigger'), 'command bar must keep the drawer trigger');
+    assert.ok(/drawer-trigger[\s\S]*<svg[\s\S]*<path/.test(command), 'drawer trigger must render an SVG path');
 });
 
 test('manager frontend exposes one-instance preview controls', () => {


### PR DESCRIPTION
## wp5 — t3-style command bar, traffic-light inset, fullscreen contract

- Single-row [brand][search][actions] grid; 44px in the browser, 52px in Electron (--workspace-topbar-height desktop override).
- Traffic-light reserve 132px -> 90px (t3 value); collapses to 12px when html[data-window-fullscreen="true"]. Bar is a drag region, every interactive child is no-drag.
- Brand 13px/600/0.02em (cyan kept), search 28px ghost on --sidebar-control-surface, 28px icon buttons; drawer trigger is an SVG (hidden >= 1024px, own column below); refresh is an icon button with aria-label/title.
- useWindowFullscreen hook stub produces data-window-fullscreen from cliJawDesktop.window (IPC producer lands in wp7); DesktopWindowBridgeApi type on the bridge.
- Contract tests updated for the new reserve/padding/brand values. Mod+B defaults unchanged (decision item recorded for review).

Verification: typecheck/build/check 0; electron-desktop-contract 23/23, frontend-contract 23/23; broad manager/electron/dashboard set 1163/1163; verify-counts ALL PASS.

Rendered (headless Chrome 1280x720, dark+light): web bar 44px pad 10px; desktop-simulated (data-cli-jaw-desktop) 52px pad 90px, brand x=90; data-window-fullscreen -> pad 12px; search 28px, icon buttons 28px, brand 13px/600; -webkit-app-region bar=drag input/button=no-drag; no hamburger glyph, drawer trigger hidden on desktop (fixed an overlap found during render check). Screenshots wp5-topbar-*.png in devlog evidence.

Plan: devlog/_plan/260902_t3_shell_polish/050_command_bar.md
