### PR TITLE
feat(manager): t3-style browser panel chrome (wp6)

### DIFF
--- a/electron/src/main/lib/browser/ipc.ts
+++ b/electron/src/main/lib/browser/ipc.ts
@@ -25,10 +25,12 @@ type RegisteredBrowserTab = {
     sharedWithAgent: boolean;
     /** Compatibility state: Manager Browser targets allow actions by default. */
     actionsEnabled: boolean;
+    favicons: string[];
 };
 
 const ownedWebContentsIds = new Set<number>();
 const devToolsListenerIds = new Set<number>();
+const faviconListenerIds = new Set<number>();
 const tabsById = new Map<string, RegisteredBrowserTab>();
 const MAX_ACT_COORD = 100_000;
 const MAX_ACT_TEXT = 2_000;
@@ -54,6 +56,7 @@ export function markOwnedEmbeddedBrowserWebContents(contents: WebContents): void
     contents.once('destroyed', () => {
         ownedWebContentsIds.delete(contents.id);
         devToolsListenerIds.delete(contents.id);
+        faviconListenerIds.delete(contents.id);
         detachCdp(contents);
         for (const [tabId, entry] of tabsById) {
             if (entry.webContentsId === contents.id) tabsById.delete(tabId);
@@ -169,6 +172,10 @@ async function ensureDevToolsOpen(contents: WebContents, preferredMode: 'right' 
     return contents.isDevToolsOpened();
 }
 
+function clampZoom(n: number): number {
+    return Math.min(3, Math.max(0.5, Math.round(n * 10) / 10));
+}
+
 function tabState(entry: RegisteredBrowserTab, contents: WebContents) {
     const targetId = devToolsTargetId(contents);
     return {
@@ -176,6 +183,7 @@ function tabState(entry: RegisteredBrowserTab, contents: WebContents) {
         webContentsId: entry.webContentsId,
         url: contents.getURL(),
         title: contents.getTitle(),
+        favicons: entry.favicons,
         loading: contents.isLoading(),
         canGoBack: contents.navigationHistory?.canGoBack?.() ?? false,
         canGoForward: contents.navigationHistory?.canGoForward?.() ?? false,
@@ -184,6 +192,7 @@ function tabState(entry: RegisteredBrowserTab, contents: WebContents) {
         sharedWithAgent: entry.sharedWithAgent,
         actionsEnabled: entry.actionsEnabled,
         inspecting: isInspecting(contents),
+        zoomFactor: contents.getZoomFactor(),
     };
 }
 
@@ -216,6 +225,19 @@ export function registerBrowserIpc(options: BrowserIpcOptions): void {
         contents.on('devtools-closed', emit);
     }
 
+    function attachFaviconListener(entry: RegisteredBrowserTab, contents: WebContents): void {
+        if (faviconListenerIds.has(contents.id)) return;
+        faviconListenerIds.add(contents.id);
+        contents.on('page-favicon-updated', (_event, favicons: string[]) => {
+            const live = tabsById.get(entry.tabId);
+            if (!live || live.webContentsId !== contents.id) return;
+            live.favicons = Array.isArray(favicons)
+                ? favicons.filter(item => typeof item === 'string').slice(0, 8)
+                : [];
+            emitState(live, contents);
+        });
+    }
+
     ipcMain.handle('browser:register-webview', (event, input: { tabId?: unknown; webContentsId?: unknown }) => {
         if (!isManagerSender(event)) return { ok: false, error: 'unauthorized' };
         const tabId = typeof input?.tabId === 'string' ? input.tabId.trim() : '';
@@ -230,9 +252,11 @@ export function registerBrowserIpc(options: BrowserIpcOptions): void {
             // Browser tabs are agent-visible and action-enabled by default.
             sharedWithAgent: prior?.sharedWithAgent ?? true,
             actionsEnabled: true,
+            favicons: prior?.webContentsId === webContentsId ? prior.favicons : [],
         };
         tabsById.set(tabId, entry);
         attachDevToolsListeners(entry, contents);
+        attachFaviconListener(entry, contents);
         return { ok: true, state: tabState(entry, contents) };
     });
 
@@ -277,6 +301,15 @@ export function registerBrowserIpc(options: BrowserIpcOptions): void {
                 break;
             case 'stop':
                 contents.stop();
+                break;
+            case 'zoomIn':
+                contents.setZoomFactor(clampZoom(contents.getZoomFactor() + 0.1));
+                break;
+            case 'zoomOut':
+                contents.setZoomFactor(clampZoom(contents.getZoomFactor() - 0.1));
+                break;
+            case 'zoomReset':
+                contents.setZoomFactor(1);
                 break;
             default:
                 return { ok: false, error: 'unknown command' };

--- a/public/manager/src/browser-panel/BrowserPanel.tsx
+++ b/public/manager/src/browser-panel/BrowserPanel.tsx
@@ -1,7 +1,11 @@
 import { createElement, useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from 'react';
 import { getDesktop, isElectron } from '../panels/desktop-bridge';
-import type { BrowserPickedElement, BrowserWebviewNativeAction, BrowserWebviewScreenshot, BrowserWebviewTabState } from '../panels/desktop-bridge';
+import type { BrowserPickedElement, BrowserWebviewCommand, BrowserWebviewNativeAction, BrowserWebviewScreenshot, BrowserWebviewTabState } from '../panels/desktop-bridge';
 import { DEFAULT_BROWSER_URL, isRestrictedBrowserHost, normalizeBrowserTarget } from './browser-url';
+import { BrowserAddressBar } from './browser-address-bar';
+import { createAddressBarState, displayedAddress, reduceAddressBar, type AddressBarAction, type AddressBarState } from './browser-address-state';
+import { pickFaviconUrl, faviconInitial } from './browser-favicon';
+import { loadBrowserHistory, saveBrowserHistory, upsertBrowserHistory, type BrowserHistoryEntry } from './browser-history-store';
 import './browser-panel.css';
 
 // ---------------------------------------------------------------------------
@@ -69,6 +73,7 @@ type ElectronWebviewEvent = Event & {
     errorDescription?: string;
     validatedURL?: string;
     isMainFrame?: boolean;
+    favicons?: string[];
     details?: {
         reason?: string;
     };
@@ -77,7 +82,6 @@ type ElectronWebviewEvent = Event & {
 type BrowserTabState = {
     id: string;
     url: string;
-    inputUrl: string;
     title: string;
     blocked: boolean;
     loading: boolean;
@@ -85,6 +89,8 @@ type BrowserTabState = {
     error: string | null;
     canGoBack: boolean;
     canGoForward: boolean;
+    faviconUrl: string | null;
+    zoomFactor?: number;
 };
 
 type BrowserPanelProps = {
@@ -265,7 +271,6 @@ function createBrowserTab(id: string, target = DEFAULT_BROWSER_URL): BrowserTabS
     return {
         id,
         url: target,
-        inputUrl: target,
         title: titleFromUrl(target),
         blocked: false,
         loading: false,
@@ -273,7 +278,18 @@ function createBrowserTab(id: string, target = DEFAULT_BROWSER_URL): BrowserTabS
         error: null,
         canGoBack: false,
         canGoForward: false,
+        faviconUrl: null,
     };
+}
+
+function isRecordableBrowserUrl(target: string): boolean {
+    if (!target || target === 'about:blank') return false;
+    try {
+        const parsed = new URL(target);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+        return false;
+    }
 }
 
 export function BrowserPanel(props: BrowserPanelProps = {}) {
@@ -290,8 +306,9 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
     const [tabs, setTabs] = useState<BrowserTabState[]>(() => [initialTab.current]);
     const [activeTabId, setActiveTabId] = useState(initialTab.current.id);
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const editingTabIdRef = useRef<string | null>(null);
-    const inputDraftRef = useRef<{ tabId: string; value: string } | null>(null);
+    const [addressState, setAddressState] = useState<AddressBarState>(() => createAddressBarState(initialTab.current.url));
+    const [historyEntries, setHistoryEntries] = useState<BrowserHistoryEntry[]>(() => loadBrowserHistory());
+    const committedByUserRef = useRef<Set<string>>(new Set());
     const pendingNavigationRefs = useRef<Map<string, string>>(new Map());
     /**
      * The webview `src` attribute is bound ONCE per page tab and never
@@ -311,6 +328,10 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
     const webviewUserAgent = useRef(embeddedBrowserUserAgent());
 
     const activeTab = tabs.find(tab => tab.id === activeTabId) ?? tabs[0] ?? initialTab.current;
+
+    const dispatchAddress = useCallback((action: AddressBarAction) => {
+        setAddressState(current => reduceAddressBar(current, action));
+    }, []);
 
     const updateTab = useCallback((id: string, patch: Partial<BrowserTabState>) => {
         setTabs(current => {
@@ -335,6 +356,10 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
     const registrationIdFor = useCallback((tabId: string): string => (
         moduleTabId ?? `panel:${tabId}`
     ), [moduleTabId]);
+    const moduleTabIdRef = useRef(moduleTabId);
+    moduleTabIdRef.current = moduleTabId;
+    const activeTabIdRef = useRef(activeTabId);
+    activeTabIdRef.current = activeTabId;
 
     const [bridgeStates, setBridgeStates] = useState<Record<string, BrowserWebviewTabState>>({});
     const [lastScreenshot, setLastScreenshot] = useState<BrowserWebviewScreenshot | null>(null);
@@ -400,8 +425,19 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         if (!browserBridge?.onWebviewState) return undefined;
         return browserBridge.onWebviewState(state => {
             setBridgeStates(current => (state.tabId in current ? { ...current, [state.tabId]: state } : current));
+            const liveModuleTabId = moduleTabIdRef.current;
+            const pageTabId = liveModuleTabId && state.tabId === liveModuleTabId
+                ? activeTabIdRef.current
+                : state.tabId.startsWith('panel:')
+                    ? state.tabId.slice('panel:'.length)
+                    : state.tabId;
+            const patch: Partial<BrowserTabState> = {};
+            const faviconUrl = pickFaviconUrl(state.favicons);
+            if (faviconUrl) patch.faviconUrl = faviconUrl;
+            if (typeof state.zoomFactor === 'number') patch.zoomFactor = state.zoomFactor;
+            if (Object.keys(patch).length > 0) updateTab(pageTabId, patch);
         });
-    }, []);
+    }, [updateTab]);
 
     // v5: native inspect returns the REAL element (selector/role/name/bounds).
     // When it fires for this panel's active tab, pin the element and open the
@@ -462,9 +498,6 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
                 }
                 patch.url = current;
                 patch.title = titleFromUrl(current);
-                if (editingTabIdRef.current !== tabId) {
-                    patch.inputUrl = current;
-                }
             }
             updateTab(tabId, patch);
         } catch {
@@ -480,6 +513,14 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         const handleStop = () => {
             updateTab(tabId, { loading: false });
             refreshNavState(tabId);
+            const current = webview.getURL?.() ?? lastKnownUrlRefs.current.get(tabId);
+            if (!current || !isRecordableBrowserUrl(current) || !isUrlAllowed(current, desktop)) return;
+            const title = webview.getTitle?.()?.trim() || titleFromUrl(current);
+            setHistoryEntries(entries => {
+                const next = upsertBrowserHistory(entries, { url: current, title, at: Date.now() });
+                saveBrowserHistory(next);
+                return next;
+            });
         };
         const handleNavigate = (event: Event) => {
             const nextUrl = (event as ElectronWebviewEvent).url;
@@ -496,9 +537,6 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
                     url: nextUrl,
                     title: titleFromUrl(nextUrl),
                 };
-                if (editingTabIdRef.current !== tabId) {
-                    patch.inputUrl = nextUrl;
-                }
                 lastKnownUrlRefs.current.set(tabId, nextUrl);
                 updateTab(tabId, patch);
             }
@@ -507,6 +545,10 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         const handleTitle = (event: Event) => {
             const nextTitle = (event as ElectronWebviewEvent).title?.trim();
             if (nextTitle) updateTab(tabId, { title: nextTitle });
+        };
+        const handleFavicon = (event: Event) => {
+            const faviconUrl = pickFaviconUrl((event as ElectronWebviewEvent).favicons);
+            updateTab(tabId, { faviconUrl });
         };
         const handleFail = (event: Event) => {
             const failure = event as ElectronWebviewEvent;
@@ -538,6 +580,7 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         webview.addEventListener('did-navigate', handleNavigate);
         webview.addEventListener('did-navigate-in-page', handleNavigate);
         webview.addEventListener('page-title-updated', handleTitle);
+        webview.addEventListener('page-favicon-updated', handleFavicon);
         webview.addEventListener('did-fail-load', handleFail);
         webview.addEventListener('render-process-gone', handleRenderGone);
         webview.addEventListener('dom-ready', handleDomReady);
@@ -547,6 +590,7 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
             webview.removeEventListener('did-navigate', handleNavigate);
             webview.removeEventListener('did-navigate-in-page', handleNavigate);
             webview.removeEventListener('page-title-updated', handleTitle);
+            webview.removeEventListener('page-favicon-updated', handleFavicon);
             webview.removeEventListener('did-fail-load', handleFail);
             webview.removeEventListener('render-process-gone', handleRenderGone);
             webview.removeEventListener('dom-ready', handleDomReady);
@@ -610,7 +654,6 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
             pendingNavigationRefs.current.delete(tabId);
             updateTab(tabId, {
                 blocked: true,
-                inputUrl: rawTarget,
                 error: blockedUrlMessage(),
             });
             return;
@@ -620,9 +663,9 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
             blocked: false,
             error: null,
             status: canUseElectronWebview ? null : 'Opened in a new browser tab. Embedded browser is only available in the Electron manager window.',
-            inputUrl: target,
             url: target,
             title: titleFromUrl(target),
+            faviconUrl: null,
         });
         if (canUseElectronWebview) {
             lastKnownUrlRefs.current.set(tabId, target);
@@ -652,7 +695,6 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         const tab = createBrowserTab(`browser-tab-${nextTabIndex.current++}`, allowed ? target : DEFAULT_BROWSER_URL);
         if (!allowed) {
             tab.blocked = true;
-            tab.inputUrl = rawTarget;
             tab.error = blockedUrlMessage();
         }
         setTabs(current => [...current, tab]);
@@ -663,6 +705,7 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         pendingNavigationRefs.current.delete(id);
         initialSrcRefs.current.delete(id);
         lastKnownUrlRefs.current.delete(id);
+        committedByUserRef.current.delete(id);
         stableWebviewRefCallbacks.current.delete(id);
         unregisterWebviewTarget(id);
         setTabs(current => {
@@ -682,30 +725,30 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
     }, [activeTabId, unregisterWebviewTarget]);
 
     const navigate = useCallback(() => {
-        const rawTarget = inputDraftRef.current?.tabId === activeTab.id
-            ? inputDraftRef.current.value
-            : inputRef.current?.value ?? activeTab.inputUrl;
-        editingTabIdRef.current = null;
-        inputDraftRef.current = null;
+        const rawTarget = addressState.focused ? addressState.draft : displayedAddress(addressState);
+        dispatchAddress({ type: 'submit' });
+        const normalized = normalizeBrowserTarget(rawTarget);
+        if (normalized && normalized !== DEFAULT_BROWSER_URL) {
+            committedByUserRef.current.add(activeTab.id);
+        }
         openUrlInTab(activeTab.id, rawTarget);
-    }, [activeTab.id, activeTab.inputUrl, openUrlInTab]);
+        inputRef.current?.blur();
+    }, [activeTab.id, addressState, dispatchAddress, openUrlInTab]);
 
-    const markUrlEditing = useCallback(() => {
-        editingTabIdRef.current = activeTab.id;
-        inputDraftRef.current = {
-            tabId: activeTab.id,
-            value: inputRef.current?.value ?? activeTab.inputUrl,
-        };
-    }, [activeTab.id, activeTab.inputUrl]);
+    const openHistoryEntry = useCallback((url: string) => {
+        committedByUserRef.current.add(activeTab.id);
+        dispatchAddress({ type: 'submit' });
+        openUrlInTab(activeTab.id, url);
+        inputRef.current?.blur();
+    }, [activeTab.id, dispatchAddress, openUrlInTab]);
 
-    const clearUrlEditingSoon = useCallback(() => {
-        window.setTimeout(() => {
-            if (document.activeElement !== inputRef.current && editingTabIdRef.current === activeTab.id) {
-                editingTabIdRef.current = null;
-                refreshNavState(activeTab.id);
-            }
-        }, 150);
-    }, [activeTab.id, refreshNavState]);
+    useEffect(() => {
+        setAddressState({ focused: false, draft: '', liveUrl: activeTab.url });
+    }, [activeTab.id]);
+
+    useEffect(() => {
+        dispatchAddress({ type: 'sync-live', liveUrl: activeTab.url });
+    }, [activeTab.url, dispatchAddress]);
 
     // --- 030 toolbar action handlers ---
 
@@ -908,6 +951,33 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
         else webview?.reload();
     }, [activeTab.id]);
 
+    const handleReloadOrStop = useCallback(() => {
+        const webview = webviewRefs.current.get(activeTab.id);
+        if (!webview) return;
+        if (activeTab.loading) {
+            if (typeof webview.stop === 'function') webview.stop();
+            else void getDesktop()?.browser?.controlWebview?.({ kind: 'stop', tabId: activeRegistrationId });
+            return;
+        }
+        webview.reload();
+    }, [activeRegistrationId, activeTab.id, activeTab.loading]);
+
+    const handleZoom = useCallback(async (kind: 'zoomIn' | 'zoomOut' | 'zoomReset') => {
+        const command: BrowserWebviewCommand = { kind, tabId: activeRegistrationId };
+        const result = await getDesktop()?.browser?.controlWebview?.(command);
+        if (result?.ok && result.state) {
+            setBridgeStates(current => ({ ...current, [result.state!.tabId]: result.state! }));
+            const zoomFactor = result.state.zoomFactor;
+            const faviconUrl = pickFaviconUrl(result.state.favicons);
+            const patch: Partial<BrowserTabState> = {};
+            if (typeof zoomFactor === 'number') patch.zoomFactor = zoomFactor;
+            if (faviconUrl) patch.faviconUrl = faviconUrl;
+            if (Object.keys(patch).length > 0) updateTab(activeTab.id, patch);
+        } else if (result && !result.ok) {
+            reportActionError(result.error ?? 'Zoom unavailable');
+        }
+    }, [activeRegistrationId, activeTab.id, reportActionError, updateTab]);
+
     useEffect(() => {
         function handleShortcutAction(e: Event) {
             const detail = (e as CustomEvent).detail;
@@ -992,7 +1062,19 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
                             onClick={() => setActiveTabId(tab.id)}
                             title={tab.title}
                         >
-                            <span className="browser-tab-title">{tab.loading ? 'Loading...' : tab.title}</span>
+                            {tab.faviconUrl ? (
+                                <img
+                                    className="browser-tab-favicon"
+                                    src={tab.faviconUrl}
+                                    alt=""
+                                    width={16}
+                                    height={16}
+                                    onError={() => updateTab(tab.id, { faviconUrl: null })}
+                                />
+                            ) : (
+                                <span className="browser-tab-favicon is-fallback" aria-hidden="true">{faviconInitial(tab.title, tab.url)}</span>
+                            )}
+                            <span className="browser-tab-title">{tab.title}</span>
                         </button>
                         <button
                             type="button"
@@ -1021,24 +1103,12 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
             <div className="browser-toolbar">
                 <button type="button" className="browser-nav-btn" aria-label="Back" data-tooltip="Back" disabled={!canUseElectronWebview || !activeTab.canGoBack} onClick={() => webviewRefs.current.get(activeTab.id)?.goBack()}>‹</button>
                 <button type="button" className="browser-nav-btn" aria-label="Forward" data-tooltip="Forward" disabled={!canUseElectronWebview || !activeTab.canGoForward} onClick={() => webviewRefs.current.get(activeTab.id)?.goForward()}>›</button>
-                <button type="button" className="browser-nav-btn" aria-label="Reload" data-tooltip="Reload" disabled={!canUseElectronWebview} onClick={() => webviewRefs.current.get(activeTab.id)?.reload()}>↻</button>
-                <input
-                    ref={inputRef}
-                    className="browser-url-input"
-                    type="text"
-                    value={activeTab.inputUrl}
-                    onFocus={markUrlEditing}
-                    onBlur={clearUrlEditingSoon}
-                    onChange={event => {
-                        editingTabIdRef.current = activeTab.id;
-                        inputDraftRef.current = {
-                            tabId: activeTab.id,
-                            value: event.target.value,
-                        };
-                        updateTab(activeTab.id, { inputUrl: event.target.value });
-                    }}
-                    onKeyDown={event => { if (event.key === 'Enter') navigate(); }}
-                    aria-label="URL"
+                <button type="button" className="browser-nav-btn" aria-label={activeTab.loading ? 'Stop' : 'Reload'} data-tooltip="Reload" disabled={!canUseElectronWebview} onClick={handleReloadOrStop}>↻</button>
+                <BrowserAddressBar
+                    inputRef={inputRef}
+                    state={addressState}
+                    onDispatch={dispatchAddress}
+                    onSubmit={() => navigate()}
                 />
                 <button type="button" className="browser-go-btn" data-tooltip={canUseElectronWebview ? 'Go' : 'Open'} onMouseDown={event => event.preventDefault()} onClick={navigate}>{canUseElectronWebview ? 'Go' : 'Open'}</button>
                 {canUseElectronWebview && (
@@ -1059,20 +1129,44 @@ export function BrowserPanel(props: BrowserPanelProps = {}) {
                                     {activeBridgeState?.devToolsOpen && (
                                         <button type="button" role="menuitem" className="browser-more-item" onClick={handleCloseDevTools}>Close DevTools</button>
                                     )}
+                                    <div className="browser-more-zoom" role="group" aria-label="Page zoom" onClick={event => event.stopPropagation()}>
+                                        <button type="button" className="browser-more-item" onClick={() => void handleZoom('zoomOut')}>Zoom out</button>
+                                        <span className="browser-more-zoom-label">{Math.round((activeTab.zoomFactor ?? 1) * 100)}%</span>
+                                        <button type="button" className="browser-more-item" onClick={() => void handleZoom('zoomIn')}>Zoom in</button>
+                                        <button type="button" className="browser-more-item" onClick={() => void handleZoom('zoomReset')}>Reset</button>
+                                    </div>
                                 </div>
                             )}
                         </div>
                     </div>
                 )}
             </div>
-            {(activeTab.blocked || activeTab.error || activeTab.loading || activeTab.status) && (
+            <div className="browser-loading-track" aria-hidden="true">
+                <div className="browser-loading-bar" data-loading={activeTab.loading ? 'true' : 'false'} />
+            </div>
+            {(activeTab.blocked || activeTab.error) && (
                 <div className={`browser-status${activeTab.error ? ' is-error' : ''}`}>
-                    {activeTab.error ?? (activeTab.loading ? 'Loading...' : activeTab.status ?? 'Blocked')}
+                    {activeTab.error ?? 'Blocked'}
                 </div>
             )}
             {canUseElectronWebview ? (
                 <div className="browser-webview-stack">
                     <div key={activeTab.id} className="browser-webview-host is-active">
+                        {historyEntries.length > 0 && !activeTab.loading && ((addressState.focused && addressState.draft.trim() === '') || !committedByUserRef.current.has(activeTab.id)) && (
+                            <div className="browser-history-empty" aria-label="Recent visits">
+                                {historyEntries.map(entry => (
+                                    <button
+                                        key={`${entry.url}:${entry.at}`}
+                                        type="button"
+                                        className="browser-history-item"
+                                        onClick={() => openHistoryEntry(entry.url)}
+                                    >
+                                        <span className="browser-history-title">{entry.title || entry.url}</span>
+                                        <span className="browser-history-url">{entry.url}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        )}
                         {createElement('webview', {
                             ref: webviewRefCallbackFor(activeTab.id),
                             className: 'browser-webview',

--- a/public/manager/src/browser-panel/browser-address-bar.tsx
+++ b/public/manager/src/browser-panel/browser-address-bar.tsx
@@ -1,0 +1,53 @@
+import type { KeyboardEvent as ReactKeyboardEvent, RefObject } from 'react';
+import {
+    displayedAddress,
+    type AddressBarAction,
+    type AddressBarState,
+} from './browser-address-state';
+
+type BrowserAddressBarProps = {
+    inputRef: RefObject<HTMLInputElement | null>;
+    state: AddressBarState;
+    onDispatch: (action: AddressBarAction) => void;
+    onSubmit: () => void;
+};
+
+export function BrowserAddressBar(props: BrowserAddressBarProps) {
+    const { inputRef, state, onDispatch, onSubmit } = props;
+
+    function handleKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): void {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            onDispatch({ type: 'submit' });
+            onSubmit();
+            inputRef.current?.blur();
+            return;
+        }
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            onDispatch({ type: 'escape' });
+            inputRef.current?.blur();
+        }
+    }
+
+    return (
+        <input
+            ref={inputRef}
+            className="browser-url-input"
+            type="text"
+            value={displayedAddress(state)}
+            placeholder="Search or enter URL"
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+            aria-label="Search or enter URL"
+            onFocus={() => {
+                onDispatch({ type: 'focus' });
+                queueMicrotask(() => inputRef.current?.select());
+            }}
+            onBlur={() => onDispatch({ type: 'blur' })}
+            onChange={event => onDispatch({ type: 'change', draft: event.target.value })}
+            onKeyDown={handleKeyDown}
+        />
+    );
+}

--- a/public/manager/src/browser-panel/browser-address-state.ts
+++ b/public/manager/src/browser-panel/browser-address-state.ts
@@ -1,0 +1,41 @@
+export type AddressBarState = {
+    focused: boolean;
+    draft: string;
+    liveUrl: string;
+};
+
+export type AddressBarAction =
+    | { type: 'sync-live'; liveUrl: string }
+    | { type: 'focus' }
+    | { type: 'change'; draft: string }
+    | { type: 'blur' }
+    | { type: 'escape' }
+    | { type: 'submit' };
+
+export function createAddressBarState(liveUrl: string): AddressBarState {
+    return { focused: false, draft: liveUrl, liveUrl };
+}
+
+export function displayedAddress(state: AddressBarState): string {
+    return state.focused ? state.draft : state.liveUrl;
+}
+
+export function reduceAddressBar(state: AddressBarState, action: AddressBarAction): AddressBarState {
+    switch (action.type) {
+        case 'sync-live':
+            if (state.focused) return { ...state, liveUrl: action.liveUrl };
+            return { ...state, liveUrl: action.liveUrl, draft: action.liveUrl };
+        case 'focus':
+            return { ...state, focused: true, draft: state.liveUrl };
+        case 'change':
+            return { ...state, focused: true, draft: action.draft };
+        case 'blur':
+            return { ...state, focused: false };
+        case 'escape':
+            return { focused: false, draft: state.liveUrl, liveUrl: state.liveUrl };
+        case 'submit':
+            return { focused: false, draft: state.draft, liveUrl: state.draft };
+        default:
+            return state;
+    }
+}

--- a/public/manager/src/browser-panel/browser-favicon.ts
+++ b/public/manager/src/browser-panel/browser-favicon.ts
@@ -1,0 +1,18 @@
+export function pickFaviconUrl(favicons: string[] | undefined): string | null {
+    const first = favicons?.find(item => typeof item === 'string' && item.trim().length > 0);
+    return first ? first.trim() : null;
+}
+
+function hostnameOf(url: string): string {
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return url;
+    }
+}
+
+export function faviconInitial(title: string, url: string): string {
+    const source = title.trim() || hostnameOf(url);
+    const ch = source.replace(/^www\./, '').charAt(0);
+    return (ch || '?').toUpperCase();
+}

--- a/public/manager/src/browser-panel/browser-history-store.ts
+++ b/public/manager/src/browser-panel/browser-history-store.ts
@@ -1,0 +1,80 @@
+export const BROWSER_HISTORY_STORAGE_KEY = 'jaw.browserHistory';
+export const BROWSER_HISTORY_MAX = 20;
+
+export type BrowserHistoryEntry = {
+    url: string;
+    title: string;
+    at: number;
+};
+
+function isHistoryEntry(value: unknown): value is BrowserHistoryEntry {
+    if (value === null || typeof value !== 'object') return false;
+    const record = value as Record<string, unknown>;
+    return typeof record['url'] === 'string'
+        && typeof record['title'] === 'string'
+        && typeof record['at'] === 'number'
+        && Number.isFinite(record['at']);
+}
+
+export function parseBrowserHistory(raw: string | null): BrowserHistoryEntry[] {
+    if (raw == null || raw.trim() === '') return [];
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        const entries: BrowserHistoryEntry[] = [];
+        for (const item of parsed) {
+            if (!isHistoryEntry(item)) continue;
+            const url = item.url.trim();
+            if (!url) continue;
+            entries.push({
+                url,
+                title: item.title.trim().slice(0, 512),
+                at: item.at,
+            });
+            if (entries.length >= BROWSER_HISTORY_MAX) break;
+        }
+        return entries;
+    } catch {
+        return [];
+    }
+}
+
+export function upsertBrowserHistory(entries: BrowserHistoryEntry[], next: BrowserHistoryEntry): BrowserHistoryEntry[] {
+    const url = next.url.trim();
+    if (!url) return entries;
+    const without = entries.filter(item => item.url !== url);
+    return [{
+        url,
+        title: next.title.trim().slice(0, 512),
+        at: next.at,
+    }, ...without].slice(0, BROWSER_HISTORY_MAX);
+}
+
+function storage(): Storage | null {
+    try {
+        if (typeof globalThis.localStorage === 'undefined') return null;
+        return globalThis.localStorage;
+    } catch {
+        return null;
+    }
+}
+
+export function loadBrowserHistory(): BrowserHistoryEntry[] {
+    const store = storage();
+    if (!store) return [];
+    try {
+        return parseBrowserHistory(store.getItem(BROWSER_HISTORY_STORAGE_KEY));
+    } catch {
+        return [];
+    }
+}
+
+export function saveBrowserHistory(entries: BrowserHistoryEntry[]): void {
+    const store = storage();
+    if (!store) return;
+    try {
+        store.setItem(BROWSER_HISTORY_STORAGE_KEY, JSON.stringify(entries.slice(0, BROWSER_HISTORY_MAX)));
+    } catch {
+        // Storage may be disabled (private mode); fall through silently.
+    }
+}

--- a/public/manager/src/browser-panel/browser-panel.css
+++ b/public/manager/src/browser-panel/browser-panel.css
@@ -16,10 +16,10 @@
 .browser-tab-strip {
     display: flex;
     align-items: center;
-    gap: 3px;
+    gap: 4px;
     min-width: 0;
     min-height: 32px;
-    padding: 4px 6px 0;
+    padding: 5px 6px 0;
     overflow-x: auto;
     border-bottom: 1px solid var(--border-subtle);
     background: var(--bg-panel);
@@ -45,11 +45,31 @@
 .browser-tab {
     all: unset;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     flex: 1 1 auto;
     min-width: 0;
     padding: 4px 4px 4px 7px;
     color: var(--text-dim);
     font-size: 11px;
+}
+.browser-tab-favicon {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    object-fit: contain;
+    background: var(--bg-raised);
+}
+.browser-tab-favicon.is-fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--text-primary);
+    background: var(--bg-hover);
 }
 .browser-tab-item.is-active .browser-tab {
     color: var(--text-base);
@@ -195,6 +215,90 @@
 .browser-status.is-error {
     color: var(--status-error);
     background: color-mix(in srgb, var(--status-error) 10%, transparent);
+}
+.browser-loading-track {
+    flex-shrink: 0;
+    height: 2px;
+    overflow: hidden;
+    background: transparent;
+}
+.browser-loading-bar {
+    height: 2px;
+    width: 100%;
+    transform-origin: left center;
+    background: var(--accent-primary);
+    box-shadow: 0 0 6px 1px var(--accent-primary);
+    opacity: 0;
+    transform: scaleX(1);
+    transition: transform 150ms ease-out, opacity 150ms ease-out 220ms;
+}
+.browser-loading-bar[data-loading="true"] {
+    opacity: 1;
+    animation: browser-loading-progress 5.3s cubic-bezier(0.1, 0.5, 0.2, 1) forwards;
+}
+@keyframes browser-loading-progress {
+    from { transform: scaleX(0.04); }
+    to { transform: scaleX(0.9); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .browser-loading-bar,
+    .browser-loading-bar[data-loading="true"] {
+        transition: none;
+        animation: none;
+    }
+    .browser-loading-bar[data-loading="true"] {
+        transform: scaleX(0.9);
+        opacity: 1;
+    }
+}
+.browser-history-empty {
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    overflow: auto;
+    padding: 16px;
+    background: var(--canvas-deep);
+}
+.browser-history-item {
+    all: unset;
+    box-sizing: border-box;
+    display: grid;
+    gap: 2px;
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+}
+.browser-history-item:hover,
+.browser-history-item:focus-visible {
+    background: var(--sidebar-row-hover);
+}
+.browser-history-item:focus-visible { outline: var(--focus-ring); outline-offset: -2px; }
+.browser-history-title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.browser-history-url {
+    color: var(--text-dim);
+    font-size: 11px;
+    font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.browser-history-empty::before {
+    content: 'Recent';
+    display: block;
+    margin: 0 10px 8px;
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 .browser-webview-stack {
     display: flex;
@@ -346,6 +450,19 @@
 .browser-more-item:hover,
 .browser-more-item:focus-visible {
     background: var(--bg-hover);
+}
+.browser-more-zoom {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+}
+.browser-more-zoom-label {
+    min-width: 3.5ch;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+    color: var(--text-dim);
 }
 
 /* Transparent click-catcher for element inspect picking */

--- a/public/manager/src/panels/desktop-bridge.ts
+++ b/public/manager/src/panels/desktop-bridge.ts
@@ -191,6 +191,8 @@ export type BrowserWebviewTabState = {
     inspecting?: boolean;
     crashed?: boolean;
     error?: string;
+    favicons?: string[];
+    zoomFactor?: number;
 };
 
 /** v5: element resolved from the native inspect pick (CDP DOM/AX domains). */
@@ -225,7 +227,10 @@ export type BrowserWebviewCommand =
     | { kind: 'reload'; tabId: string; ignoreCache?: boolean }
     | { kind: 'goBack'; tabId: string }
     | { kind: 'goForward'; tabId: string }
-    | { kind: 'stop'; tabId: string };
+    | { kind: 'stop'; tabId: string }
+    | { kind: 'zoomIn'; tabId: string }
+    | { kind: 'zoomOut'; tabId: string }
+    | { kind: 'zoomReset'; tabId: string };
 
 export type BrowserWebviewNativeAction =
     | { kind: 'openExternal'; tabId: string }

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -245,6 +245,11 @@ settings.ts (barrel)
 탑바는 한 줄 `[brand][search][actions]` 그리드다. 높이는 `--workspace-topbar-height`(브라우저 44px, `:root[data-cli-jaw-desktop="true"]`에서 52px). Electron에서는 `--electron-titlebar-left-reserve`가 90px(t3 값)이고 `html[data-window-fullscreen="true"]`이면 12px로 접힌다; 바 자체는 `-webkit-app-region: drag`, 모든 인터랙티브 자식은 `no-drag`(p0-1-1.css 상단 블록이 권위). 브랜드 13px/600/0.02em(`--manager-brand-cyan` 유지), 검색은 28px ghost(`--sidebar-control-surface`), 액션은 28px `.command-icon-button`. 드로어 트리거는 SVG이며 1024px 이상에서는 숨고 그 아래에서는 `drawer` 열을 따로 가진다. `hooks/useWindowFullscreen.ts`가 `getDesktop()?.window?.getFullscreenState?.()`를 읽어 `data-window-fullscreen` 속성을 생산한다(fullscreen이 아니면 속성 제거); IPC 생산자는 wp7. Mod+B 기본값(`Meta+B` 우측 패널, `Meta+Shift+B` 좌측)은 바꾸지 않았다.
 
 
+### Manager browser panel chrome (260902 t3 shell polish, wp6)
+
+`browser-panel/browser-address-state.ts`가 주소창 상태기계다: blur 상태에서는 live URL, focus 시 draft(전체 선택), Enter는 `submit` → `openUrlInTab` → blur, Escape는 live로 되돌리고 blur, 포커스 중 도착한 `sync-live`는 draft를 덮지 않는다. 탭이 바뀌면 상태를 재생성한다. `BrowserAddressBar`(placeholder "Search or enter URL")가 옛 `inputUrl`/`editingTabIdRef`/draft ref를 대체하며 Go 버튼과 `data-tooltip="Reload"`는 유지된다. 로딩은 툴바 아래 2px `.browser-loading-bar`(`scaleX .04→.9` 5.3s, reduced-motion이면 정적 .9)만 보이고 status 줄은 blocked/error에만 남는다. 탭 스트립은 16px favicon(`browser-favicon.ts`, 없으면 이니셜 원)을 달고, Electron `ipc.ts`가 guest `page-favicon-updated`를 contents-id 가드로 한 번만 구독해 `favicons`/`zoomFactor`를 `browser:webview-state` payload에 싣는다. 최근 방문은 `browser-history-store.ts`(localStorage `jaw.browserHistory`, 최대 20)로 empty/new tab 위에 표시된다. more 메뉴의 zoom in/out/reset은 `control-webview` kind `zoomIn|zoomOut|zoomReset`(0.5-3, 0.1 단계)이다. mini player·device viewport·cookie/cache 삭제는 범위 밖.
+
+
 ### Manager preview memory note
 
 2026-06-14 점검 기준, Chrome에서 manager Web UI를 열었을 때 1GB 근처까지 올라갔다가 약 10분 뒤 300MB대 근처로 안정화되는 패턴은 `jaw dashboard serve` manager 서버 누수보다 preview iframe의 cold-load peak로 해석한다. 실제 관찰에서는 manager 서버 `dist/src/manager/server.js` RSS가 약 170~220MB 수준이었고, 큰 RSS는 Chrome renderer와 각 `jaw serve` worker(`dist/server.js`) 쪽에 있었다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -425,7 +425,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 567 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 571 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (1223L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -425,7 +425,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 571 files source/assets, ~100500L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 571 files source/assets, ~100900L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (1223L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시

--- a/tests/unit/electron-browser-webcontents-ipc-contract.test.ts
+++ b/tests/unit/electron-browser-webcontents-ipc-contract.test.ts
@@ -98,3 +98,12 @@ test('main index marks owned webview guests on web-contents-created', () => {
 test('destroyed guests are pruned from the registry', () => {
     assert.ok(ipcSource.includes("once('destroyed'"), 'destroyed listener prunes stale ids');
 });
+
+test('tabState emits favicons and zoomFactor; control-webview accepts zoom kinds', () => {
+    assert.ok(ipcSource.includes('page-favicon-updated'), 'guest favicon updates are observed in main');
+    assert.ok(ipcSource.includes('favicons'), 'tabState includes favicons');
+    assert.ok(ipcSource.includes('zoomFactor'), 'tabState includes zoomFactor');
+    assert.ok(ipcSource.includes("case 'zoomIn'"), 'control-webview accepts zoomIn');
+    assert.ok(ipcSource.includes("case 'zoomOut'"), 'control-webview accepts zoomOut');
+    assert.ok(ipcSource.includes("case 'zoomReset'"), 'control-webview accepts zoomReset');
+});

--- a/tests/unit/manager-browser-address-state.test.ts
+++ b/tests/unit/manager-browser-address-state.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createAddressBarState,
+    displayedAddress,
+    reduceAddressBar,
+} from '../../public/manager/src/browser-panel/browser-address-state.js';
+
+test('unfocused displayed address is the live URL', () => {
+    const state = createAddressBarState('https://example.com/');
+    assert.equal(state.focused, false);
+    assert.equal(displayedAddress(state), 'https://example.com/');
+});
+
+test('focus copies live URL into draft', () => {
+    const started = createAddressBarState('https://example.com/');
+    const focused = reduceAddressBar(started, { type: 'focus' });
+    assert.equal(focused.focused, true);
+    assert.equal(focused.draft, 'https://example.com/');
+    assert.equal(displayedAddress(focused), 'https://example.com/');
+});
+
+test('sync-live while focused preserves draft', () => {
+    const focused = reduceAddressBar(
+        reduceAddressBar(createAddressBarState('https://example.com/'), { type: 'focus' }),
+        { type: 'change', draft: 'search terms' },
+    );
+    const synced = reduceAddressBar(focused, { type: 'sync-live', liveUrl: 'https://redirect.example/' });
+    assert.equal(synced.focused, true);
+    assert.equal(synced.draft, 'search terms');
+    assert.equal(synced.liveUrl, 'https://redirect.example/');
+    assert.equal(displayedAddress(synced), 'search terms');
+});
+
+test('sync-live while unfocused updates draft and live URL', () => {
+    const synced = reduceAddressBar(
+        createAddressBarState('https://example.com/'),
+        { type: 'sync-live', liveUrl: 'https://next.example/' },
+    );
+    assert.equal(synced.focused, false);
+    assert.equal(synced.draft, 'https://next.example/');
+    assert.equal(synced.liveUrl, 'https://next.example/');
+    assert.equal(displayedAddress(synced), 'https://next.example/');
+});
+
+test('escape reverts draft to live and unfocuses', () => {
+    const edited = reduceAddressBar(
+        reduceAddressBar(createAddressBarState('https://example.com/'), { type: 'focus' }),
+        { type: 'change', draft: 'partial' },
+    );
+    const escaped = reduceAddressBar(edited, { type: 'escape' });
+    assert.equal(escaped.focused, false);
+    assert.equal(escaped.draft, 'https://example.com/');
+    assert.equal(escaped.liveUrl, 'https://example.com/');
+    assert.equal(displayedAddress(escaped), 'https://example.com/');
+});
+
+test('submit unfocuses and keeps the submitted draft as live', () => {
+    const edited = reduceAddressBar(
+        reduceAddressBar(createAddressBarState('https://example.com/'), { type: 'focus' }),
+        { type: 'change', draft: 'https://next.example/' },
+    );
+    const submitted = reduceAddressBar(edited, { type: 'submit' });
+    assert.equal(submitted.focused, false);
+    assert.equal(submitted.draft, 'https://next.example/');
+    assert.equal(submitted.liveUrl, 'https://next.example/');
+    assert.equal(displayedAddress(submitted), 'https://next.example/');
+});
+
+test('empty draft displays as an empty string while focused', () => {
+    const emptied = reduceAddressBar(
+        reduceAddressBar(createAddressBarState('https://example.com/'), { type: 'focus' }),
+        { type: 'change', draft: '' },
+    );
+    assert.equal(displayedAddress(emptied), '');
+});
+
+test('blur keeps draft without reverting to live', () => {
+    const edited = reduceAddressBar(
+        reduceAddressBar(createAddressBarState('https://example.com/'), { type: 'focus' }),
+        { type: 'change', draft: 'kept draft' },
+    );
+    const blurred = reduceAddressBar(edited, { type: 'blur' });
+    assert.equal(blurred.focused, false);
+    assert.equal(blurred.draft, 'kept draft');
+    assert.equal(blurred.liveUrl, 'https://example.com/');
+    assert.equal(displayedAddress(blurred), 'https://example.com/');
+});

--- a/tests/unit/manager-browser-history-store.test.ts
+++ b/tests/unit/manager-browser-history-store.test.ts
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    BROWSER_HISTORY_MAX,
+    BROWSER_HISTORY_STORAGE_KEY,
+    loadBrowserHistory,
+    parseBrowserHistory,
+    saveBrowserHistory,
+    upsertBrowserHistory,
+    type BrowserHistoryEntry,
+} from '../../public/manager/src/browser-panel/browser-history-store.js';
+
+type MemoryStorage = {
+    store: Map<string, string>;
+    getItem(key: string): string | null;
+    setItem(key: string, value: string): void;
+    removeItem(key: string): void;
+    clear(): void;
+    key(index: number): string | null;
+    readonly length: number;
+};
+
+function createMemoryStorage(): MemoryStorage {
+    const store = new Map<string, string>();
+    return {
+        store,
+        getItem(key: string): string | null {
+            return store.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+            store.set(key, value);
+        },
+        removeItem(key: string): void {
+            store.delete(key);
+        },
+        clear(): void {
+            store.clear();
+        },
+        key(index: number): string | null {
+            return [...store.keys()][index] ?? null;
+        },
+        get length(): number {
+            return store.size;
+        },
+    };
+}
+
+const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+const memory = createMemoryStorage();
+Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    get() {
+        return memory;
+    },
+});
+
+test.after(() => {
+    if (originalLocalStorage) {
+        Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+        return;
+    }
+    Reflect.deleteProperty(globalThis, 'localStorage');
+});
+
+function entry(url: string, title: string, at: number): BrowserHistoryEntry {
+    return { url, title, at };
+}
+
+test('upserting the same url moves it forward and updates the title', () => {
+    const first = upsertBrowserHistory([], entry('https://a.example/', 'A', 1));
+    const second = upsertBrowserHistory(first, entry('https://b.example/', 'B', 2));
+    const updated = upsertBrowserHistory(second, entry('https://a.example/', 'A updated', 3));
+    assert.deepEqual(updated, [
+        entry('https://a.example/', 'A updated', 3),
+        entry('https://b.example/', 'B', 2),
+    ]);
+});
+
+test('upsert keeps at most 20 entries', () => {
+    let entries: BrowserHistoryEntry[] = [];
+    for (let index = 0; index < BROWSER_HISTORY_MAX + 1; index += 1) {
+        entries = upsertBrowserHistory(entries, entry(`https://n${index}.example/`, `N${index}`, index));
+    }
+    assert.equal(entries.length, 20);
+    assert.equal(entries[0]?.url, 'https://n20.example/');
+    assert.equal(entries[19]?.url, 'https://n1.example/');
+});
+
+test('broken JSON parses as an empty list', () => {
+    assert.deepEqual(parseBrowserHistory('{not json'), []);
+    assert.deepEqual(parseBrowserHistory('{"url":"https://a.example/"}'), []);
+    assert.deepEqual(parseBrowserHistory(null), []);
+});
+
+test('blank urls are skipped', () => {
+    const kept = upsertBrowserHistory(
+        [entry('https://kept.example/', 'Kept', 1)],
+        entry('   ', 'Blank', 2),
+    );
+    assert.deepEqual(kept, [entry('https://kept.example/', 'Kept', 1)]);
+    assert.deepEqual(parseBrowserHistory(JSON.stringify([
+        { url: '  ', title: 'Blank', at: 1 },
+        { url: 'https://ok.example/', title: 'Ok', at: 2 },
+        { url: 1, title: 'Bad', at: 3 },
+    ])), [entry('https://ok.example/', 'Ok', 2)]);
+});
+
+test('load and save round-trip through the stubbed localStorage key', () => {
+    memory.clear();
+    saveBrowserHistory([entry('https://saved.example/', 'Saved', 9)]);
+    assert.equal(memory.getItem(BROWSER_HISTORY_STORAGE_KEY), JSON.stringify([
+        entry('https://saved.example/', 'Saved', 9),
+    ]));
+    assert.deepEqual(loadBrowserHistory(), [entry('https://saved.example/', 'Saved', 9)]);
+    memory.setItem(BROWSER_HISTORY_STORAGE_KEY, 'not-json');
+    assert.deepEqual(loadBrowserHistory(), []);
+});

--- a/tests/unit/manager-browser-webcontents-bridge-contract.test.ts
+++ b/tests/unit/manager-browser-webcontents-bridge-contract.test.ts
@@ -153,3 +153,11 @@ test('webview src is bound once and navigation is imperative', () => {
     assert.ok(panelSource.includes('initialSrcRefs'), 'initial src is pinned per page tab');
     assert.ok(panelSource.includes('loadURL'), 'navigation goes through loadURL, not src rebinding');
 });
+
+test('desktop-bridge tab state and commands include favicons and zoom kinds', () => {
+    assert.ok(bridgeSource.includes('favicons'), 'BrowserWebviewTabState includes favicons');
+    assert.ok(bridgeSource.includes('zoomFactor'), 'BrowserWebviewTabState includes zoomFactor');
+    assert.ok(bridgeSource.includes("kind: 'zoomIn'"), 'BrowserWebviewCommand includes zoomIn');
+    assert.ok(bridgeSource.includes("kind: 'zoomOut'"), 'BrowserWebviewCommand includes zoomOut');
+    assert.ok(bridgeSource.includes("kind: 'zoomReset'"), 'BrowserWebviewCommand includes zoomReset');
+});

--- a/tests/unit/manager-electron-desktop-contract.test.ts
+++ b/tests/unit/manager-electron-desktop-contract.test.ts
@@ -411,16 +411,20 @@ test('Electron right sidebar exposes icon panel switcher and document preview pa
     assert.ok(browserPanel.includes('isRestrictedBrowserHost(parsed.hostname)'), 'web UI browser policy must continue blocking local/private hosts');
     assert.ok(browserPanel.includes('Local, private, and same-origin URLs are blocked.'), 'web UI must keep the explicit local/private URL rejection message');
     assert.ok(browserPanel.includes('const inputRef = useRef<HTMLInputElement | null>(null);'), 'browser Go action must read the visible URL input value for native accessibility value injection');
-    assert.ok(browserPanel.includes('const editingTabIdRef = useRef<string | null>(null);'), 'browser address bar must track when a user is editing the visible URL');
-    assert.ok(browserPanel.includes('const inputDraftRef = useRef<{ tabId: string; value: string } | null>(null);'), 'browser address bar must preserve the latest typed draft across pointer blur/click ordering');
+    // 260902 t3 shell (wp6): the address bar is a reducer (browser-address-state.ts).
+    // While focused, live-URL syncs land in liveUrl and never overwrite the draft;
+    // Go/Enter submit the draft, so the old editing/draft refs are gone.
+    const addressState = read('public/manager/src/browser-panel/browser-address-state.ts');
+    assert.ok(addressState.includes("if (state.focused) return { ...state, liveUrl: action.liveUrl };"), 'browser address bar must not overwrite a draft being edited when the live URL changes');
+    assert.ok(addressState.includes('export function displayedAddress'), 'browser address bar must render liveUrl when blurred and the draft when focused');
+    assert.ok(browserPanel.includes("dispatchAddress({ type: 'sync-live', liveUrl: activeTab.url })"), 'webview navigation must sync the live URL through the reducer');
     assert.ok(browserPanel.includes('const pendingNavigationRefs = useRef<Map<string, string>>(new Map());'), 'browser panel must track pending navigation targets so stale webview events cannot cancel a requested URL');
     assert.ok(browserPanel.includes('function sameBrowserUrl'), 'browser panel must compare pending URLs after URL normalization');
     assert.ok(browserPanel.includes('pendingNavigationRefs.current.set(tabId, target);'), 'opening a URL must mark the requested target as pending before React re-renders the webview');
     assert.ok(browserPanel.includes('if (pendingTarget && !sameBrowserUrl(current, pendingTarget))'), 'stale webview refreshes must not overwrite a pending requested URL');
     assert.ok(browserPanel.includes('const failedUrl = failure.validatedURL ?? failure.url;'), 'old webview load aborts must not clear a different pending target');
-    assert.ok(browserPanel.includes('const rawTarget = inputDraftRef.current?.tabId === activeTab.id'), 'browser Go action must prefer the preserved user draft when click blur races with React state updates');
+    assert.ok(browserPanel.includes('const rawTarget = addressState.focused ? addressState.draft : displayedAddress(addressState);'), 'browser Go action must prefer the user draft while the address bar is focused');
     assert.ok(browserPanel.includes('openUrlInTab(activeTab.id, rawTarget)'), 'browser Go action must not depend only on React change events');
-    assert.ok(browserPanel.includes('if (editingTabIdRef.current !== tabId)'), 'webview navigation events must not overwrite an address currently being edited');
     assert.ok(browserPanel.includes('onMouseDown={event => event.preventDefault()}'), 'Go button must avoid blurring the URL input before click navigation reads it');
     assert.ok(browserUrl.includes("DEFAULT_BROWSER_URL = 'https://www.google.com/'"), 'browser tabs must default to Google instead of example.com');
     assert.ok(browserUrl.includes('GOOGLE_SEARCH_URL'), 'browser URL helper must route search-like input through Google');


### PR DESCRIPTION
## wp6 — Browser panel chrome: address bar state machine, loading bar, favicons, history, zoom

- browser-address-state.ts reducer: blurred shows the live URL, focused shows a draft (select-all on focus), Enter submits then blurs, Escape reverts then blurs, live-URL syncs never overwrite an in-progress draft; state resets per tab. BrowserAddressBar (placeholder 'Search or enter URL') replaces the inputUrl/editingTabIdRef/draft-ref machinery; Go button and Reload tooltip preserved.
- 2px indeterminate loading bar under the toolbar (scaleX .04->.9 / 5.3s; static .9 under prefers-reduced-motion); status text only for blocked/error.
- Tab strip 16px favicon or initial fallback; Electron ipc.ts subscribes page-favicon-updated once per contents id and emits favicons + zoomFactor in the webview-state payload.
- Recent visits (localStorage jaw.browserHistory, max 20) on empty/new tabs; more-menu zoomIn/zoomOut/zoomReset control-webview kinds clamped 0.5-3.
- Contract tests: address-state 8, history-store 5, bridge/ipc additive asserts, electron-desktop-contract follows the reducer.

Verification: frontend + electron typecheck 0, build:frontend + electron:build 0, check:frontend-build-output 0; broad manager/electron/dashboard set 1178/1178; verify-counts ALL PASS.

Rendered (headless Chrome, BrowserPanel harness with a stubbed desktop bridge): focus selects all (0..23), typing shows draft, Escape restores live URL and blurs, Enter commits and blurs; loading bar 2px animating (5.3s) and static scaleX(0.9) under reduced motion; favicon fallback initial on the tab; Recent list with 2 entries. Screenshots wp6-browser-*.png in devlog evidence. Live favicon events and zoom need a real Electron guest (wp7 launch proof).

Plan: devlog/_plan/260902_t3_shell_polish/060_browser_chrome.md
