### PR TITLE
feat(steer): preserve interrupted-turn context across kill-path steer (wp1/3)

### DIFF
--- a/src/agent/prompt-context.ts
+++ b/src/agent/prompt-context.ts
@@ -12,6 +12,46 @@ export function withHistoryPrompt(prompt: string, historyBlock: string): string 
     return `${historyBlock}\n\n${HISTORY_BOUNDARY_INSTRUCTION}\n\n---\n[Current Message]\n${body}`;
 }
 
+/** Max chars of interrupted-turn partial output reinjected into a follow-up run. */
+export const STEER_SALVAGE_MAX_CHARS = 4000;
+
+/**
+ * Prepend the salvaged partial output of a steer-interrupted turn.
+ *
+ * Kill-path steer (explicit /steer, /queue steer) kills the running CLI and
+ * starts a fresh run. The vendor session only holds COMPLETED items, so the
+ * in-flight partial output would otherwise be invisible to the follow-up model
+ * (history injection is skipped on successful native resume). This block makes
+ * the interruption and the partial output explicit, in both directions of the
+ * resume matrix. Identity of the prompt itself is unchanged when there is no
+ * salvage, so non-steer spawns are byte-identical to before.
+ */
+export function withSteerContext(prompt: string, steerContext?: string | null): string {
+    const body = String(prompt || '');
+    let salvage = String(steerContext || '').trim();
+    if (!salvage) return body;
+    let truncated = false;
+    if (salvage.length > STEER_SALVAGE_MAX_CHARS) {
+        salvage = salvage.slice(-STEER_SALVAGE_MAX_CHARS);
+        truncated = true;
+    }
+    return [
+        '[Interrupted Turn Context — cli-jaw steer]',
+        'The previous turn was interrupted by a new instruction from the user (steer).',
+        'Its partial output before the interruption is below and is INCOMPLETE.',
+        'Remember what it was doing, do not repeat completed work, and continue with the current message.',
+        '[이전 턴이 사용자의 새 지시(steer)로 중단되었습니다. 아래는 중단 시점까지의 미완성 부분 출력입니다.',
+        '완료된 작업을 반복하지 말고, 맥락을 기억한 채 현재 메시지를 이어서 수행하세요.]',
+        '',
+        '<partial_output>',
+        `${truncated ? '... [truncated]\n' : ''}${salvage}`,
+        '</partial_output>',
+        '',
+        '---',
+        body,
+    ].join('\n');
+}
+
 export function shouldBuildHistoryBlock(input: {
     skipHistory: boolean;
     isResume: boolean;

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -24,6 +24,7 @@ import {
     clearEmployeeSession, getSession, insertMessage, insertMessageWithTraceRun, getRecentMessages,
     listQueuedMessages, insertQueuedMessage, deleteQueuedMessage, migrateQueuedMessagesV1ToV2,
     getSessionBucket, clearSessionBucket, setSessionBucketSnapshot,
+    getMaxMessageId, getSteerSalvageAfter,
 } from '../core/db.js';
 import { sanitizeToolLogForDurableStorage } from '../shared/tool-log-sanitize.js';
 import { buildTaskSnapshot } from '../memory/runtime.js';
@@ -55,7 +56,7 @@ import {
     setSpawnRef as setMemorySpawnRef,
 } from './memory-flush-controller.js';
 import { applyCliEnvDefaults, buildSessionResumeKey, ensureOpencodeAlwaysAllowPermissions, mergeEnvWindowsSafe } from './spawn-env.js';
-import { buildPromptForArgs, shouldBuildHistoryBlock, withHistoryPrompt } from './prompt-context.js';
+import { buildPromptForArgs, shouldBuildHistoryBlock, withHistoryPrompt, withSteerContext } from './prompt-context.js';
 import { attachWatchdog, DEFAULT_WATCHDOG_ABSOLUTE_HARD_CAP_MS } from './watchdog.js';
 import {
     buildOpencodeRuntimeSnapshot,
@@ -522,6 +523,46 @@ function consumeKillReason(pid: number | undefined): string | null {
     return reason;
 }
 
+// ─── Steer exit-settle barrier ─────────────────────
+// killActiveAgent removes the scope's activeMainProcesses entry synchronously,
+// so waitForProcessEnd() resolves immediately on a steer kill — long before the
+// exit handler has written the interrupted partial output to the messages table.
+// A follow-up spawn could then read history without the salvage row. The barrier
+// is armed at kill time (never at exit-handler entry — that is already too late)
+// and settled by the exit handler's completion, success or failure.
+const exitSettlers = new Map<string, { promise: Promise<void>; resolve: () => void }>();
+
+/** Arm the barrier. Idempotent: a repeated steer keeps the first arm. */
+export function armExitSettle(scopeKey: string): void {
+    if (exitSettlers.has(scopeKey)) return;
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => { resolve = r; });
+    exitSettlers.set(scopeKey, { promise, resolve });
+}
+
+/** Settle the barrier; a no-op when no steer kill armed it. */
+export function settleExit(scopeKey: string): void {
+    const entry = exitSettlers.get(scopeKey);
+    if (!entry) return;
+    exitSettlers.delete(scopeKey);
+    entry.resolve();
+}
+
+/**
+ * Await the armed exit handler's completion, bounded. A timeout releases the
+ * waiter and drops the arm — a wedged exit handler must not hang the steer.
+ */
+export function waitForExitSettled(scopeKey: string, timeoutMs = 5000): Promise<void> {
+    const entry = exitSettlers.get(scopeKey);
+    if (!entry) return Promise.resolve();
+    return Promise.race([entry.promise, new Promise<void>(r => {
+        const t = setTimeout(r, timeoutMs);
+        t.unref?.();
+    })]).then(() => {
+        if (exitSettlers.get(scopeKey) === entry) exitSettlers.delete(scopeKey);
+    });
+}
+
 /**
  * Fix A: 사용자 stop은 메모리 큐 + DB persisted_queue + frontend pending row를
  * 모두 폐기한다. exit handler의 scoped queue 자동 드레인이 stop 직후 잔존
@@ -585,6 +626,7 @@ export function killActiveAgent(scopeKeyOrReason = 'user', scopedReason?: string
     if (run?.cancelTurn && (getActiveMainCli(scopeKey) === 'codex-app' || getActiveMainCli(scopeKey) === 'pi')) {
         if (run.process?.pid) killReasons.set(run.process.pid, reason);
         console.log(`[jaw:kill] reason=${reason} scope=${scopeKey} cli=${getActiveMainCli(scopeKey)} action=lease.cancel`);
+        if (reason === 'steer' || reason === 'interrupt') armExitSettle(scopeKey);
         run.cancelTurn(reason);
         if (reason === 'api' || reason === 'user' || reason === 'steer' || reason === 'interrupt') activeMainProcesses.delete(scopeKey);
         return true;
@@ -597,6 +639,7 @@ export function killActiveAgent(scopeKeyOrReason = 'user', scopedReason?: string
     const policy = getKillPolicy(scopeKey, reason);
     console.log(`[jaw:kill] reason=${reason} scope=${scopeKey} cli=${getActiveMainCli(scopeKey) || 'unknown'} signal=${policy.signal} escalationMs=${policy.escalationMs}`);
     if (activeProcess.pid) killReasons.set(activeProcess.pid, reason);
+    if (reason === 'steer' || reason === 'interrupt') armExitSettle(scopeKey);
     const proc = activeProcess;
     // One owner runs the whole termination: tree walk with the policy signal,
     // then escalation after policy.escalationMs that re-checks the ORIGINAL
@@ -721,18 +764,33 @@ export async function steerAgent(
         return;
     }
     const steerWaitMs = getSteerWaitMsForActiveAgent(scopeKey);
+    // Snapshot BEFORE the kill: the interrupted partial-output row is identified
+    // as the first ⏹️-tagged assistant message with id above this mark. A
+    // created_at comparison is not safe (second-resolution UTC column).
+    const maxIdBeforeKill = getMaxMessageId(chatSessionId);
     const wasRunning = killActiveAgent(scopeKey, 'steer');
     if (wasRunning) await waitForProcessEnd(scopeKey, steerWaitMs);
+    // The kill removes the scope's map entry synchronously, so the wait above can
+    // return before the exit handler's salvage insert. Wait for the settle barrier
+    // armed by the kill so the follow-up run actually sees the partial output.
+    if (wasRunning) await waitForExitSettled(scopeKey);
+    let steerContext: string | null = null;
+    if (wasRunning) {
+        const salvage = getSteerSalvageAfter(chatSessionId, maxIdBeforeKill);
+        // The ⏹️ tag is a human-facing marker; the model gets the payload only.
+        steerContext = salvage ? salvage.replace(/^⏹️ \[interrupted\]\s*/, '') : null;
+    }
     insertMessage.run('user', newPrompt, source, '', settings["workingDir"] || null, chatSessionId);
     broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
     broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey, requestId: meta?.requestId }));
     const { orchestrate, orchestrateContinue, orchestrateReset, isContinueIntent, isResetIntent } = await import('../orchestrator/pipeline.js');
     const origin = source || 'web';
+    const steerMeta = stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId, _skipInsert: true, _steerContext: steerContext || undefined });
     const task = isResetIntent(newPrompt)
-        ? orchestrateReset(stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId, _skipInsert: true }))
+        ? orchestrateReset(steerMeta)
         : isContinueIntent(newPrompt)
-            ? orchestrateContinue(stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId, _skipInsert: true }))
-            : orchestrate(newPrompt, stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId, _skipInsert: true }));
+            ? orchestrateContinue(steerMeta)
+            : orchestrate(newPrompt, steerMeta);
     task.catch(async (err: Error) => {
         console.error('[steer:orchestrate]', err.message);
         broadcast('orchestrate_done', stripUndefined({ text: `[error] ${err.message}`, error: true, origin, requestId: meta?.requestId }));
@@ -956,6 +1014,13 @@ interface SpawnOpts {
     lifecycle?: SpawnLifecycle;
     _settingsGateWaited?: boolean;
     _heartbeatAnchorId?: number;
+    /**
+     * Salvaged partial output of a steer-interrupted turn. When present, it is
+     * prepended to the outgoing prompt (resume and fresh paths alike) via
+     * withSteerContext so the follow-up model sees what the interrupted turn
+     * had been doing. Empty/undefined keeps prompts byte-identical.
+     */
+    steerContext?: string;
 }
 
 type SpawnResult = {
@@ -1372,6 +1437,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
         sysPrompt,
         isResume,
     });
+    promptForArgs = withSteerContext(promptForArgs, opts.steerContext);
     const agyResumeReplayPrefix = cli === 'agy' && isResume
         ? getLatestAssistantContentForAgyResume(settings["workingDir"], chatSessionId)
         : null;
@@ -1755,7 +1821,8 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 const acpPrompt = needsHistoryFallback
                     ? withHistoryPrompt(prompt, fallbackHistory)
                     : (isResume ? prompt : withHistoryPrompt(prompt, historyBlock));
-                const { promise: promptPromise } = acp.prompt(acpPrompt);
+                const acpPromptWithSteer = withSteerContext(acpPrompt, opts.steerContext);
+                const { promise: promptPromise } = acp.prompt(acpPromptWithSteer);
                 const promptResult = await promptPromise;
                 promptCompleted = true;
                 if (process.env["DEBUG"]) console.log('[acp:prompt:result]', JSON.stringify(promptResult).slice(0, 200));
@@ -1833,7 +1900,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 processQueue,
             }).catch((err: Error) => {
                 console.error('[jaw:lifecycle] handleAgentExit failed (ACP):', err.message);
-            });
+            }).finally(() => settleExit(scopeKey));
         });
 
         return { child, promise: resultPromise };
@@ -1849,7 +1916,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
         }
         const piSessionId = isResume && bucketSessionId ? bucketSessionId : '';
         console.log(`[jaw:pi] isResume=${isResume}, bucketSessionId=${bucketSessionId || 'none'}, piSessionId=${piSessionId || 'new'}`);
-        const piPrompt = piSessionId ? prompt : withHistoryPrompt(prompt, historyBlock);
+        const piPrompt = withSteerContext(piSessionId ? prompt : withHistoryPrompt(prompt, historyBlock), opts.steerContext);
         const traceRunId = startTraceRun({ cli, model: runtimeModel, workingDir: settings["workingDir"] || null, agentLabel, audience: traceAudience });
         const ctx: SpawnContext = {
             fullText: '',
@@ -2013,7 +2080,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                     fallbackState: queueCtrl.fallbackStateForScope(scopeKey),
                     fallbackMaxRetries: FALLBACK_MAX_RETRIES,
                     processQueue,
-                });
+                }).finally(() => settleExit(scopeKey));
             }).catch(async (err: Error) => {
                 piWatchdog.stop();
                 await releaseLease().catch(() => {});
@@ -2038,7 +2105,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                     processQueue,
                 }).catch((handleErr: Error) => {
                     console.error('[jaw:lifecycle] handleAgentExit failed (Pi):', handleErr.message);
-                });
+                }).finally(() => settleExit(scopeKey));
             });
         };
 
@@ -2357,8 +2424,9 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 const codexAppPrompt = (shouldPrependHistory && historyBlock)
                     ? `${historyBlock}\n\n[User Message]\n${prompt}`
                     : prompt;
+                const codexAppPromptWithSteer = withSteerContext(codexAppPrompt, opts.steerContext);
 
-                const startTurn = appClient.startTurn(laneScope, codexAppPrompt);
+                const startTurn = appClient.startTurn(laneScope, codexAppPromptWithSteer);
                 await Promise.race([startTurn, turnDone]);
                 await turnDone;
                 turnCompleted = !turnReportedFailure;
@@ -2440,7 +2508,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 processQueue,
             }).catch((err: Error) => {
                 console.error('[jaw:lifecycle] handleAgentExit failed (codex-app):', err.message);
-            });
+            }).finally(() => settleExit(scopeKey));
         };
 
         if (opts.agentId) {
@@ -2742,18 +2810,18 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
     }
 
     if (cli === 'claude') {
-        child.stdin.write(isResume ? prompt : withHistoryPrompt(prompt, historyBlock));
+        child.stdin.write(withSteerContext(isResume ? prompt : withHistoryPrompt(prompt, historyBlock), opts.steerContext));
     } else if (cli === 'claude-e' || (cli === 'ai-e' && effectiveProvider === 'claude')) {
-        child.stdin.write(isResume ? prompt : withHistoryPrompt(prompt, historyBlock));
+        child.stdin.write(withSteerContext(isResume ? prompt : withHistoryPrompt(prompt, historyBlock), opts.steerContext));
     } else if (cli === 'codex' && !isResume) {
         const codexStdin = historyBlock
             ? `${historyBlock}\n\n[User Message]\n${prompt}`
             : `[User Message]\n${prompt}`;
-        child.stdin.write(codexStdin);
+        child.stdin.write(withSteerContext(codexStdin, opts.steerContext));
     } else if (cli === 'codex' && isResume) {
         // Resume passes '-' in argv (see args.ts) so the prompt travels on stdin,
         // matching the fresh path.
-        child.stdin.write(prompt || '');
+        child.stdin.write(withSteerContext(prompt || '', opts.steerContext));
     }
     child.stdin.end();
 
@@ -3323,7 +3391,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             ...(agyTotalOutputLen > 0 ? { outputLen: agyTotalOutputLen } : {}),
         }).catch((err: Error) => {
             console.error('[jaw:lifecycle] handleAgentExit failed (CLI):', err.message);
-        });
+        }).finally(() => settleExit(scopeKey));
     });
 
     return { child, promise: resultPromise };

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -555,10 +555,12 @@ export function settleExit(scopeKey: string): void {
 export function waitForExitSettled(scopeKey: string, timeoutMs = 5000): Promise<void> {
     const entry = exitSettlers.get(scopeKey);
     if (!entry) return Promise.resolve();
-    return Promise.race([entry.promise, new Promise<void>(r => {
-        const t = setTimeout(r, timeoutMs);
-        t.unref?.();
-    })]).then(() => {
+    // The timer is NOT unref'd and is always cleared: an unref'd timer can vanish
+    // with a drained event loop (test runner), leaving the waiter pending forever.
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<void>(r => { timer = setTimeout(r, timeoutMs); });
+    return Promise.race([entry.promise, timeout]).then(() => {
+        clearTimeout(timer);
         if (exitSettlers.get(scopeKey) === entry) exitSettlers.delete(scopeKey);
     });
 }

--- a/src/cli/handlers-runtime.ts
+++ b/src/cli/handlers-runtime.ts
@@ -237,15 +237,27 @@ export async function steerHandler(args: string[], ctx: CliCommandContext): Prom
     }
     const { currentSessionScope } = await import('../core/session-context.js');
     const scopeKey = currentSessionScope()?.scope ?? 'default';
-    const { isAgentBusy, killActiveAgent, waitForProcessEnd, getSteerWaitMsForActiveAgent } = await import('../agent/spawn.js');
+    const { isAgentBusy, killActiveAgent, waitForProcessEnd, waitForExitSettled, getSteerWaitMsForActiveAgent } = await import('../agent/spawn.js');
     if (!isAgentBusy(scopeKey)) {
         return { ok: false, type: 'error', text: t('cmd.steer.noAgent', {}, L) };
     }
 
     // Kill running agent (or cancel retry timer) and wait for clean exit
+    // Snapshot before the kill: the interrupted partial-output row is the first
+    // ⏹️-tagged assistant message above this mark (second-resolution created_at
+    // comparisons are not race-safe).
+    const { getMaxMessageId, getSteerSalvageAfter } = await import('../core/db.js');
+    const steerSessionId = sessionScopeMeta().chatSessionId
+        || (await import('../core/chat-sessions.js')).getActiveChatSession();
+    const maxIdBeforeKill = getMaxMessageId(steerSessionId);
     const steerWaitMs = getSteerWaitMsForActiveAgent(scopeKey);
     killActiveAgent(scopeKey, 'steer');
     await waitForProcessEnd(scopeKey, steerWaitMs);
+    // killActiveAgent drops the scope's map entry synchronously, so the wait above
+    // can return before the exit handler has saved the interrupted partial output.
+    await waitForExitSettled(scopeKey);
+    const salvage = getSteerSalvageAfter(steerSessionId, maxIdBeforeKill);
+    const steerContext = salvage ? salvage.replace(/^⏹️ \[interrupted\]\s*/, '') : undefined;
 
     // Remote interfaces: clear stale session before re-orchestrate
     const iface = ctx.interface || 'cli';
@@ -253,14 +265,14 @@ export async function steerHandler(args: string[], ctx: CliCommandContext): Prom
         if (typeof ctx.clearSession === 'function') {
             await ctx.clearSession();
         }
-        return { ok: true, type: 'steer', text: t('cmd.steer.started', {}, L), steerPrompt: prompt };
+        return { ok: true, type: 'steer', text: t('cmd.steer.started', {}, L), steerPrompt: prompt, ...(steerContext ? { steerContext } : {}) };
     }
 
     // Web/CLI: fire orchestration directly via submitMessage
     const { submitMessage } = await import('../orchestrator/gateway.js');
     // Same session carry-through as the other slash handlers: steering a run
     // must land in the lane that run belongs to.
-    submitMessage(prompt, { origin: iface as 'cli' | 'web' | 'telegram' | 'discord' | 'slack', ...sessionScopeMeta() });
+    submitMessage(prompt, { origin: iface as 'cli' | 'web' | 'telegram' | 'discord' | 'slack', ...sessionScopeMeta(), ...(steerContext ? { _steerContext: steerContext } : {}) });
     return { ok: true, type: 'success', text: t('cmd.steer.started', {}, L) };
 }
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -10,6 +10,8 @@ export interface SlashResult {
     type?: string;
     code?: string;
     steerPrompt?: string;
+    /** Salvaged partial output of the turn this steer interrupted (kill-path). */
+    steerContext?: string;
     text?: string;
     originalText?: string;
     recovery?: UnknownCommandRecovery;

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -546,6 +546,27 @@ export const insertMessage = db.prepare('INSERT INTO messages (role, content, cl
 export const insertMessageWithTrace = db.prepare('INSERT INTO messages (role, content, cli, model, trace, tool_log, working_dir, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
 export const insertMessageWithTraceRun = db.prepare('INSERT INTO messages (role, content, cli, model, trace, tool_log, working_dir, trace_run_id, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
 export const getMessages = db.prepare('SELECT id, role, content, cli, model, tool_log, trace_run_id, cost_usd, duration_ms, working_dir, created_at FROM messages WHERE session_id = ? ORDER BY id ASC');
+const maxMessageIdStmt = db.prepare('SELECT MAX(id) AS maxId FROM messages WHERE session_id = ?');
+const steerSalvageStmt = db.prepare(`SELECT content FROM messages
+    WHERE session_id = ? AND id > ? AND role = 'assistant' AND content LIKE '⏹️ [interrupted]%'
+    ORDER BY id ASC LIMIT 1`);
+
+/** Snapshot of the newest message id in a session, taken before a steer kill. */
+export function getMaxMessageId(sessionId: string): number {
+    const row = maxMessageIdStmt.get(sessionId) as { maxId?: number | null } | undefined;
+    return typeof row?.maxId === 'number' ? row.maxId : 0;
+}
+
+/**
+ * Salvage identity for kill-path steer. The interrupted assistant row is the
+ * first ⏹️-tagged assistant message with id greater than the pre-kill snapshot.
+ * created_at comparisons are NOT safe here: the column is second-resolution UTC
+ * and same-second collisions across concurrent scopes misattribute salvage.
+ */
+export function getSteerSalvageAfter(sessionId: string, afterId: number): string | null {
+    const row = steerSalvageStmt.get(sessionId, afterId) as { content?: string } | undefined;
+    return typeof row?.content === 'string' ? row.content : null;
+}
 export const searchMessages = db.prepare(`
     SELECT id, role, content, cli, tool_log, created_at,
            CASE WHEN content LIKE '%' || $q || '%' THEN 'content' ELSE 'tool_log' END AS match_field

--- a/src/orchestrator/gateway.ts
+++ b/src/orchestrator/gateway.ts
@@ -57,6 +57,8 @@ type SubmitMeta = {
     replyViaTarget?: boolean;
     external?: boolean;
     midRunPolicy?: ActiveRunPolicy;
+    /** Salvaged partial output of a steer-interrupted turn (kill-path callers). */
+    _steerContext?: string;
 };
 
 function resolveMidRunPolicy(meta: SubmitMeta, chatSessionId: string): ActiveRunPolicy {
@@ -301,8 +303,8 @@ export function submitMessage(
         runDetached(
             sessionLanes.run(scope, () => (
                 multiSessionEnabled
-                    ? withSessionScope(sessionScope, () => orchestrate(trimmed, stripUndefined({ origin: meta.origin, target: meta.target, chatId: meta.chatId, requestId, scope, chatSessionId, ...(remoteKey ? { remoteKey } : {}), _skipInsert: true, overrides: meta.overrides, replyViaTarget: meta.replyViaTarget })))
-                    : orchestrate(trimmed, stripUndefined({ origin: meta.origin, target: meta.target, chatId: meta.chatId, requestId, _skipInsert: true, overrides: meta.overrides, replyViaTarget: meta.replyViaTarget }))
+                    ? withSessionScope(sessionScope, () => orchestrate(trimmed, stripUndefined({ origin: meta.origin, target: meta.target, chatId: meta.chatId, requestId, scope, chatSessionId, ...(remoteKey ? { remoteKey } : {}), _skipInsert: true, overrides: meta.overrides, replyViaTarget: meta.replyViaTarget, _steerContext: meta._steerContext })))
+                    : orchestrate(trimmed, stripUndefined({ origin: meta.origin, target: meta.target, chatId: meta.chatId, requestId, _skipInsert: true, overrides: meta.overrides, replyViaTarget: meta.replyViaTarget, _steerContext: meta._steerContext }))
             )),
             'orchestrate',
             { ...meta, requestId, ...(eventScope ? { eventScope } : {}) },

--- a/src/orchestrator/pipeline.ts
+++ b/src/orchestrator/pipeline.ts
@@ -473,6 +473,11 @@ export async function orchestrate(
         } : {}),
         _skipInsert: !!meta["_skipInsert"],
         _heartbeatAnchorId: meta["_heartbeatAnchorId"],
+        // Kill-path steer salvage: the interrupted turn's partial output,
+        // prepended to this run's prompt by spawn (see withSteerContext).
+        ...(typeof meta["_steerContext"] === 'string' && meta["_steerContext"]
+            ? { steerContext: meta["_steerContext"] as string }
+            : {}),
         ...(overrides?.model ? { model: overrides.model } : {}),
         ...(overrides?.systemPrompt ? { sysPrompt: overrides.systemPrompt } : {}),
     });

--- a/src/routes/command.ts
+++ b/src/routes/command.ts
@@ -198,7 +198,10 @@ export function registerCommandRoutes(app: Router, requireAuth: RequestHandler):
                         )
                         : await executeCommand(parsed, makeWebCommandCtx(req, locale));
                     if (cmdResult?.steerPrompt) {
-                        const submit = submitMessage(cmdResult.steerPrompt, submitMeta);
+                        const submit = submitMessage(cmdResult.steerPrompt, {
+                            ...submitMeta,
+                            ...(cmdResult.steerContext ? { _steerContext: cmdResult.steerContext as string } : {}),
+                        });
                         if (submit.action === 'rejected') {
                             const status = (submit.reason === 'busy' || submit.reason === 'duplicate') ? 409 : 400;
                             res.status(status).json({ ok: false, command: true, error: submit.reason, ...publicSubmitResult(submit) });

--- a/src/routes/orchestrate.ts
+++ b/src/routes/orchestrate.ts
@@ -1,7 +1,7 @@
 import type { Express } from 'express';
 import type { AuthMiddleware } from './types.js';
 import { fail } from '../http/response.js';
-import { isAgentBusy, messageQueue, getQueuedMessageSnapshotForScope, removeQueuedMessage, killActiveAgent, waitForProcessEnd, getCurrentMainMeta, getSteerWaitMsForActiveAgent, setQueueHold, clearQueueHold, setSteerInProgress, isSteerInProgress } from '../agent/spawn.js';
+import { isAgentBusy, messageQueue, getQueuedMessageSnapshotForScope, removeQueuedMessage, killActiveAgent, waitForProcessEnd, waitForExitSettled, getCurrentMainMeta, getSteerWaitMsForActiveAgent, setQueueHold, clearQueueHold, setSteerInProgress, isSteerInProgress } from '../agent/spawn.js';
 import { getLiveRun } from '../agent/live-run-state.js';
 import { countToolTraceRows, listToolEntriesForRun } from '../trace/store.js';
 import { orchestrate, orchestrateContinue, orchestrateReset, isResetIntent, isContinueIntent, drainPendingReplays } from '../orchestrator/pipeline.js';
@@ -406,8 +406,21 @@ export function registerOrchestrateRoutes(app: Express, requireAuth: AuthMiddlew
         void (async () => {
             try {
                 if (wasBusyBeforeSteer) {
+                    // Snapshot before the kill: the salvage row is the first
+                    // ⏹️-tagged assistant message above this mark.
+                    const { getMaxMessageId, getSteerSalvageAfter } = await import('../core/db.js');
+                    const maxIdBeforeKill = getMaxMessageId(chatSessionId);
                     const stopped = killActiveAgent(scope, 'steer');
-                    if (stopped) await waitForProcessEnd(scope, steerWaitMs);
+                    if (stopped) {
+                        await waitForProcessEnd(scope, steerWaitMs);
+                        // The kill drops the scope's map entry synchronously, so the
+                        // wait above can precede the exit handler's salvage insert.
+                        await waitForExitSettled(scope);
+                        const salvage = getSteerSalvageAfter(chatSessionId, maxIdBeforeKill);
+                        if (salvage) {
+                            (steerMeta as { _steerContext?: string })._steerContext = salvage.replace(/^⏹️ \[interrupted\]\s*/, '');
+                        }
+                    }
                 }
                 setSteerInProgress(scope, false);
                 const task = isResetIntent(prompt)

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -152,6 +152,7 @@ export async function handleSlackSlashCommand(payload: Record<string, unknown>):
             const reply = String(await withSessionScope(sessionScope, () => orchestrateAndCollect(steerPrompt, {
                 origin: 'slack', target, chatId: channelId,
                 ...(remoteKey ? { remoteKey } : {}), chatSessionId, scope, _skipInsert: true,
+                ...(result.steerContext ? { _steerContext: result.steerContext } : {}),
             })));
             await sendSlackText(token, target, reply);
             return;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -768,6 +768,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
         prompt: string,
         displayMsg: string,
         ackInput: { anchorId?: number; isMention?: boolean } = {},
+        steerContext?: string,
     ) {
         const chatId = ctx.chat?.id;
         if (!ctx.chat) return;
@@ -1111,6 +1112,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                 scope: result.sessionContext?.scope,
                 chatSessionId: result.sessionContext?.chatSessionId,
                 remoteKey: result.sessionContext?.remoteKey,
+                _steerContext: steerContext,
             }));
             clearInterval(typingInterval);
             if (statusUpdateTimer) {
@@ -1216,7 +1218,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                 const steerPrompt = result.steerPrompt;
                 await ctx.reply(redactOutboundText(result.text || '🔄'));
                 try {
-                    await tgOrchestrate(ctx, steerPrompt, steerPrompt);
+                    await tgOrchestrate(ctx, steerPrompt, steerPrompt, {}, result.steerContext as string | undefined);
                 } catch (err: unknown) {
                     log.error('[tg:steer]', logErrorText(err));
                     await ctx.reply(`❌ Steer failed: ${userErrorText(err)}`.slice(0, 500)).catch(() => {});

--- a/tests/unit/api-message-command-contract.test.ts
+++ b/tests/unit/api-message-command-contract.test.ts
@@ -40,7 +40,10 @@ test('/api/message slash steerPrompt rejects visibly when submitMessage rejects'
     const normalStart = block.indexOf('const result = submitMessage(trimmed');
     assert.ok(steerStart >= 0 && normalStart > steerStart, 'steerPrompt branch should precede normal submit');
     const steerBlock = block.slice(steerStart, normalStart);
-    assert.match(steerBlock, /const submit = submitMessage\(cmdResult\.steerPrompt, submitMeta\);/);
+    // wp1: the submit meta may carry _steerContext from the interrupted turn;
+    // the contract is that steering goes through submitMessage with the shared meta.
+    assert.match(steerBlock, /const submit = submitMessage\(cmdResult\.steerPrompt, \{/);
+    assert.match(steerBlock, /\.\.\.submitMeta/);
     assert.match(steerBlock, /submit\.action === 'rejected'/);
     assert.match(steerBlock, /res\.status\(status\)\.json\(\{ ok: false, command: true, error: submit\.reason, \.\.\.publicSubmitResult\(submit\) \}\);/);
 });

--- a/tests/unit/dual-insert-guard.test.ts
+++ b/tests/unit/dual-insert-guard.test.ts
@@ -149,11 +149,15 @@ test('DI-008: steerAgent passes _skipInsert: true to orchestrate calls', () => {
     const steerStart = spawnSrc.indexOf('export async function steerAgent');
     const steerEnd = spawnSrc.indexOf('// ─── Helpers', steerStart);
     const steerBlock = spawnSrc.slice(steerStart, steerEnd > 0 ? steerEnd : steerStart + 5000);
-    assert.equal(
-        steerBlock.match(/_skipInsert:\s*true/g)?.length,
-        3,
-        'reset, continue, and normal steer paths must all suppress duplicate inserts',
+    // wp1: the three intent branches share one steerMeta object, so the flag is
+    // declared once and every branch consumes it.
+    assert.ok(
+        steerBlock.includes('_skipInsert: true'),
+        'shared steer metadata must suppress duplicate inserts',
     );
+    for (const branch of ['orchestrateReset(steerMeta)', 'orchestrateContinue(steerMeta)', 'orchestrate(newPrompt, steerMeta)']) {
+        assert.ok(steerBlock.includes(branch), 'steer branch must use shared metadata: ' + branch);
+    }
 });
 
 // ─── DI-009: processQueue retains its own insertMessage (existing behavior) ───

--- a/tests/unit/steer-context-salvage.test.ts
+++ b/tests/unit/steer-context-salvage.test.ts
@@ -1,0 +1,144 @@
+// wp1 (devlog/_plan/260903_steer_default_context/010): kill-path steer must
+// deliver the interrupted turn's partial output to the follow-up run.
+// Behavioral tests only — no source scanning.
+// Must be the FIRST import: config.ts binds DB_PATH at module evaluation.
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withSteerContext, STEER_SALVAGE_MAX_CHARS } from '../../src/agent/prompt-context.ts';
+import { db, insertMessage, getMaxMessageId, getSteerSalvageAfter } from '../../src/core/db.ts';
+import { armExitSettle, settleExit, waitForExitSettled } from '../../src/agent/spawn.ts';
+import { orchestrate } from '../../src/orchestrator/pipeline.ts';
+import { resetState } from '../../src/orchestrator/state-machine.ts';
+
+// ─── SC-001..003: withSteerContext pure prompt assembly ───
+
+test('SC-001: no salvage leaves the prompt byte-identical', () => {
+    assert.equal(withSteerContext('do X'), 'do X');
+    assert.equal(withSteerContext('do X', ''), 'do X');
+    assert.equal(withSteerContext('do X', '   '), 'do X');
+    assert.equal(withSteerContext('do X', null), 'do X');
+    assert.equal(withSteerContext('do X', undefined), 'do X');
+});
+
+test('SC-002: salvage block precedes the prompt and marks it incomplete', () => {
+    const out = withSteerContext('NEW INSTRUCTION', 'partial work output');
+    assert.ok(out.includes('partial work output'), 'contains salvage');
+    assert.ok(out.includes('NEW INSTRUCTION'), 'contains prompt');
+    assert.ok(out.indexOf('partial work output') < out.indexOf('NEW INSTRUCTION'), 'salvage first');
+    assert.ok(out.includes('<partial_output>'), 'structured fence');
+    assert.ok(/INCOMPLETE/.test(out), 'marks the salvage as incomplete');
+    assert.ok(!out.includes('[truncated]'), 'no truncation marker under the cap');
+});
+
+test('SC-003: salvage longer than the cap keeps the TAIL with a truncation marker', () => {
+    const head = 'H'.repeat(100);
+    const tail = 'T'.repeat(100);
+    const salvage = head + 'M'.repeat(STEER_SALVAGE_MAX_CHARS) + tail;
+    const out = withSteerContext('p', salvage);
+    assert.ok(out.includes('[truncated]'), 'truncation marker');
+    assert.ok(out.includes(tail), 'tail preserved (recent context matters most)');
+    assert.ok(!out.includes(head), 'oldest content dropped first');
+});
+
+// ─── SC-004..006: salvage identity in the messages table ───
+
+const SC_SESSION = 'steer-salvage-test';
+
+test('SC-004: salvage row is the first interrupted assistant row ABOVE the pre-kill mark', () => {
+    db.prepare('DELETE FROM messages WHERE session_id = ?').run(SC_SESSION);
+    // A stale interrupted row from an EARLIER steer must not be picked up.
+    insertMessage.run('assistant', '⏹️ [interrupted]\n\nold partial', 'codex', '', null, SC_SESSION);
+    insertMessage.run('user', 'work on the thing', 'codex', '', null, SC_SESSION);
+    const mark = getMaxMessageId(SC_SESSION);
+    insertMessage.run('assistant', '⏹️ [interrupted]\n\nfresh partial output', 'codex', '', null, SC_SESSION);
+    const salvage = getSteerSalvageAfter(SC_SESSION, mark);
+    assert.equal(salvage, '⏹️ [interrupted]\n\nfresh partial output');
+});
+
+test('SC-005: no new interrupted row above the mark → null (no salvage attached)', () => {
+    db.prepare('DELETE FROM messages WHERE session_id = ?').run(SC_SESSION);
+    insertMessage.run('assistant', '⏹️ [interrupted]\n\nold partial', 'codex', '', null, SC_SESSION);
+    const mark = getMaxMessageId(SC_SESSION);
+    // New rows that are NOT interrupted output must not qualify.
+    insertMessage.run('assistant', 'ordinary answer', 'codex', '', null, SC_SESSION);
+    insertMessage.run('user', '⏹️ [interrupted] user-typed text is not salvage', 'codex', '', null, SC_SESSION);
+    assert.equal(getSteerSalvageAfter(SC_SESSION, mark), null);
+});
+
+test('SC-006: salvage lookup is session-scoped', () => {
+    db.prepare('DELETE FROM messages WHERE session_id = ?').run('steer-other-session');
+    insertMessage.run('assistant', '⏹️ [interrupted]\n\nother session partial', 'codex', '', null, 'steer-other-session');
+    const mark = getMaxMessageId(SC_SESSION);
+    assert.equal(getSteerSalvageAfter(SC_SESSION, mark), null);
+});
+
+// ─── SC-007..009: exit-settle barrier ───
+
+test('SC-007: unarmed scope resolves immediately', async () => {
+    const t0 = Date.now();
+    await waitForExitSettled('sc007-never-armed', 1000);
+    assert.ok(Date.now() - t0 < 500, 'should not wait without an arm');
+});
+
+test('SC-008: armed barrier pends until settleExit', async () => {
+    const scope = 'sc008-armed';
+    armExitSettle(scope);
+    let settled = false;
+    const waiter = waitForExitSettled(scope, 5000).then(() => { settled = true; });
+    await new Promise(r => setTimeout(r, 50));
+    assert.equal(settled, false, 'must still be waiting before settle');
+    settleExit(scope);
+    await waiter;
+    assert.equal(settled, true, 'settle releases the waiter');
+    // Arm is consumed: a later wait must not see the old barrier.
+    await waitForExitSettled(scope, 50);
+});
+
+test('SC-009: timeout releases and drops the arm (wedged exit handler must not hang steer)', async () => {
+    const scope = 'sc009-timeout';
+    armExitSettle(scope);
+    const t0 = Date.now();
+    await waitForExitSettled(scope, 60);
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed >= 50 && elapsed < 3000, `bounded wait, got ${elapsed}ms`);
+    // Arm dropped after timeout — no stale barrier lingers for the next steer.
+    await waitForExitSettled(scope, 20);
+});
+
+// ─── SC-010: pipeline passes _steerContext into spawn opts ───
+
+test('SC-010: orchestrate meta._steerContext reaches spawn opts as steerContext', async () => {
+    resetState('default');
+    let captured: Record<string, unknown> | undefined;
+    await orchestrate('steer follow-up', {
+        origin: 'test',
+        _skipClear: true,
+        _skipReplayDrain: true,
+        _skipInsert: true,
+        _steerContext: 'SALVAGED-PARTIAL',
+        _spawnAgent: (_prompt: string, opts: Record<string, unknown>) => {
+            captured = opts;
+            return { child: null, promise: Promise.resolve({ text: 'ok', code: 0 }) };
+        },
+    });
+    assert.equal(captured?.steerContext, 'SALVAGED-PARTIAL');
+    resetState('default');
+});
+
+test('SC-011: without _steerContext the spawn opts carry no steerContext', async () => {
+    resetState('default');
+    let captured: Record<string, unknown> | undefined;
+    await orchestrate('plain run', {
+        origin: 'test',
+        _skipClear: true,
+        _skipReplayDrain: true,
+        _skipInsert: true,
+        _spawnAgent: (_prompt: string, opts: Record<string, unknown>) => {
+            captured = opts;
+            return { child: null, promise: Promise.resolve({ text: 'ok', code: 0 }) };
+        },
+    });
+    assert.equal(captured?.steerContext, undefined);
+    resetState('default');
+});

--- a/tests/unit/steer-flow.test.ts
+++ b/tests/unit/steer-flow.test.ts
@@ -237,7 +237,9 @@ test('SF-006: queued web steer accepts item before background old-process wait',
 
     const routeIdx = routeSrc.indexOf("app.post('/api/orchestrate/queue/:id/steer'");
     assert.ok(routeIdx > 0, 'queued steer route should exist');
-    const routeBlock = routeSrc.slice(routeIdx, routeIdx + 3200);
+    // Window sized to cover the background steer block including the wp1
+    // exit-settle/salvage wait between the kill and the re-orchestrate.
+    const routeBlock = routeSrc.slice(routeIdx, routeIdx + 5200);
 
     const waitConfigIdx = routeBlock.indexOf('const steerWaitMs = getSteerWaitMsForActiveAgent(scope)');
     const busyCaptureIdx = routeBlock.indexOf('const wasBusyBeforeSteer = isAgentBusy(scope)');


### PR DESCRIPTION
## 개요

steer 스택의 1/3. kill-path steer(명시적 /steer, /queue steer)에서 중단된 턴의 부분 출력과 중단 사실이 follow-up run의 모델 맥락에 항상 도달하도록 한다.

**Stack** (merge bottom-up):
| # | Layer | 내용 |
|---|-------|------|
| 1 | ← 이 PR | kill-path 맥락 보존 코어 (salvage + race fix) |
| 2 | codex/steer-wp2-codex-native | codex-app 네이티브 turn/steer |
| 3 | codex/steer-wp3-default-ui | 설정 UI + 문서 |

## 변경

- exit-settle 배리어: killActiveAgent가 steer/interrupt kill 시점에 arm하고, 5개 exit 경로(ACP/Pi×2/codex-app/std CLI)가 salvage insert 후 settle. 종전에는 kill이 map 엔트리를 동기 삭제해 follow-up spawn이 salvage row를 못 읽는 race가 있었다
- salvage 식별: pre-kill MAX(id) 스냅샷 (created_at은 초 단위 UTC라 경쟁에 취약)
- withSteerContext: salvage 꼬리 4000자를 전 런타임 프롬프트 경로(argv/stdio/ACP/pi/codex-app)에 주입 — native resume 성공 경로도 포함
- _steerContext 투과: pipeline meta, gateway submitMessage, /steer, /queue steer, slack/telegram/command 소비자

## 검증

- 신규 behavioral 테스트 11개 (tests/unit/steer-context-salvage.test.ts): 배리어 ordering/timeout, salvage 식별/세션 격리, 절단, pipeline passthrough
- 기존 steer 계약 93개 green, 전체 unit 8482개 fail 0
- npm run build 성공 + dist 심볼 확인
- 설계/감사: devlog/_plan/260903_steer_default_context/ (010), 독립 reviewer A-gate GO-WITH-FIXES 5건 전부 fold