### PR TITLE
feat(steer): native same-turn steer for codex-app via turn/steer (wp2/3)

### DIFF
--- a/src/agent/codex-app-client.ts
+++ b/src/agent/codex-app-client.ts
@@ -10,6 +10,22 @@ import { createTextStreamReader } from './stream-text.js';
 import { spawn, type ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { createInterface, type Interface as ReadlineInterface } from 'readline';
+import { stripUndefined } from '../core/strip-undefined.js';
+
+export type CodexSteerErrorCode = 'no-active-turn' | 'not-steerable' | 'turn-mismatch' | 'rpc-error';
+
+/** Typed steer rejection. `not-steerable` carries the server-reported turnKind
+ *  (review|compact); `turn-mismatch` means the tracked turn raced to completion. */
+export class CodexSteerError extends Error {
+    readonly code: CodexSteerErrorCode;
+    readonly turnKind?: string;
+    constructor(code: CodexSteerErrorCode, message: string, opts: { turnKind?: string } = {}) {
+        super(message);
+        this.name = 'CodexSteerError';
+        this.code = code;
+        if (opts.turnKind) this.turnKind = opts.turnKind;
+    }
+}
 
 // A bogus thread/resume on codex-cli 0.146.0 returns "no rollout found for thread id ...".
 const RECOVERABLE_RESUME_RE = /not found|no rollout found|unknown thread|no such thread|invalid thread|thread.*missing/i;
@@ -442,6 +458,51 @@ export class CodexAppClient extends EventEmitter {
             return;
         }
         await this.sendInterrupt(state, state.activeTurnId);
+    }
+
+    /**
+     * Same-turn user input injection (app-server `turn/steer`).
+     *
+     * The steered text joins the ACTIVE turn's pending input and is drained at
+     * the next tool-call boundary — the model keeps the full prior context.
+     * Success means "accepted into the queue", not a new turn: no turn/started
+     * fires, and the existing turn's item/completion stream continues.
+     *
+     * This primitive deliberately performs no fallback: callers own the policy
+     * (queue the message, retry with the actual turn id, or give up).
+     */
+    async steerTurn(scope: string, text: string, opts: { clientUserMessageId?: string } = {}): Promise<{ turnId: string }> {
+        this.assertReusable();
+        const state = this.requireScope(scope);
+        if (!state.threadId) throw new CodexSteerError('no-active-turn', `No active thread for scope ${scope}`);
+        if (!state.activeTurnId) throw new CodexSteerError('no-active-turn', `No active turn for scope ${scope}`);
+        try {
+            const result = await this.request('turn/steer', stripUndefined({
+                threadId: state.threadId,
+                expectedTurnId: state.activeTurnId,
+                input: [{ type: 'text', text, text_elements: [] }],
+                clientUserMessageId: opts.clientUserMessageId,
+            })) as { turnId?: string };
+            const turnId = result?.turnId;
+            if (!turnId) throw new CodexSteerError('rpc-error', `turn/steer returned no turn id for scope ${scope}`);
+            if (turnId !== state.activeTurnId) {
+                console.warn(`[codex-app:steer] accepted by ${turnId} while tracking ${state.activeTurnId} for scope ${scope}`);
+            }
+            return { turnId };
+        } catch (err) {
+            if (err instanceof CodexSteerError) throw err;
+            const data = (err as { data?: unknown } | null)?.data as
+                { codexErrorInfo?: { activeTurnNotSteerable?: { turnKind?: string } } } | undefined;
+            const turnKind = data?.codexErrorInfo?.activeTurnNotSteerable?.turnKind;
+            if (turnKind) {
+                throw new CodexSteerError('not-steerable', (err as Error).message, { turnKind });
+            }
+            const message = (err as Error).message || '';
+            if (/expectedTurnId|turn .* not active|no active turn/i.test(message)) {
+                throw new CodexSteerError('turn-mismatch', message);
+            }
+            throw err;
+        }
     }
 
     async closeScope(scope: string): Promise<void> {
@@ -1319,9 +1380,14 @@ export class CodexAppClient extends EventEmitter {
             this.pending.delete(id);
             const error = this.recordField(msg, 'error');
             if (error) {
-                handler.reject(new Error(
+                const err = new Error(
                     `JSON-RPC error ${String(error['code'] ?? '')}: ${String(error['message'] ?? '')}`,
-                ));
+                );
+                // Preserve the structured payload: turn/steer rejections carry
+                // data.codexErrorInfo.activeTurnNotSteerable.turnKind, which the
+                // caller needs to distinguish "queue instead" from real failures.
+                if (error['data'] !== undefined) (err as Error & { data?: unknown }).data = error['data'];
+                handler.reject(err);
             } else {
                 handler.resolve(msg['result']);
             }

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -186,6 +186,14 @@ export type MainRunState = {
     meta: MainSessionMeta;
     cancelPending?: (reason: string) => void;
     cancelTurn?: (reason: string) => void;
+    /**
+     * In-band same-turn steer for runtimes that support it (codex-app turn/steer).
+     * Installed only while a steerable turn is actually in flight, so its mere
+     * presence is the capability check. 'unavailable' = race/lost turn (caller
+     * queues); 'rejected' = the turn kind rejects steer (review/compact; caller
+     * queues with a reason broadcast).
+     */
+    steerTurnInBand?: (text: string) => Promise<'steered' | 'unavailable' | 'rejected'>;
 };
 
 export const activeMainProcesses = new Map<string, MainRunState>();
@@ -742,15 +750,19 @@ export function waitForAllProcessesEnd(timeoutMs = 2000): Promise<void> {
 
 export function canSteerAgent(scopeKey: string): boolean {
     const run = activeMainProcesses.get(scopeKey);
-    return run?.meta.cli === 'jwc' && jawRuntimesByScope.get(scopeKey)?.busy === true;
+    if (run?.meta.cli === 'jwc' && jawRuntimesByScope.get(scopeKey)?.busy === true) return true;
+    // codex-app: the hook exists exactly while a steerable turn is in flight.
+    return typeof run?.steerTurnInBand === 'function';
 }
+
+export type SteerOutcome = 'steered' | 'fallback-queue' | 'new-run';
 
 export async function steerAgent(
     scopeKey: string,
     newPrompt: string,
     source: string,
     meta?: { chatSessionId?: string; target?: RemoteTarget; chatId?: string | number; requestId?: string; remoteKey?: string; replyViaTarget?: boolean },
-) {
+): Promise<SteerOutcome> {
     const run = activeMainProcesses.get(scopeKey);
     const runtime = runtimeForScope(scopeKey);
     const chatSessionId = meta?.chatSessionId || run?.meta.chatSessionId || getActiveChatSession();
@@ -763,7 +775,32 @@ export async function steerAgent(
         // event will ever carry this id. Settling here is what stops a caller
         // from waiting for an answer that structurally cannot arrive.
         settleOnce(meta?.requestId, 'steered');
-        return;
+        return 'steered';
+    }
+    if (typeof run?.steerTurnInBand === 'function') {
+        // codex-app same-turn steer. The user row is written only AFTER the
+        // server accepts — a fallback must not leave a duplicate insert for the
+        // queued path to write again.
+        let outcome: 'steered' | 'unavailable' | 'rejected';
+        try {
+            outcome = await run.steerTurnInBand(newPrompt);
+        } catch (err) {
+            console.error('[jaw:steer] codex-app in-band steer failed:', (err as Error).message);
+            return 'fallback-queue';
+        }
+        if (outcome !== 'steered') {
+            if (outcome === 'rejected') {
+                // review/compact turns structurally reject steer — tell the user
+                // their message was queued instead, not silently swallowed.
+                broadcast('steer_rejected', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey, sessionId: chatSessionId, reason: 'turn-not-steerable', requestId: meta?.requestId }));
+            }
+            return 'fallback-queue';
+        }
+        insertMessage.run('user', newPrompt, source, '', settings["workingDir"] || null, chatSessionId);
+        broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
+        broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey, sessionId: chatSessionId, target: meta?.target, chatId: meta?.chatId, requestId: meta?.requestId, remoteKey: meta?.remoteKey, replyViaTarget: meta?.replyViaTarget }));
+        settleOnce(meta?.requestId, 'steered');
+        return 'steered';
     }
     const steerWaitMs = getSteerWaitMsForActiveAgent(scopeKey);
     // Snapshot BEFORE the kill: the interrupted partial-output row is identified
@@ -798,6 +835,9 @@ export async function steerAgent(
         broadcast('orchestrate_done', stripUndefined({ text: `[error] ${err.message}`, error: true, origin, requestId: meta?.requestId }));
         settleOnce(meta?.requestId, 'failed', { error: err.message });
     });
+    // The follow-up was started as a new run (kill-path or idle race). The caller
+    // must NOT also queue the message.
+    return 'new-run';
 }
 
 
@@ -950,7 +990,7 @@ export { buildMediaPrompt, buildMediaPromptMany };
 // ─── Spawn Agent ─────────────────────────────────────
 
 import { AcpClient } from '../cli/acp-client.js';
-import { CodexAppClient, isRecoverableResumeError } from './codex-app-client.js';
+import { CodexAppClient, CodexSteerError, isRecoverableResumeError } from './codex-app-client.js';
 import {
     acquireCodexAppRuntime,
     acquirePiRuntime,
@@ -2347,6 +2387,23 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             };
             const cancelHook = (_reason: string) => { void requestLeaseCancel(); };
             if (lease && mainRun) mainRun.cancelTurn = cancelHook;
+            // Same-turn steer (turn/steer) for the duration of THIS turn only:
+            // installed and torn down with cancelHook so capability reads never
+            // outlive the steerable window.
+            const steerHook = async (text: string): Promise<'steered' | 'unavailable' | 'rejected'> => {
+                try {
+                    await appClient.steerTurn(laneScope, text, { clientUserMessageId: crypto.randomUUID() });
+                    return 'steered';
+                } catch (err) {
+                    if (err instanceof CodexSteerError) {
+                        // review/compact turns reject steer; a mismatched/finished
+                        // turn raced us. Both are queue-fallback territory.
+                        return err.code === 'not-steerable' ? 'rejected' : 'unavailable';
+                    }
+                    throw err;
+                }
+            };
+            if (mainRun) mainRun.steerTurnInBand = steerHook;
             const watchdogTimeout = (kind: 'idle' | 'absolute') => {
                 if (watchdogCancel) return;
                 console.warn(`[codex-app:turn] watchdog stall (${kind}, idleMs=${idleMs}, absoluteMs=${absoluteMs})`);
@@ -2466,6 +2523,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 markCodexProgress = () => {};
                 if (watchdogCancel) await watchdogCancel;
                 if (mainRun?.cancelTurn === cancelHook) delete mainRun.cancelTurn;
+                if (mainRun?.steerTurnInBand === steerHook) delete mainRun.steerTurnInBand;
                 listener.dispose();
                 if (lease) lease.release();
                 else {

--- a/src/cli/handlers-runtime.ts
+++ b/src/cli/handlers-runtime.ts
@@ -237,9 +237,25 @@ export async function steerHandler(args: string[], ctx: CliCommandContext): Prom
     }
     const { currentSessionScope } = await import('../core/session-context.js');
     const scopeKey = currentSessionScope()?.scope ?? 'default';
-    const { isAgentBusy, killActiveAgent, waitForProcessEnd, waitForExitSettled, getSteerWaitMsForActiveAgent } = await import('../agent/spawn.js');
+    const { isAgentBusy, killActiveAgent, waitForProcessEnd, waitForExitSettled, getSteerWaitMsForActiveAgent, canSteerAgent, steerAgent } = await import('../agent/spawn.js');
     if (!isAgentBusy(scopeKey)) {
         return { ok: false, type: 'error', text: t('cmd.steer.noAgent', {}, L) };
+    }
+
+    const iface = ctx.interface || 'cli';
+
+    // Prefer in-band same-turn steer when the runtime supports it (jwc always;
+    // codex-app while a steerable turn is in flight). No kill, no context loss.
+    // A steer that the runtime cannot accept falls back to the QUEUE — never to
+    // killing a turn we failed to steer.
+    if (canSteerAgent(scopeKey)) {
+        const outcome = await steerAgent(scopeKey, prompt, iface, sessionScopeMeta());
+        if (outcome === 'steered') {
+            return { ok: true, type: 'steer', text: t('cmd.steer.started', {}, L) };
+        }
+        const { submitMessage } = await import('../orchestrator/gateway.js');
+        submitMessage(prompt, { origin: iface, ...sessionScopeMeta(), midRunPolicy: 'followup' });
+        return { ok: true, type: 'success', text: 'Steer unavailable for the current turn — message queued as follow-up.' };
     }
 
     // Kill running agent (or cancel retry timer) and wait for clean exit
@@ -260,7 +276,6 @@ export async function steerHandler(args: string[], ctx: CliCommandContext): Prom
     const steerContext = salvage ? salvage.replace(/^⏹️ \[interrupted\]\s*/, '') : undefined;
 
     // Remote interfaces: clear stale session before re-orchestrate
-    const iface = ctx.interface || 'cli';
     if (iface === 'telegram' || iface === 'discord' || iface === 'slack') {
         if (typeof ctx.clearSession === 'function') {
             await ctx.clearSession();

--- a/src/orchestrator/gateway.ts
+++ b/src/orchestrator/gateway.ts
@@ -95,6 +95,11 @@ function applyMidRunPolicy(
 
     if (policy === 'steer') {
         if (!canSteerAgent(ctx.scopeKey)) return queue();
+        // submitMessage is a sync contract, so the response stays optimistic
+        // ('steered'). What changed: the outcome is no longer fire-and-forget.
+        // A raced ('unavailable') or kind-rejected ('rejected': review/compact)
+        // in-band steer joins the queue — with its queue_update broadcast —
+        // instead of dying silently. Kill is never the fallback here.
         runDetached(
             steerAgent(ctx.scopeKey, ctx.text, ctx.meta.origin, stripUndefined({
                 chatSessionId: ctx.chatSessionId,
@@ -103,7 +108,9 @@ function applyMidRunPolicy(
                 requestId: ctx.requestId,
                 remoteKey: ctx.remoteKey,
                 replyViaTarget: ctx.meta.replyViaTarget,
-            })),
+            })).then(outcome => {
+                if (outcome === 'fallback-queue') queue();
+            }),
             'steer',
             { ...ctx.meta, requestId: ctx.requestId, eventScope: { scope: ctx.scopeKey, sessionId: ctx.chatSessionId } },
         );

--- a/structure/commands.md
+++ b/structure/commands.md
@@ -215,7 +215,14 @@ JWC is not bundled with the default npm install or Electron sidecar. Use `jaw jw
 ### `/steer <prompt>`
 
 - Web/Telegram/Discord/Slack에서 실행 가능. CLI slash registry에는 노출되지 않는다.
-- 실행 중 agent가 없으면 에러. 실행 중이면 kill 후 재지시.
+- 실행 중 agent가 없으면 에러.
+- 런타임이 in-band steer를 지원하면(jwc, 또는 steer 가능한 turn이 진행 중인 codex-app)
+  **kill 없이** 진행 중 턴에 주입된다. codex-app은 app-server `turn/steer`로 같은 턴에
+  합류하므로 이전 맥락 손실이 없다. 주입이 불가한 경우(턴 종료 race, review/compact 턴)
+  kill 대신 follow-up 큐로 간다.
+- 그 외 런타임은 kill 후 재지시(kill-path). 이때 중단된 턴의 부분 출력이 salvage되어
+  follow-up run 프롬프트에 구조화 블록으로 주입된다 (wp1: exit-settle 배리어 +
+  `withSteerContext`). 즉 kill-path에서도 "이전 맥락"이 모델에 도달한다.
 
 ### `/fork`
 

--- a/structure/prompt_flow.md
+++ b/structure/prompt_flow.md
@@ -169,6 +169,26 @@ snapshot에 남는다고 명시한다.
 
 추가로 `skills/jaw-dev-pabcd/SKILL.md`가 있으면 `## PABCD Orchestration Guide`가 이어 붙는다. 이 인라인 가이드는 loop/multi-pass 작업을 명시한다 — 큰/"loop" 작업은 work-phase(결과 슬라이스)마다 풀 PABCD 한 바퀴를 돌고, goal 모드에서 D 이후 D→IDLE→P로 다음 work-phase의 P에 재진입하며, 각 phase의 실제 작업을 충실히 수행한다(anti-skip). devlog/_fin/260624_goal_work_phase_pabcd_loop/ 참고.
 
+### Mid-run 메시지 정책 (midRunPolicy)
+
+실행 중인 agent에 새 메시지가 도착하면 (`isAgentBusy` && multiSession enabled)
+gateway가 정책을 적용한다 (src/orchestrator/gateway.ts). 결정 순서:
+요청 `meta.midRunPolicy` > 세션 `active_run_policy` > `settings.multiSession.midRunPolicy`
+> 기본값 `'steer'` (config.ts 기본값/마이그레이션/검증 모두 steer로 정규화).
+
+런타임별 `steer` 정책의 실제 동작:
+
+| 런타임 | busy + steer 정책 | 맥락 보존 |
+|--------|-------------------|-----------|
+| jwc | in-band (pi `session.prompt` streamingBehavior 'steer') | 완전 (같은 턴) |
+| codex-app | in-band (app-server `turn/steer` — `MainRunState.steerTurnInBand` 훅이 active-turn 동안만 설치됨) | 완전 (같은 턴) |
+| 그 외 (codex legacy exec, claude, cursor, grok, opencode, pi, agy, copilot, kiro) | 큐 강등 (`canSteerAgent` false) | — |
+
+in-band 시도가 race(턴 종료)나 turn kind(review/compact)로 실패하면 kill이 아니라
+큐로 강등된다. 명시적 `/steer`·`/queue steer`는 kill-path를 쓰되, 중단된 턴의
+부분 출력이 exit-settle 배리어 + `withSteerContext`로 follow-up 프롬프트에 주입된다
+(structure/commands.md `/steer` 참고).
+
 ### PABCD evidence gate (`--attest`)
 
 Forward phase transitions **P→A, A→B, B→C, C→D** require a narrative attestation — not a boolean checkbox. Implementation: `src/orchestrator/attestation.ts`, enforced in `state-machine.ts` via `checkAttestationGate()`.

--- a/tests/unit/codex-app-multiplex-spawn.test.ts
+++ b/tests/unit/codex-app-multiplex-spawn.test.ts
@@ -213,6 +213,9 @@ test.mock.module('../../src/core/config.js', {
 test.mock.module('../../src/agent/codex-app-client.js', {
     namedExports: {
         CodexAppClient: FakeCodexAppClient,
+        // wp2: spawn.ts imports the typed steer error; the fake client never
+        // throws it, but the export must exist for the module mock to link.
+        CodexSteerError: class CodexSteerError extends Error {},
         isRecoverableResumeError: (message: string) => /not found|no rollout|unknown thread/i.test(message),
     },
 });

--- a/tests/unit/codex-app-steer.test.ts
+++ b/tests/unit/codex-app-steer.test.ts
@@ -1,0 +1,195 @@
+// wp2 (devlog/_plan/260903_steer_default_context/020): codex-app native
+// same-turn steer (turn/steer) — wire shape, error taxonomy, spawn routing.
+// Must be the FIRST import: config.ts binds DB_PATH at module evaluation.
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CodexAppClient, CodexSteerError } from '../../src/agent/codex-app-client.ts';
+import { activeMainProcesses, canSteerAgent, steerAgent } from '../../src/agent/spawn.ts';
+import { getRecentMessagesAll } from '../../src/core/db.ts';
+
+type RequestHandler = (method: string, params: Record<string, unknown>) => Promise<unknown>;
+const laneOptions = { model: 'gpt-5.5', effort: 'medium', cwd: '/tmp', fastMode: false };
+
+function injectRequest(client: CodexAppClient, handler: RequestHandler): void {
+    Object.defineProperty(client, 'request', { value: handler });
+}
+
+async function clientWithLiveTurn(scope: string, steerHandler?: RequestHandler): Promise<{
+    client: CodexAppClient;
+    requests: Array<{ method: string; params: Record<string, unknown> }>;
+}> {
+    const client = new CodexAppClient();
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    injectRequest(client, async (method, params) => {
+        requests.push({ method, params });
+        if (method === 'thread/start') return { thread: { id: 'thread-1' } };
+        if (method === 'turn/start') return { turn: { id: 'turn-1' } };
+        if (method === 'turn/steer' && steerHandler) return steerHandler(method, params);
+        if (method === 'turn/steer') return { turnId: 'turn-1' };
+        return {};
+    });
+    await client.startThread(scope, laneOptions);
+    await client.startTurn(scope, 'original task');
+    requests.length = 0;
+    return { client, requests };
+}
+
+// ─── CS-001: steerTurn wire shape (protocol: app-server-protocol v2/turn.rs) ───
+
+test('CS-001: steerTurn sends turn/steer with threadId, expectedTurnId, text input, clientUserMessageId', async () => {
+    const { client, requests } = await clientWithLiveTurn('scope-cs001');
+    const result = await client.steerTurn('scope-cs001', 'focus on failing tests first', { clientUserMessageId: 'msg-1' });
+    assert.equal(result.turnId, 'turn-1');
+    assert.deepEqual(requests, [{
+        method: 'turn/steer',
+        params: {
+            threadId: 'thread-1',
+            expectedTurnId: 'turn-1',
+            input: [{ type: 'text', text: 'focus on failing tests first', text_elements: [] }],
+            clientUserMessageId: 'msg-1',
+        },
+    }]);
+});
+
+test('CS-002: steerTurn without an active turn throws CodexSteerError no-active-turn', async () => {
+    const client = new CodexAppClient();
+    injectRequest(client, async (method) => {
+        if (method === 'thread/start') return { thread: { id: 'thread-1' } };
+        return {};
+    });
+    await client.startThread('scope-cs002', laneOptions);
+    await assert.rejects(
+        () => client.steerTurn('scope-cs002', 'too late'),
+        (err: unknown) => err instanceof CodexSteerError && err.code === 'no-active-turn',
+    );
+});
+
+test('CS-003: server not-steerable error maps to CodexSteerError not-steerable with turnKind', async () => {
+    const { client } = await clientWithLiveTurn('scope-cs003', async () => {
+        const err = new Error('JSON-RPC error -32600: cannot steer a review turn');
+        (err as Error & { data?: unknown }).data = { codexErrorInfo: { activeTurnNotSteerable: { turnKind: 'review' } } };
+        throw err;
+    });
+    await assert.rejects(
+        () => client.steerTurn('scope-cs003', 'redirect the review'),
+        (err: unknown) => err instanceof CodexSteerError && err.code === 'not-steerable' && err.turnKind === 'review',
+    );
+});
+
+test('CS-004: expectedTurnId race maps to CodexSteerError turn-mismatch', async () => {
+    const { client } = await clientWithLiveTurn('scope-cs004', async () => {
+        throw new Error('JSON-RPC error -32600: expectedTurnId does not match active turn turn-9');
+    });
+    await assert.rejects(
+        () => client.steerTurn('scope-cs004', 'stale redirect'),
+        (err: unknown) => err instanceof CodexSteerError && err.code === 'turn-mismatch',
+    );
+});
+
+test('CS-005: unstructured rpc errors propagate unchanged (no CodexSteerError wrap)', async () => {
+    const { client } = await clientWithLiveTurn('scope-cs005', async () => {
+        throw new Error('stdin not writable');
+    });
+    await assert.rejects(
+        () => client.steerTurn('scope-cs005', 'anything'),
+        (err: unknown) => !(err instanceof CodexSteerError) && (err as Error).message === 'stdin not writable',
+    );
+});
+
+test('CS-006: JSON-RPC error responses preserve error.data on the rejection', async () => {
+    const client = new CodexAppClient();
+    const seen = new Promise<Error>((resolve) => {
+        // Seed a pending request the way request() does, then answer it with an
+        // error carrying a structured payload (codexErrorInfo).
+        (client as unknown as { pending: Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }> })
+            .pending.set(42, { resolve: () => {}, reject: resolve });
+    });
+    (client as unknown as { handleLine: (line: string) => void }).handleLine(JSON.stringify({
+        id: 42,
+        error: {
+            code: -32600,
+            message: 'cannot steer a compact turn',
+            data: { codexErrorInfo: { activeTurnNotSteerable: { turnKind: 'compact' } } },
+        },
+    }));
+    const err = await seen;
+    assert.match(err.message, /-32600.*compact/);
+    assert.deepEqual(
+        (err as Error & { data?: unknown }).data,
+        { codexErrorInfo: { activeTurnNotSteerable: { turnKind: 'compact' } } },
+        'structured data must survive so steerTurn can map not-steerable',
+    );
+});
+
+// ─── CS-007..010: spawn-side routing ───
+
+type FakeRun = {
+    process: null;
+    starting: boolean;
+    steering: boolean;
+    ownerGeneration: number;
+    meta: { origin: string; cli: string; chatSessionId?: string };
+    steerTurnInBand?: (text: string) => Promise<'steered' | 'unavailable' | 'rejected'>;
+};
+
+function installFakeCodexAppRun(scope: string, outcome: 'steered' | 'unavailable' | 'rejected'): { calls: string[] } {
+    const calls: string[] = [];
+    const run: FakeRun = {
+        process: null,
+        starting: false,
+        steering: false,
+        ownerGeneration: 0,
+        meta: { origin: 'web', cli: 'codex-app', chatSessionId: 'cs-spawn' },
+        steerTurnInBand: async (text: string) => { calls.push(text); return outcome; },
+    };
+    activeMainProcesses.set(scope, run as never);
+    return { calls };
+}
+
+test('CS-007: canSteerAgent is true while a codex-app steer hook is installed', () => {
+    installFakeCodexAppRun('cs007', 'steered');
+    try {
+        assert.equal(canSteerAgent('cs007'), true);
+    } finally {
+        activeMainProcesses.delete('cs007');
+    }
+    assert.equal(canSteerAgent('cs007'), false);
+});
+
+test('CS-008: steerAgent routes in-band for codex-app and inserts the user row once accepted', async () => {
+    const { calls } = installFakeCodexAppRun('cs008', 'steered');
+    try {
+        const outcome = await steerAgent('cs008', 'remember the context', 'test', { chatSessionId: 'cs-spawn' });
+        assert.equal(outcome, 'steered');
+        assert.deepEqual(calls, ['remember the context']);
+        const rows = getRecentMessagesAll.all('cs-spawn', 5) as Array<{ role: string; content: string }>;
+        assert.ok(rows.some(r => r.role === 'user' && r.content === 'remember the context'),
+            'accepted steer writes the user row');
+    } finally {
+        activeMainProcesses.delete('cs008');
+    }
+});
+
+test('CS-009: rejected steer (review/compact turn) falls back to queue WITHOUT inserting', async () => {
+    installFakeCodexAppRun('cs009', 'rejected');
+    try {
+        const outcome = await steerAgent('cs009', 'queued instead', 'test', { chatSessionId: 'cs-spawn2' });
+        assert.equal(outcome, 'fallback-queue');
+        const rows = getRecentMessagesAll.all('cs-spawn2', 5) as Array<{ role: string; content: string }>;
+        assert.ok(!rows.some(r => r.content === 'queued instead'),
+            'unaccepted steer must not insert — the queue path owns the insert');
+    } finally {
+        activeMainProcesses.delete('cs009');
+    }
+});
+
+test('CS-010: raced steer (turn ended) falls back to queue', async () => {
+    installFakeCodexAppRun('cs010', 'unavailable');
+    try {
+        const outcome = await steerAgent('cs010', 'too late', 'test', { chatSessionId: 'cs-spawn3' });
+        assert.equal(outcome, 'fallback-queue');
+    } finally {
+        activeMainProcesses.delete('cs010');
+    }
+});

--- a/tests/unit/steer-flow.test.ts
+++ b/tests/unit/steer-flow.test.ts
@@ -50,13 +50,16 @@ test('SF-001: steerAgent flow: kill → wait → insert → orchestrate', () => 
     assert.ok(orchestrateIdx > broadcastIdx, 'should orchestrate AFTER broadcast');
 });
 
-test('SF-001b: policy steer capability is native JWC only', () => {
+test('SF-001b: policy steer capability is JWC-busy or a codex-app in-band hook', () => {
     const src = fs.readFileSync(join(__dirname, '../../src/agent/spawn.ts'), 'utf8');
     const start = src.indexOf('export function canSteerAgent');
     const end = src.indexOf('export async function steerAgent', start);
     const capability = src.slice(start, end);
     assert.ok(capability.includes("run?.meta.cli === 'jwc'"));
     assert.ok(capability.includes('jawRuntimesByScope.get(scopeKey)?.busy === true'));
+    // wp2: codex-app advertises same-turn steer by installing steerTurnInBand
+    // for exactly the duration of a steerable turn.
+    assert.ok(capability.includes('steerTurnInBand'), 'codex-app in-band steer capability');
 });
 
 // ─── SF-002: steerAgent saves interrupted output via exit handler ───


### PR DESCRIPTION
## 개요

steer 스택의 2/3. codex-app 런타임이 busy + midRunPolicy 'steer'일 때 큐 강등이 아니라 app-server 네이티브 turn/steer로 같은 턴에 주입한다 — 모델 맥락 손실 0.

(구 #513은 wp1 머지 시 base 브랜치 삭제로 자동 close되어 새 PR로 대체. head는 CI 통과한 67de5a71c 그대로.)

**Stack** (merge bottom-up):
| # | Layer | 내용 |
|---|-------|------|
| 1 | #512 (merged) | kill-path 맥락 보존 코어 |
| 2 | ← 이 PR | codex-app 네이티브 steer |
| 3 | codex/steer-wp3-default-ui | 설정 UI + 문서 |

## 변경

- CodexAppClient.steerTurn: turn/steer JSON-RPC (threadId + expectedTurnId + input). CodexSteerError로 not-steerable(review/compact turnKind)/turn-mismatch race 매핑
- request() 에러 경로가 error.data(codexErrorInfo)를 보존
- MainRunState.steerTurnInBand 훅: cancelHook과 같은 수명 → canSteerAgent가 steer 가능한 turn 동안에만 true
- steerAgent: in-band 라우팅, 서버 수락 후에만 user row insert
- gateway: race/kind 거부된 steer는 kill이 아니라 큐로 강등
- /steer 핸들러: in-band 우선, 실패 시 followup 큐

## 검증

- tests/unit/codex-app-steer.test.ts 10개 신규 + 전체 unit 8482 fail 0 (동일 head CI pass)
- 설계: devlog/_plan/260903_steer_default_context/020