### PR TITLE
fix(doctor,pkg): count skills the way the prompt loads them, and stop advertising 107

### DIFF
--- a/bin/commands/doctor.ts
+++ b/bin/commands/doctor.ts
@@ -15,7 +15,7 @@ import { sendFileAllowedRoots } from '../../src/security/path-guards.js';
 import { checkPsExecutionPolicy, inspectInstallIntegrity, formatRecoveryCommands } from '../../src/core/install-integrity.js';
 import { detectSharedPathContamination } from '../../lib/mcp-sync.js';
 import { migrateAllJawHomes, hasPendingLegacySkillDirs, discoverJawHomes } from '../../lib/mcp/skills-migration.js';
-import { isDiscoverableSkillDirName } from '../../lib/mcp/skills-utils.js';
+import { dedupeSkillDirEntries } from '../../lib/mcp/skills-utils.js';
 import { classifyClaudeInstall } from '../../src/core/claude-install.js';
 import { isWsl, isWindowsNative, resolvePlatformKind } from '../../src/core/platform-kind.js';
 import { checkNonInteractivePath, nonInteractivePathRemedy } from '../../src/core/noninteractive-path.js';
@@ -600,8 +600,12 @@ check('에이전트 타임아웃', () => {
 check('Skills directory', () => {
     const skillsDir = settings?.skillsDir || path.join(JAW_HOME, 'skills');
     if (!fs.existsSync(skillsDir)) throw new Error('WARN: not found');
-    const entries = fs.readdirSync(skillsDir, { withFileTypes: true })
-        .filter(d => d.isDirectory() && isDiscoverableSkillDirName(d.name));
+    // Count each skill once, whatever the platform calls an alias. A Dirent for a
+    // POSIX symlink reports isDirectory() === false, so the old filter skipped the
+    // 30-odd alias links by accident — and skipped a skill symlinked in from
+    // outside the directory too, reporting a populated home as empty. A Windows
+    // junction reports true and was counted twice (#446, #524).
+    const entries = dedupeSkillDirEntries(skillsDir);
     if (entries.length === 0) {
         const refDir = path.join(JAW_HOME, 'skills_ref').replace(/\\/g, '/');
         throw new Error(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cli-jaw",
   "version": "2.17.36",
-  "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Telegram, and Discord interfaces with 107 built-in skills",
+  "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Slack, Telegram, and Discord interfaces with 33 skills active by default from a 230-skill reference library",
   "type": "module",
   "keywords": [
     "ai-assistant",

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -465,7 +465,7 @@ cli-jaw/
 │       ├── history.ts        ← 채팅 히스토리 검색 CLI (65L)
 │       ├── init.ts           ← 초기화 마법사 + --safe/--dry-run + --help (516L)
 │       ├── slack.ts          ← `jaw slack manifest|setup` — 앱 매니페스트 출력 + 가이드 설정 (토큰 prefix 가드 + auth.test/apps.connections.open 라이브 검증 + settings 병합, channel 미변경) (440L)
-│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1196L)
+│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1200L)
 │       ├── jwc.ts            ← optional external-only JWC runtime install/clean/doctor helper (234L)
 │       ├── status.ts         ← 서버 상태 (--json) (122L)
 │       ├── mcp.ts            ← MCP 관리 (install/sync/list/reset) (230L)

--- a/tests/unit/repo-hygiene.test.ts
+++ b/tests/unit/repo-hygiene.test.ts
@@ -118,3 +118,48 @@ test('RH-008: root npm package stays lean and excludes Electron app/deps', () =>
     assert.equal(includesElectronApp, false, 'published npm files must not include electron/');
     assert.deepEqual(files, ['dist/', '!dist/src/lib/native/*.node', 'public/', 'scripts/', 'package.json']);
 });
+
+// ── RH-009: the npm description's skill counts must be true (#524) ──
+//
+// The published blurb claimed "107 built-in skills", a number matching nothing on
+// disk. Both counts are recomputed here the way an install computes them, not read
+// from a set that install MUTATES: skills-distribution.ts adds every registry entry
+// with category 'orchestration' to OPENCLAW_ACTIVE at copy time, so importing that
+// singleton yields 18 or 33 depending on what else touched it first in the same
+// process. Deriving the union instead makes this test independent of process order.
+
+test('RH-009: the package description reports the real skill counts', () => {
+    const pkg = JSON.parse(fs.readFileSync(join(root, 'package.json'), 'utf8'));
+    const description: string = pkg.description || '';
+
+    const registryPath = join(root, 'skills_ref', 'registry.json');
+    if (!fs.existsSync(registryPath)) return; // skills_ref is a submodule; absent in some checkouts
+    const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    const skills: Record<string, { category?: string }> = registry.skills || {};
+
+    const utils = fs.readFileSync(join(root, 'lib', 'mcp', 'skills-utils.ts'), 'utf8');
+    const staticIds = (name: string): string[] => {
+        const start = utils.indexOf(`export const ${name} = new Set([`);
+        if (start < 0) return [];
+        const body = utils.slice(start, utils.indexOf(']', start));
+        return [...body.matchAll(/'([^']+)'/g)].map(m => m[1] as string);
+    };
+    const autoActivate = new Set([
+        ...staticIds('CODEX_ACTIVE'),
+        ...staticIds('OPENCLAW_ACTIVE'),
+        ...Object.entries(skills).filter(([, meta]) => meta?.category === 'orchestration').map(([id]) => id),
+    ]);
+    const referenceSkills = Object.keys(skills)
+        .filter(id => fs.existsSync(join(root, 'skills_ref', id, 'SKILL.md')));
+
+    assert.ok(autoActivate.size > 0, 'the auto-activate set must be derivable, or this test proves nothing');
+
+    const claimed = [...description.matchAll(/(\d+)[- ]skill|(\d+) skills/g)]
+        .map(m => Number(m[1] ?? m[2]));
+    assert.ok(claimed.includes(autoActivate.size),
+        `description must state the real auto-activate count (${autoActivate.size}); got ${JSON.stringify(claimed)}`);
+    assert.ok(claimed.some(n => n <= referenceSkills.length && n > referenceSkills.length - 10),
+        `description must state the reference-library size near ${referenceSkills.length}; got ${JSON.stringify(claimed)}`);
+    assert.ok(!/built-in skills/.test(description),
+        'skills_ref is npmignored and cloned at install, so they are not "built-in"');
+});

--- a/tests/unit/skills-alias-dedupe.test.ts
+++ b/tests/unit/skills-alias-dedupe.test.ts
@@ -76,3 +76,47 @@ test('SKILL-446f: a missing directory yields an empty list', () => {
     assert.deepEqual(dedupeSkillDirEntries(join(tmpdir(), 'cli-jaw-does-not-exist-446')), []);
 });
 
+// ── SKILL-446g: the doctor path counts what the prompt loads (#524) ──
+//
+// `jaw doctor` used to filter dirents by `isDirectory()`, which is false for a
+// POSIX symlink. That skipped alias links by accident on this platform — and it
+// also skipped a skill symlinked in from OUTSIDE the directory, so a home whose
+// skills are all links reported "skills directory is empty" and told the user to
+// re-clone a working install. On Windows the same filter counted junction
+// aliases twice. Both are the same defect: the count did not match what
+// `loadActiveSkills` actually loads.
+//
+// Only the COUNT is asserted. Which name survives a fold is readdir order, which
+// is not a guarantee this suite should pin.
+
+test('SKILL-446g: skills reachable only through links are counted, not dropped', () => {
+    const dir = scratch();
+    const store = mkdtempSync(join(tmpdir(), 'cli-jaw-446g-store-'));
+    fs.mkdirSync(join(store, 'jaw-outside'));
+    fs.writeFileSync(join(store, 'jaw-outside', 'SKILL.md'), '# outside\n');
+    fs.mkdirSync(join(dir, 'jaw-real'));
+    try {
+        symlinkSync(join(store, 'jaw-outside'), join(dir, 'jaw-outside'));
+    } catch {
+        return; // no symlink privilege (unprivileged Windows); nothing to observe
+    }
+
+    const counted = dedupeSkillDirEntries(dir);
+    assert.equal(counted.length, 2, 'a skill linked in from outside is a skill, not absent');
+
+    // The shape the old doctor line used, kept here as the contrast that makes
+    // the assertion above mean something: it sees one, and a link-only home zero.
+    const direntOnly = fs.readdirSync(dir, { withFileTypes: true }).filter(d => d.isDirectory());
+    assert.equal(direntOnly.length, 1, 'the dirent filter is what made a populated home read as empty');
+});
+
+test('SKILL-446h: an in-directory alias folds to one skill', () => {
+    const dir = scratch();
+    fs.mkdirSync(join(dir, 'jaw-dev'));
+    try {
+        symlinkSync(join(dir, 'jaw-dev'), join(dir, 'dev'));
+    } catch {
+        return;
+    }
+    assert.equal(dedupeSkillDirEntries(dir).length, 1, 'an alias and its target are one skill');
+});


### PR DESCRIPTION
## What

wp8 of the #517–#524 stack. Closes the **counts** half of #524. The prompt-budget half is a product decision and is written up below rather than decided unilaterally.

## `jaw doctor` counted skills differently from the prompt

`doctor.ts` filtered dirents by `isDirectory()`. That is **false for a POSIX symlink**, so the ~30 alias links in a typical home were skipped by accident of platform, not by rule. Two consequences, both real:

- A skill **symlinked in from outside** the skills directory was invisible. A home whose skills are all links reported `skills directory is empty — agents will not work correctly` and told the user to re-clone a working install. Reproduced in a fixture: the dirent filter sees 1 where 2 skills are loadable.
- On Windows the migration writes **junctions** (`skills-migration.ts:218`), which *do* read as directories, so the same skill was counted under both names — the exact #446 bug, in the one path #446 missed.

`dedupeSkillDirEntries` is already what `src/prompt/builder.ts:200` uses to decide what to load. Doctor now counts what the agent actually gets.

## The description advertised a number that matches nothing

`package.json` said **"107 built-in skills"**. Measured on this tree:

| Quantity | Value |
|---|---|
| auto-activated at install | **33** (18 static ∪ 15 registry orchestration, zero overlap) |
| reference skills with a `SKILL.md` | **230** |
| registry entries | 236 |

They are also not "built-in" — `skills_ref` is npmignored and git-cloned at install.

### The audit caught that the first fix was wrong too

The plan originally proposed **18**, reading the static union of `CODEX_ACTIVE` and `OPENCLAW_ACTIVE`. But `lib/mcp/skills-distribution.ts:205` **mutates** that set at install:

```ts
if (meta.category === 'orchestration') OPENCLAW_ACTIVE.add(id);
```

So the shipped number is 33, and 18 would have replaced one false number on the npm page with another. Independently re-measured before writing it.

That cascades into the test. RH-009 as first drafted compared the blurb against `new Set([...CODEX_ACTIVE, ...OPENCLAW_ACTIVE]).size` — which is **process-order dependent**, because the value differs depending on whether anything already called `copyDefaultSkills` in the same process. It would have pinned 18 forever while installs shipped 33. The version here **recomputes the union the way install computes it** and never imports the mutable singleton.

Red-green verified rather than assumed:

```
# old "107 built-in skills" description restored
✖ RH-009: the package description reports the real skill counts     fail 1
# corrected description
✔ RH-009: the package description reports the real skill counts     pass 18
```

## The prompt budget — needs your decision

`src/prompt/templates/a1-system.md` is **38,688 of 38,750** characters. **62 left.** The budget lives only at `tests/unit/prompt-slim-contract.test.ts:100`; there is no production constant, which is why it has been raised seven times — it costs one digit.

Three options, with the numbers corrected by audit ([081_phase8_audit_amendment.md](devlog/_plan/260904_issue_517_524_hardening/081_phase8_audit_amendment.md)):

| | Option | Cost |
|---|---|---|
| **(a)** | Raise it an eighth time | One digit, breaks nothing — which is the objection. Pending demand is ~750 chars, so a raise that clears only today's diff is back within one phase |
| **(b)** | Move `## Desktop / Browser Control` (lines 169–291, **8,442 chars, 21.8% of the file**) out from behind the anchor it already sits in | Returns more headroom than all seven historical raises combined. Needs new anchor hashes and migration for user-edited A-1 files |
| **(c)** | Move low-frequency guidance into `SKILL.md` stubs | Cheap for deep reference material, wrong for first-sentence rules — a stub costs 100–200 chars, so moving a 130-char line makes the file *bigger* |

**Recommendation (not a decision): (b) on desktop-control.** It is the only option that removes the pressure instead of deferring it, and the anchor machinery is already shipped and tested.

One correction worth noting: the plan claimed A-1 is 88% of the assembled prompt. That was an **empty-home measurement**. On a real install with 33 skills the assembled prompt is 71,659 chars and A-1 is **54%** — so no assembled-prompt bound ships here; it would have been home-dependent by ~28,600 characters.

## Also corrected by audit

The blocking claim was overstated. PSC-006 bounds only the template file, and `### Slack Lookup` is covered by no retention assertion, so #519 can land by trimming. **PR #473 targets `main`** and never sat on this stack. The dependency is downgraded from blocking to advisory.

## Verification

```
npx tsc --noEmit                 exit 0
npm run build                    exit 0
bash structure/verify-counts.sh  ALL PASS — 453/453
npm test                         8486 tests · 8460 pass · 0 fail
```

Refs #524
