### PR TITLE
fix(slack,codex-app): stop dropping the answer on file sends and repeating it on finals

### DIFF
--- a/src/agent/codex-app-events.ts
+++ b/src/agent/codex-app-events.ts
@@ -365,6 +365,17 @@ export function applyCodexAppTextEvent(
             ctx.fullText = '';
             ctx.outputTextStarted = false;
         }
+        // RESTATEMENT COLLAPSE (#517). The protected accumulation above is what
+        // makes a multi-item answer whole; it is also what lets an item that
+        // REPEATS the previous one arrive as one paragraph printed twice. So the
+        // surviving text becomes a candidate: if the incoming item turns out to
+        // start with it, the earlier copy is removed and the new item stands
+        // alone. Clearing the latch instead would fix this case and truncate
+        // every genuine continuation.
+        ctx.codexAppItemText = '';
+        ctx.codexAppRestatementCandidate = hadPreviousItem && ctx.fullText
+            ? ctx.fullText
+            : undefined;
     }
     // After the boundary, so this event's own phase wins over the cleared sticky.
     if (parsed.channel !== undefined) ctx.codexAppActiveChannel = parsed.channel;
@@ -373,6 +384,22 @@ export function applyCodexAppTextEvent(
     const effectiveChannel = parsed.channel || ctx.codexAppActiveChannel;
     if (effectiveChannel === 'commentary') return { durable: '', live: parsed.text };
     if (effectiveChannel === 'final') ctx.codexAppDurableIsFinal = true;
+    // Deltas are token-granular, so the decision is made incrementally: keep the
+    // candidate alive while this item is still a PREFIX of it, drop it the moment
+    // the two diverge, and collapse as soon as the item covers it entirely. The
+    // comparison stops the first time the item outgrows the candidate either way,
+    // so it is bounded by the candidate's own length rather than by the stream.
+    if (ctx.codexAppRestatementCandidate !== undefined) {
+        const candidate = ctx.codexAppRestatementCandidate;
+        const itemText = (ctx.codexAppItemText ?? '') + parsed.text;
+        ctx.codexAppItemText = itemText;
+        if (itemText.startsWith(candidate)) {
+            ctx.fullText = ctx.fullText.slice(candidate.length);
+            ctx.codexAppRestatementCandidate = undefined;
+        } else if (!candidate.startsWith(itemText)) {
+            ctx.codexAppRestatementCandidate = undefined;
+        }
+    }
     return { durable: parsed.text, live: parsed.text };
 }
 

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -47,6 +47,37 @@ export function stampOutboundSend(
     });
 }
 
+/** How long a caption may be before the channel refuses the whole send.
+ *
+ *  These are rejection ceilings, not style guidance. Telegram caps a caption at
+ *  1024 characters and answers 400 — which `isTransient` in
+ *  `src/telegram/telegram-file.ts` correctly does NOT retry, so the upload fails
+ *  outright. Discord's `content` caps at 2000 and returns
+ *  `BASE_TYPE_MAX_LENGTH`; `payload_json` is only the multipart wrapper and does
+ *  not lift it. Slack posts `initial_comment` as message text, where the ceiling
+ *  is the 40000-character message limit and overflow truncates rather than
+ *  refuses.
+ *
+ *  This matters because an answer promoted into a caption is arbitrarily long.
+ *  Without a clamp, fixing the empty-message bug would convert a working bare
+ *  attachment into a hard failure on two of three channels — a worse outcome
+ *  than the defect. `src/manager/routes/telegram-hub.ts` already clamps this way. */
+const CAPTION_LIMITS: Record<MessengerChannel, number> = {
+    slack: 40_000,
+    telegram: 1024,
+    discord: 2000,
+};
+
+/** Fit a promoted answer into the caption field without losing that it was cut. */
+export function clampCaptionForChannel(text: string, channel: MessengerChannel): string {
+    const limit = CAPTION_LIMITS[channel];
+    if (!limit || [...text].length <= limit) return text;
+    // Count by code point: a Korean or emoji-heavy answer is what pushes a
+    // caption over, and slicing by UTF-16 unit can split a surrogate pair.
+    const ellipsis = '…';
+    return [...text].slice(0, limit - ellipsis.length).join('') + ellipsis;
+}
+
 /**
  * The outbound side of the same allowlist the inbound gate reads.
  *
@@ -428,6 +459,24 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     if (typeof req.text === 'string') {
         req.text = applyOutputPolicy(req.text, { scope: 'main', channel }).text;
     }
+    // A file send renders exactly one piece of text: its caption. An agent that
+    // wrote its answer into `text` and attached a chart had that answer dropped
+    // on the floor — the transports read `caption` and nothing else, so the user
+    // received a bare upload under no explanation. 33% of one bot's Slack posts
+    // were empty messages with a file attached (#517).
+    //
+    // Promoted here rather than in a transport handler because `deliveredText`
+    // below is computed from `req`: a handler-side fallback would put the caption
+    // on screen while the ledger recorded `null`, and the turn's dispatch post
+    // would then fire again with the same words.
+    //
+    // Only when `caption` is absent. An explicit caption is a deliberate choice
+    // about what belongs beside the file.
+    if ((req.type === 'photo' || req.type === 'document' || req.type === 'voice')
+        && !req.caption?.trim()
+        && typeof req.text === 'string' && req.text.trim()) {
+        req.caption = clampCaptionForChannel(req.text, channel);
+    }
     // Single choke point for every outbound send. A transport builds its error
     // string from a vendor SDK, and the Telegram Bot API puts the token in the
     // request URL — so the failure result is a credential sink, and it flows
@@ -447,10 +496,13 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     // caller's target may have been absent and filled in by the chain above.
     if (req.fromAgentSurface && sanitized.ok !== false) {
         // Only what the transport ACTUALLY put on screen may be claimed. A
-        // `photo`/`document`/`voice` send carries the file and the CAPTION; the
-        // handlers ignore `req.text` entirely. Claiming it anyway would let an
-        // uncaptioned image cancel the turn's real written answer — the exact
-        // silence this module is built to avoid causing.
+        // `photo`/`document`/`voice` send carries the file and the CAPTION, and
+        // reading `req.caption` here is what keeps that true: the promotion above
+        // already moved `text` into it, clamped to what the channel will accept,
+        // so this names the string the transport displayed. Reading `req.text`
+        // directly would go wrong the moment a caller passes BOTH — the explicit
+        // caption is what ships, and claiming the unshipped text would let an
+        // invisible string cancel the turn's real written answer.
         const deliveredText = req.type === 'text' || req.type === 'keyboard'
             ? (typeof req.text === 'string' ? req.text : null)
             : (typeof req.caption === 'string' ? req.caption : null);

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -174,7 +174,15 @@ export interface SpawnContext {
   codexAppActiveItemId?: string;
   /** True once durable text was appended under an explicit 'final' phase. Protects a
    *  delivered answer from being erased by a trailing commentary/untagged item. */
-  codexAppDurableIsFinal?: boolean;
+    codexAppDurableIsFinal?: boolean;
+    /** Text the PREVIOUS codex-app item left behind, pending a restatement check.
+     *  Set at an item boundary and cleared the moment the new item either covers
+     *  it (collapse) or diverges from it (genuine continuation). See #517. */
+    codexAppRestatementCandidate?: string | undefined;
+    /** The current item's text so far, accumulated only while a candidate is
+     *  pending — deltas are token-granular, so the prefix test needs the whole
+     *  item rather than one delta. */
+    codexAppItemText?: string | undefined;
   scheduleWakeup?: {
     delaySeconds: number;
     prompt: string;

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -106,7 +106,7 @@ cli-jaw/
 │   │   ├── cli-helpers.ts    ← Claude-like CLI 판별 helper (9L)
 │   │   ├── codex-app-client.ts ← Codex App stdio server client (1496L)
 │   │   ├── codex-host-pool.ts ← Codex App shared host generation + lane lease/FIFO/reaper/shutdown owner (494L)
-│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (504L)
+│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (531L)
 │   │   ├── error-classifier.ts ← stderr/result 기반 에러 분류 헬퍼 + shouldAnnounceStallTruncation (부분 출력 워치독 종료를 독자에게 알릴지 판정) (111L)
 │   │   ├── stall-notice.ts   ← 워치독 중단 통지 문구 + 접미사 전용 제거 (사람에겐 보이고 모델 컨텍스트엔 안 들어가도록 db 조회 경계가 사용) (21L) ✨
 │   │   ├── grok-trace-backfill.ts ← Grok trace backfill helper (167L) ✨
@@ -122,7 +122,7 @@ cli-jaw/
 │   │   └── events.ts         ← legacy re-export stub → events/ 모듈 (15L)
 │   ├── messaging/            ← 통합 메시징 런타임 (33 files)
 │   │   ├── runtime.ts        ← 채널 lifecycle (init/shutdown/restart) + transport registry (285L)
-│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (464L)
+│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (516L)
 │   │   ├── turn-conversation.ts ← 턴이 답하는 대화 주소 encode/decode + 채널 매칭 (60L) ✨
 │   │   ├── turn-delivery.ts  ← 에이전트 자가 전송 claim (턴 앵커 + digest, 소비형) → dispatch 중복 게시 억제 (252L) ✨
 │   │   ├── dedupe.ts         ← 배달 중복 제거 (TTL seen-set, 미만료 항목 보존) (118L) ✨
@@ -352,7 +352,7 @@ cli-jaw/
 │   │   ├── async-handler.ts  ← asyncHandler 래퍼 (14L)
 │   │   └── error-middleware.ts ← notFoundHandler, errorHandler (26L)
 │   ├── types/                ← 공유 타입 정의 (3 files, 329L)
-│   │   ├── agent.ts          ← ToolEntry, SpawnContext, SpawnResult 인터페이스 (193L)
+│   │   ├── agent.ts          ← ToolEntry, SpawnContext, SpawnResult 인터페이스 (201L)
 │   │   ├── cli-engine.ts     ← CliEngine union + registry key tuple + `agy`/`ai-e`/`claude-e`/`kiro-code` discriminators (58L)
 │   │   └── cli-events.ts     ← CLI event record/discriminator helpers (154L)
 │   ├── command-contract/     ← 커맨드 인터페이스 통합 (3 files)

--- a/tests/unit/caption-promotion-clamp.test.ts
+++ b/tests/unit/caption-promotion-clamp.test.ts
@@ -1,0 +1,111 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { registerSendTransport, sendChannelOutput, clampCaptionForChannel } from '../../src/messaging/send.ts';
+import { settings } from '../../src/core/config.ts';
+import type { RemoteTarget } from '../../src/messaging/types.ts';
+
+// #517 promotes an agent's written answer into the caption field so a file send
+// stops arriving as an empty message. An answer is arbitrarily long and the
+// caption field is not: Telegram refuses over 1024 with a 400 that
+// `isTransient` (src/telegram/telegram-file.ts) correctly does not retry, and
+// Discord's `content` refuses over 2000. Unclamped, the fix for an empty
+// message would turn a working bare attachment into a hard failure — a worse
+// outcome than the defect it repairs. These tests drive those ceilings.
+
+function targetFor(channel: 'slack' | 'telegram' | 'discord'): RemoteTarget {
+    return {
+        channel,
+        targetKind: 'channel',
+        peerKind: 'channel',
+        targetId: channel === 'slack' ? 'C_CLAMP_TEST' : '99887766',
+    };
+}
+
+function allowSlack(id: string): void {
+    settings['slack'] = { ...(settings['slack'] || {}), channelIds: [id] };
+}
+
+/** Telegram enforces its own allowlist before a send is dispatched, so a target
+ *  that is not configured is refused and never reaches the transport — the test
+ *  would then pass for the wrong reason. */
+function allowTelegram(id: string): void {
+    settings['telegram'] = { ...(settings['telegram'] || {}), allowedChatIds: [id] };
+}
+
+test('CAP-001: the clamp is a no-op below every channel ceiling', () => {
+    const short = 'a short answer';
+    for (const channel of ['slack', 'telegram', 'discord'] as const) {
+        assert.equal(clampCaptionForChannel(short, channel), short);
+    }
+});
+
+test('CAP-002: Telegram is cut at 1024, the length its API refuses beyond', () => {
+    const long = 'ㄱ'.repeat(5000);
+    const out = clampCaptionForChannel(long, 'telegram');
+    assert.equal([...out].length, 1024, 'a caption over 1024 is a non-transient 400, not a retry');
+    assert.ok(out.endsWith('…'), 'the truncation must be visible to the reader');
+});
+
+test('CAP-003: Discord is cut at 2000, the content ceiling', () => {
+    const long = 'x'.repeat(5000);
+    const out = clampCaptionForChannel(long, 'discord');
+    assert.equal([...out].length, 2000, 'over 2000 Discord answers BASE_TYPE_MAX_LENGTH');
+});
+
+test('CAP-004: Slack keeps far more, because it truncates rather than refusing', () => {
+    const long = 'x'.repeat(50_000);
+    const out = clampCaptionForChannel(long, 'slack');
+    assert.equal([...out].length, 40_000, 'initial_comment is message text, bounded by the message limit');
+});
+
+test('CAP-005: clamping counts code points, so a surrogate pair is never split', () => {
+    // A Korean or emoji-heavy answer is exactly what pushes a caption over the
+    // line, and slicing by UTF-16 unit would leave a broken half-character.
+    const emoji = '😀'.repeat(3000);
+    const out = clampCaptionForChannel(emoji, 'telegram');
+    assert.equal([...out].length, 1024);
+    assert.ok(!/[\uD800-\uDBFF]$/.test(out.slice(0, -1)), 'no dangling high surrogate');
+});
+
+test('CAP-006: a long promoted answer reaches Telegram already clamped', async () => {
+    // The activation case: without the clamp at the promotion site this send is
+    // rejected outright and the user loses both the answer AND the file.
+    const target = targetFor('telegram');
+    allowTelegram(target.targetId);
+    const sent: Record<string, unknown>[] = [];
+    registerSendTransport('telegram', async (req) => { sent.push(req as Record<string, unknown>); return { ok: true }; });
+
+    await sendChannelOutput({
+        channel: 'telegram',
+        type: 'photo',
+        filePath: '/tmp/never-read-by-this-test.png',
+        text: 'ㄱ'.repeat(4000),
+        target,
+        fromAgentSurface: true,
+    });
+
+    const caption = sent[0]?.['caption'];
+    assert.equal(typeof caption, 'string');
+    assert.equal([...(caption as string)].length, 1024, 'the transport must never see a caption it will refuse');
+});
+
+test('CAP-007: Slack receives the whole answer, not a Telegram-sized one', async () => {
+    const id = 'C_CLAMP_TEST';
+    allowSlack(id);
+    const sent: Record<string, unknown>[] = [];
+    registerSendTransport('slack', async (req) => { sent.push(req as Record<string, unknown>); return { ok: true }; });
+
+    const answer = 'ㄱ'.repeat(4000);
+    await sendChannelOutput({
+        channel: 'slack',
+        type: 'document',
+        filePath: '/tmp/never-read-by-this-test.pdf',
+        text: answer,
+        target: targetFor('slack'),
+        fromAgentSurface: true,
+    });
+
+    assert.equal(sent[0]?.['caption'], answer, 'clamping to the strictest channel would truncate Slack for no reason');
+});

--- a/tests/unit/codex-app-events.test.ts
+++ b/tests/unit/codex-app-events.test.ts
@@ -134,6 +134,49 @@ test('codex-app trailing untagged item does not erase a delivered final answer',
     assert.equal(ctx.fullText, '설정했습니다.(추가 메모)', 'protected text accumulates, never resets');
 });
 
+// ── #517: an item that RESTATES the previous one must not print it twice ──
+//
+// The live Slack artifact: one paragraph delivered, then a second final item that
+// began by repeating the whole first paragraph before continuing. Both items are
+// tagged final, so the latch protects the accumulation — correctly, for a genuine
+// continuation — and the user saw the opening sentence twice.
+//
+// The three tests directly above are the fence. Clearing the latch fixes this
+// case and breaks all of them.
+
+test('WP2-517-a: a final item restating the previous one collapses to one copy', () => {
+    const ctx = createCtx() as unknown as SpawnContext;
+    feedMessage(ctx, 'msg_1', ['스레드에 업무 요청 전송 완료했습니다.'], { phase: 'final_answer' });
+    feedMessage(ctx, 'msg_2', ['스레드에 업무 요청 전송 완료했습니다. 코드 탐색도 끝났습니다.'], { phase: 'final_answer' });
+    assert.equal(
+        ctx.fullText,
+        '스레드에 업무 요청 전송 완료했습니다. 코드 탐색도 끝났습니다.',
+        'the restated opening is removed, not printed a second time',
+    );
+});
+
+test('WP2-517-b: the collapse survives token-granular deltas', () => {
+    // Deltas arrive a token at a time, so the prefix test has to hold across
+    // partial text rather than seeing the finished item in one event.
+    const ctx = createCtx() as unknown as SpawnContext;
+    feedMessage(ctx, 'msg_1', ['완료했습니다.'], { phase: 'final_answer' });
+    feedMessage(ctx, 'msg_2', ['완료', '했습니다.', ' 이어서 정리합니다.'], { phase: 'final_answer' });
+    assert.equal(ctx.fullText, '완료했습니다. 이어서 정리합니다.', 'a restatement split across deltas still collapses');
+});
+
+test('WP2-517-c: an item that merely starts similarly is NOT collapsed', () => {
+    // The guard has to distinguish "repeats the previous item" from "happens to
+    // begin with the same word", or a genuine continuation loses its opening.
+    const ctx = createCtx() as unknown as SpawnContext;
+    feedMessage(ctx, 'msg_1', ['완료했습니다. 첫 번째 항목입니다.'], { phase: 'final_answer' });
+    feedMessage(ctx, 'msg_2', ['완료했습니다만 두 번째는 다릅니다.'], { phase: 'final_answer' });
+    assert.equal(
+        ctx.fullText,
+        '완료했습니다. 첫 번째 항목입니다.완료했습니다만 두 번째는 다릅니다.',
+        'divergence after a shared prefix keeps both items whole',
+    );
+});
+
 test('codex-app detects a message boundary from a changed delta itemId alone', () => {
     // item/started can be dropped or buffered; item/completed returns null for
     // agentMessage, so the delta's itemId is the only remaining seam.

--- a/tests/unit/turn-delivery-send-claim.test.ts
+++ b/tests/unit/turn-delivery-send-claim.test.ts
@@ -32,20 +32,52 @@ function allowTarget(): void {
     settings['slack'] = { ...(settings['slack'] || {}), channelIds: [target.targetId] };
 }
 
-test('a file send does not claim text the transport never delivered', async () => {
+test('WP2-SEND-001: a file send promotes its text into the caption and claims it (#517)', async () => {
     resetTurnDeliveryState();
     stubSlackTransport();
     allowTarget();
     const turnStartedAt = nextDeliverySeq();
 
-    // The agent uploads a chart and passes its written answer in `text`. The
-    // Slack/Telegram/Discord file handlers all ignore `text` and send only
-    // `caption` — so nothing of this string reached the user.
+    // The agent uploads a chart and passes its written answer in `text`. This
+    // used to be dropped on the floor: the file handlers read `caption` and
+    // nothing else, so the user got a bare upload under no explanation — 33% of
+    // one bot's posts were empty messages with a file attached (#517).
+    const answer = 'the full written answer the user is waiting for';
+    const sent: Record<string, unknown>[] = [];
+    registerSendTransport('slack', async (req) => { sent.push(req as Record<string, unknown>); return { ok: true }; });
+
+    await sendChannelOutput({
+        channel: 'slack',
+        type: 'photo',
+        filePath: '/tmp/never-read-by-this-test.png',
+        text: answer,
+        target,
+        fromAgentSurface: true,
+    });
+
+    assert.equal(sent[0]?.['caption'], answer, 'the answer must reach the field the transport displays');
+    assert.equal(
+        wasSelfDelivered({ target, text: answer, since: turnStartedAt }),
+        true,
+        'now that the text is on screen, the claim is honest and the dispatch post must not repeat it',
+    );
+});
+
+test('WP2-SEND-001b: an explicit caption still wins, and the unsent text is not claimed', async () => {
+    resetTurnDeliveryState();
+    stubSlackTransport();
+    allowTarget();
+    const turnStartedAt = nextDeliverySeq();
+
+    // The invariant the original test protected, on the input where it still
+    // applies: when the caller chose a caption, THAT is what ships, and claiming
+    // the unshipped `text` would let an invisible string cancel the real answer.
     await sendChannelOutput({
         channel: 'slack',
         type: 'photo',
         filePath: '/tmp/never-read-by-this-test.png',
         text: 'the full written answer the user is waiting for',
+        caption: 'chart',
         target,
         fromAgentSurface: true,
     });
@@ -57,7 +89,7 @@ test('a file send does not claim text the transport never delivered', async () =
             since: turnStartedAt,
         }),
         false,
-        'an uncaptioned file must never suppress the written answer',
+        'text that lost to an explicit caption never reached the user, so it cannot be claimed',
     );
 });
 
@@ -130,5 +162,4 @@ test('a failed send is not claimed', async () => {
         'nothing reached the user, so nothing may be suppressed',
     );
 });
-
 


### PR DESCRIPTION
## What

wp2 of the #517–#524 stack. **Closes #517** — two independent corruptions of what the user actually sees in Slack.

## 1. Empty messages (33% of a live sample)

A file send renders exactly one piece of text: its caption. An agent that wrote its answer into `text` and attached a chart had that answer **dropped on the floor**, because every transport reads `caption` and nothing else. Four attached images meant four empty posts.

The promotion happens in `sendChannelOutput`, not in a transport handler, and that placement is load-bearing: `deliveredText` is computed from the same `req`, so a handler-side fallback would put the caption on screen while the ledger recorded `null` — and the turn's dispatch post would then fire again with the same words. Promoting before dispatch means the ledger names the string the transport actually displayed.

### The clamp is not cosmetic

An answer is arbitrarily long; the caption field is not. Verified in the transports themselves:

| Channel | Ceiling | What happens past it |
|---|---|---|
| Telegram | **1024** | `400`, and `isTransient` (`telegram-file.ts:62`) correctly does **not** retry → the upload fails outright |
| Discord | **2000** | `BASE_TYPE_MAX_LENGTH`; `payload_json` is only the multipart wrapper and does not lift it |
| Slack | **40,000** | `initial_comment` is message text — truncates, does not refuse |

Unclamped, fixing the empty-message bug would have converted a **working bare attachment into a hard failure** on two of three channels. Clamping everything to the strictest would have thrown away 39k characters of a Slack answer to satisfy a Telegram limit. So the clamp is per channel, and it counts code points — a Korean or emoji-heavy answer is exactly what pushes a caption over, and slicing by UTF-16 unit would split a surrogate pair.

The repo already clamps this way at `src/manager/routes/telegram-hub.ts:108`, so this is the established shape rather than an invented one.

## 2. Duplicated paragraphs

codex-app delivers an answer as multiple items, and the durable-final latch protects the accumulation — correct for a genuine continuation. But an item that **restates** the previous one then arrives as the same paragraph printed twice, which is the live artifact in the issue.

**The issue's proposed diff is not used.** It clears the latch at the item boundary; executed against the real reducer, that fixes this case and **breaks three passing tests** — it truncates every multi-item answer and re-opens the empty-reply bug the latch exists to prevent.

Instead the surviving text becomes a candidate: if the incoming item turns out to start with it, the earlier copy is removed. The decision is incremental because deltas are token-granular — the candidate stays alive while the item is still a prefix, and is dropped the moment they diverge. Three new tests cover the collapse, the token-granular case, and the case that **must not** collapse (an item that merely begins with the same word). The three pre-existing tests are the regression fence and stay green.

## Dropped from the plan

The `relaySlackImages` caption parameter is **not** included. It would have shipped with no production writer in this phase, which the roadmap's own audit rules forbid. The `send.ts` promotion is what actually fixes the empty-message defect; the forwarder needs no change.

## One test inverted, deliberately

`turn-delivery-send-claim.test.ts` asserted that a file send does **not** claim its `text` — true only because the text was being dropped. That premise is what this PR removes. The real invariant it protected is preserved in WP2-SEND-001b: when the caller passes an **explicit** caption, that is what ships, and the unshipped `text` still must not be claimed.

## Verification

```
npx tsc --noEmit                 exit 0
npm run build                    exit 0
bash structure/verify-counts.sh  ALL PASS — 453/453
npm test                         8497 tests · 8471 pass · 0 fail
tests/unit/codex-app-events.test.ts        22/22  (19 pre-existing + 3 new)
tests/unit/caption-promotion-clamp.test.ts  7/7   (new)
tests/unit/turn-delivery-send-claim.test.ts 6/6
```

Closes #517
