### PR TITLE
fix(errors): deliver classified runtime failures, and recover from 429 instead of dying

### DIFF
--- a/src/agent/alert-escalation.ts
+++ b/src/agent/alert-escalation.ts
@@ -2,6 +2,7 @@ import { broadcast, addBroadcastListener } from '../core/bus.js';
 import { settings } from '../core/config.js';
 import { sendChannelOutput } from '../messaging/send.js';
 import type { MessengerChannel } from '../messaging/types.js';
+import { getHomeChannel } from '../messaging/runtime.js';
 
 interface ErrorRecord {
     ts: number;
@@ -26,7 +27,10 @@ function getConfig() {
         threshold: (cfg["threshold"] as number) ?? 3,
         windowMs: (cfg["windowMs"] as number) ?? 600_000,
         cooldownMs: (cfg["cooldownMs"] as number) ?? 1_800_000,
-        channels: (cfg["channels"] as string[]) ?? ['telegram'],
+        // An operator alert belongs wherever this install actually talks. The
+        // old hardcoded 'telegram' meant a Slack-only deployment escalated into
+        // a channel nobody had configured, so the alert was simply lost (#519).
+        channels: (cfg["channels"] as string[]) ?? [getHomeChannel()],
     };
 }
 
@@ -66,7 +70,9 @@ export function initAlertDelivery(): void {
 
     addBroadcastListener((type, data) => {
         if (type !== 'alert_escalation') return;
-        const channels = (data["channels"] as string[]) ?? ['telegram'];
+        // The payload normally carries the configured list; this fallback is the
+        // second hardcoded 'telegram' and had the same effect as the first.
+        const channels = (data["channels"] as string[]) ?? [getHomeChannel()];
         const text = data["message"] as string;
         if (!text) return;
 

--- a/src/agent/error-classifier.ts
+++ b/src/agent/error-classifier.ts
@@ -1,6 +1,7 @@
 // ─── Error Classification for Agent Exit ─────────────
 
 import { isClaudeLikeCli } from './cli-helpers.js';
+import type { ErrorKind } from '../messaging/error-block.js';
 
 export interface ErrorClassification {
     is429: boolean;
@@ -15,6 +16,15 @@ export interface ErrorClassification {
      *  fixed by respawning. */
     isConnection: boolean;
     message: string;
+    /** The classification a forwarder can act on without re-parsing prose.
+     *  Carried on the `agent_done` payload; a payload without one is not
+     *  rendered into a channel at all (#519). */
+    errorKind: ErrorKind;
+    /** Raw child output, bounded, for the TRACE only. Never a channel message:
+     *  it is unbounded, frequently carries paths, and is not actionable. */
+    detail: string;
+    /** Provider-requested wait, when the provider stated one. */
+    retryAfterMs?: number | undefined;
 }
 
 /** Transport failures as the wrapped CLIs actually print them. `unavailable`
@@ -74,9 +84,48 @@ export function classifyExitError(
     else if (is429) message = '⚡ API 용량 초과 (429)';
     else if (isAuth) message = '🔐 인증 오류 — CLI 로그인 상태를 확인해주세요';
     else if (isConnection) message = `🔌 ${cli} 연결 오류 — 재시도합니다`;
-    else if (combined.trim()) message = combined.trim().slice(0, 200);
 
-    return { is429, isAuth, isStall, isModelCapacity, isClaudeRateLimit, isTransientStartup, isConnection, message };
+    // The raw stderr slice used to become the user-facing message. It is
+    // unbounded child output — paths, stack frames, sometimes credentials — and
+    // the user cannot act on any of it. It stays in `detail` for the trace, and
+    // the message keeps the exit line, which is the part that says what happened.
+    const detail = combined.trim() ? combined.trim().slice(0, 200) : '';
+
+    // What the next action depends on, decided once here instead of re-parsed
+    // from Korean prose by each forwarder (#519).
+    const errorKind: ErrorKind = isStall ? 'stall'
+        : is429 ? 'rate_limit'
+        : isAuth ? 'auth'
+        : isConnection ? 'connection'
+        : 'exit';
+
+    return {
+        is429, isAuth, isStall, isModelCapacity, isClaudeRateLimit, isTransientStartup,
+        isConnection, message, errorKind, detail,
+        retryAfterMs: parseRetryAfterMs(combined),
+    };
+}
+
+/** How long the provider asked us to wait, when it said so.
+ *
+ *  Providers report this three ways and the units differ: `retry_after_ms` is
+ *  milliseconds while `Retry-After` is seconds. The millisecond spelling is
+ *  matched FIRST — otherwise `retry_after_ms: 1500` matches the second-based
+ *  pattern, `ms` is swallowed as part of the key, and a 1.5-second wait becomes
+ *  a 25-minute one. */
+export function parseRetryAfterMs(text: string): number | undefined {
+    const ms = /retry[-_ ]?after[-_ ]?ms["'\s:=]+(\d+)/i.exec(text);
+    if (ms?.[1]) return capRetryAfter(Number(ms[1]));
+    const secs = /retry[-_ ]?after["'\s:=]+(\d+)/i.exec(text);
+    if (secs?.[1]) return capRetryAfter(Number(secs[1]) * 1000);
+    return undefined;
+}
+
+/** A provider that asks for an hour is not worth obeying literally: the turn is
+ *  already lost and a bounded wait lets the fallback runtime take over. */
+function capRetryAfter(ms: number): number | undefined {
+    if (!Number.isFinite(ms) || ms <= 0) return undefined;
+    return Math.min(ms, 600_000);
 }
 
 // Lives in its own leaf module so `core/db` can strip it without importing the

--- a/src/agent/error-cooldown.ts
+++ b/src/agent/error-cooldown.ts
@@ -1,0 +1,46 @@
+// Which runtimes just told us they are out of capacity.
+//
+// Without this, a 429 on the primary runtime picks a fallback, that fallback
+// finishes, and the very next turn walks back into the same exhausted runtime —
+// so a rate limit that lasts a minute costs every turn in that minute. The
+// registry lets the fallback search skip a runtime that is still parked.
+//
+// Keyed by the RUNTIME name (`lifecycleRuntimeCli`'s output), not the registry
+// name, and read with the same key: an `ai-e` turn records under `claude-e`,
+// so a search keyed on `ai-e` would never see its own cooldown and the feature
+// would silently do nothing for exactly the aliased runtime.
+
+const cooldowns = new Map<string, number>();
+
+/** How long to park a runtime that returned 429 without saying for how long.
+ *  Short on purpose: the cost of guessing high is a runtime skipped while it
+ *  was already healthy again. */
+export const DEFAULT_COOLDOWN_MS = 60_000;
+
+/** Park a runtime for as long as the provider asked, bounded by the caller. */
+export function noteRuntimeCooldown(runtimeCli: string, ms: number): void {
+    if (!runtimeCli || !Number.isFinite(ms) || ms <= 0) return;
+    cooldowns.set(runtimeCli, Date.now() + ms);
+}
+
+/** True while the runtime is still parked. Expiry is lazy — a stale entry is
+ *  dropped on read rather than swept, so nothing has to own a timer. */
+export function isRuntimeCoolingDown(runtimeCli: string): boolean {
+    const until = cooldowns.get(runtimeCli);
+    if (until === undefined) return false;
+    if (Date.now() >= until) {
+        cooldowns.delete(runtimeCli);
+        return false;
+    }
+    return true;
+}
+
+/** A successful run is the only proof that capacity came back. */
+export function clearRuntimeCooldown(runtimeCli: string): void {
+    cooldowns.delete(runtimeCli);
+}
+
+/** Tests only: the registry outlives a single turn by design. */
+export function resetRuntimeCooldowns(): void {
+    cooldowns.clear();
+}

--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -14,6 +14,7 @@ import { classifyExitError, shouldAnnounceStallTruncation, STALL_TRUNCATION_NOTI
 import { backfillGrokTraceTools } from './grok-trace-backfill.js';
 import { shouldClearHighTurnSessionBucket, shouldUseTurnCountRefresh } from './spawn/resume.js';
 import { recordError, clearErrors } from './alert-escalation.js';
+import { noteRuntimeCooldown, isRuntimeCoolingDown, clearRuntimeCooldown, DEFAULT_COOLDOWN_MS } from './error-cooldown.js';
 import { stripInterviewTracker } from '../orchestrator/sanitize.js';
 import { clearLiveRun, getLiveRun } from './live-run-state.js';
 import { sanitizeToolLogForDurableStorage, serializeSanitizedToolLog } from '../shared/tool-log-sanitize.js';
@@ -501,6 +502,9 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         fallbackState.delete(cli);
     }
     if (code === 0) clearErrors(cli);
+    // Capacity came back: only a successful run proves it, so the park is
+    // cleared here and nowhere else. Same key space as the write (#519).
+    if (code === 0) clearRuntimeCooldown(runtimeCli);
 
     if (code === 0 && runtimeCli === 'grok') {
         const recovered = backfillGrokTraceTools(ctx);
@@ -727,7 +731,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
     } else if (mainManaged && code !== 0 && !wasKilled) {
         // ─── Error handling ───
         const diagnosticText = `${ctx.fullText}\n${ctx.traceLog.join('\n')}`;
-        const { is429, isStall, isModelCapacity, isClaudeRateLimit, isTransientStartup, isConnection, message: errMsg } = classifyExitError(
+        const { is429, isStall, isModelCapacity, isClaudeRateLimit, isTransientStartup, isConnection, message: errMsg, errorKind, detail: errDetail, retryAfterMs } = classifyExitError(
             runtimeCli,
             code,
             ctx.stderrBuf,
@@ -744,6 +748,12 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         // on ConnectRPC loss with no retry (2026-08-24).
         const effectiveIs429 = is429 || isClaudeRateLimit || isTransientStartup || isConnection;
         recordError(cli, isStall ? 'stall' : isModelCapacity ? 'model_capacity' : effectiveIs429 ? '429' : 'error');
+        // Park the runtime that just refused us so the fallback search below —
+        // and the next turn's — can skip it instead of walking back into the
+        // same exhausted provider. Keyed by runtimeCli on write AND read (#519).
+        if (is429) noteRuntimeCooldown(runtimeCli, retryAfterMs ?? DEFAULT_COOLDOWN_MS);
+        // The raw child output is evidence for the trace, not a channel message.
+        if (errDetail) ctx.traceLog.push(`[exit-detail] ${errDetail}`);
 
         const invalidatedResume = isResume
             && shouldInvalidateResumeSession(runtimeCli, code, ctx.stderrBuf, diagnosticText);
@@ -830,7 +840,10 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
             && !performedSideEffects(ctx)
             && mainAttempt < MAIN_MAX_RETRIES
         ) {
-            const delayMs = computeBackoff(mainAttempt);
+            // Obey a provider that stated its own wait, when it asked for longer
+            // than our backoff: retrying before it expires just burns an attempt
+            // against a runtime that already said no (#519).
+            const delayMs = Math.max(computeBackoff(mainAttempt), retryAfterMs ?? 0);
             const delaySec = Math.round(delayMs / 1000);
             console.log(`[jaw:retry] ${cli} 429 detected — waiting ${delaySec}s before retry (attempt ${mainAttempt + 1}/${MAIN_MAX_RETRIES})`);
             broadcast('agent_retry', { cli, delay: delaySec, reason: errMsg, attempt: mainAttempt + 1, maxRetries: MAIN_MAX_RETRIES, ...empTag }, isEmployee ? 'internal' : 'public');
@@ -870,7 +883,15 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         // the protection is trivially bypassed.
         if (!opts.internal && !opts._isFallback && !suppressClaudeRateLimitFallback && !performedSideEffects(ctx)) {
             const fallbackCli = (settings["fallbackOrder"] || [])
-                .find((fc: string) => fc !== cli && detectCli(fc).available);
+                // Skip a runtime that just told us it was out of capacity: the
+                // whole point of falling back is to reach one that can answer.
+                //
+                // `fc` is a REGISTRY name from settings while cooldowns are keyed
+                // by RUNTIME name, and `ai-e` maps to `claude-e`. Comparing the
+                // two key spaces directly would make the skip a silent no-op for
+                // exactly the aliased runtime, so the name is mapped first.
+                .find((fc: string) => fc !== cli && detectCli(fc).available
+                    && !isRuntimeCoolingDown(lifecycleRuntimeCli(fc, settings["perCli"]?.[fc]?.provider)));
             if (fallbackCli) {
                 const st = fallbackState.get(cli);
                 if (st) {
@@ -907,7 +928,21 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
                 return;
             }
         }
-        broadcast('agent_done', { ...runTag(ctx), text: `❌ ${errMsg}`, error: true, origin, ...empTag }, isEmployee ? 'internal' : 'public');
+        // The `{ ...runTag(ctx),` opening stays on this line: RID-001 in
+        // tests/unit/web-sse-replay-idempotency.test.ts matches that exact shape
+        // to prove every agent_done carries its trace run id.
+        broadcast('agent_done', { ...runTag(ctx),
+            text: `❌ ${errMsg}`,
+            error: true,
+            // Classified here so a forwarder never re-parses Korean prose to
+            // decide what happened, and so an untagged error payload stays out
+            // of the channel entirely (#519).
+            errorKind,
+            cli: runtimeCli,
+            origin,
+            ...(isEmployee ? { audience: 'internal' } : {}),
+            ...empTag,
+        }, isEmployee ? 'internal' : 'public');
     } else if (isEmployee && code !== 0 && !wasKilled && !opts._isFallback) {
         // ─── Employee transient retry (exponential backoff, up to EMP_MAX_RETRIES) ───
         const diagnosticText = `${ctx.fullText}\n${ctx.traceLog.join('\n')}`;

--- a/src/discord/forwarder.ts
+++ b/src/discord/forwarder.ts
@@ -11,6 +11,7 @@ import { assertSendFilePath } from '../security/path-guards.js';
 import { asSendable } from './channel-types.js';
 import { sendDiscordFile } from './discord-file.js';
 import { redactOutboundText, logErrorText } from '../messaging/redact.js';
+import { renderAgentErrorBlock } from '../messaging/error-block.js';
 
 export async function relayDiscordImages(
     client: Client,
@@ -71,7 +72,11 @@ export function createDiscordForwarder(opts: {
 }) {
     return async (type: string, data: Record<string, unknown>) => {
         const text = data?.["text"];
-        if (type !== 'agent_done' || typeof text !== 'string' || !text || data["error"]) return;
+        if (type !== 'agent_done' || typeof text !== 'string' || !text) return;
+        // Same opt-in rule as the Slack forwarder: only a classified failure is
+        // worth posting, and only to a non-internal audience (#519).
+        const errorBlock = data["error"] ? renderAgentErrorBlock(data) : null;
+        if (data["error"] && !errorBlock) return;
         if (opts.shouldSkip?.(data)) return;
         const target = opts.getLastTarget();
         if (!target?.targetId || !opts.client) return;
@@ -79,12 +84,13 @@ export function createDiscordForwarder(opts: {
             const channel = await opts.client.channels.fetch(target.targetId);
             const sendable = asSendable(channel);
             if (!sendable) return;
-            const chunks = chunkDiscordMessage(`${opts.prefix || ''}${text}`);
+            const body = errorBlock ?? text;
+            const chunks = chunkDiscordMessage(`${opts.prefix || ''}${body}`);
             for (const chunk of chunks) {
                 await sendable.send(chunk);
             }
-            await relayDiscordImages(opts.client, target, text);
-            opts.log?.({ channelId: target.targetId, preview: redactOutboundText(text).slice(0, 60) });
+            if (!errorBlock) await relayDiscordImages(opts.client, target, text);
+            opts.log?.({ channelId: target.targetId, preview: redactOutboundText(body).slice(0, 60) });
         } catch (e) {
             log.error('[discord:forward]', logErrorText(e));
         }

--- a/src/messaging/error-block.ts
+++ b/src/messaging/error-block.ts
@@ -1,0 +1,57 @@
+// A runtime failure the user can act on, rendered once for every channel.
+//
+// Before this module, `agent_done` payloads carrying `error: true` were dropped
+// by a single clause in each forwarder, so a 429 or an expired login reached the
+// user only as whatever prose the model had produced before it died — usually an
+// apology with no cause (#519). The fix is not "stop dropping": most error
+// broadcasts carry raw exception text, a slice of the model's own output, or an
+// internal employee diagnostic, and posting those verbatim would trade silence
+// for leakage.
+//
+// So delivery is OPT-IN. A payload is rendered only when the classifier tagged it
+// with a known `errorKind`, which is true at exactly the sites that already build
+// a user-facing message. Everything else stays out of the channel and stays in
+// the trace, where it was already going.
+
+/** What went wrong, in terms the next action depends on. */
+export type ErrorKind = 'rate_limit' | 'auth' | 'stall' | 'connection' | 'exit';
+
+/** Whether this payload is a classified failure meant for a human in a channel. */
+export function isRenderableError(data: Record<string, unknown>): boolean {
+    if (data['error'] !== true) return false;
+    // An internal-audience payload is a diagnostic for the operator surface.
+    // `broadcast(..., 'internal')` suppresses only the SSE publish (core/bus.ts),
+    // not the forwarder listeners, so the audience check has to happen here or an
+    // employee-lane error posts into the user's conversation.
+    if (data['audience'] === 'internal' || data['isEmployee'] === true) return false;
+    return isErrorKind(data['errorKind']);
+}
+
+export function isErrorKind(value: unknown): value is ErrorKind {
+    return value === 'rate_limit' || value === 'auth' || value === 'stall'
+        || value === 'connection' || value === 'exit';
+}
+
+/** What the user can do about it — the half the old prose never supplied. */
+const ACTION: Record<ErrorKind, string> = {
+    rate_limit: '잠시 후 자동으로 재시도합니다. 폴백 런타임이 설정돼 있으면 그쪽으로 넘어갑니다.',
+    auth: '해당 CLI의 로그인 상태를 확인해주세요. 재시도해도 같은 오류가 납니다.',
+    stall: '런타임이 응답을 멈췄습니다. 같은 요청을 다시 보내면 새 세션에서 시작합니다.',
+    connection: '연결이 끊겼습니다. 자동으로 재시도합니다.',
+    exit: '런타임이 비정상 종료했습니다. 반복되면 로그를 확인해주세요.',
+};
+
+/** Render the block a channel actually posts.
+ *
+ *  Deliberately built from the CLASSIFIED fields only. The raw stderr that
+ *  produced the classification stays in the trace: it is unbounded, frequently
+ *  contains paths and tokens, and the user cannot act on it. */
+export function renderAgentErrorBlock(data: Record<string, unknown>): string | null {
+    if (!isRenderableError(data)) return null;
+    const kind = data['errorKind'] as ErrorKind;
+    const text = typeof data['text'] === 'string' ? data['text'].trim() : '';
+    const cli = typeof data['cli'] === 'string' ? data['cli'] : '';
+    const header = text || '❌ 런타임 오류';
+    const where = cli ? ` (${cli})` : '';
+    return `${header}${where}\n↳ ${ACTION[kind]}`;
+}

--- a/src/slack/forwarder.ts
+++ b/src/slack/forwarder.ts
@@ -11,6 +11,7 @@ import { assertSendFilePath } from '../security/path-guards.js';
 import { sendSlackFile } from './slack-file.js';
 import { sendSlackText } from './send-only-client.js';
 import { logErrorText } from '../messaging/redact.js';
+import { renderAgentErrorBlock } from '../messaging/error-block.js';
 
 export async function relaySlackImages(
     token: string,
@@ -52,19 +53,27 @@ export function createSlackForwarder(opts: {
 }) {
     return async (type: string, data: Record<string, unknown>) => {
         const text = data?.["text"];
-        if (type !== 'agent_done' || typeof text !== 'string' || !text || data["error"]) return;
+        if (type !== 'agent_done' || typeof text !== 'string' || !text) return;
+        // A failure the classifier tagged is the one thing worth interrupting a
+        // conversation with; every other error payload carries raw exception
+        // text, a slice of the model's own output, or an internal diagnostic, and
+        // those stay in the trace (#519).
+        const errorBlock = data["error"] ? renderAgentErrorBlock(data) : null;
+        if (data["error"] && !errorBlock) return;
         if (opts.shouldSkip?.(data)) return;
         const target = opts.getLastTarget();
         const token = opts.getToken();
         if (!target?.targetId || !token) return;
         try {
-            const result = await sendSlackText(token, target, `${opts.prefix || ''}${text}`);
+            const body = errorBlock ?? text;
+            const result = await sendSlackText(token, target, `${opts.prefix || ''}${body}`);
             if (!result.ok) {
                 log.error('[slack:forward]', logErrorText(result.error || 'send failed'));
                 return;
             }
-            await relaySlackImages(token, target, text);
-            opts.log?.({ channelId: target.targetId, preview: text.slice(0, 60) });
+            // An error block names no image; relaying would re-scan the failure text.
+            if (!errorBlock) await relaySlackImages(token, target, text);
+            opts.log?.({ channelId: target.targetId, preview: body.slice(0, 60) });
         } catch (e) {
             log.error('[slack:forward]', logErrorText(e));
         }

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -94,7 +94,7 @@ cli-jaw/
 │   │   ├── agy-capabilities.ts ← AGY `--help`/`--version` capability probe + cached optional flag support map + legacy emit-all fallback marker (124L)
 │   │   ├── agy-transcript-watcher.ts ← AGY transcript/log watcher and session-id extraction support (291L)
 │   │   ├── pi-runtime.ts     ← Pi profile 정규화 + isolated `PI_CODING_AGENT_DIR` models/settings 생성 + `pi --offline --list-models` discovery + `pi --mode rpc` JSONL parser/spawner (803L) ✨
-│   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1227L)
+│   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1260L)
 │   │   ├── jwc-runtime.ts    ← resident/in-process JWC runtime bridge and event handling (222L)
 │   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (253L)
 │   │   ├── kiro-models.ts    ← Kiro live model inventory (KiroModelEntry, KiroModelInventory, parseKiroModelListJson, fetchKiroModelInventory) (98L)
@@ -102,12 +102,12 @@ cli-jaw/
 │   │   ├── cursor-runtime.ts ← Cursor CLI event adapter + session management (395L) ✨
 │   │   ├── agy-runtime.ts    ← AGY timeout stdout/close-text 판별 + 최종 planner 기준 timeout suffix 정규화 + stdout/log conversation id 추출 + quiet completion/replay/prompt-echo stripping helper (321L)
 │   │   ├── claude-e-runtime.ts ← `jaw_runtime` helper event를 internal `agent:claude-e:*` broadcast로 변환 (46L)
-│   │   ├── alert-escalation.ts ← alert escalation event helper (88L)
+│   │   ├── alert-escalation.ts ← alert escalation event helper (94L)
 │   │   ├── cli-helpers.ts    ← Claude-like CLI 판별 helper (9L)
 │   │   ├── codex-app-client.ts ← Codex App stdio server client (1496L)
 │   │   ├── codex-host-pool.ts ← Codex App shared host generation + lane lease/FIFO/reaper/shutdown owner (494L)
 │   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (531L)
-│   │   ├── error-classifier.ts ← stderr/result 기반 에러 분류 헬퍼 + shouldAnnounceStallTruncation (부분 출력 워치독 종료를 독자에게 알릴지 판정) (111L)
+│   │   ├── error-classifier.ts ← stderr/result 기반 에러 분류 헬퍼 + shouldAnnounceStallTruncation (부분 출력 워치독 종료를 독자에게 알릴지 판정) (160L)
 │   │   ├── stall-notice.ts   ← 워치독 중단 통지 문구 + 접미사 전용 제거 (사람에겐 보이고 모델 컨텍스트엔 안 들어가도록 db 조회 경계가 사용) (21L) ✨
 │   │   ├── grok-trace-backfill.ts ← Grok trace backfill helper (167L) ✨
 │   │   ├── live-run-state.ts ← active run snapshot / hydrate helper (108L)
@@ -265,7 +265,7 @@ cli-jaw/
 │   │   ├── commands.ts       ← Discord slash command 등록 + 핸들러 (153L)
 │   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (201L) ✨
 │   │   ├── channel-types.ts  ← Discord channel type helpers (50L) ✨
-│   │   ├── forwarder.ts      ← Discord text chunk 포워딩 + guarded local-image attachment relay (92L)
+│   │   ├── forwarder.ts      ← Discord text chunk 포워딩 + guarded local-image attachment relay (98L)
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (23 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (407L)
@@ -286,7 +286,7 @@ cli-jaw/
 │   │   ├── inbound-file.ts   ← 인바운드 첨부 단일 IO owner (files.info → 인증 스트리밍 다운로드 → saveUpload, 파일/메시지 바이트 예산, 고정 error code) (280L) ✨
 │   │   ├── inbound-url.ts    ← 인바운드 다운로드 URL 검증 (Slack host allowlist + https-only hop + 사설망 거부) (44L) ✨
 │   │   ├── send-only-client.ts ← bot-token 전용 outbound + conversations.open DM 해석 (180L)
-│   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (72L)
+│   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (81L)
 │   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 (65L)
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (161L)
 │   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (179L) ✨

--- a/tests/unit/error-visibility.test.ts
+++ b/tests/unit/error-visibility.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderAgentErrorBlock, isRenderableError } from '../../src/messaging/error-block.ts';
+import { classifyExitError, parseRetryAfterMs } from '../../src/agent/error-classifier.ts';
+import {
+    noteRuntimeCooldown,
+    isRuntimeCoolingDown,
+    clearRuntimeCooldown,
+    resetRuntimeCooldowns,
+} from '../../src/agent/error-cooldown.ts';
+
+// #519: a runtime failure used to reach the user as whatever prose the model had
+// produced before it died. One clause in each forwarder dropped every payload
+// carrying `error: true`, so a 429 or an expired login arrived as an apology
+// with no cause — 20 minutes burned, then "I can't access that."
+//
+// The fix is opt-in rather than "stop dropping", because most error broadcasts
+// carry raw exception text, a slice of the model's own output, or an internal
+// employee diagnostic. These tests pin BOTH directions: the classified failure
+// arrives, and the unclassified one still does not.
+
+test('EV-001: a classified failure renders a block naming the next action', () => {
+    const block = renderAgentErrorBlock({
+        error: true, errorKind: 'rate_limit', text: '⚡ API 용량 초과 (429)', cli: 'codex',
+    });
+    assert.ok(block, 'a 429 must reach the user at all');
+    assert.match(block, /429/);
+    assert.match(block, /재시도/, 'the block says what happens next, which the prose never did');
+    assert.match(block, /codex/, 'and which runtime it was');
+});
+
+test('EV-002: an UNCLASSIFIED error payload is still not rendered', () => {
+    // The reason this is opt-in. Removing the drop outright would post raw
+    // exception text, a 200-char slice of the model's own output, and unbounded
+    // vendor notices into the conversation.
+    assert.equal(renderAgentErrorBlock({
+        error: true, text: '❌ Pi AppServer acquire failed: ENOENT /Users/someone/.pi/socket',
+    }), null);
+    assert.equal(isRenderableError({ error: true, text: 'raw stack frame' }), false);
+});
+
+test('EV-003: an internal-audience failure never reaches the conversation', () => {
+    // broadcast(..., 'internal') suppresses only the SSE publish; the forwarder
+    // listeners still run. Without this check an employee-lane error posts into
+    // the user's channel.
+    assert.equal(isRenderableError({
+        error: true, errorKind: 'auth', audience: 'internal', text: '🔐 인증 오류',
+    }), false);
+    assert.equal(isRenderableError({
+        error: true, errorKind: 'auth', isEmployee: true, text: '🔐 인증 오류',
+    }), false);
+});
+
+test('EV-004: a successful agent_done is untouched by any of this', () => {
+    assert.equal(isRenderableError({ text: 'the answer' }), false);
+    assert.equal(renderAgentErrorBlock({ text: 'the answer' }), null);
+});
+
+test('EV-005: the classifier tags each failure with the kind a forwarder acts on', () => {
+    assert.equal(classifyExitError('codex', 1, 'HTTP 429 too many requests').errorKind, 'rate_limit');
+    assert.equal(classifyExitError('codex', 1, 'invalid credentials').errorKind, 'auth');
+    assert.equal(classifyExitError('codex', 1, '', 'no output for 900s').errorKind, 'stall');
+    assert.equal(classifyExitError('codex', 1, 'ECONNRESET').errorKind, 'connection');
+    assert.equal(classifyExitError('codex', 1, 'something else entirely').errorKind, 'exit');
+});
+
+test('EV-006: raw child output leaves the user-facing message and stays in detail', () => {
+    // The message used to BE the stderr slice. It is unbounded, carries paths,
+    // and the user cannot act on it.
+    const cls = classifyExitError('codex', 1, 'Traceback: /Users/someone/secret/path.py line 4');
+    assert.ok(!cls.message.includes('/Users/someone'), 'a path must not be the channel message');
+    assert.match(cls.message, /exit 1/, 'the message still says what happened');
+    assert.match(cls.detail, /Traceback/, 'and the evidence is kept for the trace');
+});
+
+test('EV-007: retry_after_ms is milliseconds and retry-after is seconds', () => {
+    // Alternation order is the whole test. Matching the second-based pattern
+    // first swallows `ms` as part of the key, so a 1.5-second wait becomes 25
+    // minutes and the turn parks until the cap.
+    assert.equal(parseRetryAfterMs('retry_after_ms: 1500'), 1500);
+    assert.equal(parseRetryAfterMs('"retry_after_ms":1500'), 1500);
+    assert.equal(parseRetryAfterMs('Retry-After: 30'), 30_000);
+    assert.equal(parseRetryAfterMs('retry_after: 2'), 2000);
+    assert.equal(parseRetryAfterMs('nothing here'), undefined);
+});
+
+test('EV-008: an absurd retry-after is capped rather than obeyed', () => {
+    assert.equal(parseRetryAfterMs('Retry-After: 86400'), 600_000);
+});
+
+test('EV-009: a parked runtime is skipped until it expires', () => {
+    resetRuntimeCooldowns();
+    assert.equal(isRuntimeCoolingDown('codex'), false);
+    noteRuntimeCooldown('codex', 5000);
+    assert.equal(isRuntimeCoolingDown('codex'), true, 'the fallback search must skip an exhausted runtime');
+    assert.equal(isRuntimeCoolingDown('claude'), false, 'and only that one');
+    clearRuntimeCooldown('codex');
+    assert.equal(isRuntimeCoolingDown('codex'), false, 'a successful run is what proves capacity returned');
+});
+
+test('EV-010: an expired cooldown lapses on read, with no sweeper', () => {
+    resetRuntimeCooldowns();
+    noteRuntimeCooldown('codex', 1);
+    const until = Date.now() + 30;
+    while (Date.now() < until) { /* spin briefly past the expiry */ }
+    assert.equal(isRuntimeCoolingDown('codex'), false, 'nothing should have to own a timer for this');
+});


### PR DESCRIPTION
## What

wp3 of the #517–#524 stack. **Closes #519** — runtime failures reached the user as model prose, and a single 429 killed the turn even though fallback code existed.

## One clause dropped every failure

Both forwarders discarded any `agent_done` carrying `error: true`. Every error the agent generates carries it, so the structured strings the classifier already built (`⚡ API 용량 초과 (429)`, `🔐 인증 오류`) never reached anyone. What the user saw instead was whatever the model said before it died.

**The fix is opt-in delivery, not "stop dropping."** That distinction is the whole review. Of the **22** `agent_done` broadcast sites, the untagged ones carry:

- raw exception text (`spawn.ts:2200`, `:2727` — `ENOENT /Users/…`)
- a 200-char slice of the model's own output (`lifecycle-handler.ts:371`)
- unbounded vendor notices (`jwc-event-mapper.ts:164`)
- **internal employee diagnostics** (`lifecycle-handler.ts:948`, `:977`)

That last one is an audience boundary, not noise: `broadcast(..., 'internal')` suppresses only the SSE publish, **not** the forwarder listeners. Removing the filter outright would have started posting employee-lane errors into the user's conversation. So a payload renders only when the classifier tagged it with a known `errorKind` **and** its audience is not internal.

Raw stderr also stops being the user-facing message. It was unbounded child output — paths, stack frames, sometimes credentials — that nobody can act on. It moves to a `detail` field bound for the trace; the message keeps the exit line.

## 429 recovery

**Units.** `retry_after_ms` is milliseconds, `Retry-After` is seconds. The millisecond spelling is matched **first** — otherwise `ms` is swallowed as part of the key and `retry_after_ms: 1500` parses as 1500 *seconds*, capping into a 10-minute park. Caught by the audit executing the regex rather than reading it.

**Backoff** takes the larger of its own curve and the provider's request, capped at 10 minutes.

**Cooldown.** A runtime that returns 429 is parked, and the fallback search skips a parked runtime — otherwise the next turn walks straight back into the exhausted provider. The registry uses **one key space end to end**: cooldowns are keyed by *runtime* name while `fallbackOrder` holds *registry* names, and `ai-e` maps to `claude-e`. Comparing the two directly would have made the skip a silent no-op for exactly the aliased runtime — and a source-scanning guard could not have caught it. Only a successful run clears the park.

## Two smaller ones

Operator alerts stopped defaulting to `telegram` at **both** sites — a Slack-only install escalated into a channel nobody had configured, so the alert was lost.

`fallbackOrder` **keeps** its empty default. The devlog records that as deliberate (`_fin/260224_orch/phase0_fallback.md:28` — empty means disabled) and `/fallback off` writes the same state, so enabling it by default would spend a second provider's quota for users who never opted in. Verified before changing rather than assumed.

## Review gate

Independent audit returned **GO-WITH-FIXES (blockers=10)**, three High — all folded, none rebutted. The three High findings are exactly the three decisions above: the audience filter, the cooldown key space, and the retry-after alternation order. The audit also **falsified a correction from an earlier phase's amendment** (a claimed line drift in `lifecycle-handler.ts` that did not exist), which is recorded rather than propagated.

Fields with no consumer were **dropped**, not shipped — the same rule that removed a parameter in #528.

## Activation evidence

Ten tests drive the branches rather than asserting the code exists:

| | |
|---|---|
| EV-002 | an unclassified error is **still** not rendered |
| EV-003 | an internal/employee failure never reaches the conversation |
| EV-006 | a path in stderr is absent from the message and present in the trace |
| EV-007 | `retry_after_ms: 1500` → 1500 ms, `Retry-After: 30` → 30000 ms |
| EV-009/010 | a parked runtime is skipped, and expiry lapses on read with no sweeper |

## Verification

```
npx tsc --noEmit                 exit 0
npm run build                    exit 0
bash structure/verify-counts.sh  ALL PASS — 453/453
npm test                         8507 tests · 8481 pass · 0 fail
```

Closes #519
