### PR TITLE
fix(slack): stop minting a session per top-level message

### DIFF
--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -364,7 +364,13 @@ async function runMentionWatchJob(job: Record<string, any>, watch: HeartbeatMent
  *  choose the thread. */
 function slackThreadTarget(hit: MentionHit): RemoteTarget {
     const base = targetFromChatId('slack', hit.channelId);
-    return { ...base, threadId: hit.threadTs };
+    // The flag rides along or this target keys a thread that does not exist,
+    // which is the #520 defect on the mention-watch side.
+    return {
+        ...base,
+        threadId: hit.threadTs,
+        ...(hit.threadIsSynthetic ? { threadIsSynthetic: true } : {}),
+    };
 }
 
 

--- a/src/messaging/session-key.ts
+++ b/src/messaging/session-key.ts
@@ -34,7 +34,14 @@ export function buildRemoteSessionKey(target: RemoteTarget): string {
 export function buildRemoteBindingKey(target: RemoteTarget): string {
     const part = (value: string) => encodeURIComponent(value);
     const base = `jaw:${part(target.channel)}:${part(target.peerKind)}:${part(target.targetId)}`;
-    const threadId = normalizedThreadId(target);
+    // A SYNTHETIC thread id addresses a reply; it does not identify a
+    // conversation. Keying on it made every top-level Slack message its own
+    // session (#520). The check lives here and NOT in `normalizedThreadId`,
+    // which `buildRemoteSessionKey` also uses: that one feeds
+    // `deliveryTargetKey`, where a thread reply and a channel post genuinely are
+    // different destinations, and folding it would break per-turn delivery
+    // dedupe.
+    const threadId = target.threadIsSynthetic === true ? undefined : normalizedThreadId(target);
     return threadId ? `${base}:thread:${part(threadId)}` : base;
 }
 

--- a/src/messaging/slack-target.ts
+++ b/src/messaging/slack-target.ts
@@ -24,7 +24,7 @@ export function slackTargetKind(conversationId: string): RemoteTargetKind {
 
 export function slackTargetFromId(
     conversationId: string,
-    options: { threadTs?: string; teamId?: string } = {},
+    options: { threadTs?: string; teamId?: string; threadIsSynthetic?: boolean } = {},
 ): RemoteTarget {
     const target: RemoteTarget = {
         channel: 'slack',
@@ -33,6 +33,9 @@ export function slackTargetFromId(
         targetId: conversationId,
     };
     if (options.threadTs) target.threadId = options.threadTs;
+    // Only meaningful alongside a threadTs: it says that ts names a message, not
+    // an existing thread, so the session key must not use it (#520).
+    if (options.threadTs && options.threadIsSynthetic) target.threadIsSynthetic = true;
     if (options.teamId) target.guildId = options.teamId;
     return target;
 }
@@ -53,4 +56,19 @@ export function resolveSlackThreadTs(
 ): string | undefined {
     if (!replyInThread) return undefined;
     return event.thread_ts || event.ts;
+}
+
+/** The same resolution, with the two concerns kept apart.
+ *
+ *  `threadTs` is where a reply goes. `synthetic` says the thread does not exist
+ *  yet, so the SESSION key must fall back to the conversation. Returning one
+ *  value for both is what made every top-level message its own session (#520):
+ *  the reply address and the conversation identity are not the same question. */
+export function resolveSlackThreadPlacement(
+    event: { ts?: string; thread_ts?: string },
+    replyInThread: boolean,
+): { threadTs?: string; synthetic: boolean } {
+    if (!replyInThread) return { synthetic: false };
+    if (event.thread_ts) return { threadTs: event.thread_ts, synthetic: false };
+    return { ...(event.ts ? { threadTs: event.ts } : {}), synthetic: Boolean(event.ts) };
 }

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -14,6 +14,14 @@ export type RemoteTarget = {
     peerKind: RemotePeerKind;
     targetId: string;
     threadId?: string;
+    /** The thread named by `threadId` does not exist yet: it is the ts of a
+     *  TOP-LEVEL message, carried so a reply can open a thread under it.
+     *
+     *  It is a REPLY ADDRESS only and must never key a session. Keying on it
+     *  meant every top-level message minted its own `chat_sessions` row, a table
+     *  with no eviction, no TTL and no cap — one live database reached 186MB
+     *  (#520). Slack only; see `resolveSlackThreadPlacement`. */
+    threadIsSynthetic?: boolean;
     guildId?: string;
     parentTargetId?: string;
 };
@@ -94,6 +102,12 @@ export function isRemoteTarget(value: unknown): value is RemoteTarget {
     for (const field of ['threadId', 'guildId', 'parentTargetId'] as const) {
         if (target[field] != null && typeof target[field] !== 'string') return false;
     }
+    // `threadIsSynthetic` is deliberately NOT validated into a rejection. This
+    // predicate guards a routing address, and a malformed flag on an otherwise
+    // valid address would discard the whole target — sending the reply down the
+    // last-active fallback chain and into a different conversation (#474). The
+    // flag is read only through `=== true`, so anything else is simply not
+    // synthetic, which is the safe default: a real thread keeps its own key.
     return true;
 }
 

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -17,7 +17,7 @@ import {
     setLastActiveTarget, setLatestSeenTarget, getLastActiveTarget,
     transportStarted, transportNotStarted, type TransportStartOutcome,
 } from '../messaging/runtime.js';
-import { slackTargetFromId, resolveSlackThreadTs } from '../messaging/slack-target.js';
+import { slackTargetFromId, resolveSlackThreadPlacement } from '../messaging/slack-target.js';
 import type { RemoteTarget } from '../messaging/types.js';
 import { buildMediaPromptMany } from '../agent/spawn.js';
 import {
@@ -295,10 +295,15 @@ function gateConfig() {
 
 function buildSlackTarget(event: SlackMessageEvent): RemoteTarget {
     const replyInThread = settings["slack"]?.replyInThread !== false;
-    const threadTs = resolveSlackThreadTs(event, replyInThread);
+    // Reply address and session identity are separate questions: a top-level
+    // message's own ts is where a reply would open a thread, but it does not
+    // name a conversation (#520). Both callers of this function reach the
+    // journal and dispatch paths through the returned target.
+    const placement = resolveSlackThreadPlacement(event, replyInThread);
     const teamId = settings["slack"]?.teamId;
     return slackTargetFromId(event.channel as string, {
-        ...(threadTs ? { threadTs } : {}),
+        ...(placement.threadTs ? { threadTs: placement.threadTs } : {}),
+        ...(placement.synthetic ? { threadIsSynthetic: true } : {}),
         ...(teamId ? { teamId: String(teamId) } : {}),
     });
 }

--- a/src/slack/mention-watch.ts
+++ b/src/slack/mention-watch.ts
@@ -27,6 +27,12 @@ export type MentionHit = {
      *  message itself. Replying to `ts` when the message already lives in a
      *  thread would start a second thread off a reply. */
     threadTs: string;
+    /** True when `threadTs` is the message's OWN ts — a reply address for a
+     *  thread that does not exist yet, not a conversation. The session key must
+     *  fall back to the channel, exactly as the inbound path does, or the two
+     *  producers key the same top-level message differently and a mention answer
+     *  lands in a session the conversation cannot read (#520). */
+    threadIsSynthetic?: boolean;
     authorId: string | null;
     text: string;
 };
@@ -341,6 +347,10 @@ export async function scanSlackMentions(
                     channelId,
                     ts: message.ts,
                     threadTs: message.threadTs || message.ts,
+                    // Same promotion as the inbound path, so it carries the same
+                    // flag: without it this producer keeps minting one session
+                    // per top-level mention (#520).
+                    ...(message.threadTs ? {} : { threadIsSynthetic: true }),
                     authorId: message.user ?? null,
                     text: message.text,
                 });

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -133,9 +133,9 @@ cli-jaw/
 │   │   ├── channel-health.ts ← 채널 헬스 체크 helper + additive ingress/metrics snapshot (202L) ✨
 │   │   ├── channel-validate.ts ← 온보딩 마법사 라이브 크리덴셜 검증 (telegram getMe / discord users@me / slack auth.test+connections.open, 토큰 비로깅) (139L) ✨
 │   │   ├── send-result.ts    ← send result type helper (14L) ✨
-│   │   ├── session-key.ts    ← 세션 키 헬퍼 (49L)
+│   │   ├── session-key.ts    ← 세션 키 헬퍼 (56L)
 │   │   ├── thread-target.ts  ← Telegram forum topic `message_thread_id` 정규화 helper (21L)
-│   │   ├── types.ts          ← MessengerChannel, OutboundType, RemoteTarget 타입 (123L)
+│   │   ├── types.ts          ← MessengerChannel, OutboundType, RemoteTarget 타입 (137L)
 │   │   ├── extract-images.ts ← Markdown AST 로컬 이미지 후보 추출 + 확장자 필터/중복 제거/4개 cap (36L)
 │   │   ├── access-policy.ts   ← remote command access-policy substrate (deny/allowlist/paired/all) (45L)
 │   │   ├── approval-presentation.ts ← Telegram/Discord/Slack Approve/Deny keyboards + opaque appr/aprd ids (128L)
@@ -155,7 +155,7 @@ cli-jaw/
 │   │   ├── channel-capabilities.ts ← closed capability set + generated matrix (101L)
 │   │   ├── delivery-outcome.ts ← DeliveryReceipt classification (145L)
 │   │   ├── draft-stream.ts   ← draft stream helper (180L)
-│   │   └── slack-target.ts   ← Slack target helper (56L)
+│   │   └── slack-target.ts   ← Slack target helper (74L)
 │   ├── orchestrator/         ← 직원 오케스트레이션 + 인터페이스 통합 (19 files)
 │   │   ├── state-machine.ts ← IPABCD 상태 머신 (I=Interview pre-plan) + broadcast(state,title) + worklog 타이틀 파싱 + employee terminology + OrcContext.workingDir + OrcContext.interview + Project root dispatch contract + Phase60 actor-aware canTransition(GateInput) form-only evidence gate + STATE_PROMPTS --attest instructions (806L)
 │   │   ├── pipeline.ts       ← IPABCD orchestration (explicit entry only) + interview first-turn detection + plan context persistence + memorySnapshot injection + reset clears boss session + OrcContext workingDir init + Approved Plan Project root guard + remote-channel elicitation guard + bounded delayed worker replay notice + Phase60 phase_attestation strip/fallback + no-state narration warn (771L)
@@ -234,7 +234,7 @@ cli-jaw/
 │   ├── memory/               ← 데이터 영속화 + advanced memory runtime (17 files)
 │   │   ├── advanced.ts       ← Advanced Memory re-export stub (1L)
 │   │   ├── bootstrap.ts      ← legacy memory/bootstrap import + structured root 초기화 (588L)
-│   │   ├── heartbeat.ts      ← Heartbeat 잡 스케줄 + cron/every timer orchestration + minute-slot dedupe + fs.watch (647L)
+│   │   ├── heartbeat.ts      ← Heartbeat 잡 스케줄 + cron/every timer orchestration + minute-slot dedupe + fs.watch (653L)
 │   │   ├── heartbeat-schedule.ts ← Heartbeat schedule normalize + cron validate/match + timezone validate + immediate cron loop helper (410L)
 │   │   ├── heartbeat-mention-watch.ts ← Slack mention 항목 loop + busy yield + server-owned thread send + WatchNamespace 경유 ledger 접근 (249L)
 │   │   ├── mention-watch-ledger.ts ← v2 ledger 단일 접근 경로 (WatchNamespace = job+workspace+user, 모든 SQL이 3파트 predicate 유지, A/B 대칭 테스트가 최종 보증) (104L) ✨
@@ -269,7 +269,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (23 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (407L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1404L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + envelope routing + orchestrate 경로 + queued-result waiter (1409L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (408L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (66L)
 │   │   ├── events.ts         ← inbound gating (self-echo/bot/subtype/allowlist/mention) + Block Kit 텍스트 추출 (283L)
@@ -278,7 +278,7 @@ cli-jaw/
 │   │   ├── conversation.ts   ← 대화/스레드 컨텍스트 (conversations.info + replies, 참여자는 author 유도, method별 억제·시작률) (347L)
 │   │   ├── context.ts        ← 프롬프트 컨텍스트 블록 조립 (채널 id·thread_ts 무절단, 섹션별 코드포인트 예산, 신뢰 경계 문구 보존) (260L)
 │   │   ├── history.ts        ← 동적 조회 (conversations.history/replies form-encoded 래퍼 + 재시도 + 에이전트용 포맷/redact) (251L)
-│   │   ├── mention-watch.ts  ← 가입 채널 backward mention scan + frontier/resume/round-robin/429 stop/60-channel overflow (359L)
+│   │   ├── mention-watch.ts  ← 가입 채널 backward mention scan + frontier/resume/round-robin/429 stop/60-channel overflow (369L)
 │   │   ├── attachment-recovery.ts ← app_mention 봉투에 없는 첨부를 channel+ts 재조회로 복구 (oldest+inclusive+limit=1) (53L)
 │   │   ├── commands.ts       ← slash command → 공유 parseCommand/executeCommand 파이프라인 (166L)
 │   │   ├── slack-file.ts     ← files.getUploadURLExternal → upload → completeUploadExternal 3단계 업로드 (파일명·캡션 모두 아웃바운드 마스킹) (117L)

--- a/tests/unit/synthetic-thread-keying.test.ts
+++ b/tests/unit/synthetic-thread-keying.test.ts
@@ -1,0 +1,87 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveSlackThreadPlacement, resolveSlackThreadTs, slackTargetFromId } from '../../src/messaging/slack-target.ts';
+import { buildRemoteBindingKey, buildRemoteSessionKey } from '../../src/messaging/session-key.ts';
+import { deliveryTargetKey } from '../../src/messaging/turn-delivery.ts';
+import { isRemoteTarget } from '../../src/messaging/types.ts';
+
+// #520: a top-level Slack message has no thread_ts, so its OWN ts was promoted
+// into the session key. Every such message therefore minted a fresh
+// chat_sessions row — a table with no eviction, no TTL and no cap. One live
+// database reached 186MB.
+//
+// The fix has to separate two questions that shared one value: WHERE a reply
+// goes, and WHICH conversation this is.
+
+function topLevel() {
+    const p = resolveSlackThreadPlacement({ ts: '1000.1' }, true);
+    return slackTargetFromId('C520', {
+        ...(p.threadTs ? { threadTs: p.threadTs } : {}),
+        ...(p.synthetic ? { threadIsSynthetic: true } : {}),
+    });
+}
+
+test('STK-001: two top-level messages in one channel share one binding key', () => {
+    const a = topLevel();
+    const b = slackTargetFromId('C520', { threadTs: '2000.2', threadIsSynthetic: true });
+    assert.equal(buildRemoteBindingKey(a), 'jaw:slack:channel:C520', 'no :thread: segment for a thread that does not exist');
+    assert.equal(buildRemoteBindingKey(a), buildRemoteBindingKey(b), 'one channel conversation, not one per message');
+});
+
+test('STK-002: the reply address survives the fold', () => {
+    // The whole risk of a naive fix: losing the ts means the reply can no longer
+    // open a thread under the message it answers.
+    const t = topLevel();
+    assert.equal(t.threadId, '1000.1', 'the reply still knows where to go');
+    assert.equal(t.threadIsSynthetic, true);
+});
+
+test('STK-003: a REAL thread keeps its own session', () => {
+    const real = slackTargetFromId('C520', { threadTs: '1000.1' });
+    assert.equal(buildRemoteBindingKey(real), 'jaw:slack:channel:C520:thread:1000.1');
+    assert.equal(real.threadIsSynthetic, undefined, 'nothing synthetic about a thread that exists');
+});
+
+test('STK-004: delivery keys stay DISTINCT — the lane invariant is not folded', () => {
+    // This is the assertion that catches the tempting wrong fix. Putting the
+    // check inside the shared normalizedThreadId would fold buildRemoteSessionKey
+    // too, and turn-delivery states plainly that a thread reply and a channel
+    // post are different destinations. Two messages must not dedupe each other.
+    const a = topLevel();
+    const b = slackTargetFromId('C520', { threadTs: '2000.2', threadIsSynthetic: true });
+    assert.notEqual(deliveryTargetKey(a), deliveryTargetKey(b), 'per-turn delivery must still tell them apart');
+    assert.notEqual(buildRemoteSessionKey(a), buildRemoteSessionKey(b), 'and so must the session key that feeds it');
+});
+
+test('STK-005: resolveSlackThreadPlacement separates address from identity', () => {
+    assert.deepEqual(resolveSlackThreadPlacement({ ts: '1.1' }, true), { threadTs: '1.1', synthetic: true });
+    assert.deepEqual(resolveSlackThreadPlacement({ ts: '2.2', thread_ts: '1.1' }, true), { threadTs: '1.1', synthetic: false });
+    assert.deepEqual(resolveSlackThreadPlacement({ ts: '1.1' }, false), { synthetic: false });
+});
+
+test('STK-006: the legacy resolver is unchanged for its own callers', () => {
+    // Four existing tests pin this contract; the reply address it returns is
+    // still correct, it simply no longer decides the session.
+    assert.equal(resolveSlackThreadTs({ ts: '1.1' }, true), '1.1');
+    assert.equal(resolveSlackThreadTs({ ts: '2.2', thread_ts: '1.1' }, true), '1.1');
+    assert.equal(resolveSlackThreadTs({ ts: '1.1' }, false), undefined);
+});
+
+test('STK-007: a malformed flag never discards the address', () => {
+    // Rejecting the whole target would send the reply down the last-active
+    // fallback chain and into a different conversation (#474). A bad value must
+    // degrade to "not synthetic", which is the safe default.
+    const target = { channel: 'slack', targetKind: 'channel', peerKind: 'channel', targetId: 'C520', threadId: '1.1', threadIsSynthetic: 'yes' };
+    assert.equal(isRemoteTarget(target), true, 'the address is still valid and must be kept');
+    assert.equal(buildRemoteBindingKey(target as never), 'jaw:slack:channel:C520:thread:1.1',
+        'anything but true is not synthetic, so the thread keeps its own key');
+});
+
+test('STK-008: Telegram and Discord are untouched', () => {
+    const tg = { channel: 'telegram', targetKind: 'user', peerKind: 'direct', targetId: '99', threadId: '7' } as const;
+    const dc = { channel: 'discord', targetKind: 'channel', peerKind: 'channel', targetId: 'D1', threadId: 'T9' } as const;
+    assert.equal(buildRemoteBindingKey(tg), 'jaw:telegram:direct:99:thread:7');
+    assert.equal(buildRemoteBindingKey(dc), 'jaw:discord:channel:D1:thread:T9');
+});


### PR DESCRIPTION
## What

wp5 of the #517–#524 stack. **Closes #520** — a Slack message with no `thread_ts` had its **own ts** promoted into the session key, so every top-level message created a fresh `chat_sessions` row. That table has no eviction, no TTL and no cap; one live database reached **186MB**.

The value was answering two different questions at once: **where a reply goes**, and **which conversation this is**. A top-level ts is a correct answer to the first and a wrong answer to the second, because the thread it names does not exist yet.

## The placement of the check is the whole review

The fold lives in `buildRemoteBindingKey` **only**. `normalizedThreadId` is shared with `buildRemoteSessionKey`, which feeds `deliveryTargetKey` — and `turn-delivery.ts:152-155` states plainly that a thread reply and a channel post are different destinations. Folding there would also change `groupQueueKey` and the gateway dedupe key, making two different top-level messages **suppress each other as duplicates**.

`STK-004` exists to catch exactly that mistake: it asserts the delivery keys stay distinct after the session keys fold.

## Both producers are folded

`mention-watch.ts` does the identical `threadTs || message.ts` promotion. The plan claimed it carried a real parent ts; the audit falsified that from the type's own doc comment.

Half-applying this would have been **worse than not applying it**:

| | inbound | mention-watch |
|---|---|---|
| before | `…:thread:<ts>` | `…:thread:<ts>` |
| after, half-applied | `jaw:slack:channel:C1` | `…:thread:<ts>` ❌ |

A mention answer would land in a session the folded conversation cannot read, and `mentionThreadYield` would probe a scope nothing uses — letting a background answer run **concurrently with a human turn**, the collision that guard exists to prevent. The reviewer then searched every `threadId` assignment in `src/` and confirmed there is no third producer.

## A malformed flag never discards the address

The first design had `isRemoteTarget` reject a target carrying a bad `threadIsSynthetic`. Rejection discards the **entire echoed address** and falls through to `getLastActiveTarget` — the #474 cross-conversation misdelivery. Since the model can echo this field back, that would have been a prompt-reachable way to redirect a reply.

Anything but `true` is simply not synthetic. Safe default, address preserved (`STK-007`).

The residual is disclosed rather than overclaimed: a well-formed `true` on a *real* thread folds that thread's key. It cannot cross a conversation — `targetId` is untouched and the flag is read only by `buildRemoteBindingKey` — so the worst case is scope-widening **within the same channel**.

## The tradeoff, stated plainly

Top-level traffic in one channel now shares a scope. That means:

- it **serializes at two points** — the session lane and the Slack ingress lane, both keyed by `buildRemoteBindingKey`;
- because `midRunPolicy` defaults to `'steer'`, **a second speaker's top-level message now steers the turn answering the first speaker's**;
- vendor context buckets are scope-keyed, so top-level turns in a channel share one CLI conversation.

That last one is simultaneously the cost and the benefit — it is the shared channel context this issue asks for. **Real threads keep their own sessions and their own parallelism.** `maxConcurrent` tuning is deliberately deferred to #489.

## Migration: stranded, not swept

Pre-fix per-message rows are left alone. Slack has N `:thread:` rows per channel and **nothing on disk marks which were synthetic**, so an automatic rebind would sometimes attach a real thread's history to the channel.

⚠️ **On deploy, each channel's top-level conversation starts empty.** Prior history stays reachable through the stranded sessions; nothing is deleted.

## Verification

```
npx tsc --noEmit                 exit 0
npm run build                    exit 0
bash structure/verify-counts.sh  ALL PASS — 453/453
npm test                         8522 tests · 8496 pass · 0 fail
tests/unit/synthetic-thread-keying.test.ts  8/8 (new)
```

Two audit rounds: **FAIL** → amendment → **GO-WITH-FIXES**. All blockers folded, none rebutted.

Closes #520
