### PR TITLE
feat(orchestrator): refuse a phase that produced a document nobody looked at

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make g++ \
     chromium \
+    fonts-noto-cjk fonts-nanum \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/orchestrator/attestation.ts
+++ b/src/orchestrator/attestation.ts
@@ -215,6 +215,18 @@ export function checkAttestationGate(
         reason: `C → D requires a passing check, but the attestation reports exitCode ${att.exitCode}. Fix the failure (orchestrate B) before advancing.`,
       };
     }
+    // A produced BINARY document is the one artifact class where "it compiled" says
+    // nothing: a PDF with tofu boxes for every Korean glyph passes every static gate
+    // and is unreadable (#522). That is a refusal, not a warning.
+    //
+    // BEFORE the advisory, and the order is load-bearing: the widened
+    // RENDER_ARTIFACT_PATTERN now matches a produced document too, so an
+    // advisory-first arrangement would return ok:true here and leave this
+    // block unreachable.
+    const binaryBlock = checkBinaryArtifactGrounding(att);
+    if (binaryBlock) {
+      return { ok: false, reason: binaryBlock };
+    }
     // Render-grounding soft warning (C-RENDER-GROUNDING-01): when the did/checkOutput
     // mentions render-artifact file types but lacks observation vocabulary, emit an
     // advisory. The gate remains a pass — this is a warning, never a block.
@@ -255,7 +267,7 @@ export function checkAuditEvidenceAdvisory(att: PhaseAttestation): string | null
 // emit an advisory warning. The gate result always remains ok:true.
 
 /** File-type keywords that indicate a render artifact was likely involved. */
-const RENDER_ARTIFACT_PATTERN = /(?:\b|\.)(html|svg|css|jsx|tsx|canvas|chart|animation)\b|\b(ui|game)\b/i;
+const RENDER_ARTIFACT_PATTERN = /(?:\b|\.)(html|svg|css|jsx|tsx|canvas|chart|animation|pdf|docx|pptx|xlsx|hwpx?|png|jpe?g)\b|\b(ui|game)\b/i;
 
 /** Observation vocabulary that indicates the agent actually ran and observed the artifact. */
 const RENDER_OBSERVATION_PATTERN = /\b(screenshot|render|rendered|observed|headless|viewport|render-not-applicable|visual|browser|puppeteer|playwright|pdftoppm|opened|displayed|inspected)\b/i;
@@ -275,6 +287,59 @@ export function checkRenderGroundingAdvisory(att: PhaseAttestation): string | nu
     '(screenshot/render/observed/headless/viewport). If this work-phase produced a ' +
     'visual artifact, consider running and observing it before advancing. ' +
     'If render grounding does not apply, mention "render-not-applicable" in the did.'
+  );
+}
+
+/** A document format whose correctness only exists when someone opens it.
+ *
+ *  The extension must be TERMINAL. Matching `.pdf` anywhere would refuse
+ *  `export.pdf.ts` — a source file — because `.` is a word boundary, turning a
+ *  pure code change into a demand to screenshot a document it never produced. */
+const BINARY_DOCUMENT_PATTERN = /\.(pdf|docx|pptx|xlsx|hwpx?)(?![\p{L}\p{N}._-])/iu;
+
+/** Evidence that someone actually LOOKED AT the document.
+*
+ *  `render`/`rendered`/`렌더` are deliberately ABSENT. Rendering is how the
+ *  document was PRODUCED, not evidence that anyone saw the result — and
+ *  "rendered the report to report.pdf" is the exact sentence this gate exists
+ *  to question.
+ *
+*  Korean terms are included deliberately: attestations in this repo are
+*  routinely written in Korean, and an English-only vocabulary would refuse an
+*  agent that DID open the file and said so. */
+const BINARY_OBSERVATION_PATTERN = /\b(screenshot|observed|headless|pdftoppm|opened|displayed|inspected|viewed|render-not-applicable|preview|thumbnail)\b|열어|열었|확인했|확인함|검토했|스크린샷|미리보기/i;
+
+/** Work that NAMES a document without producing one.
+ *
+ *  A filename is also how you refer to a file you changed, replaced or deleted.
+ *  Without this, `replaced the stale fixtures/invoice.docx test input` is
+ *  refused — and an agent that learns the gate fires on work it did not do
+ *  learns to reach for the override, which is worse than no gate. */
+const BINARY_NON_PRODUCTION_PATTERN = /\b(fixture|fixtures|golden|snapshot|test input|deleted|removed|obsolete|stale|documented|documentation|readme|parser|writer|import|imports|imported|parse|parsing)\b|삭제|제거|픽스처|문서화/i;
+
+/**
+ * Refuse a C→D that claims a produced binary document with no sign anyone looked
+ * at it. Returns the refusal reason, or null when the phase may advance.
+ *
+ * Separate from the advisory on purpose: `html` without observation must stay a
+ * warning (three existing tests assert exactly that), while a produced PDF is
+ * the case where passing static gates proves nothing at all.
+ */
+export function checkBinaryArtifactGrounding(att: PhaseAttestation): string | null {
+  // `did` only. A fixture path in pasted command output is not a claim to have
+  // produced a document.
+  const did = att.did || '';
+  if (!BINARY_DOCUMENT_PATTERN.test(did)) return null;
+  if (BINARY_OBSERVATION_PATTERN.test(did)) return null;
+  if (BINARY_OBSERVATION_PATTERN.test(att.checkOutput || '')) return null;
+  if (BINARY_NON_PRODUCTION_PATTERN.test(did)) return null;
+  return (
+    '[C-RENDER-GROUNDING-01] This attestation says it produced a binary document, ' +
+    'but nothing in it says anyone opened the result. A document can satisfy every ' +
+    'static gate and still be unreadable — missing CJK fonts render every Korean ' +
+    'glyph as a tofu box, and no test catches that. Open the output (pdftoppm, a ' +
+    'screenshot, a viewer), say what you saw, and attest again. ' +
+    'If you did not produce this document, say "render-not-applicable" in the did.'
   );
 }
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -175,7 +175,7 @@ cli-jaw/
 │   │   ├── friction.ts       ← Interview friction/stagnation detector (76L)
 │   │   ├── seed.ts           ← Interview seed/ontology builder (107L)
 │   │   ├── sanitize.ts       ← Interview tracker strip helper + stripPhaseAttestation re-export (79L)
-│   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> (tagged block + --attest object) + form-only checkAttestationGate (gates P→A/A→B/B→C/C→D; narrative did required, C→D needs checkOutput) + stripPhaseAttestation + warn-only no-state narration detector (305L)
+│   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> (tagged block + --attest object) + form-only checkAttestationGate (gates P→A/A→B/B→C/C→D; narrative did required, C→D needs checkOutput) + stripPhaseAttestation + warn-only no-state narration detector (370L)
 │   ├── prompt/               ← 프롬프트 조립 (4 files + templates/ 10 files)
 │   │   ├── builder.ts        ← A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1211L)
 │   │   ├── runtime-context.ts ← 런타임 컨텍스트 주입 (RuntimeContextEntry, loadEntries, getActiveEntries, addEntry, removeEntry, clearAll, buildInjectionBlock) (80L)

--- a/tests/unit/binary-artifact-grounding.test.ts
+++ b/tests/unit/binary-artifact-grounding.test.ts
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkBinaryArtifactGrounding, checkAttestationGate } from '../../src/orchestrator/attestation.ts';
+import type { PhaseAttestation } from '../../src/orchestrator/attestation.ts';
+
+// #522: the bot rendered PDFs and posted them without ever looking at what it
+// produced. A document with missing CJK fonts renders every Korean glyph as a
+// tofu box, passes every static gate, and reaches the user broken — twice
+// observed live, both times found by the user rather than by us.
+//
+// The refusal surface is the risk. This sits on the main forward path of every
+// PABCD cycle, so the tests that matter most are the ones proving it does NOT
+// fire on work that merely names a document.
+
+function att(did: string, checkOutput = 'tsc clean'): PhaseAttestation {
+    return { from: 'C', to: 'D', did, checkOutput, exitCode: 0 } as PhaseAttestation;
+}
+
+test('ATT-BIN-001: a produced document with no observation is refused', () => {
+    const reason = checkBinaryArtifactGrounding(att('rendered the quarterly report to report.pdf and posted it'));
+    assert.ok(reason, 'this is the case the issue reported twice');
+    assert.match(reason, /opened|open/i, 'the refusal must say what to do about it');
+});
+
+test('ATT-BIN-002: observing the output lets the phase advance', () => {
+    assert.equal(checkBinaryArtifactGrounding(att('rendered report.pdf, opened page 1 with pdftoppm, Korean text renders')), null);
+    assert.equal(checkBinaryArtifactGrounding(att('built deck.pptx and took a screenshot of every slide')), null);
+});
+
+test('ATT-BIN-003: a Korean observation counts, because these attestations are Korean', () => {
+    // An English-only vocabulary would refuse an agent that DID open the file.
+    assert.equal(checkBinaryArtifactGrounding(att('보고서.pdf 를 렌더하고 직접 열어서 한글 깨짐 없는지 확인함')), null);
+});
+
+test('ATT-BIN-004: the escape hatch survives', () => {
+    assert.equal(checkBinaryArtifactGrounding(att('fixed the export bug for report.pdf (render-not-applicable)')), null);
+});
+
+test('ATT-BIN-005: a SOURCE file with a format segment is not a document', () => {
+    // The one that matters most. `.` is a word boundary, so a naive pattern
+    // refuses `export.pdf.ts` — a pure code change — and demands a screenshot of
+    // a document that was never produced.
+    assert.equal(checkBinaryArtifactGrounding(att('fixed the crash in export.pdf.ts writer')), null);
+    assert.equal(checkBinaryArtifactGrounding(att('updated report.docx.snap after the schema change')), null);
+    assert.equal(checkBinaryArtifactGrounding(att('refactored pdf-export.ts into two modules')), null);
+});
+
+test('ATT-BIN-006: naming a document you did not produce is not a claim', () => {
+    // A filename is also how you refer to a file you changed, replaced or
+    // deleted. An agent that learns the gate fires on work it did not do learns
+    // to reach for the override instead.
+    for (const did of [
+        'replaced the stale tests/fixtures/invoice.docx test input',
+        'regenerated the golden fixtures/sample.pdf and updated the parser',
+        'deleted the obsolete report.pdf and dropped its route',
+        'documented how to export report.pdf in the README',
+    ]) {
+        assert.equal(checkBinaryArtifactGrounding(att(did)), null, did);
+    }
+});
+
+test('ATT-BIN-007: ordinary code work never reaches this gate', () => {
+    assert.equal(checkBinaryArtifactGrounding(att('refactored database query in user-service.ts')), null);
+    assert.equal(checkBinaryArtifactGrounding(att('added rate limiting to the auth middleware')), null);
+});
+
+test('ATT-BIN-008: the block runs BEFORE the advisory, or it is unreachable', () => {
+    // The widened RENDER_ARTIFACT_PATTERN now matches a produced document too,
+    // so an advisory-first order would return ok:true and this would be dead code.
+    const result = checkAttestationGate('C', 'D', att('exported the summary to report.pdf'));
+    assert.equal(result.ok, false, 'the produced document must refuse, not merely warn');
+});
+
+test('ATT-BIN-009: html without observation stays an ADVISORY, not a refusal', () => {
+    // The reason this is a separate predicate: three existing tests assert the
+    // html case advances with a warning. Reusing the advisory for blocking
+    // would have turned them red.
+    const result = checkAttestationGate('C', 'D', att('built dashboard.html with the new chart'));
+    assert.equal(result.ok, true, 'a render artifact warns; a binary document refuses');
+    assert.ok(result.advisory, 'and the warning still fires');
+});


### PR DESCRIPTION
## What

wp6 of the #517–#524 stack. **Closes #522** — the bot rendered PDFs and posted them without ever seeing what it produced. A document with missing CJK fonts renders every Korean glyph as a **tofu box**, passes every static gate, and reaches the user broken. Found twice by the user; never by us.

The render-grounding advisory already existed but **could not fire**: its pattern covered `html|svg|css|canvas` and stopped there, so a PDF-producing phase matched nothing and the gate returned a bare pass.

## A produced document is a hard block, not a warning

It is the one artifact class where *"it compiled"* says nothing at all.

Two design points, both load-bearing:

**Order.** The block runs **before** the advisory. The widened `RENDER_ARTIFACT_PATTERN` now matches a produced document too, so an advisory-first arrangement would return `ok: true` and leave the block unreachable dead code. `ATT-BIN-008` pins this.

**Separate predicate.** Not a reuse of `checkRenderGroundingAdvisory` — `html` without observation must stay a *warning*, and three existing tests assert exactly that. Reusing it for blocking turns ATT-RENDER-001/005/007 red. `ATT-BIN-009` pins the distinction.

## The refusal surface is the real risk

This sits on the **main forward path of every PABCD cycle**, so a false refusal is expensive. The audit constructed the cases that would have been wrongly blocked; each is now a test:

| Case | Why it must pass |
|---|---|
| `fixed the crash in export.pdf.ts writer` | `.` is a word boundary, so a naive `\.pdf\b` matches **mid-path** and refuses a pure source change. The extension must be **terminal**. |
| `replaced the stale fixtures/invoice.docx test input` | A filename is also how you refer to a file you *changed*, not produced |
| `deleted the obsolete report.pdf and dropped its route` | Same — deletion is not production |
| `documented how to export report.pdf in the README` | Naming ≠ producing |

And one the plan had backwards: **`rendered` is not observation.** Rendering is how the document was *produced*; "rendered the report to report.pdf" is the exact sentence this gate exists to question, so that word cannot be what satisfies it. Removing it from the observation vocabulary is what made ATT-BIN-001 go from green-for-the-wrong-reason to actually failing the unobserved case.

**Korean counts.** Attestations in this repo are routinely Korean, and an English-only vocabulary would refuse an agent that *did* open the file and said so (`ATT-BIN-003`).

The reasoning behind all of this: an agent that learns the gate fires on work it did not do learns to reach for the override — which is worse than having no gate.

## Fonts

The Docker image now installs `fonts-noto-cjk fonts-nanum` — the missing piece that made the tofu boxes possible in the first place. Note this touches an installer-sensitive path, so a release containing it will require fresh-machine install evidence.

## Dropped from the plan

The `renderGrounding: true` response field. It would have shipped with **no reader** — `bin/commands/orchestrate.ts` prints only `body.error` and `body.state` — and the 409 already carries the reason. That is the third consumerless field this train has dropped under the same rule (after `caption` in #528 and `errorDetailAvailable` in #529).

`officecli`'s mermaid `font-family` is out of scope — it is a submodule. Recorded with its exact location for a future unit.

## Verification

```
npx tsc --noEmit                 exit 0
npm run build                    exit 0
bash structure/verify-counts.sh  ALL PASS — 453/453
npm test                         8531 tests · 8505 pass · 0 fail
tests/unit/binary-artifact-grounding.test.ts  9/9 (new)
```

Closes #522
