### PR TITLE
docs(structure): the test driver isolates processes, not databases

### DIFF
--- a/structure/infra.md
+++ b/structure/infra.md
@@ -50,7 +50,7 @@ aliases: [CLI-JAW Infra, infrastructure modules, core runtime]
 | `i18n:registry` | `tsx scripts/i18n-registry.ts` |
 | `check:deps:online` | `bash scripts/check-deps-online.sh` |
 | `prebuild`, `pretest`, `pretest:all`, `pretest:integration`, `pretest:smoke` | `npm run ensure:native` |
-| `test` | `tsx --experimental-test-module-mocks tests/run.mts` — programmatic driver, `isolation:'process'` for subprocess DB isolation |
+| `test` | `tsx --experimental-test-module-mocks tests/run.mts` — programmatic driver, `isolation:'process'` + `concurrency:true` |
 | `test:all` | `tsx --experimental-test-module-mocks tests/run.mts --all` |
 | `test:integration` | `tsx --experimental-test-module-mocks --test tests/integration/*.test.ts` |
 | `test:coverage` | `tsx --experimental-test-module-mocks --experimental-test-coverage tests/run.mts --all` |
@@ -126,6 +126,26 @@ The policy change is user-scoped. Operators who must not change policy can use
 the cmd shim or direct Node entry point instead.
 
 ### Direct smoke utilities
+
+#### 테스트 격리는 프로세스 단위지 DB 단위가 아니다
+
+`tests/run.mts` 는 `isolation:'process'` 로 파일마다 자식 프로세스를 띄우지만, **모든
+자식이 `tests/setup/test-home.ts` 가 한 번 정한 같은 `CLI_JAW_HOME` 을 상속한다.** 즉
+프로세스는 갈라져도 `jaw.db` 는 하나다. 이 문장을 "subprocess DB isolation" 으로 읽으면
+없는 보장을 있다고 믿게 된다 (#521 조사에서 실제로 그 오독으로 잘못된 가설을 세웠다).
+
+실제로 스위트를 지켜주는 것은 두 가지다:
+
+- `src/core/db.ts` 의 `journal_mode = WAL` + `busy_timeout = 5000`. WAL 에서 리더는
+  라이터를 막지 않으므로 평범한 동시 접근은 잠금이 되지 않는다.
+- 파일별 opt-in 격리 `tests/setup/isolated-home.ts`. 이건 좁고 구체적인 위험
+  — `isAlive` 를 스텁한 전역 파괴적 sweep 이 다른 프로세스의 행을 지우는 경우 —
+  에만 필요하며, DB 를 여는 파일 전부가 아니라 그런 sweep 을 하는 파일만 넣는다.
+
+로그에서 `database is locked` 를 봤다고 곧장 경합이라고 결론내지 말 것.
+`tests/unit/memory-search-provider.test.ts` 는 `BEGIN IMMEDIATE` 를 4.2초 잡는 자식을
+**의도적으로** 띄워 재시도 경로를 검증하며, 그건 `jaw.db` 가 아니라 메모리 인덱스 DB다.
+통과하는 테스트의 정상 출력이다.
 
 | utility | command | purpose |
 | --- | --- | --- |


### PR DESCRIPTION
## What

A documentation fix that came out of a wrong diagnosis, which is the part worth reading.

`infra.md` described `tests/run.mts` as using `isolation:'process'` for **"subprocess DB isolation"**. Process isolation is real, but every child inherits the same `CLI_JAW_HOME` from `tests/setup/test-home.ts` — so they share one `jaw.db`. The phrase reads as a guarantee that does not exist.

## Why it mattered

Two receipt runs during this stack failed where direct runs passed, and both logs contained `SqliteError: database is locked`. That sentence made a shared-lock hypothesis plausible enough that I enumerated nine files and prepared to add per-file isolation to all of them.

An independent audit killed it on three counts, each verified directly:

- **It does not reproduce.** Three consecutive full runs, `8536 / 8510 pass / 0 fail`. This PR's receipt is a fourth.
- **WAL and `busy_timeout = 5000` have been enabled all along** (`src/core/db.ts:29-30`). The "fix at the source" I would have argued for was already in place.
- **The lock line is a deliberate fixture in a passing test.** `memory-search-provider.test.ts:178-195` spawns a child holding `BEGIN IMMEDIATE` for 4.2s to exercise a retry path — on the *memory index* database, not `jaw.db`.

And neither failing test touches SQLite: `bumpSessionOwnershipGeneration` is a plain in-memory counter. Six of the nine candidate files never open the database, two replace it with `mock.module`, and the one real writer already self-isolates by pid. The change would have altered nothing while looking like a fix.

## What this ships

The corrected description, plus a section recording what actually protects the suite: WAL, and narrow opt-in isolation via `tests/setup/isolated-home.ts` for the specific hazard it was built for — a global destructive sweep with a stubbed `isAlive` clobbering another process's rows. It also warns that a `database is locked` line in the log is normal output from that fixture, not a defect signature.

## What remains open

**The two failures are unexplained.** Four consecutive green runs means there is no captured failing run to diagnose. They are recorded as mock/reset-ordering candidates (`resetSessionOwnershipGenerationForTest`, `resetThreadPrefetchClaims`) rather than closed.

Per `TEST-ANTI-FLAKE-01`, "it passed on rerun" is not a fix — but neither is patching a mechanism that measurement says is not involved. The honest state is documented instead of papered over. Full record: `devlog/_plan/260904_issue_517_524_hardening/100_phase10_flake_investigation.md`.

## Verification

```
npm test                         8536 tests / 8510 pass / 0 fail
bash structure/verify-counts.sh  ALL PASS - 453/453
```

Refs #521
