### PR TITLE
fix(slack,agent): classify stall kills, downgrade oversized files, caption relayed images (#517/#519 r2)

### DIFF
--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -702,7 +702,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         // bypasses the generic retry/fallback path below. Surface that reason
         // before the final resolver turns the empty process output into the
         // channel's generic "no response" message.
-        const { message: errMsg } = classifyExitError(
+        const { message: errMsg, errorKind } = classifyExitError(
             runtimeCli,
             code,
             ctx.stderrBuf,
@@ -721,7 +721,10 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
         }
         broadcast(
             'agent_done',
-            { ...runTag(ctx), text: `❌ ${errMsg}`, error: true, origin, ...empTag },
+            // Classified like the retry-exhausted site below: a watchdog kill is
+            // the one failure the channel MUST show, and the forwarder gate
+            // drops anything without errorKind (#519 round 2).
+            { ...runTag(ctx), text: `❌ ${errMsg}`, error: true, errorKind, cli: runtimeCli, origin, ...empTag },
             isEmployee ? 'internal' : 'public',
         );
         finalizeTraceRun(ctx.traceRunId, 'error', errMsg);
@@ -822,7 +825,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
                 }
                 insertMessage.run('assistant', `⏱️ ${errMsg}`, cli, model, settings["workingDir"] || null, chatSessionId);
             }
-            broadcast('agent_done', { ...runTag(ctx), text: `❌ ${errMsg}`, error: true, origin, ...empTag, ...(wasSteer ? { steered: true } : {}) }, isEmployee ? 'internal' : 'public');
+            broadcast('agent_done', { ...runTag(ctx), text: `❌ ${errMsg}`, error: true, errorKind, cli: runtimeCli, origin, ...empTag, ...(wasSteer ? { steered: true } : {}) }, isEmployee ? 'internal' : 'public');
             finalizeTraceRun(ctx.traceRunId, 'error', errMsg);
             resolve({ text: '', code: 1 });
             if (mainManaged && !opts.internal) processQueue(scopeKey);

--- a/src/slack/forwarder.ts
+++ b/src/slack/forwarder.ts
@@ -7,6 +7,7 @@ import { settings } from '../core/config.js';
 import { log } from '../core/logger.js';
 import { extractLocalImagePaths } from '../messaging/extract-images.js';
 import type { RemoteTarget } from '../messaging/types.js';
+import { basename } from 'node:path';
 import { assertSendFilePath } from '../security/path-guards.js';
 import { sendSlackFile } from './slack-file.js';
 import { sendSlackText } from './send-only-client.js';
@@ -27,8 +28,13 @@ export async function relaySlackImages(
                 settings["workingDir"] || undefined,
                 settings["projectDirs"] || null,
             );
-            const result = await sendSlackFile(token, target, filePath,
-                options.signal ? { signal: options.signal } : {});
+            // The answer text was already posted by the caller; a bare file row
+            // under it read as "empty message" in the field (#517). Caption with
+            // the image's own name so the row says what it is, never the answer again.
+            const result = await sendSlackFile(token, target, filePath, {
+                caption: basename(filePath),
+                ...(options.signal ? { signal: options.signal } : {}),
+            });
             if (!result.ok) {
                 log.warn('[slack:image-relay] send failed', {
                     path: candidate,

--- a/src/slack/send-handler.ts
+++ b/src/slack/send-handler.ts
@@ -3,6 +3,8 @@
 
 import type { ChannelSendRequest } from '../messaging/send.js';
 import { slackTargetFromId } from '../messaging/slack-target.js';
+import { log } from '../core/logger.js';
+import type { ChannelOperation } from '../messaging/types.js';
 import { getSlackSendClient, resolveSlackDmChannel, sendSlackText } from './send-only-client.js';
 import { sendSlackFile } from './slack-file.js';
 
@@ -56,9 +58,30 @@ export async function slackSendHandler(
         }
         case 'photo':
         case 'document':
-        case 'voice':
+        case 'voice': {
             if (!req.filePath) return { ok: false, error: 'missing_file_path', status: 400 };
-            return sendSlackFile(client.token, target, req.filePath, req.caption ? { caption: req.caption } : {});
+            try {
+                return await sendSlackFile(client.token, target, req.filePath, req.caption ? { caption: req.caption } : {});
+            } catch (error) {
+                // validateSlackFileSize throws 413 BEFORE any upload call. After
+                // caption promotion (messaging/send.ts) the answer text lives only
+                // in req.caption, so an oversized file used to take the whole
+                // answer down with it — three 50 MiB+ refusals on suji, each with
+                // a full answer attached (#517 round 2). Deliver the words.
+                const status = (error as { statusCode?: number }).statusCode;
+                const body = (req.caption ?? req.text ?? '').trim();
+                if (status !== 413 || !body) throw error;
+                log.warn('[slack:send] file exceeds transport limit — delivering caption as text', {
+                    filePath: req.filePath,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+                const operation: ChannelOperation = req.type === 'voice' ? 'voice' : 'fileUpload';
+                const fallback = await sendSlackText(client.token, target, body);
+                return fallback.ok
+                    ? { ...fallback, downgraded: { operation, to: 'text' } }
+                    : fallback;
+            }
+        }
         default:
             return { ok: false, error: `unsupported_outbound_type_${String(req.type)}`, status: 400 };
     }

--- a/src/slack/send-handler.ts
+++ b/src/slack/send-handler.ts
@@ -4,6 +4,7 @@
 import type { ChannelSendRequest } from '../messaging/send.js';
 import { slackTargetFromId } from '../messaging/slack-target.js';
 import { log } from '../core/logger.js';
+import { logErrorText } from '../messaging/redact.js';
 import type { ChannelOperation } from '../messaging/types.js';
 import { getSlackSendClient, resolveSlackDmChannel, sendSlackText } from './send-only-client.js';
 import { sendSlackFile } from './slack-file.js';
@@ -71,10 +72,10 @@ export async function slackSendHandler(
                 const status = (error as { statusCode?: number }).statusCode;
                 const body = (req.caption ?? req.text ?? '').trim();
                 if (status !== 413 || !body) throw error;
-                log.warn('[slack:send] file exceeds transport limit — delivering caption as text', {
-                    filePath: req.filePath,
-                    error: error instanceof Error ? error.message : String(error),
-                });
+                // The filename is agent-chosen text and the message quotes the
+                // size; both go through the masker like every other channel sink
+                // (gate:redaction-sinks).
+                log.warn('[slack:send] file exceeds transport limit — delivering caption as text', logErrorText(error));
                 const operation: ChannelOperation = req.type === 'voice' ? 'voice' : 'fileUpload';
                 const fallback = await sendSlackText(client.token, target, body);
                 return fallback.ok

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -328,6 +328,8 @@ static → employees → heartbeat → skills → jaw-memory → orchestrate
 | `orchestrate_done` / `orchestrate_warning` | orchestration 완료/실패 + 비차단 경고 |
 | `request_settled` | 요청 하나의 최종 결말 (`completed｜steered｜merged｜failed｜cancelled｜dropped｜skipped`). `src/orchestrator/request-registry.ts`의 `settleOnce()`가 멱등이라 요청당 정확히 한 번 발생한다. `orchestrate_done`을 대체하지 않고 보완한다 — steer 성공처럼 완료 이벤트가 없는 경로를 덮기 위한 것. 전체 payload 스키마는 `structure/stream-events.md` 참고 (#276) |
 | `steer_started` | `/steer` 또는 pending queue steer가 새 프롬프트를 accepted 상태로 전환 |
+| `steer_rejected` | in-band steer 가 거부됨 — `reason: 'turn-not-steerable'` (review/compact 중 등). payload `{ prompt, origin, scope, sessionId, reason, requestId? }` (`src/agent/spawn.ts`, #533) |
+| `steer_context_lost` | kill-steer 에서 중단된 턴의 부분 출력을 salvage 하지 못함. payload `{ origin, scope, sessionId, requestId? }`. Web UI(`public/js/ws.ts`)가 경고 배너로 표시 (#533) |
 | `agent_added` / `agent_updated` / `agent_deleted` | employee CRUD 반영 |
 | `agent:claude-e:runtime_started` / `agent:claude-e:spawned` / `agent:claude-e:session` / `agent:claude-e:prompt_injected` | Claude E native helper start/session/prompt lifecycle bridge |
 | `agent:claude-e:stop` / `agent:claude-e:stop_failure` / `agent:claude-e:interrupted` / `agent:claude-e:cleanup` / `agent:claude-e:error` | Claude E native helper stop/error lifecycle bridge |

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -287,7 +287,7 @@ cli-jaw/
 │   │   ├── inbound-url.ts    ← 인바운드 다운로드 URL 검증 (Slack host allowlist + https-only hop + 사설망 거부) (44L) ✨
 │   │   ├── send-only-client.ts ← bot-token 전용 outbound + conversations.open DM 해석 (180L)
 │   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (filename caption) (87L)
-│   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 + 413 텍스트 다운그레이드 (88L)
+│   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 + 413 텍스트 다운그레이드 (89L)
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (161L)
 │   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (179L) ✨
 │   │   ├── allowlist-audit.ts ← channelIds 변경 방향 분류 + 축소 감사 기록 (게이트 리더 기준 정규화, route·settings watcher 양쪽이 공유) (125L) ✨

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -94,7 +94,7 @@ cli-jaw/
 │   │   ├── agy-capabilities.ts ← AGY `--help`/`--version` capability probe + cached optional flag support map + legacy emit-all fallback marker (124L)
 │   │   ├── agy-transcript-watcher.ts ← AGY transcript/log watcher and session-id extraction support (291L)
 │   │   ├── pi-runtime.ts     ← Pi profile 정규화 + isolated `PI_CODING_AGENT_DIR` models/settings 생성 + `pi --offline --list-models` discovery + `pi --mode rpc` JSONL parser/spawner (803L) ✨
-│   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1262L)
+│   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1265L)
 │   │   ├── jwc-runtime.ts    ← resident/in-process JWC runtime bridge and event handling (222L)
 │   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (253L)
 │   │   ├── kiro-models.ts    ← Kiro live model inventory (KiroModelEntry, KiroModelInventory, parseKiroModelListJson, fetchKiroModelInventory) (98L)
@@ -286,8 +286,8 @@ cli-jaw/
 │   │   ├── inbound-file.ts   ← 인바운드 첨부 단일 IO owner (files.info → 인증 스트리밍 다운로드 → saveUpload, 파일/메시지 바이트 예산, 고정 error code) (280L) ✨
 │   │   ├── inbound-url.ts    ← 인바운드 다운로드 URL 검증 (Slack host allowlist + https-only hop + 사설망 거부) (44L) ✨
 │   │   ├── send-only-client.ts ← bot-token 전용 outbound + conversations.open DM 해석 (180L)
-│   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (81L)
-│   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 (65L)
+│   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (filename caption) (87L)
+│   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 + 413 텍스트 다운그레이드 (88L)
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (161L)
 │   │   ├── scope-status.ts   ← OAuth grant drift 단일 소유자 (auth.test의 x-oauth-scopes를 manifest 요구 집합과 대조, 미관측을 '이상 없음'과 구분, doctor·health·identity 경고가 공유) (179L) ✨
 │   │   ├── allowlist-audit.ts ← channelIds 변경 방향 분류 + 축소 감사 기록 (게이트 리더 기준 정규화, route·settings watcher 양쪽이 공유) (125L) ✨

--- a/structure/stream-events.md
+++ b/structure/stream-events.md
@@ -86,7 +86,7 @@ SSE behavior:
 | `agent_status` | `{ running? \| status?, agentId, cli?, isEmployee?, phase?, phaseLabel? }` | `spawn.ts`, `lifecycle-handler.ts`, `orchestrator/distribute.ts`; agent 실행/종료/worker phase |
 | `agent_tool` | `{ agentId, icon, label, toolType?, detail?, stepRef?, status?, isEmployee? }` | `agent/events.ts`, `spawn.ts`; CLI/ACP tool, thinking, search, subagent step |
 | `agent_output` | `{ agentId, cli, text, isEmployee? }` | `spawn.ts`; live preview chunk, including AGY plain stdout |
-| `agent_done` | `{ text, toolLog?, error?, origin?, isEmployee? }` | `lifecycle-handler.ts`, `spawn.ts`, `server.ts`; authoritative final/error |
+| `agent_done` | `{ text, toolLog?, error?, errorKind?, cli?, origin?, isEmployee? }` | `lifecycle-handler.ts`, `spawn.ts`, `server.ts`; authoritative final/error. `errorKind` (`rate_limit|auth|stall|connection|exit`) + `cli` 는 분류된 실패에만 실리며, Slack/Discord forwarder 는 이 필드가 없는 error 페이로드를 채널로 내보내지 않는다 (#519) |
 | `agent_retry` | `{ cli, delay, reason, attempt?, maxRetries?, isEmployee? }` | 429/transient retry 안내. Main runs use exponential backoff up to 3 attempts; employee transient retries use a shorter backoff up to 2 attempts. |
 | `agent_fallback` | `{ from, to, reason, isEmployee? }` | fallback CLI 전환 안내 |
 | `agent_smoke` | `{ cli, confidence, reason, agentId, isEmployee? }` | smoke response auto-continue 안내 |

--- a/tests/unit/lifecycle-error-forwarding.test.ts
+++ b/tests/unit/lifecycle-error-forwarding.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleAgentExit } from '../../src/agent/lifecycle-handler.ts';
+import { createSlackForwarder } from '../../src/slack/forwarder.ts';
+import { addBroadcastListener, removeBroadcastListener } from '../../src/core/bus.ts';
+
+// #519 round 2: the two stall branches of handleAgentExit emitted error:true
+// without errorKind, so the very failure the user most needs to see (a watchdog
+// kill after minutes of silence) was the one the Slack/Discord gate dropped.
+// This drives the REAL exit handler into the REAL forwarder through the bus.
+
+function stallParams(overrides: Record<string, unknown> = {}) {
+    return {
+        ctx: { fullText: '', sessionId: null, toolLog: [], traceLog: [], stderrBuf: '', stallReason: 'absolute timeout 2045s' },
+        code: 124, cli: 'codex', model: 'test', resumeKey: null, agentLabel: 'Boss', mainManaged: true,
+        origin: 'web', prompt: 'test', opts: {}, cfg: {}, ownerGeneration: 1,
+        persistenceOwner: { global: 0, scope: 0 }, forceNew: false, empSid: null, isResume: false,
+        wasKilled: true, wasSteer: false, smokeResult: { isSmoke: false, confidence: 'low', reason: '' },
+        effortDefault: 'medium', costLine: '', resolve: () => {}, activeProcesses: new Map(), scopeKey: 'lef-test',
+        chatSessionId: 'lef-test', childProcess: null, releaseMainRun: () => false,
+        retryState: { setTimer: () => {}, setResolve: () => {}, setOrigin: () => {}, setIsEmployee: () => {} },
+        fallbackState: new Map(), fallbackMaxRetries: 1, processQueue: () => {},
+        ...overrides,
+    } as never;
+}
+
+async function runStall(overrides: Record<string, unknown> = {}) {
+    const realFetch = globalThis.fetch;
+    let fetches = 0;
+    globalThis.fetch = (async () => {
+        fetches++;
+        return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+    const seen: Record<string, unknown>[] = [];
+    const capture = (type: string, data: Record<string, unknown>) => { if (type === 'agent_done') seen.push(data); };
+    const forward = createSlackForwarder({
+        getToken: () => 'xoxb-test',
+        getLastTarget: () => ({ channel: 'slack', targetKind: 'channel', peerKind: 'channel', targetId: 'C1' }),
+    });
+    addBroadcastListener(capture);
+    addBroadcastListener(forward);
+    try {
+        await handleAgentExit(stallParams(overrides));
+        await new Promise((r) => setTimeout(r, 20));
+        return { payload: seen[0], fetches };
+    } finally {
+        removeBroadcastListener(capture);
+        removeBroadcastListener(forward);
+        globalThis.fetch = realFetch;
+    }
+}
+
+test('LEF-001: a watchdog kill (wasKilled + stallReason) reaches Slack as a classified stall', async () => {
+    const { payload, fetches } = await runStall();
+    assert.equal(payload?.error, true);
+    assert.equal(payload?.errorKind, 'stall', 'the kill branch must carry the classifier kind');
+    assert.equal(payload?.cli, 'codex');
+    assert.equal(fetches, 1, 'the forwarder gate must let it through');
+});
+
+test('LEF-002: a non-killed stall exit (isStall branch) is classified the same way', async () => {
+    const { payload, fetches } = await runStall({ wasKilled: false, code: 1,
+        ctx: { fullText: '', sessionId: null, toolLog: [], traceLog: [], stderrBuf: 'stall detected', stallReason: 'no output for 900s' } });
+    assert.equal(payload?.errorKind, 'stall');
+    assert.equal(fetches, 1);
+});

--- a/tests/unit/slack-forwarding.test.ts
+++ b/tests/unit/slack-forwarding.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { settings } from '../../src/core/config.ts';
+import { createSlackForwarder } from '../../src/slack/forwarder.ts';
+
+// #517 round 2: the forwarder posts text, then relays local images with a
+// filename caption. Nothing executed that order or the caption before — bot
+// tests mocked relaySlackImages to a no-op.
+
+type Seen = { url: string; body: Record<string, unknown> };
+function fakeFetch(log: Seen[]) {
+    return (async (url: string | URL | Request, init?: RequestInit) => {
+        let body: Record<string, unknown> = {};
+        const raw = init?.body;
+        if (typeof raw === 'string') { try { body = JSON.parse(raw); } catch { /* multipart */ } }
+        log.push({ url: String(url), body });
+        const payload = /getUploadURLExternal/.test(String(url))
+            ? { ok: true, upload_url: 'https://files.slack.com/up', file_id: 'F1' }
+            : { ok: true, ts: '1.1' };
+        return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
+    }) as unknown as typeof fetch;
+}
+
+test('SFW-001: text goes first, then each image is relayed with its filename as caption', async () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'sfw-')));
+    const img = join(dir, 'chart.png');
+    writeFileSync(img, 'png');
+    const log: Seen[] = [];
+    const priorFetch = globalThis.fetch;
+    const priorWorkingDir = settings['workingDir'];
+    globalThis.fetch = fakeFetch(log);
+    settings['workingDir'] = dir;
+    try {
+        const forward = createSlackForwarder({
+            getToken: () => 'xoxb-t',
+            getLastTarget: () => ({ channel: 'slack', targetKind: 'channel', peerKind: 'channel', targetId: 'C1' }),
+        });
+        await forward('agent_done', { text: `done\n![chart](${img})` });
+        assert.match(log[0]!.url, /chat\.postMessage/, 'the answer text is posted first');
+        const complete = log.find((l) => /completeUploadExternal/.test(l.url));
+        assert.ok(complete, 'the image was relayed');
+        assert.equal(complete!.body['initial_comment'], 'chart.png');
+        assert.ok(log.indexOf(complete!) > 0, 'relay happens after the text post');
+    } finally {
+        globalThis.fetch = priorFetch;
+        settings['workingDir'] = priorWorkingDir;
+    }
+});

--- a/tests/unit/slack-outbound.test.ts
+++ b/tests/unit/slack-outbound.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, openSync, ftruncateSync, closeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -869,4 +869,43 @@ test('SOR-004: the filename is masked everywhere it reaches Slack', async () => 
     const files = bodyOf(complete!).files as Array<{ title?: string }>;
     assert.ok(files?.[0]?.title, 'the file must still have a title');
     assert.ok(!files[0]!.title!.includes(FAKE_APP_TOKEN));
+});
+
+
+// ─── #517 round 2: oversized file → caption-as-text downgrade ──────
+
+test('SO-413: an oversized file send delivers its caption as text instead of losing the answer', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'slack-huge-'));
+    const path = join(dir, 'huge.bin');
+    const fh = openSync(path, 'w'); ftruncateSync(fh, 50 * 1024 * 1024 + 1); closeSync(fh); // sparse
+    const seen: string[] = [];
+    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+        seen.push(`${String(url)}|${String(init?.body)}`);
+        return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, ts: '1.2' }) } as unknown as Response;
+    // justified: same minimal Response harness as the keyboard downgrade test
+    }) as unknown as typeof fetch;
+    const priorFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+        const result = await withSlack({ enabled: true, botToken: 'xoxb-t' }, () =>
+            slackSendHandler({ type: 'photo', filePath: path, caption: 'the answer body', target: slackTargetFromId('C1') }));
+        assert.equal(result.ok, true);
+        assert.deepEqual(result['downgraded'], { operation: 'fileUpload', to: 'text' });
+        assert.equal(seen.length, 1, 'zero upload calls, one chat.postMessage');
+        assert.ok(seen[0]!.includes('chat.postMessage') && seen[0]!.includes('the answer body'));
+    } finally {
+        globalThis.fetch = priorFetch;
+    }
+});
+
+test('SO-413b: an oversized file with no text still refuses (nothing to downgrade to)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'slack-huge-'));
+    const path = join(dir, 'huge.bin');
+    const fh = openSync(path, 'w'); ftruncateSync(fh, 50 * 1024 * 1024 + 1); closeSync(fh);
+    await withSlack({ enabled: true, botToken: 'xoxb-t' }, async () => {
+        await assert.rejects(
+            () => slackSendHandler({ type: 'document', filePath: path, target: slackTargetFromId('C1') }),
+            (e: { statusCode?: number }) => e.statusCode === 413,
+        );
+    });
 });


### PR DESCRIPTION
## Round 2 of #517–#524 — deploy blockers

The 2026-09-05 field audit found the round-1 fixes were attached beside the symptom paths. This PR fixes the three things that would make a release *worse* than what suji runs today, plus the local release gate.

| Symptom | Root cause (verified by execution) | Fix |
|---|---|---|
| `⏱️ 응답 없음 — absolute timeout 2045s` reaches Slack today but would be **dropped** after #529 | `lifecycle-handler` kill-stall and `isStall` branches emit `agent_done error:true` without `errorKind`; the #529 gate requires it (21 emitters, only 1 tagged) | both branches carry the classifier's `errorKind` + `cli` |
| 50 MiB+ file → whole answer lost (3× on suji) | after #528's caption promotion the answer lives only in `req.caption`; `validateSlackFileSize` throws 413 before any upload, no fallback | 413 with text → post the text, `downgraded: {fileUpload\|voice → text}`; 413 without text still throws |
| file rows under an answer read as "empty message" | `relaySlackImages` sent no caption (text itself was already posted) | caption = `basename(file)`; the answer is never repeated |
| `npm run gate:all` fails locally (CI skips doc-drift) | #533 added `steer_rejected`/`steer_context_lost` without catalog rows | rows added |

Tests: `lifecycle-error-forwarding` (real `handleAgentExit` → real Slack forwarder via the bus, RED on the old tree), `slack-forwarding` SFW-001 (text → upload order + caption), `slack-outbound` SO-413/SO-413b. Independent verifier also drove Discord and Telegram forwarders: each delivers the stall once.

`npm test`: 8541 / 0 fail (baseline 8536 / 0). typecheck, build, doc-drift, verify-counts all green.

Plan: `devlog/_plan/260905_517_524_round2/010_phase1_deploy_blockers.md`. Refs #517 #519 #533
