### PR TITLE
feat(prompt): runtime-conditional Desktop / Browser Control section — 7.8K headroom without raising the A-1 budget (#524 r2)

### DIFF
--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -314,7 +314,9 @@ const SESSION_POLL_ANCHOR_CLOSE = '<!-- /anchor:session-poll -->';
 const DESKTOP_CONTROL_INTENT_RE = /(?:\$?computer-use|\bdesktop\b|\bbrowser\b|\bcdp\b|\burl\b|\bui[\s-]*qa\b|브라우저|화면|스크린샷)/iu;
 // Proper-noun app names: word-bounded and case-sensitive so that "release notes",
 // "keyword", or "search" do not read as Notes / Word / Arc and pull in the 8K block.
-const DESKTOP_APP_NAME_RE = /\b(?:Finder|System Settings|Chrome|Safari|Microsoft Edge|Firefox|Arc|Spotify|Excel|Word|PowerPoint|Slack|Discord|Telegram|Calendar|Reminders|Notes)\b/u;
+// Excel / Word / PowerPoint are deliberately absent: those names almost always
+// mean a FILE to produce (the officecli path), not an app to drive.
+const DESKTOP_APP_NAME_RE = /\b(?:Finder|System Settings|Chrome|Safari|Microsoft Edge|Firefox|Arc|Spotify|Slack|Discord|Telegram|Calendar|Reminders|Notes)\b/u;
 const DESKTOP_SKILL_METADATA_RE = /(?:desktop|browser|computer-use|\bcdp\b|브라우저|화면|스크린샷)/iu;
 
 export function shouldIncludeDesktopControlSection(currentPrompt: string, activeCli?: string | null): boolean {

--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -311,6 +311,46 @@ const DASHBOARD_CONNECTOR_ANCHOR_OPEN = '<!-- anchor:dashboard-connector-intent 
 const DASHBOARD_CONNECTOR_ANCHOR_CLOSE = '<!-- /anchor:dashboard-connector-intent -->';
 const SESSION_POLL_ANCHOR_OPEN = '<!-- anchor:session-poll -->';
 const SESSION_POLL_ANCHOR_CLOSE = '<!-- /anchor:session-poll -->';
+const DESKTOP_CONTROL_INTENT_RE = /(?:\$?computer-use|\bdesktop\b|\bbrowser\b|\bcdp\b|\burl\b|\bui[\s-]*qa\b|브라우저|화면|스크린샷)/iu;
+// Proper-noun app names: word-bounded and case-sensitive so that "release notes",
+// "keyword", or "search" do not read as Notes / Word / Arc and pull in the 8K block.
+const DESKTOP_APP_NAME_RE = /\b(?:Finder|System Settings|Chrome|Safari|Microsoft Edge|Firefox|Arc|Spotify|Excel|Word|PowerPoint|Slack|Discord|Telegram|Calendar|Reminders|Notes)\b/u;
+const DESKTOP_SKILL_METADATA_RE = /(?:desktop|browser|computer-use|\bcdp\b|브라우저|화면|스크린샷)/iu;
+
+export function shouldIncludeDesktopControlSection(currentPrompt: string, activeCli?: string | null): boolean {
+    const prompt = String(currentPrompt || '').trim();
+    const routingText = `${prompt}\n${activeCli || ''}`;
+    if (DESKTOP_CONTROL_INTENT_RE.test(routingText) || DESKTOP_APP_NAME_RE.test(routingText)) return true;
+
+    const normalizedPrompt = prompt.toLowerCase();
+    try {
+        return loadActiveSkills().some(skill => {
+            if (!skill) return false;
+            const metadata = [
+                skill.id,
+                skill.name,
+                skill.description,
+                ...skill.keywords,
+                ...skill.triggers,
+            ].join(' ');
+            if (!DESKTOP_SKILL_METADATA_RE.test(metadata)) return false;
+            return [skill.id, skill.name].some(name => {
+                const routedName = String(name || '').trim().toLowerCase();
+                return routedName.length > 0
+                    && (normalizedPrompt.includes(routedName) || normalizedPrompt.includes(`$${routedName}`));
+            });
+        });
+    } catch {
+        return false;
+    }
+}
+
+function omitDesktopControlSection(a1: string): string {
+    const topology = findAnchorTopology(a1, DESKTOP_CONTROL_ANCHOR_OPEN, DESKTOP_CONTROL_ANCHOR_CLOSE);
+    const block = extractAnchorBlock(a1, DESKTOP_CONTROL_ANCHOR_OPEN, DESKTOP_CONTROL_ANCHOR_CLOSE);
+    if (topology.kind !== 'single' || !block) return a1;
+    return `${a1.slice(0, topology.start).trimEnd()}\n\n${a1.slice(topology.end).trimStart()}`;
+}
 
 function extractAnchorBlock(rendered: string, open: string, close: string): string | null {
     const start = rendered.indexOf(open);
@@ -731,13 +771,18 @@ function getCurrentSessionIdentityLine(): string {
 export function getSystemPrompt(opts: { currentPrompt?: string; forDisk?: boolean; memorySnapshot?: string; activeCli?: string; freshSession?: boolean } = {}) {
     const forDisk = opts.forDisk === true;
     const diskWorkingDir = forDisk ? resolveDiskWorkingDir() : '';
-    // A-1: file takes priority (user-editable), rendered template fallback
-    const a1 = fs.existsSync(A1_PATH) ? fs.readFileSync(A1_PATH, 'utf8') : getA1Content();
+    const currentPrompt = String(opts.currentPrompt || '').trim();
+    // A-1: file takes priority (user-editable), rendered template fallback.
+    // Runtime prompts drop desktop-control unless the current turn routes there;
+    // persisted A-1.md and forDisk B.md/AGENTS.md remain complete.
+    const persistedA1 = fs.existsSync(A1_PATH) ? fs.readFileSync(A1_PATH, 'utf8') : getA1Content();
+    const a1 = forDisk || shouldIncludeDesktopControlSection(currentPrompt, opts.activeCli)
+        ? persistedA1
+        : omitDesktopControlSection(persistedA1);
     const rawA2 = fs.existsSync(A2_PATH) ? fs.readFileSync(A2_PATH, 'utf8') : '';
     const a2 = forDisk ? renderA2ForDisk(rawA2, diskWorkingDir) : rawA2;
     let prompt = `${a1}\n\n${a2}`;
     // Project root is now injected per-message in spawn.ts (user prompt wrapper)
-    const currentPrompt = String(opts.currentPrompt || '').trim();
 
     // Phase 15: Telegram guidance is now part of A1_CONTENT (hardcoded)
     // No dynamic injection needed — Bot-First policy with curl examples included

--- a/structure/prompt_basic_A1.md
+++ b/structure/prompt_basic_A1.md
@@ -20,10 +20,11 @@ aliases: [A1 system prompt, CLI-JAW A1, system prompt template]
 
 | 단계 | 동작 | 코드 |
 |---|---|---|
-| 1 | `A-1.md` 존재 시 파일 내용을 그대로 사용 | `getSystemPrompt()` |
-| 2 | `A-1.md`가 없으면 `a1-system.md`를 렌더링해서 사용 | `getA1Content()` |
-| 3 | 첫 설치 시 `initPromptFiles()`가 `A-1.md`와 `.hash`를 생성 | `initPromptFiles()` |
-| 4 | 해시가 달라졌을 때 사용자 편집본이면 보존, stock 파일이면 새 템플릿으로 이관 | `resolveLegacyA1Migration()` |
+| 1 | `A-1.md` 존재 시 이를 persisted 원본으로 사용 | `getSystemPrompt()` |
+| 2 | `A-1.md`가 없으면 `a1-system.md`를 렌더링한 원본 사용 | `getA1Content()` |
+| 3 | 런타임은 desktop/browser 의도일 때만 원본의 `desktop-control` anchor를 포함; `forDisk`는 항상 원본 유지 | `shouldIncludeDesktopControlSection()` / `getSystemPrompt()` |
+| 4 | 첫 설치 시 `initPromptFiles()`가 `A-1.md`와 `.hash`를 생성 | `initPromptFiles()` |
+| 5 | 해시가 달라졌을 때 사용자 편집본이면 보존, stock 파일이면 새 템플릿으로 이관 | `resolveLegacyA1Migration()` |
 
 > 핵심은 "파일 우선, 템플릿 폴백"이다. 예전처럼 코드 상수 하나로 고정된 구조가 아니다.
 

--- a/structure/prompt_basic_B.md
+++ b/structure/prompt_basic_B.md
@@ -24,7 +24,7 @@ aliases: [B prompt cache, CLI-JAW B prompt, regenerated prompt]
 | `~/.cli-jaw/prompts/B.md` | 디스크 캐시 |
 | `{workDir}/AGENTS.md` | 현재 워크스페이스용 지침 파일 |
 
-`AGENTS.md`는 Codex, Copilot, OpenCode가 직접 읽는 런타임 지침이라서, B.md와 같은 본문을 공유한다.
+`AGENTS.md`는 Codex, Copilot, OpenCode가 직접 읽는 런타임 지침이라서, B.md와 같은 본문을 공유한다. `forDisk: true`이므로 persisted A-1의 `desktop-control` anchor를 항상 유지하고, 조건부 제외는 turn별 `forDisk: false` 조립에만 적용한다.
 
 ---
 

--- a/structure/prompt_flow.md
+++ b/structure/prompt_flow.md
@@ -51,7 +51,7 @@ graph TD
 - 템플릿 폴백: `src/prompt/templates/a1-system.md`
 - 역할: 시스템 규칙, browser control, memory/heartbeat, jaw employee vs CLI sub-agent 구분, 채널 전송 규칙
 
-핵심은 "파일 우선, 템플릿 폴백"이다. `A-1.md`가 있으면 그대로 쓰고, 없을 때만 템플릿을 렌더한다.
+핵심은 "파일 우선, 템플릿 폴백"이다. 디스크 원본은 그대로 보존한다. `forDisk: false` 런타임 조립만 현재 prompt/active skill routing이 desktop/browser 의도를 가질 때 `desktop-control` anchor를 포함하고, 그 외에는 단일 정상 anchor block을 제외한다.
 
 ### A-2.md
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -178,7 +178,7 @@ cli-jaw/
 │   │   ├── sanitize.ts       ← Interview tracker strip helper + stripPhaseAttestation re-export (79L)
 │   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> + C→D binary/raster artifact observation hard-block + stripPhaseAttestation + warn-only no-state narration detector (370L)
 │   ├── prompt/               ← 프롬프트 조립 (4 files + templates/ 10 files)
-│   │   ├── builder.ts        ← runtime-only desktop-control 조건부 주입(shouldIncludeDesktopControlSection, persisted A-1 불변) + A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1256L)
+│   │   ├── builder.ts        ← runtime-only desktop-control 조건부 주입(shouldIncludeDesktopControlSection, persisted A-1 불변) + A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1258L)
 │   │   ├── runtime-context.ts ← 런타임 컨텍스트 주입 (RuntimeContextEntry, loadEntries, getActiveEntries, addEntry, removeEntry, clearAll, buildInjectionBlock) (80L)
 │   │   ├── soul-bootstrap-prompt.ts ← LLM 기반 soul.md 개인화 부트스트랩 프롬프트 빌더 (52L)
 │   │   ├── template-loader.ts ← 프롬프트 템플릿 로더 (50L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -178,7 +178,7 @@ cli-jaw/
 │   │   ├── sanitize.ts       ← Interview tracker strip helper + stripPhaseAttestation re-export (79L)
 │   │   └── attestation.ts    ← Phase60 PABCD evidence gate: parse/validate <phase_attestation> + C→D binary/raster artifact observation hard-block + stripPhaseAttestation + warn-only no-state narration detector (370L)
 │   ├── prompt/               ← 프롬프트 조립 (4 files + templates/ 10 files)
-│   │   ├── builder.ts        ← A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1211L)
+│   │   ├── builder.ts        ← runtime-only desktop-control 조건부 주입(shouldIncludeDesktopControlSection, persisted A-1 불변) + A-1/A-2 + 스킬 + 직원 프롬프트 v2 + promptCache (4-segment key: emp:role:phase:workingDir) + on-demand dev skill path contract + advanced memory mode branch + bounded disk soul/instance context + task snapshot injection + dashboard-connector anchor preserve + Phase60 inline PABCD guide --attest evidence note (1256L)
 │   │   ├── runtime-context.ts ← 런타임 컨텍스트 주입 (RuntimeContextEntry, loadEntries, getActiveEntries, addEntry, removeEntry, clearAll, buildInjectionBlock) (80L)
 │   │   ├── soul-bootstrap-prompt.ts ← LLM 기반 soul.md 개인화 부트스트랩 프롬프트 빌더 (52L)
 │   │   ├── template-loader.ts ← 프롬프트 템플릿 로더 (50L)

--- a/tests/unit/prompt-slim-contract.test.ts
+++ b/tests/unit/prompt-slim-contract.test.ts
@@ -3,10 +3,24 @@
 // replace inlined bodies, retained sections stay, and the template cannot
 // silently regrow past its budget.
 
+import '../setup/isolated-home.ts';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { SKILLS_DIR } from '../../src/core/config.ts';
+import { A2_PATH, getSystemPrompt, shouldIncludeDesktopControlSection } from '../../src/prompt/builder.ts';
+
+const A2_MARKER = 'PSC-A2-BOUNDARY-7f21';
+
+function runtimeA1(currentPrompt: string): string {
+    mkdirSync(dirname(A2_PATH), { recursive: true });
+    writeFileSync(A2_PATH, A2_MARKER, 'utf8');
+    const prompt = getSystemPrompt({ currentPrompt, activeCli: 'codex-app', forDisk: false });
+    const boundary = prompt.indexOf(`\n\n${A2_MARKER}`);
+    assert.ok(boundary > 0, 'A2 marker must delimit the runtime A-1');
+    return prompt.slice(0, boundary);
+}
 
 const root = join(import.meta.dirname, '..', '..');
 const a1Src = readFileSync(join(root, 'src/prompt/templates/a1-system.md'), 'utf8');
@@ -24,13 +38,13 @@ test('PSC-001: externalized sections carry strong MUST-READ skill stubs', () => 
     assert.ok(a1Src.includes('MUST read `{{JAW_HOME}}/skills/jaw-diagram/SKILL.md` before writing any output'), 'diagram read stays mandatory');
 });
 
-test('PSC-002: retained backbone sections are untouched by the slim', () => {
-    assert.ok(a1Src.includes('## Desktop / Browser Control (MANDATORY)'), 'desktop control stays (deferred by decision)');
-    assert.ok(a1Src.includes('### Compact Handoff Interpretation'), 'compact interpretation stays (always-on by decision)');
-    // round-2 (260610 phase 2, interview Q1=(a)): Goal Mode Rules moved to the
-    // continuation prompt (single owner); A-1 keeps the command list + pointer.
+test('PSC-002: desktop control stays persisted but runtime routing is conditional', () => {
+    assert.ok(a1Src.includes('## Desktop / Browser Control (MANDATORY)'), 'persisted A-1 keeps desktop control');
+    assert.equal(shouldIncludeDesktopControlSection('브라우저에서 이 페이지를 확인해', 'codex-app'), true);
+    assert.equal(shouldIncludeDesktopControlSection('릴리스 노트를 요약해', 'codex-app'), false);
+    assert.ok(a1Src.includes('### Compact Handoff Interpretation'), 'compact interpretation stays always-on');
     assert.ok(a1Src.includes('## Goal System'), 'goal CLI command list stays in A-1');
-    assert.ok(!a1Src.includes('### Goal Mode Rules'), 'goal mode rules moved to continuation (round-1 always-on decision superseded)');
+    assert.ok(!a1Src.includes('### Goal Mode Rules'), 'goal mode rules stay in continuation only');
     assert.ok(a1Src.includes('Korean "검색" intent guard'), 'korean search guard heading stays');
 });
 
@@ -97,5 +111,33 @@ test('PSC-006: A-1 template stays under its size budget', () => {
     // second routes 윤문/답변 구성 to jaw-dev-write / jaw-dev-speech, and a routing
     // line the agent never sees routes nothing. The depth lives in those skills;
     // only the trigger is here.
-    assert.ok(a1Src.length <= 38750, `a1-system.md is ${a1Src.length} chars — over the 38,750 budget`);
+    const alwaysOnA1 = runtimeA1('Summarize the release notes.');
+    assert.ok(alwaysOnA1.length <= 38750,
+        `runtime A-1 is ${alwaysOnA1.length} chars — over the 38,750 budget`);
+});
+
+test('PSC-007: getSystemPrompt includes desktop control for Korean browser intent', () => {
+    const prompt = runtimeA1('브라우저에서 URL을 열고 화면 스크린샷을 확인해');
+    assert.match(prompt, /## Desktop \/ Browser Control \(MANDATORY\)/);
+});
+
+test('PSC-008: getSystemPrompt excludes desktop control otherwise and saves at least 8,000 chars', () => {
+    const included = runtimeA1('브라우저에서 이 페이지를 확인해');
+    const excluded = runtimeA1('변경된 릴리스 노트를 세 문장으로 요약해');
+    assert.doesNotMatch(excluded, /## Desktop \/ Browser Control \(MANDATORY\)/);
+    assert.ok(included.length - excluded.length >= 8000,
+        `desktop-control removal saved only ${included.length - excluded.length} chars`);
+});
+
+test('PSC-009: a routed active skill with desktop/browser metadata includes the section', () => {
+    const skillDir = join(SKILLS_DIR, 'window-driver');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: window-driver',
+        'description: "Controls desktop windows through native UI"',
+        '---',
+    ].join('\n'), 'utf8');
+    assert.match(runtimeA1('Use $window-driver to finish this task.'),
+        /## Desktop \/ Browser Control \(MANDATORY\)/);
 });

--- a/tests/unit/prompt-slim-contract.test.ts
+++ b/tests/unit/prompt-slim-contract.test.ts
@@ -42,6 +42,9 @@ test('PSC-002: desktop control stays persisted but runtime routing is conditiona
     assert.ok(a1Src.includes('## Desktop / Browser Control (MANDATORY)'), 'persisted A-1 keeps desktop control');
     assert.equal(shouldIncludeDesktopControlSection('브라우저에서 이 페이지를 확인해', 'codex-app'), true);
     assert.equal(shouldIncludeDesktopControlSection('릴리스 노트를 요약해', 'codex-app'), false);
+    // An Office document is a file to produce, not an app to drive (verifier residual).
+    assert.equal(shouldIncludeDesktopControlSection('Excel 파일 만들어', 'codex-app'), false);
+    assert.equal(shouldIncludeDesktopControlSection('use Chrome to open it', 'codex-app'), true);
     assert.ok(a1Src.includes('### Compact Handoff Interpretation'), 'compact interpretation stays always-on');
     assert.ok(a1Src.includes('## Goal System'), 'goal CLI command list stays in A-1');
     assert.ok(!a1Src.includes('### Goal Mode Rules'), 'goal mode rules stay in continuation only');


### PR DESCRIPTION
## #524 round 2 — A-1 prompt budget, option (b)

`a1-system.md` sat at **38,688 of 38,750** chars — 62 of headroom, raised seven times, and both #518 and #519 wanted lines in it. Rather than raise the number an eighth time, the 8.4K `## Desktop / Browser Control` block (already behind its own `desktop-control` anchor) becomes **runtime-conditional**:

- `getSystemPrompt` keeps it when the current turn names computer-use, desktop/browser/CDP/URL/UI-QA terms (or 브라우저/화면/스크린샷), a desktop app by proper name, or routes to an active skill whose metadata is about desktop/browser.
- Otherwise the anchor block is omitted from the **runtime copy only**. Persisted `A-1.md`, `forDisk` B.md/AGENTS.md, and anchor migration are untouched (verifier: `forDisk` output byte-equal to persisted A-1; malformed/duplicate anchors left alone).
- App names are word-bounded and case-sensitive ("release notes" ≠ Notes); Excel/Word/PowerPoint are excluded because they name files to produce, not apps to drive.

Measured: `릴리스 노트 요약` → 30,954 chars; `브라우저에서 확인` → 39,397. The always-on runtime A-1 now has **~7.8K headroom under the unchanged 38,750 budget** (PSC-006 measures the runtime copy). Prompt-cache byte-identity across identical turns verified; a cache miss happens only at an intent-boundary turn.

Also posted the #489 recorded answer (C option, stays open). PR #473 disposition is the next work-phase (090).

`npm test`: 8560 / 0 fail. typecheck, build, doc-drift, verify-counts green.

Plan: `devlog/_plan/260905_517_524_round2/070_phase7_prompt_budget_and_dispositions.md`. Refs #524 #489
