### PR TITLE
test: add cross-runtime Activity burst and resource conformance checks

### DIFF
--- a/tests/fixtures/native-activity-burst-server.mts
+++ b/tests/fixtures/native-activity-burst-server.mts
@@ -1,0 +1,460 @@
+// Canonical writer/SQLite/SSE fixture. Importing this module performs no app work.
+import type { RuntimeEventBody } from '../../src/shared/runtime-contract.ts';
+import type { Request, Response, RequestHandler } from 'express';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+export const BURST_PROTOCOL = 'wp29-burst-v2' as const;
+export const BURST_SPEC = Object.freeze({ specId: '512x4096+129-small-v1' as const,
+    totalEvents: 643, bulkEvents: 512, bulkOutputBytes: 4096, tailEvents: 129, batchSize: 32,
+    submittedOutputBytes: 2_097_410, preflightCycles: 5, warmupCycles: 5, measuredCycles: 20 });
+export type BurstPhase = 'preflight' | 'warmup' | 'measured';
+export type BurstCycle = { phase: BurstPhase; index: number };
+export type BurstBinding = { protocol: typeof BURST_PROTOCOL; cycle: BurstCycle; sessionId: string;
+    scope: string; runId: string; turnId: string; specId: typeof BURST_SPEC.specId };
+export type BurstMetrics = {
+    protocol: typeof BURST_PROTOCOL; state: 'idle' | 'prepared' | 'running' | 'terminal' | 'settled' | 'failed';
+    cycle: BurstCycle | null; binding: BurstBinding | null;
+    attempted: number; committed: number; published: number; submittedOutputBytes: number;
+    committedCanonicalBytes: number; storedRuntimeBytes: number;
+    firstBulkTraceSeq: number | null; lastTailTraceSeq: number | null; terminalTraceSeq: number | null;
+    firstBusId: number | null; lastBusId: number | null;
+    producerDurationMs: number; batchHighWaterMs: number; writableHighWaterBytes: number;
+    memory: { rss: number; heapUsed: number; heapTotal: number; external: number; arrayBuffers: number };
+    sse: { activeConnections: number; droppedInternalTopicEvents: number; slowClientClosed: number; replayGapCount: number };
+    resources: { busListeners: number; heartbeatIntervals: number; ringCount: number; currentBusId: number;
+        watermarkCount: number; traceRuns: number; traceEvents: number; runtimeRows: number; runtimeBytes: number;
+        dbBytes: number; walBytes: number; pendingBatches: number; rawReads: number };
+    failure: string | null;
+};
+function exact(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        && Object.keys(value).length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+export function isBurstCycle(value: unknown): value is BurstCycle {
+    if (!exact(value, ['phase', 'index']) || !Number.isSafeInteger(value.index)) return false;
+    return (value.phase === 'preflight' || value.phase === 'warmup' || value.phase === 'measured')
+        && Number(value.index) >= 1 && Number(value.index) <= (value.phase === 'measured' ? 20 : 5);
+}
+export function nextBurstCycle(previous: BurstCycle | null): BurstCycle | null {
+    if (previous === null) return { phase: 'preflight', index: 1 };
+    if (!isBurstCycle(previous)) throw new TypeError('invalid_previous_cycle');
+    const limit = previous.phase === 'measured' ? 20 : 5;
+    if (previous.index < limit) return { phase: previous.phase, index: previous.index + 1 };
+    return previous.phase === 'preflight' ? { phase: 'warmup', index: 1 }
+        : previous.phase === 'warmup' ? { phase: 'measured', index: 1 } : null;
+}
+export function* burstBodies(cycle: BurstCycle): Generator<RuntimeEventBody> {
+    if (!isBurstCycle(cycle)) throw new TypeError('invalid_burst_cycle');
+    const cc = String(cycle.index).padStart(2, '0');
+    yield { kind: 'turn-start', provider: 'fixture' };
+    for (let i = 0; i < 512; i++) {
+        const id = String(i).padStart(4, '0');
+        yield { kind: 'tool', itemId: `bulk-${id}`, name: `tool-${id}`, status: 'done',
+            output: `C${cc}B${id}|${'x'.repeat(4079)}|END${id}` };
+    }
+    for (let i = 0; i < 129; i++) {
+        const id = String(i).padStart(4, '0');
+        yield { kind: 'tool', itemId: `tail-${id}`, name: `tail-${id}`, status: 'done', output: 'ok' };
+    }
+    yield { kind: 'turn-end', status: 'done', finalText: `WP29 cycle ${cc} final` };
+}
+
+async function main(): Promise<void> {
+    const [{ default: fs }, path, { createServer }, { EventEmitter }, crypto] = await Promise.all([
+        import('node:fs'), import('node:path'), import('node:http'), import('node:events'), import('node:crypto'),
+    ]);
+    if (!process.send || !process.connected || process.argv.length !== 2) throw Error('private_ipc_required');
+    const config = await new Promise<{ nonce: string; uiOrigin: string }>((resolve, reject) => {
+        const timer = setTimeout(() => finish(new Error('config_timeout')), 15_000);
+        const disconnected = () => finish(new Error('config_disconnected'));
+        function finish(error?: Error, value?: { nonce: string; uiOrigin: string }) {
+            clearTimeout(timer); process.off('message', message); process.off('disconnect', disconnected);
+            if (error) reject(error); else resolve(value!);
+        }
+        function message(value: unknown) {
+            if (!exact(value, ['protocol', 'nonce', 'uiOrigin']) || value.protocol !== BURST_PROTOCOL
+                || typeof value.nonce !== 'string' || !/^[0-9a-f]{64}$/.test(value.nonce)
+                || typeof value.uiOrigin !== 'string') return finish(new Error('invalid_private_config'));
+            try {
+                const url = new URL(value.uiOrigin);
+                if (url.origin !== value.uiOrigin || url.protocol !== 'http:' || url.hostname !== '127.0.0.1'
+                    || !/^[1-9]\d{0,4}$/.test(url.port) || Number(url.port) > 65535) throw Error();
+            } catch { return finish(new Error('invalid_ui_origin')); }
+            finish(undefined, { nonce: value.nonce, uiOrigin: value.uiOrigin });
+        }
+        process.on('message', message); process.once('disconnect', disconnected);
+    });
+    const repo = fs.realpathSync(fileURLToPath(new URL('../../', import.meta.url)));
+    const within = (root: string, candidate: string) => candidate.startsWith(root + path.sep);
+    const envHome = process.env.HOME;
+    if (!envHome || !path.isAbsolute(envHome)) throw Error('owned_home_required');
+    const root = fs.realpathSync(path.dirname(envHome));
+    if (root === repo || within(repo, root) || within(root, repo)) throw Error('separate_owned_root_required');
+    for (const key of ['HOME', 'CLI_JAW_HOME', 'CLI_JAW_DASHBOARD_HOME', 'CODEX_HOME', 'CLAUDE_CONFIG_DIR',
+        'PI_CODING_AGENT_DIR', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME', 'XDG_DATA_HOME', 'npm_config_cache', 'TMPDIR']) {
+        const value = process.env[key];
+        if (!value || !path.isAbsolute(value) || !within(root, fs.realpathSync(value))) throw Error(`invalid_owned_path:${key}`);
+    }
+    const jawHome = fs.realpathSync(process.env.CLI_JAW_HOME!);
+    for (const suffix of ['jaw.db', 'jaw.db-wal', 'jaw.db-shm', 'claw.db']) {
+        if (fs.lstatSync(path.join(jawHome, suffix), { throwIfNoEntry: false })) throw Error('fresh_database_required');
+    }
+    const seed = (name: string): unknown => {
+        const file = path.join(jawHome, name), info = fs.lstatSync(file);
+        if (!info.isFile() || info.isSymbolicLink() || info.size > 65_536 || !within(jawHome, fs.realpathSync(file))) throw Error('invalid_seed_file');
+        return JSON.parse(fs.readFileSync(file, 'utf8'));
+    };
+    const seeded = seed('settings.json') as Record<string, unknown>;
+    if (typeof seeded.workingDir !== 'string' || !within(root, fs.realpathSync(seeded.workingDir))) throw Error('owned_project_required');
+    const project = fs.realpathSync(seeded.workingDir);
+    if (project === jawHome || project === fs.realpathSync(envHome)) throw Error('separate_project_required');
+    const messaging = seeded.messaging as { enabledChannels?: unknown } | undefined;
+    const memory = seeded.memory as { enabled?: unknown } | undefined;
+    if (!Array.isArray(messaging?.enabledChannels) || messaging.enabledChannels.length || memory?.enabled !== false)
+        throw Error('disabled_messaging_memory_required');
+    const heartbeat = seed('heartbeat.json') as { jobs?: unknown };
+    const mcp = seed('mcp.json');
+    if (!Array.isArray(heartbeat.jobs) || heartbeat.jobs.length || !exact(mcp, ['servers'])
+        || !exact(mcp.servers, [])) throw Error('empty_jobs_mcp_required');
+
+    // No production/config/DB import occurs above the nonce/origin/path/seed checks.
+    const { default: express } = await import('express');
+    const appConfig = await import('../../src/core/config.ts');
+    appConfig.loadSettings();
+    if (fs.realpathSync(appConfig.JAW_HOME) !== jawHome || fs.realpathSync(path.dirname(appConfig.DB_PATH)) !== jawHome
+        || fs.realpathSync(String(appConfig.settings.workingDir)) !== project) throw Error('config_identity_changed');
+    const database = await import('../../src/core/db.ts');
+    const { db, closeDb } = database;
+    let dbCloseNeeded = true;
+    let emergencyCleanup = async (): Promise<void> => {};
+    try {
+        const [sessions, store, writer, codec, redact, events, traces, bus] = await Promise.all([
+            import('../../src/core/chat-sessions.ts'), import('../../src/trace/store.ts'),
+            import('../../src/agent/runtime/events.ts'), import('../../src/trace/runtime-body-codec.ts'),
+            import('../../src/trace/redact.ts'), import('../../src/routes/events.ts'),
+            import('../../src/routes/traces.ts'), import('../../src/core/event-bus.ts'),
+        ]);
+        const app = express(); app.disable('x-powered-by');
+        const server = createServer(app);
+        const sockets = new Set<import('node:net').Socket>();
+        const responses = new Set<Response>();
+        server.on('connection', socket => { sockets.add(socket); socket.once('close', () => sockets.delete(socket)); });
+        let restoreObservation = () => {}, unsubscribeOnFailure = () => {}, cancelOnFailure = () => {};
+        emergencyCleanup = async () => {
+            cancelOnFailure();
+            for (const response of responses) response.end();
+            const closes = [...sockets].map(socket => new Promise<void>(resolve => socket.once('close', () => resolve())));
+            for (const socket of sockets) socket.destroy();
+            let timer: NodeJS.Timeout | undefined;
+            try {
+                await Promise.race([Promise.all([
+                    ...closes, new Promise<void>(resolve => server.close(() => resolve())),
+                ]), new Promise<void>(resolve => { timer = setTimeout(resolve, 5000); })]);
+            } finally { clearTimeout(timer); unsubscribeOnFailure(); restoreObservation(); }
+        };
+        let state: BurstMetrics['state'] = 'idle', binding: BurstBinding | null = null, previous: BurstCycle | null = null;
+        let failure: string | null = null, stopping = false, stopPromise: Promise<void> | undefined;
+        let batch: NodeJS.Immediate | null = null, generator: Generator<RuntimeEventBody> | null = null;
+        let attempted = 0, committed = 0, published = 0, submittedOutputBytes = 0, committedCanonicalBytes = 0;
+        let firstBulkTraceSeq: number | null = null, lastTailTraceSeq: number | null = null, terminalTraceSeq: number | null = null;
+        let firstBusId: number | null = null, lastBusId: number | null = null, lastTraceSeq = 0;
+        let producerStart = 0, producerDurationMs = 0, batchHighWaterMs = 0, writableHighWaterBytes = 0, encodedBytes = 0;
+        let expectedBody: RuntimeEventBody | null = null;
+        const rawReads = new Set<number>();
+        const heartbeatHandles = new Set<ReturnType<typeof setInterval>>();
+        const originalInterval = globalThis.setInterval, originalClearInterval = globalThis.clearInterval;
+        restoreObservation = () => { globalThis.setInterval = originalInterval; globalThis.clearInterval = originalClearInterval; };
+        let installingSse = false;
+        globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
+            const handle = Reflect.apply(originalInterval, globalThis, args) as ReturnType<typeof setInterval>;
+            if (installingSse && args[1] === 15_000) heartbeatHandles.add(handle);
+            return handle;
+        }) as typeof setInterval;
+        globalThis.clearInterval = ((handle: Parameters<typeof clearInterval>[0]) => {
+            heartbeatHandles.delete(handle as ReturnType<typeof setInterval>); originalClearInterval(handle);
+        }) as typeof clearInterval;
+        const observed: { emitter: import('node:events').EventEmitter | null } = { emitter: null };
+        const originalOn = EventEmitter.prototype.on;
+        try {
+            EventEmitter.prototype.on = function (name, listener) {
+                if (name === 'event') observed.emitter = this;
+                return originalOn.call(this, name, listener);
+            };
+            const unsubscribe = bus.subscribe(() => {}); unsubscribe();
+        } finally { EventEmitter.prototype.on = originalOn; }
+        if (!observed.emitter) throw Error('bus_observer_unavailable');
+        const emitter = observed.emitter;
+        const countStmt = db.prepare(`SELECT (SELECT COUNT(*) FROM trace_runs) traceRuns,
+            (SELECT COUNT(*) FROM trace_events) traceEvents,
+            (SELECT COUNT(*) FROM trace_events WHERE source='runtime') runtimeRows,
+            (SELECT COALESCE(SUM(bytes),0) FROM trace_events WHERE source='runtime') runtimeBytes,
+            (SELECT COALESCE(SUM(length(CAST(raw_json AS BLOB))),0) FROM trace_events WHERE source='runtime') storedRuntimeBytes`);
+        type Counts = { traceRuns: number; traceEvents: number; runtimeRows: number; runtimeBytes: number; storedRuntimeBytes: number };
+        const counts = () => countStmt.get() as Counts;
+        const fileBytes = (file: string) => { try { return fs.statSync(file).size; } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0; throw error;
+        } };
+        function fail(code: string) {
+            failure ??= code.slice(0, 240); state = 'failed';
+            if (batch) clearImmediate(batch); batch = null; generator?.return(undefined); generator = null; expectedBody = null;
+        }
+        cancelOnFailure = () => { if (batch) clearImmediate(batch); batch = null; generator?.return(undefined); generator = null; };
+        function metrics(): BurstMetrics {
+            const rows = counts(); const memory = process.memoryUsage();
+            return { protocol: BURST_PROTOCOL, state, cycle: binding?.cycle ?? null, binding,
+                attempted, committed, published, submittedOutputBytes, committedCanonicalBytes, storedRuntimeBytes: rows.storedRuntimeBytes,
+                firstBulkTraceSeq, lastTailTraceSeq, terminalTraceSeq, firstBusId, lastBusId,
+                producerDurationMs, batchHighWaterMs, writableHighWaterBytes,
+                memory: { rss: memory.rss, heapUsed: memory.heapUsed, heapTotal: memory.heapTotal, external: memory.external, arrayBuffers: memory.arrayBuffers },
+                sse: events.getSseMetrics(), resources: { busListeners: emitter.listenerCount('event'),
+                    heartbeatIntervals: heartbeatHandles.size, ringCount: bus.replaySince(0).length,
+                    currentBusId: bus.currentSeq(), watermarkCount: bus.deliveryWatermarkCount(),
+                    traceRuns: rows.traceRuns, traceEvents: rows.traceEvents, runtimeRows: rows.runtimeRows, runtimeBytes: rows.runtimeBytes,
+                    dbBytes: fileBytes(appConfig.DB_PATH), walBytes: fileBytes(appConfig.DB_PATH + '-wal'),
+                    pendingBatches: batch ? 1 : 0, rawReads: rawReads.size }, failure };
+        }
+        function send(res: Response, data: unknown, status = 200) {
+            const body = JSON.stringify({ ok: true, data });
+            if (Buffer.byteLength(body) > 32_768) throw Error('metrics_limit');
+            res.status(status).type('json').send(body);
+        }
+        const deny = (res: Response, status: number, error: string) => { res.status(status).json({ ok: false, error }); };
+        const equalNonce = (value: unknown) => typeof value === 'string' && Buffer.byteLength(value) === Buffer.byteLength(config.nonce)
+            && crypto.timingSafeEqual(Buffer.from(value), Buffer.from(config.nonce));
+        const auth: RequestHandler = (req, res, next) => {
+            const cookies = (req.headers.cookie ?? '').split(';').map(value => value.trim()).filter(value => value.startsWith('wp29_probe='));
+            const cookie = cookies.length === 1 ? cookies[0]!.slice('wp29_probe='.length) : undefined;
+            if (stopping || req.socket.remoteAddress !== '127.0.0.1'
+                || req.headers.origin !== undefined && req.headers.origin !== config.uiOrigin
+                || !equalNonce(req.headers['x-wp29-probe']) && !equalNonce(cookie)) { deny(res, 403, 'probe_auth'); return; }
+            next();
+        };
+        app.use(auth);
+        app.use((req, res, next) => {
+            const get = req.path === '/api/events' || req.path === '/__probe/metrics' || req.path.startsWith('/api/traces/');
+            const post = ['/__probe/prepare', '/__probe/start', '/__probe/settle', '/__probe/stop'].includes(req.path);
+            if (!get && !post) { deny(res, 404, 'probe_not_found'); return; }
+            if (!(get && req.method === 'GET') && !(post && req.method === 'POST')) { deny(res, 405, 'probe_method'); return; }
+            next();
+        });
+        app.use((req, res, next) => {
+            res.setHeader('Cache-Control', 'no-store');
+            if (req.method === 'GET' && req.path === '/api/events') {
+                responses.add(res); res.once('close', () => responses.delete(res));
+                const write = res.write;
+                res.write = ((...args: Parameters<Response['write']>) => {
+                    const result = Reflect.apply(write, res, args) as boolean;
+                    writableHighWaterBytes = Math.max(writableHighWaterBytes, res.writableLength); return result;
+                }) as Response['write'];
+                installingSse = true; try { next(); } finally { installingSse = false; }
+                return;
+            }
+            const captured = binding;
+            const match = /^\/api\/traces\/(tr_[A-Za-z0-9_-]+)\/events\/([1-9]\d*)$/.exec(req.path);
+            if (req.method === 'GET' && state === 'terminal' && match && captured && match[1] === captured.runId
+                && req.query.session === captured.sessionId && Object.keys(req.query).length === 1) {
+                const seq = Number(match[2]);
+                res.once('finish', () => {
+                    if (state === 'terminal' && binding === captured && res.statusCode === 200
+                        && (seq === firstBulkTraceSeq || seq === lastTailTraceSeq)) rawReads.add(seq);
+                });
+            }
+            next();
+        });
+        events.registerEventsRoutes(app, auth);
+        traces.registerTraceRoutes(app, auth);
+        let setup = true, switched = 0, created = 0;
+        const unsubscribe = bus.subscribe(entry => {
+            if (setup) {
+                if (entry.topic === 'session' && entry.event === 'session_switched') switched++;
+                else if (entry.topic === 'session' && entry.event === 'session_created') created++;
+                else fail('unexpected_setup_publication');
+                return;
+            }
+            if (!binding || state !== 'running' || !expectedBody || entry.topic !== 'agent' || entry.event !== 'agent_runtime'
+                || entry.data.runId !== binding.runId || entry.data.turnId !== binding.turnId
+                || entry.data.sessionId !== binding.sessionId || entry.data.scope !== binding.scope
+                || entry.data.kind !== expectedBody.kind || (lastBusId !== null && entry.id <= lastBusId)) { fail('unexpected_publication'); return; }
+            firstBusId ??= entry.id; lastBusId = entry.id; published++;
+        });
+        unsubscribeOnFailure = unsubscribe;
+        if (bus.currentSeq() !== 0 || emitter.listenerCount('event') !== 1 || counts().traceRuns !== 0 || counts().traceEvents !== 0)
+            throw Error('nonexclusive_startup');
+        const { id: sessionId } = sessions.createChatSession('WP29 isolated canonical burst');
+        setup = false;
+        if (switched !== 1 || created !== 1 || bus.currentSeq() !== 2 || failure) throw Error('setup_event_mismatch');
+        const scope = 'wp29:owned';
+        const sameCycle = (cycle: BurstCycle) => binding?.cycle.phase === cycle.phase && binding.cycle.index === cycle.index;
+        let sseBaseline = events.getSseMetrics();
+        function runBatch() {
+            batch = null;
+            if (stopping || state !== 'running' || !binding || !generator) return;
+            const started = performance.now();
+            try {
+                for (let i = 0; i < BURST_SPEC.batchSize; i++) {
+                    const next = generator.next();
+                    if (next.done) throw Error('generator_ended_without_terminal');
+                    const body = next.value;
+                    const identity = { version: 1 as const, ...binding, seq: 1 };
+                    const raw = codec.encodeRuntimeBody(identity, body).raw;
+                    const bytes = Buffer.byteLength(redact.stringifyTraceValue(raw), 'utf8');
+                    if (bytes > codec.RUNTIME_BODY_BYTES || encodedBytes + bytes >= 4 * 1024 * 1024) throw Error('stored_byte_limit');
+                    attempted++; expectedBody = body;
+                    if (body.kind === 'tool') submittedOutputBytes += Buffer.byteLength(body.output!, 'utf8');
+                    const event = writer.recordRuntimeEvent({ ...binding, audience: 'public' }, body);
+                    expectedBody = null;
+                    if (failure || !event || event.seq <= lastTraceSeq || published !== attempted) throw Error(failure ?? 'canonical_commit_or_publish_failed');
+                    if (event.runId !== binding.runId || event.sessionId !== binding.sessionId || event.scope !== binding.scope || event.turnId !== binding.turnId)
+                        throw Error('canonical_identity_changed');
+                    if (JSON.stringify(codec.encodeRuntimeBody({ ...identity, seq: event.seq }, event).body) !== JSON.stringify(body)) throw Error('canonical_body_changed');
+                    lastTraceSeq = event.seq; committed++; encodedBytes += bytes;
+                    committedCanonicalBytes += Buffer.byteLength(JSON.stringify(event), 'utf8');
+                    if (body.kind === 'tool' && body.itemId === 'bulk-0000') firstBulkTraceSeq = event.seq;
+                    if (body.kind === 'tool' && body.itemId === 'tail-0128') lastTailTraceSeq = event.seq;
+                    if (body.kind === 'turn-end') {
+                        terminalTraceSeq = event.seq;
+                        store.finalizeTraceRun(binding.runId, 'done', null, { onlyIfRunning: true });
+                        if (store.getTraceRun(binding.runId)?.status !== 'done') throw Error('trace_finalize_failed');
+                        const rows = counts();
+                        if (committed !== 643 || published !== 643 || submittedOutputBytes !== 2_097_410
+                            || rows.traceEvents !== 644 || rows.runtimeRows !== 643 || rows.runtimeBytes !== encodedBytes
+                            || rows.storedRuntimeBytes !== encodedBytes || committedCanonicalBytes < 1_048_576) throw Error('terminal_accounting_mismatch');
+                        if (firstBusId === null || lastBusId === null || lastBusId - firstBusId + 1 !== 643
+                            || bus.replaySince(0).length > bus.RING_SIZE || bus.deliveryWatermarkCount() > 3)
+                            throw Error('bus_resource_mismatch');
+                        generator.return(undefined); generator = null;
+                        state = 'terminal'; producerDurationMs = performance.now() - producerStart;
+                        break;
+                    }
+                }
+            } catch (error) { fail(error instanceof Error ? error.message : 'writer_failed'); }
+            batchHighWaterMs = Math.max(batchHighWaterMs, performance.now() - started);
+            if (state === 'running') batch = setImmediate(runBatch);
+        }
+        const bodyParser = express.json({ limit: 16_384, strict: true });
+        for (const route of ['prepare', 'start', 'settle', 'stop']) app.post('/__probe/' + route, bodyParser);
+        app.get('/__probe/metrics', (req, res) => {
+            if (Object.keys(req.query).length) { deny(res, 400, 'invalid_metrics'); return; }
+            try { send(res, metrics()); } catch { fail('metrics_observation_failed'); deny(res, 500, 'metrics_observation_failed'); }
+        });
+        app.post('/__probe/prepare', (req, res) => {
+            if (Object.keys(req.query).length || !exact(req.body, ['cycle']) || !isBurstCycle(req.body.cycle)) { deny(res, 400, 'invalid_control'); return; }
+            const expected = nextBurstCycle(previous);
+            if (stopping || !['idle', 'settled'].includes(state) || !expected || expected.phase !== req.body.cycle.phase
+                || expected.index !== req.body.cycle.index || events.getActiveSseConnections() !== 0) { deny(res, 409, 'cycle_order'); return; }
+            try {
+                if (counts().traceRuns || counts().traceEvents || emitter.listenerCount('event') !== 1 || heartbeatHandles.size) throw Error('prepare_resource_mismatch');
+                const runId = store.startTraceRun({ cli: 'fixture', sessionId, scopeKey: scope, audience: 'public', workingDir: project });
+                binding = { protocol: BURST_PROTOCOL, cycle: { ...req.body.cycle }, sessionId, scope, runId, turnId: runId, specId: BURST_SPEC.specId };
+                attempted = committed = published = submittedOutputBytes = committedCanonicalBytes = encodedBytes = lastTraceSeq = 0;
+                firstBulkTraceSeq = lastTailTraceSeq = terminalTraceSeq = firstBusId = lastBusId = null;
+                producerDurationMs = batchHighWaterMs = writableHighWaterBytes = 0; rawReads.clear();
+                sseBaseline = events.getSseMetrics(); state = 'prepared'; send(res, binding);
+            } catch { fail('prepare_failed'); deny(res, 500, 'prepare_failed'); }
+        });
+        app.post('/__probe/start', (req, res) => {
+            if (Object.keys(req.query).length || !exact(req.body, ['cycle']) || !isBurstCycle(req.body.cycle)) { deny(res, 400, 'invalid_control'); return; }
+            if (state !== 'prepared' || !sameCycle(req.body.cycle) || events.getActiveSseConnections() !== 1) { deny(res, 409, 'start_state'); return; }
+            state = 'running'; generator = burstBodies(req.body.cycle); producerStart = performance.now();
+            send(res, { state }, 202); batch = setImmediate(runBatch);
+        });
+        app.post('/__probe/settle', (req, res) => {
+            if (Object.keys(req.query).length || !exact(req.body, ['cycle', 'lastObservedTraceSeq', 'receivedCount'])
+                || !isBurstCycle(req.body.cycle) || !Number.isSafeInteger(req.body.lastObservedTraceSeq)
+                || !Number.isSafeInteger(req.body.receivedCount)) { deny(res, 400, 'invalid_control'); return; }
+            if (state !== 'terminal' || !sameCycle(req.body.cycle) || req.body.lastObservedTraceSeq !== terminalTraceSeq
+                || req.body.receivedCount !== 643 || rawReads.size !== 2 || batch || events.getActiveSseConnections() !== 0) {
+                deny(res, 409, 'settle_barrier'); return;
+            }
+            try {
+                const sse = events.getSseMetrics();
+                if (emitter.listenerCount('event') !== 1 || heartbeatHandles.size || sse.slowClientClosed !== sseBaseline.slowClientClosed
+                    || sse.replayGapCount !== sseBaseline.replayGapCount || sse.droppedInternalTopicEvents !== sseBaseline.droppedInternalTopicEvents)
+                    throw Error('settle_resource_mismatch');
+                store.finalizeTraceRun(binding!.runId, 'done', null, { onlyIfRunning: true });
+                store.pruneTraceEvents(7, 0);
+                if (counts().traceRuns || counts().traceEvents) throw Error('real_prune_failed');
+                previous = { ...binding!.cycle }; state = 'settled'; send(res, metrics());
+            } catch (error) { fail(error instanceof Error ? error.message : 'settle_failed'); deny(res, 500, failure!); }
+        });
+        let watchdog: NodeJS.Timeout;
+        async function stop(reason: string) {
+            if (stopPromise) return stopPromise;
+            stopping = true; clearTimeout(watchdog);
+            if (!['idle', 'settled', 'failed'].includes(state)) fail('stopped_before_settlement');
+            if (batch) clearImmediate(batch); batch = null; generator?.return(undefined); generator = null;
+            stopPromise = (async () => {
+                let closed = false, timer: NodeJS.Timeout | undefined;
+                try {
+                    const httpClosed = new Promise<boolean>(resolve => server.close(error => resolve(!error)));
+                    for (const res of responses) res.end(); server.closeIdleConnections();
+                    closed = await Promise.race([httpClosed, new Promise<boolean>(resolve => {
+                        timer = setTimeout(() => resolve(false), 5000);
+                    })]);
+                } finally { clearTimeout(timer); }
+                // Only sockets captured from this listener are eligible, never numeric PIDs.
+                if (!closed || sockets.size) {
+                    const closes = [...sockets].map(socket => new Promise<void>(resolve => socket.once('close', () => resolve())));
+                    for (const socket of sockets) socket.destroy();
+                    try { await Promise.race([Promise.all(closes), new Promise<void>(resolve => { timer = setTimeout(resolve, 1000); })]); }
+                    finally { clearTimeout(timer); }
+                }
+                unsubscribe();
+                const beforeClose = { activeSse: events.getActiveSseConnections(), busListeners: emitter.listenerCount('event'),
+                    heartbeatIntervals: heartbeatHandles.size, sockets: sockets.size, pendingBatches: batch ? 1 : 0 };
+                globalThis.setInterval = originalInterval; globalThis.clearInterval = originalClearInterval;
+                closeDb(); dbCloseNeeded = false;
+                const certified = closed && !server.listening && !db.open && Object.values(beforeClose).every(value => value === 0);
+                const receipt = { kind: 'stopped', protocol: BURST_PROTOCOL, pid: process.pid, reason, closed: certified,
+                    httpClosed: closed, dbOpen: db.open, resources: beforeClose, failure, rootRetained: true };
+                process.exitCode = certified && !failure ? 0 : 1;
+                if (process.connected) await new Promise<void>(resolve => process.send!(receipt, () => resolve()));
+                if (process.connected) process.disconnect?.();
+                emergencyCleanup = async () => {};
+            })();
+            return stopPromise;
+        }
+        app.post('/__probe/stop', (req, res) => {
+            if (Object.keys(req.query).length || !exact(req.body, [])) { deny(res, 400, 'invalid_control'); return; }
+            res.once('finish', () => { void stop('http-stop'); }); send(res, { stopping: true });
+        });
+        app.use((_req, res) => deny(res, 404, 'probe_not_found'));
+        app.use((_error: unknown, _req: Request, res: Response, _next: import('express').NextFunction) => deny(res, 400, 'invalid_control_body'));
+        watchdog = setTimeout(() => { fail('watchdog'); void stop('watchdog'); }, 15 * 60_000);
+        process.on('message', value => {
+            if (exact(value, ['kind']) && value.kind === 'stop') void stop('ipc-stop');
+            else { fail('invalid_ipc_control'); void stop('invalid-ipc'); }
+        });
+        process.once('disconnect', () => { if (!stopping) { fail('ipc_disconnected'); void stop('ipc-disconnected'); } });
+        process.once('SIGTERM', () => { void stop('SIGTERM'); });
+        process.once('SIGINT', () => { void stop('SIGINT'); });
+        server.on('error', () => { fail('http_error'); void stop('http-error'); });
+        const sourceFiles = ['tests/fixtures/native-activity-burst-server.mts', 'src/core/config.ts', 'src/core/db.ts',
+            'src/core/chat-sessions.ts', 'src/core/bus.ts', 'src/core/event-bus.ts', 'src/core/event-scope.ts',
+            'src/routes/events.ts', 'src/routes/traces.ts', 'src/agent/runtime/events.ts', 'src/trace/store.ts',
+            'src/trace/runtime-body-codec.ts', 'src/trace/redact.ts', 'src/trace/activity-journal.ts',
+            'src/trace/activity-control.ts', 'src/trace/activity-retention.ts', 'src/shared/runtime-contract.ts',
+            'src/shared/runtime-event-parse.ts', 'src/shared/activity-state.ts', 'src/shared/activity-replay.ts',
+            'public/js/features/activity-live.ts', 'public/js/features/activity-view.ts', 'public/js/event-channel.ts',
+            'public/js/ui.ts', 'src/agent/spawn/process-kill.ts', 'package.json', 'package-lock.json'];
+        const sourceHashes = Object.fromEntries(sourceFiles.map(file => [file, crypto.createHash('sha256').update(fs.readFileSync(path.join(repo, file))).digest('hex')]));
+        await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', () => { server.off('error', reject); resolve(); }); });
+        const address = server.address();
+        if (!address || typeof address === 'string') throw Error('missing_listener');
+        if (process.connected) process.send!({ kind: 'ready', protocol: BURST_PROTOCOL, pid: process.pid,
+            origin: `http://127.0.0.1:${address.port}`, home: jawHome, sessionId, scope, sourceHashes });
+        await new Promise<void>(resolve => server.once('close', () => resolve()));
+        if (stopPromise) await stopPromise;
+    } finally { await emergencyCleanup(); if (dbCloseNeeded) closeDb(); }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch(error => {
+        process.exitCode = 1;
+        const failure = error instanceof Error ? error.message.slice(0, 240) : 'producer_startup_failed';
+        console.error('[wp29 producer]', failure);
+        if (process.connected) process.send?.({ kind: 'failed', protocol: BURST_PROTOCOL, failure }, () => {
+            if (process.connected) process.disconnect?.();
+        });
+    });
+}

--- a/tests/fixtures/web-activity-burst.ts
+++ b/tests/fixtures/web-activity-burst.ts
@@ -52,6 +52,7 @@ declare global {
             prepare(binding: BurstBinding): Promise<void>;
             snapshot(): BurstBrowserSnapshot;
             disposeCycle(): Promise<BurstDisposal>;
+            takeBulkCapture(): { receivedCount: number; html: string };
         };
     }
 }
@@ -123,6 +124,7 @@ let pageDisposed = false;
 let lastSnapshot: BurstBrowserSnapshot | null = null;
 let disposing: Promise<BurstDisposal> | null = null;
 let localeReady: Promise<void> | null = null;
+let bulkCapture: { receivedCount: number; html: string } | null = null;
 const pageErrors: string[] = [];
 function errorText(error: unknown): string {
     return (error instanceof Error ? error.message : String(error)).replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 180);
@@ -330,6 +332,11 @@ function receive(token: number, wire: Record<string, unknown>): void {
         if ([65, 257, 449].includes(cycle.received)) queueControl(cycle);
         if (cycle.received === 513) {
             cycle.bulk = preview(cycle); checkPreview(cycle.bulk, true);
+            if (cycle.binding.cycle.phase === 'preflight' && cycle.binding.cycle.index === 1) {
+                const html = turn.view.element.outerHTML;
+                requireFact(new TextEncoder().encode(html).byteLength <= 131072, 'bulk_capture_bound');
+                bulkCapture = { receivedCount: cycle.received, html };
+            }
         }
         if (cycle.received === 642) {
             cycle.final = preview(cycle); checkPreview(cycle.final, false);
@@ -506,6 +513,7 @@ async function dispose(): Promise<BurstDisposal> {
         retiredPending: !!retiredUnsubscribe, errors: activeEventSources ? ['disposal_source_still_active'] : [] };
     const disposalErrors: string[] = [];
     cycle.retired = true; cycle.ready = false;
+    bulkCapture = null;
     if (cycle.binding.cycle.phase === 'preflight' && cycle.binding.cycle.index === 2 && cycle.unsubscribe) {
         requireFact(!retiredUnsubscribe, 'retired_already_pending');
         retiredUnsubscribe = cycle.unsubscribe; // One scalar-only retired callback for preflight3.
@@ -568,7 +576,10 @@ configureLiveActivityHost({
             .finally(() => { cycle.rawPending = null; });
     },
 });
-window.__wp29Probe = Object.freeze({ prepare, snapshot, disposeCycle });
+window.__wp29Probe = Object.freeze({ prepare, snapshot, disposeCycle, takeBulkCapture() {
+    requireFact(bulkCapture, 'bulk_capture_unavailable');
+    const capture = bulkCapture; bulkCapture = null; return capture;
+} });
 window.addEventListener('pagehide', () => {
     pageDisposed = true;
     void disposeCycle().finally(() => {

--- a/tests/fixtures/web-activity-burst.ts
+++ b/tests/fixtures/web-activity-burst.ts
@@ -53,6 +53,7 @@ declare global {
             snapshot(): BurstBrowserSnapshot;
             disposeCycle(): Promise<BurstDisposal>;
             takeBulkCapture(): { receivedCount: number; html: string };
+            readDiagnostics(): { timeOrigin: number; now: number; reads: ProbeReadDiagnostic[]; disposals: ProbeDisposalDiagnostic[] };
         };
     }
 }
@@ -125,6 +126,14 @@ let lastSnapshot: BurstBrowserSnapshot | null = null;
 let disposing: Promise<BurstDisposal> | null = null;
 let localeReady: Promise<void> | null = null;
 let bulkCapture: { receivedCount: number; html: string } | null = null;
+interface ProbeReadDiagnostic {
+    id: string; path: string; cycle: BurstCycle; startedAt: number; endedAt: number | null;
+    doneAt: number | null; timeoutAt: number | null; cycleAbortAt: number | null;
+    requireFactAt: number | null; error: string | null;
+}
+interface ProbeDisposalDiagnostic { cycle: BurstCycle; enteredAt: number; abortAt: number | null }
+const readDiagnostics: ProbeReadDiagnostic[] = [], disposalDiagnostics: ProbeDisposalDiagnostic[] = [];
+let readSerial = 0;
 const pageErrors: string[] = [];
 function errorText(error: unknown): string {
     return (error instanceof Error ? error.message : String(error)).replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 180);
@@ -160,13 +169,19 @@ function subscribe(topic: string, event: string | null, callback: (data: Record<
 
 // Per-request byte/time bounds; response payloads never enter retained telemetry.
 async function readJson(cycle: CycleState, path: string, limit: number): Promise<unknown> {
+    const diagnostic: ProbeReadDiagnostic = { id: String(++readSerial), path, cycle: { ...cycle.binding.cycle },
+        startedAt: performance.now(), endedAt: null, doneAt: null, timeoutAt: null, cycleAbortAt: null,
+        requireFactAt: null, error: null };
+    if (readDiagnostics.length === 128) readDiagnostics.shift();
+    readDiagnostics.push(diagnostic);
     const controller = new AbortController();
-    const abort = () => controller.abort();
+    const abort = () => { diagnostic.cycleAbortAt = performance.now(); controller.abort(); };
     cycle.abort.signal.addEventListener('abort', abort, { once: true });
     if (cycle.abort.signal.aborted) abort();
-    const timer = window.setTimeout(abort, 5000);
+    const timer = window.setTimeout(() => { diagnostic.timeoutAt = performance.now(); controller.abort(); }, 5000);
     try {
-        const response = await fetch(path, { signal: controller.signal, credentials: 'same-origin', headers: { Accept: 'application/json' } });
+        const response = await fetch(path, { signal: controller.signal, credentials: 'same-origin',
+            headers: { Accept: 'application/json', 'x-wp29-read-id': diagnostic.id } });
         if (!response.ok || !response.headers.get('content-type')?.includes('json') || !response.body) {
             await response.body?.cancel(); throw new Error(`read_status_${response.status}`);
         }
@@ -177,8 +192,9 @@ async function readJson(cycle: CycleState, path: string, limit: number): Promise
         try {
             for (;;) {
                 const part = await reader.read();
-                if (part.done) { completed = true; break; }
+                if (part.done) { completed = true; diagnostic.doneAt = performance.now(); break; }
                 bytes += part.value.byteLength;
+                if (bytes > limit) diagnostic.requireFactAt = performance.now();
                 requireFact(bytes <= limit, 'read_size_limit');
                 text += decoder.decode(part.value, { stream: true });
             }
@@ -188,7 +204,10 @@ async function readJson(cycle: CycleState, path: string, limit: number): Promise
             if (!completed) await reader.cancel().catch(() => {});
             reader.releaseLock();
         }
+    } catch (error) {
+        diagnostic.error = errorText(error); throw error;
     } finally {
+        diagnostic.endedAt = performance.now();
         clearTimeout(timer); cycle.abort.signal.removeEventListener('abort', abort);
     }
 }
@@ -513,6 +532,9 @@ async function dispose(): Promise<BurstDisposal> {
     if (!cycle) return { activeEventSources, rootConnected: false, handlerCount: 0,
         retiredPending: !!retiredUnsubscribe, errors: activeEventSources ? ['disposal_source_still_active'] : [] };
     const disposalErrors: string[] = [];
+    const diagnostic: ProbeDisposalDiagnostic = { cycle: { ...cycle.binding.cycle }, enteredAt: performance.now(), abortAt: null };
+    if (disposalDiagnostics.length === 64) disposalDiagnostics.shift();
+    disposalDiagnostics.push(diagnostic);
     cycle.retired = true; cycle.ready = false;
     bulkCapture = null;
     if (cycle.binding.cycle.phase === 'preflight' && cycle.binding.cycle.index === 2 && cycle.unsubscribe) {
@@ -520,7 +542,7 @@ async function dispose(): Promise<BurstDisposal> {
         retiredUnsubscribe = cycle.unsubscribe; // One scalar-only retired callback for preflight3.
     } else cycle.unsubscribe?.();
     cycle.unsubscribe = null;
-    closeEventChannel(); cycle.abort.abort();
+    closeEventChannel(); diagnostic.abortAt = performance.now(); cycle.abort.abort();
     for (const timer of cycle.timers) clearTimeout(timer); cycle.timers.clear();
     for (const id of cycle.animationFrames) cancelAnimationFrame(id); cycle.animationFrames.clear();
     await cycle.rawPending;
@@ -577,7 +599,11 @@ configureLiveActivityHost({
             .finally(() => { cycle.rawPending = null; });
     },
 });
-window.__wp29Probe = Object.freeze({ prepare, snapshot, disposeCycle, takeBulkCapture() {
+window.__wp29Probe = Object.freeze({ prepare, snapshot, disposeCycle,
+readDiagnostics() { return { timeOrigin: performance.timeOrigin, now: performance.now(),
+    reads: readDiagnostics.map(row => ({ ...row, cycle: { ...row.cycle } })),
+    disposals: disposalDiagnostics.map(row => ({ ...row, cycle: { ...row.cycle } })) }; },
+takeBulkCapture() {
     requireFact(bulkCapture, 'bulk_capture_unavailable');
     const capture = bulkCapture; bulkCapture = null; return capture;
 } });

--- a/tests/fixtures/web-activity-burst.ts
+++ b/tests/fixtures/web-activity-burst.ts
@@ -173,10 +173,11 @@ async function readJson(cycle: CycleState, path: string, limit: number): Promise
         const reader = response.body.getReader();
         const decoder = new TextDecoder('utf-8', { fatal: true });
         let bytes = 0, text = '';
+        let completed = false;
         try {
             for (;;) {
                 const part = await reader.read();
-                if (part.done) break;
+                if (part.done) { completed = true; break; }
                 bytes += part.value.byteLength;
                 requireFact(bytes <= limit, 'read_size_limit');
                 text += decoder.decode(part.value, { stream: true });
@@ -184,7 +185,7 @@ async function readJson(cycle: CycleState, path: string, limit: number): Promise
             text += decoder.decode();
             return JSON.parse(text) as unknown;
         } finally {
-            await reader.cancel().catch(() => {});
+            if (!completed) await reader.cancel().catch(() => {});
             reader.releaseLock();
         }
     } finally {

--- a/tests/fixtures/web-activity-burst.ts
+++ b/tests/fixtures/web-activity-burst.ts
@@ -1,0 +1,578 @@
+// wp29 browser-only fixture. Real channel/consumer/view; no ws bootstrap or provider.
+import type { BurstBinding, BurstCycle } from './native-activity-burst-server.mts';
+import type { RuntimeEvent } from '../../src/shared/runtime-contract.js';
+import { parseRuntimeEvent } from '../../src/shared/runtime-event-parse.js';
+import { activityRetainedChars } from '../../src/shared/activity-state.js';
+import {
+    setEventChannelScopeProvider, subscribe as subscribeChannel, onChannelOpen,
+    onChannelDisconnect, onChannelUnavailable, connectEventChannel, closeEventChannel,
+} from '../../public/js/event-channel.js';
+import {
+    configureLiveActivityHost, setLiveActivityIdentity, setActivityTransportHealthy,
+    ingestLiveActivity, findLiveActivity, clearLiveActivity,
+} from '../../public/js/features/activity-live.js';
+import { addMessage } from '../../public/js/features/chat-messages.js';
+import { cleanupToolActivity, replaceAgentAnswer } from '../../public/js/ui.js';
+import { state } from '../../public/js/state.js';
+import { getVirtualScroll } from '../../public/js/virtual-scroll.js';
+import { cancelPostRender } from '../../public/js/render/post-render.js';
+import { initI18n } from '../../public/js/features/i18n.js';
+
+export interface BurstPreview {
+    entryCount: number; retainedChars: number; observedFieldChars: number;
+    omittedEntries: number; omittedTextChars: number; latestAction: string;
+    retainedIds: string[]; visibleRows: number; omissionVisible: boolean;
+}
+interface ControlObservation {
+    queuedAt: number; completedAt: number | null; frameAt: number | null;
+    queuedOrdinal: number; completedOrdinal: number | null; frameOrdinal: number | null;
+    open: boolean | null;
+}
+interface RawProof {
+    runId: string; seq: number; outputBytes: number; prefix: string; suffix: string;
+}
+export interface BurstBrowserSnapshot {
+    protocol: 'wp29-burst-v2'; binding: BurstBinding | null; ready: boolean; terminal: boolean;
+    receivedCount: number; ingestedCount: number; retiredCallbackHits: number;
+    retiredCallbackHitsTotal: number; suppressedIngestions: number;
+    activeEventSources: number; maxEventSources: number;
+    bulk: BurstPreview | null; final: BurstPreview | null;
+    finalText: string | null; finalDomRaw: string | null; finalDomText: string | null;
+    answerCount: number; controls: ControlObservation[]; frames: Array<[number, number]>;
+    ingest: { count: number; p50Ms: number; p95Ms: number; maxMs: number };
+    errors: string[]; rawProof: RawProof[];
+}
+export interface BurstDisposal {
+    activeEventSources: number; rootConnected: boolean; handlerCount: number;
+    retiredPending: boolean; errors: string[];
+}
+declare global {
+    interface Window {
+        __wp29Probe: {
+            prepare(binding: BurstBinding): Promise<void>;
+            snapshot(): BurstBrowserSnapshot;
+            disposeCycle(): Promise<BurstDisposal>;
+        };
+    }
+}
+
+// Independent literal expectations, never imported from the Node generator.
+const PROTOCOL = 'wp29-burst-v2';
+const SPEC = '512x4096+129-small-v1';
+const TOTAL = 643;
+const MAX_ERRORS = 64;
+const record = (value: unknown): value is Record<string, unknown> =>
+    value !== null && typeof value === 'object' && !Array.isArray(value);
+function requireFact(value: unknown, message: string): asserts value {
+    if (!value) throw new Error(message);
+}
+function exactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+    return Object.keys(value).length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+const decimal = (value: number, width: number) => String(value).padStart(width, '0');
+const finalFor = (binding: BurstBinding) => `WP29 cycle ${decimal(binding.cycle.index, 2)} final`;
+function nextCycle(previous: BurstCycle | null): BurstCycle | null {
+    if (!previous) return { phase: 'preflight', index: 1 };
+    if (previous.index < (previous.phase === 'measured' ? 20 : 5))
+        return { phase: previous.phase, index: previous.index + 1 };
+    if (previous.phase === 'preflight') return { phase: 'warmup', index: 1 };
+    if (previous.phase === 'warmup') return { phase: 'measured', index: 1 };
+    return null;
+}
+function bindingFrom(value: unknown): BurstBinding {
+    requireFact(record(value) && exactKeys(value, ['protocol', 'cycle', 'sessionId', 'scope', 'runId', 'turnId', 'specId']), 'binding_shape');
+    requireFact(value.protocol === PROTOCOL && value.specId === SPEC, 'binding_protocol');
+    requireFact(record(value.cycle) && exactKeys(value.cycle, ['phase', 'index']), 'cycle_shape');
+    const { phase, index } = value.cycle;
+    requireFact((phase === 'preflight' || phase === 'warmup' || phase === 'measured')
+        && typeof index === 'number' && Number.isSafeInteger(index)
+        && index >= 1 && index <= (phase === 'measured' ? 20 : 5), 'cycle_range');
+    for (const key of ['sessionId', 'scope', 'runId', 'turnId'])
+        requireFact(typeof value[key] === 'string' && /^[A-Za-z0-9:_-]{1,240}$/.test(value[key]), 'binding_identity');
+    requireFact(value.turnId === value.runId, 'binding_turn');
+    return Object.freeze({ protocol: PROTOCOL, specId: SPEC, cycle: Object.freeze({ phase, index }),
+        sessionId: value.sessionId as string, scope: value.scope as string,
+        runId: value.runId as string, turnId: value.turnId as string });
+}
+function sameBinding(a: BurstBinding, b: BurstBinding): boolean {
+    return a.protocol === b.protocol && a.specId === b.specId && a.cycle.phase === b.cycle.phase
+        && a.cycle.index === b.cycle.index && a.sessionId === b.sessionId && a.scope === b.scope
+        && a.runId === b.runId && a.turnId === b.turnId;
+}
+
+interface CycleState {
+    token: number; binding: BurstBinding; retired: boolean; ready: boolean; opened: number;
+    terminal: boolean; received: number; ingested: number; suppressed: number; retiredBaseline: number;
+    lastSeq: number | null; firstBulkSeq: number | null; lastTailSeq: number | null;
+    bulk: BurstPreview | null; final: BurstPreview | null; finalText: string | null;
+    message: HTMLElement | null; rawUi: HTMLOutputElement | null;
+    controls: ControlObservation[]; frames: Array<[number, number]>;
+    timings: Float64Array; timingCount: number; errors: string[]; rawProof: RawProof[];
+    abort: AbortController; unsubscribe: (() => void) | null;
+    timers: Set<number>; animationFrames: Set<number>; rawPending: Promise<void> | null;
+}
+let current: CycleState | null = null;
+let previous: BurstBinding | null = null;
+let serial = 0, activeEventSources = 0, maxEventSources = 0, subscriptions = 0;
+// Native construction/close changes this after prepare's initial zero check.
+function activeSourceCount(): number { return activeEventSources; }
+let retiredCallbackHitsTotal = 0;
+let retiredUnsubscribe: (() => void) | null = null;
+let retiredRemovalQueued = false;
+let pageDisposed = false;
+let lastSnapshot: BurstBrowserSnapshot | null = null;
+let disposing: Promise<BurstDisposal> | null = null;
+let localeReady: Promise<void> | null = null;
+const pageErrors: string[] = [];
+function errorText(error: unknown): string {
+    return (error instanceof Error ? error.message : String(error)).replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 180);
+}
+function note(error: unknown, cycle: CycleState | null = current): void {
+    const errors = cycle?.errors ?? pageErrors;
+    if (errors.length < MAX_ERRORS) errors.push(errorText(error));
+}
+const live = (cycle: CycleState) => current === cycle && !cycle.retired && !pageDisposed;
+
+// Pass-through native construction/close, with no strong collection of sources.
+const NativeEventSource = window.EventSource;
+const sourceOpen = new WeakMap<EventSource, boolean>();
+class ObservedEventSource extends NativeEventSource {
+    constructor(url: string | URL, options?: EventSourceInit) {
+        super(url, options);
+        sourceOpen.set(this, true);
+        activeEventSources++;
+        maxEventSources = Math.max(maxEventSources, activeEventSources);
+        if (activeEventSources > 1) note('multiple_event_sources');
+    }
+    override close(): void {
+        super.close();
+        if (sourceOpen.get(this)) { sourceOpen.set(this, false); activeEventSources--; }
+    }
+}
+function subscribe(topic: string, event: string | null, callback: (data: Record<string, unknown>) => void): () => void {
+    const remove = subscribeChannel(topic, event, callback);
+    subscriptions++;
+    let removed = false;
+    return () => { if (!removed) { removed = true; remove(); subscriptions--; } };
+}
+
+// Per-request byte/time bounds; response payloads never enter retained telemetry.
+async function readJson(cycle: CycleState, path: string, limit: number): Promise<unknown> {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    cycle.abort.signal.addEventListener('abort', abort, { once: true });
+    if (cycle.abort.signal.aborted) abort();
+    const timer = window.setTimeout(abort, 5000);
+    try {
+        const response = await fetch(path, { signal: controller.signal, credentials: 'same-origin', headers: { Accept: 'application/json' } });
+        if (!response.ok || !response.headers.get('content-type')?.includes('json') || !response.body) {
+            await response.body?.cancel(); throw new Error(`read_status_${response.status}`);
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder('utf-8', { fatal: true });
+        let bytes = 0, text = '';
+        try {
+            for (;;) {
+                const part = await reader.read();
+                if (part.done) break;
+                bytes += part.value.byteLength;
+                requireFact(bytes <= limit, 'read_size_limit');
+                text += decoder.decode(part.value, { stream: true });
+            }
+            text += decoder.decode();
+            return JSON.parse(text) as unknown;
+        } finally {
+            await reader.cancel().catch(() => {});
+            reader.releaseLock();
+        }
+    } finally {
+        clearTimeout(timer); cycle.abort.signal.removeEventListener('abort', abort);
+    }
+}
+function outputMatches(value: unknown, binding: BurstBinding, index: number): value is string {
+    if (typeof value !== 'string' || value.length !== 4096
+        || !value.startsWith(`C${decimal(binding.cycle.index, 2)}B${decimal(index, 4)}|`)
+        || !value.endsWith(`|END${decimal(index, 4)}`)) return false;
+    for (let i = 9; i < 4088; i++) if (value.charCodeAt(i) !== 120) return false;
+    return true;
+}
+function checkEvent(cycle: CycleState, event: RuntimeEvent): void {
+    const binding = cycle.binding, ordinal = cycle.received;
+    requireFact(event.runId === binding.runId && event.turnId === binding.turnId
+        && event.sessionId === binding.sessionId && event.scope === binding.scope
+        && event.parentItemId === undefined, 'event_identity');
+    requireFact(cycle.lastSeq === null || event.seq > cycle.lastSeq, 'event_sequence');
+    requireFact(ordinal <= TOTAL && !cycle.terminal, 'event_after_terminal');
+    if (ordinal === 1) requireFact(event.kind === 'turn-start' && event.provider === 'fixture', 'start_body');
+    else if (ordinal <= 513) {
+        const index = ordinal - 2, id = decimal(index, 4);
+        requireFact(event.kind === 'tool' && event.itemId === `bulk-${id}` && event.name === `tool-${id}`
+            && event.status === 'done' && event.input === undefined && event.detail === undefined
+            && outputMatches(event.output, binding, index), 'bulk_body');
+    } else if (ordinal <= 642) {
+        const id = decimal(ordinal - 514, 4);
+        requireFact(event.kind === 'tool' && event.itemId === `tail-${id}` && event.name === `tail-${id}`
+            && event.status === 'done' && event.output === 'ok' && event.input === undefined
+            && event.detail === undefined, 'tail_body');
+    } else requireFact(event.kind === 'turn-end' && event.status === 'done'
+        && event.finalText === finalFor(binding) && event.error === undefined, 'terminal_body');
+}
+function preview(cycle: CycleState): BurstPreview {
+    const turn = findLiveActivity(cycle.binding.runId);
+    requireFact(turn, 'missing_live_turn');
+    let observedFieldChars = 0;
+    for (const entry of turn.model.entries.values()) {
+        requireFact(entry.kind === 'tool', 'unexpected_preview_kind');
+        observedFieldChars += entry.name.length + (entry.input?.length ?? 0)
+            + (entry.output?.length ?? 0) + (entry.detail?.length ?? 0);
+    }
+    const ids = [...turn.model.entries.keys()];
+    requireFact(ids.length <= 128, 'preview_id_limit');
+    const root = turn.view.element;
+    for (const node of root.querySelectorAll<HTMLElement>('.activity-item')) {
+        const id = node.dataset.activityItemId ?? '';
+        const expected = id.startsWith('bulk-')
+            ? `C${decimal(cycle.binding.cycle.index, 2)}B${id.slice(5)}|${'x'.repeat(2991)}\n[Preview limited; some text is omitted]`
+            : 'ok';
+        requireFact(node.querySelector('.activity-item-text')?.textContent === expected, 'visible_preview_oracle');
+    }
+    return { entryCount: turn.model.entries.size, retainedChars: activityRetainedChars(turn.model), observedFieldChars,
+        omittedEntries: turn.model.omitted.entries, omittedTextChars: turn.model.omitted.textChars,
+        latestAction: turn.model.latestAction, retainedIds: ids, visibleRows: root.querySelectorAll('.activity-item').length,
+        omissionVisible: root.querySelector<HTMLElement>('.activity-omitted')?.checkVisibility() === true };
+}
+function checkPreview(value: BurstPreview, bulk: boolean): void {
+    requireFact(value.entryCount === (bulk ? 16 : 128) && value.retainedChars === (bulk ? 65536 : 1408)
+        && value.observedFieldChars === (bulk ? 65536 : 1408) && value.omittedEntries === (bulk ? 496 : 513)
+        && value.omittedTextChars === 4608 && value.latestAction === (bulk ? 'tool-0511 (done)' : 'tail-0128 (done)')
+        && value.visibleRows === (bulk ? 16 : 8) && value.omissionVisible, bulk ? 'bulk_preview_oracle' : 'tail_preview_oracle');
+    requireFact(value.retainedIds.every((id, index) => id === (bulk ? `bulk-${decimal(index + 496, 4)}` : `tail-${decimal(index + 1, 4)}`)), 'retained_ids_oracle');
+}
+
+function frame(cycle: CycleState, callback: (timestamp: number) => void): void {
+    const id = requestAnimationFrame(timestamp => {
+        cycle.animationFrames.delete(id);
+        if (live(cycle)) callback(timestamp);
+    });
+    cycle.animationFrames.add(id);
+}
+function observeFrame(cycle: CycleState): void {
+    frame(cycle, timestamp => {
+        if (cycle.frames.length === 128) cycle.frames.shift();
+        cycle.frames.push([timestamp, cycle.received]);
+        if (!cycle.terminal) observeFrame(cycle);
+    });
+}
+function queueControl(cycle: CycleState): void {
+    requireFact(cycle.controls.length < 3, 'control_limit');
+    const observation: ControlObservation = { queuedAt: performance.now(), completedAt: null, frameAt: null,
+        queuedOrdinal: cycle.received, completedOrdinal: null, frameOrdinal: null, open: null };
+    cycle.controls.push(observation);
+    const timer = window.setTimeout(() => {
+        cycle.timers.delete(timer);
+        if (!live(cycle)) return;
+        try {
+            const summary = cycle.message?.querySelector<HTMLElement>('.activity-summary');
+            const disclosure = cycle.message?.querySelector<HTMLDetailsElement>('.activity-disclosure');
+            requireFact(summary && disclosure, 'control_missing_disclosure');
+            const before = disclosure.open;
+            summary.click(); // Real native summary default action, not a model setter.
+            observation.completedAt = performance.now(); observation.completedOrdinal = cycle.received;
+            observation.open = disclosure.open;
+            requireFact(before !== disclosure.open, 'control_did_not_toggle');
+            frame(cycle, timestamp => { observation.frameAt = timestamp; observation.frameOrdinal = cycle.received; });
+        } catch (error) { note(error, cycle); }
+    }, 0);
+    cycle.timers.add(timer);
+}
+function removeRetiredAfterDispatch(): void {
+    if (retiredRemovalQueued) return;
+    retiredRemovalQueued = true;
+    queueMicrotask(() => {
+        retiredUnsubscribe?.(); retiredUnsubscribe = null; retiredRemovalQueued = false;
+    });
+}
+// Separate lexical environment: a deliberately retained subscriber must never
+// capture prepare()'s CycleState through a shared closure environment.
+function callbackForToken(token: number): (wire: Record<string, unknown>) => void {
+    return wire => receive(token, wire);
+}
+function receive(token: number, wire: Record<string, unknown>): void {
+    const cycle = current;
+    if (!cycle || cycle.retired || cycle.token !== token) {
+        retiredCallbackHitsTotal++;
+        // Splicing event-channel's live subscription array synchronously skips
+        // the current subscriber. Retire only after this dispatch has finished.
+        removeRetiredAfterDispatch(); return;
+    }
+    cycle.received++;
+    try {
+        requireFact(wire.sseReplay !== true, 'replayed_runtime_frame');
+        const event = parseRuntimeEvent(wire);
+        requireFact(event, 'invalid_runtime_frame');
+        checkEvent(cycle, event);
+        cycle.lastSeq = event.seq;
+        if (cycle.received === 1) observeFrame(cycle);
+        if (cycle.received === 2) cycle.firstBulkSeq = event.seq;
+        if (cycle.received === 642) cycle.lastTailSeq = event.seq;
+        // Fixed preflight4 only: counted wire frame, deliberately no ingest.
+        if (cycle.binding.cycle.phase === 'preflight' && cycle.binding.cycle.index === 4 && cycle.received === 129) {
+            cycle.suppressed++; return;
+        }
+        const start = performance.now();
+        let turn: ReturnType<typeof ingestLiveActivity>;
+        try { turn = ingestLiveActivity(event); }
+        finally {
+            if (cycle.timingCount < TOTAL) cycle.timings[cycle.timingCount++] = performance.now() - start;
+        }
+        requireFact(turn && turn.model.seq === event.seq, 'ingest_rejected');
+        cycle.ingested++;
+        if ([65, 257, 449].includes(cycle.received)) queueControl(cycle);
+        if (cycle.received === 513) {
+            cycle.bulk = preview(cycle); checkPreview(cycle.bulk, true);
+        }
+        if (cycle.received === 642) {
+            cycle.final = preview(cycle); checkPreview(cycle.final, false);
+        }
+        if (event.kind === 'turn-end') {
+            cycle.terminal = true;
+            cycle.finalText = event.finalText;
+            replaceAgentAnswer(turn.message, event.finalText ?? '');
+            cycle.final = preview(cycle);
+            requireFact(cycle.received === TOTAL && cycle.ingested === TOTAL, 'ingestion_count_oracle');
+            requireFact(cycle.controls.some(control => control.completedOrdinal !== null && control.frameOrdinal !== null
+                && control.completedOrdinal < TOTAL && control.frameOrdinal < TOTAL), 'control_not_serviced_before_terminal');
+        }
+    } catch (error) { note(error, cycle); }
+}
+
+function rawFields(value: unknown, binding: BurstBinding): Record<string, unknown> {
+    requireFact(record(value) && value.turnId === binding.turnId && Array.isArray(value.fields)
+        && value.fields.length <= 8 && exactKeys(value, ['turnId', 'fields']), 'raw_codec_shape');
+    const fields: Record<string, unknown> = Object.create(null);
+    for (const pair of value.fields) {
+        requireFact(Array.isArray(pair) && pair.length === 2 && typeof pair[0] === 'string'
+            && ['kind', 'itemId', 'name', 'status', 'output'].includes(pair[0])
+            && !Object.hasOwn(fields, pair[0]), 'raw_field_tuple');
+        fields[pair[0]] = pair[1];
+    }
+    requireFact(exactKeys(fields, ['kind', 'itemId', 'name', 'status', 'output']), 'raw_field_keys');
+    return fields;
+}
+async function inspect(cycle: CycleState): Promise<void> {
+    requireFact(cycle.terminal && cycle.firstBulkSeq !== null && cycle.lastTailSeq !== null, 'raw_before_terminal');
+    for (const [seq, bulk] of [[cycle.firstBulkSeq, true], [cycle.lastTailSeq, false]] as const) {
+        const binding = cycle.binding;
+        const envelope = await readJson(cycle, `/api/traces/${encodeURIComponent(binding.runId)}/events/${seq}?session=${encodeURIComponent(binding.sessionId)}`, 65536);
+        requireFact(live(cycle) && record(envelope) && envelope.ok === true && record(envelope.data), 'raw_envelope');
+        const data = envelope.data;
+        requireFact(data.runId === binding.runId && data.seq === seq && data.source === 'runtime'
+            && data.eventType === 'tool' && data.retentionStatus === 'available'
+            && typeof data.raw === 'string' && data.raw.length > 0 && data.raw.length <= 32768, 'raw_identity');
+        const fields = rawFields(JSON.parse(data.raw), binding);
+        requireFact(fields.kind === 'tool' && fields.status === 'done'
+            && fields.itemId === (bulk ? 'bulk-0000' : 'tail-0128')
+            && fields.name === (bulk ? 'tool-0000' : 'tail-0128'), 'raw_body');
+        const output = fields.output;
+        requireFact(bulk ? outputMatches(output, binding, 0) : output === 'ok', 'raw_output');
+        requireFact(typeof output === 'string', 'raw_output_type');
+        cycle.rawProof.push({ runId: binding.runId, seq, outputBytes: output.length,
+            prefix: bulk ? output.slice(0, 9) : output, suffix: bulk ? output.slice(-8) : output });
+    }
+    if (live(cycle)) {
+        const output = document.createElement('output');
+        output.id = 'wp29-raw-proof'; output.setAttribute('role', 'status');
+        output.textContent = 'Two owned Trace reads verified: bulk 4096 bytes; compact ok.';
+        cycle.message?.after(output); cycle.rawUi = output;
+    }
+}
+
+function freshSnapshot(): BurstBrowserSnapshot {
+    return { protocol: PROTOCOL, binding: null, ready: false, terminal: false,
+        receivedCount: 0, ingestedCount: 0, retiredCallbackHits: 0, retiredCallbackHitsTotal,
+        suppressedIngestions: 0, activeEventSources, maxEventSources, bulk: null, final: null,
+        finalText: null, finalDomRaw: null, finalDomText: null, answerCount: 0,
+        controls: [], frames: [], ingest: { count: 0, p50Ms: 0, p95Ms: 0, maxMs: 0 }, errors: [], rawProof: [] };
+}
+function snapshot(): BurstBrowserSnapshot {
+    const cycle = current;
+    let result: BurstBrowserSnapshot;
+    if (!cycle) result = { ...(lastSnapshot ?? freshSnapshot()), activeEventSources, maxEventSources, retiredCallbackHitsTotal,
+        errors: [...pageErrors, ...(lastSnapshot?.errors ?? [])].slice(0, MAX_ERRORS) };
+    else {
+        const timings = Array.from(cycle.timings.subarray(0, cycle.timingCount)).sort((a, b) => a - b);
+        const quantile = (fraction: number) => timings[Math.max(0, Math.ceil(timings.length * fraction) - 1)] ?? 0;
+        const content = cycle.message?.querySelector<HTMLElement>('.msg-content');
+        result = { protocol: PROTOCOL, binding: cycle.binding, ready: cycle.ready, terminal: cycle.terminal,
+            receivedCount: cycle.received, ingestedCount: cycle.ingested,
+            retiredCallbackHits: retiredCallbackHitsTotal - cycle.retiredBaseline, retiredCallbackHitsTotal,
+            suppressedIngestions: cycle.suppressed, activeEventSources, maxEventSources,
+            bulk: cycle.bulk, final: cycle.final && live(cycle) ? preview(cycle) : cycle.final,
+            finalText: cycle.finalText, finalDomRaw: cycle.terminal ? content?.getAttribute('data-raw') ?? null : null,
+            finalDomText: cycle.terminal ? content?.innerText ?? null : null,
+            answerCount: document.querySelectorAll('#chatMessages .msg-agent').length,
+            controls: cycle.controls, frames: cycle.frames,
+            ingest: { count: cycle.timingCount, p50Ms: quantile(0.5), p95Ms: quantile(0.95), maxMs: quantile(1) },
+            errors: [...pageErrors, ...cycle.errors].slice(0, MAX_ERRORS), rawProof: cycle.rawProof };
+    }
+    // No DOM/model/event references escape. Returned scalars cannot mutate proof.
+    const encoded = JSON.stringify(result);
+    requireFact(new TextEncoder().encode(encoded).byteLength <= 32768, 'snapshot_size_limit');
+    return JSON.parse(encoded) as BurstBrowserSnapshot;
+}
+function waitWhilePreparing<T>(cycle: CycleState, work: Promise<T>, milliseconds: number): Promise<T> {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = (error: Error | null, value?: T) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer); cycle.timers.delete(timer);
+            cycle.abort.signal.removeEventListener('abort', abort);
+            if (error) reject(error); else resolve(value as T);
+        };
+        const abort = () => finish(new Error('prepare_aborted'));
+        const timer = window.setTimeout(() => finish(new Error('prepare_timeout')), milliseconds);
+        cycle.timers.add(timer);
+        cycle.abort.signal.addEventListener('abort', abort, { once: true });
+        if (cycle.abort.signal.aborted) abort();
+        work.then(value => finish(null, value), error => finish(new Error(errorText(error))));
+    });
+}
+function preparationTick(cycle: CycleState): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const finish = (aborted: boolean) => {
+            clearTimeout(timer); cycle.timers.delete(timer);
+            cycle.abort.signal.removeEventListener('abort', abort);
+            if (aborted) reject(new Error('prepare_aborted')); else resolve();
+        };
+        const abort = () => finish(true);
+        const timer = window.setTimeout(() => finish(false), 20);
+        cycle.timers.add(timer);
+        cycle.abort.signal.addEventListener('abort', abort, { once: true });
+        if (cycle.abort.signal.aborted) abort();
+    });
+}
+async function prepare(binding: BurstBinding): Promise<void> {
+    const next = bindingFrom(binding), expected = nextCycle(previous?.cycle ?? null);
+    requireFact(!pageDisposed && !current && !disposing && activeEventSources === 0, 'prepare_not_idle');
+    requireFact(expected && expected.phase === next.cycle.phase && expected.index === next.cycle.index, 'prepare_order');
+    if (previous) requireFact(previous.sessionId === next.sessionId && previous.scope === next.scope
+        && previous.runId !== next.runId, 'prepare_owner');
+    requireFact(location.protocol === 'http:' && location.hostname === '127.0.0.1'
+        && location.pathname === '/burst-fixture', 'fixture_origin');
+    requireFact(document.getElementById('chatMessages') && !state.currentAgentDiv
+        && !document.querySelector('#chatMessages .msg-agent'), 'fixture_host_not_empty');
+    const cycle: CycleState = { token: ++serial, binding: next, retired: false, ready: false, opened: 0,
+        terminal: false, received: 0, ingested: 0, suppressed: 0, retiredBaseline: retiredCallbackHitsTotal,
+        lastSeq: null, firstBulkSeq: null, lastTailSeq: null, bulk: null, final: null, finalText: null,
+        message: null, rawUi: null, controls: [], frames: [], timings: new Float64Array(TOTAL), timingCount: 0,
+        errors: [], rawProof: [], abort: new AbortController(), unsubscribe: null,
+        timers: new Set(), animationFrames: new Set(), rawPending: null };
+    current = cycle; previous = next; lastSnapshot = null;
+    try {
+        await waitWhilePreparing(cycle, localeReady ??= initI18n(), 10000);
+        requireFact(live(cycle), 'prepare_disposed');
+        setLiveActivityIdentity({ sessionId: next.sessionId, scope: next.scope });
+        setActivityTransportHealthy(true);
+        // This closure captures only a number, not the retired cycle/model/DOM.
+        cycle.unsubscribe = subscribe('agent', 'agent_runtime', callbackForToken(cycle.token));
+        connectEventChannel('en');
+        const deadline = performance.now() + 10000;
+        for (;;) {
+            requireFact(live(cycle) && cycle.errors.length === 0 && performance.now() < deadline, 'prepare_channel_failed');
+            if (cycle.opened === 1) {
+                const response = await readJson(cycle, '/__probe/metrics', 32768);
+                requireFact(record(response) && response.ok === true && record(response.data), 'metrics_envelope');
+                const metrics = response.data;
+                requireFact(metrics.protocol === PROTOCOL && metrics.state === 'prepared'
+                    && sameBinding(bindingFrom(metrics.binding), next) && record(metrics.sse), 'metrics_binding');
+                if (metrics.sse.activeConnections === 1) break;
+            }
+            await preparationTick(cycle);
+        }
+        requireFact(activeSourceCount() === 1 && subscriptions === (retiredUnsubscribe ? 3 : 2), 'subscription_baseline');
+        cycle.ready = true;
+    } catch (error) { note(error, cycle); throw error; }
+}
+function boundary(): Promise<boolean> {
+    return new Promise(resolve => {
+        const timeout = window.setTimeout(() => { cancelAnimationFrame(id); resolve(false); }, 2000);
+        const id = requestAnimationFrame(() => { clearTimeout(timeout); resolve(true); });
+    });
+}
+async function dispose(): Promise<BurstDisposal> {
+    const cycle = current;
+    if (!cycle) return { activeEventSources, rootConnected: false, handlerCount: 0,
+        retiredPending: !!retiredUnsubscribe, errors: activeEventSources ? ['disposal_source_still_active'] : [] };
+    const disposalErrors: string[] = [];
+    cycle.retired = true; cycle.ready = false;
+    if (cycle.binding.cycle.phase === 'preflight' && cycle.binding.cycle.index === 2 && cycle.unsubscribe) {
+        requireFact(!retiredUnsubscribe, 'retired_already_pending');
+        retiredUnsubscribe = cycle.unsubscribe; // One scalar-only retired callback for preflight3.
+    } else cycle.unsubscribe?.();
+    cycle.unsubscribe = null;
+    closeEventChannel(); cycle.abort.abort();
+    for (const timer of cycle.timers) clearTimeout(timer); cycle.timers.clear();
+    for (const id of cycle.animationFrames) cancelAnimationFrame(id); cycle.animationFrames.clear();
+    await cycle.rawPending;
+    lastSnapshot = snapshot();
+    let root: HTMLElement | null = findLiveActivity(cycle.binding.runId)?.view.element ?? null;
+    clearLiveActivity(); cancelPostRender(); getVirtualScroll().clear(); cleanupToolActivity();
+    cycle.rawUi?.remove(); cycle.rawUi = null;
+    cycle.message?.remove(); cycle.message = null;
+    const rootConnected = root?.isConnected ?? false;
+    let handlerCount = 0;
+    for (const node of root ? [root, ...root.querySelectorAll<HTMLElement>('*')] : []) {
+        if (node.onclick) handlerCount++;
+        if ((node as HTMLDetailsElement).ontoggle) handlerCount++;
+    }
+    root = null; current = null;
+    if (rootConnected || handlerCount || activeEventSources !== 0 || subscriptions !== (retiredUnsubscribe ? 2 : 1))
+        disposalErrors.push('disposal_resource_oracle');
+    if (!(await boundary()) || !(await boundary())) disposalErrors.push('disposal_frame_timeout');
+    return { activeEventSources, rootConnected, handlerCount, retiredPending: !!retiredUnsubscribe,
+        errors: disposalErrors };
+}
+function disposeCycle(): Promise<BurstDisposal> {
+    if (!disposing) disposing = dispose().finally(() => { disposing = null; });
+    return disposing;
+}
+
+requireFact(!window.__wp29Probe, 'duplicate_burst_fixture');
+window.EventSource = ObservedEventSource;
+setEventChannelScopeProvider(() => current?.binding.scope ?? null);
+const removeSentinel = subscribe('*', null, wire => {
+    if (wire.sseReplay === true || (wire.topic === 'system' && wire.event === 'replay_gap')) note('transport_replay_or_gap');
+});
+onChannelOpen(() => {
+    if (!current || current.retired) { note('open_without_cycle'); return; }
+    if (++current.opened !== 1) note('same_cycle_reconnect');
+});
+onChannelDisconnect(() => { if (current && !current.retired) { setActivityTransportHealthy(false); note('channel_disconnect'); } });
+onChannelUnavailable(() => { if (current && !current.retired) note('channel_unavailable'); });
+configureLiveActivityHost({
+    currentMessage: () => state.currentAgentDiv,
+    useMessage: message => {
+        requireFact(current && live(current), 'host_without_cycle');
+        state.currentAgentDiv = message; current.message = message;
+    },
+    createMessage: () => { cleanupToolActivity(); return addMessage('agent', '', 'fixture'); },
+    reconcileMessage: (id, update) => getVirtualScroll().reconcileMessage(id, update),
+    replaceAnswer: replaceAgentAnswer,
+    inspectTrace: (runId, sessionId) => {
+        const cycle = current;
+        if (!cycle || !live(cycle)) return;
+        if (runId !== cycle.binding.runId || sessionId !== cycle.binding.sessionId) { note('inspect_owner', cycle); return; }
+        if (cycle.rawPending || cycle.rawProof.length) return;
+        cycle.rawPending = inspect(cycle).catch(error => { if (!cycle.retired) note(error, cycle); })
+            .finally(() => { cycle.rawPending = null; });
+    },
+});
+window.__wp29Probe = Object.freeze({ prepare, snapshot, disposeCycle });
+window.addEventListener('pagehide', () => {
+    pageDisposed = true;
+    void disposeCycle().finally(() => {
+        retiredUnsubscribe?.(); retiredUnsubscribe = null; removeSentinel();
+        setEventChannelScopeProvider(null); window.EventSource = NativeEventSource;
+    });
+}, { once: true });

--- a/tests/smoke/native-activity-burst.mts
+++ b/tests/smoke/native-activity-burst.mts
@@ -1,0 +1,564 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
+import { randomBytes, createHash } from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { OwnedProcess } from '../../src/agent/spawn/process-kill.js';
+import type { BurstBinding, BurstCycle, BurstMetrics } from '../fixtures/native-activity-burst-server.mts';
+import type { BurstBrowserSnapshot } from '../fixtures/web-activity-burst.js';
+import type { Browser, BrowserContext, CDPSession, Page, Request as BrowserRequest } from 'playwright-core';
+
+const ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const PROTOCOL = 'wp29-burst-v2';
+const OUTPUT_BYTES = 2_097_152;
+const HEADER = 'x-wp29-probe';
+const COOKIE = 'wp29_probe';
+const LIMIT_MS = 15 * 60_000;
+const CYCLE_MS = 30_000;
+const LOG_BYTES = 4 * 1024 * 1024;
+
+export interface MemorySeriesInput {
+    initial: number[]; measured: number[]; final: number[]; pageBytes: number; identityStable: boolean;
+}
+export interface MemoryVerdict {
+    verdict: 'PLATEAU_OBSERVED' | 'GROWTH_OBSERVED' | 'INCONCLUSIVE';
+    reason: string; noise: number | null; windows: number[]; lateSlope: number | null;
+    totalChange: number | null; lateChange: number | null; nineSlope: number | null;
+}
+export function median(values: readonly number[]): number {
+    assert.ok(values.length > 0 && values.every(Number.isFinite));
+    const sorted = [...values].sort((a, b) => a - b), middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 ? sorted[middle]! : (sorted[middle - 1]! + sorted[middle]!) / 2;
+}
+export function classifyMemory(input: MemorySeriesInput): MemoryVerdict {
+    const unavailable = (reason: string): MemoryVerdict => ({ verdict: 'INCONCLUSIVE', reason,
+        noise: null, windows: [], lateSlope: null, totalChange: null, lateChange: null, nineSlope: null });
+    if (!input.identityStable) return unavailable('process identity changed or unavailable');
+    if (input.initial.length !== 5 || input.final.length !== 5 || input.measured.length !== 20
+        || !Number.isSafeInteger(input.pageBytes) || input.pageBytes <= 0
+        || [...input.initial, ...input.final, ...input.measured].some(value => !Number.isSafeInteger(value) || value <= 0))
+        return unavailable('missing or invalid same-seam samples');
+    const range = (values: number[]) => Math.max(...values) - Math.min(...values);
+    const mad = (values: number[]) => { const center = median(values); return median(values.map(value => Math.abs(value - center))); };
+    const noise = Math.max(input.pageBytes, range(input.initial), range(input.final), 3 * mad(input.initial), 3 * mad(input.final));
+    const windows = [0, 5, 10, 15].map(start => median(input.measured.slice(start, start + 5)));
+    const late = input.measured.slice(10), slopes: number[] = [];
+    for (let left = 0; left < late.length; left++) for (let right = left + 1; right < late.length; right++)
+        slopes.push((late[right]! - late[left]!) / (right - left));
+    const lateSlope = median(slopes), totalChange = windows[3]! - windows[0]!, lateChange = windows[3]! - windows[2]!;
+    const nineSlope = 9 * lateSlope;
+    const common = { noise, windows, lateSlope, totalChange, lateChange, nineSlope };
+    if (noise >= OUTPUT_BYTES) return { ...common, verdict: 'INCONCLUSIVE', reason: 'noise is at least one bulk submission' };
+    const increases = [1, 2, 3].map(index => windows[index]! - windows[index - 1]!);
+    if (Math.abs(lateChange) <= noise && Math.abs(nineSlope) <= noise && !(increases[1]! > noise && increases[2]! > noise))
+        return { ...common, verdict: 'PLATEAU_OBSERVED', reason: 'no sustained late increase above measured noise over20 fixed cycles' };
+    if (increases.every(value => value > noise) && nineSlope > noise)
+        return { ...common, verdict: 'GROWTH_OBSERVED', reason: 'all measured windows and late slope grow above noise' };
+    return { ...common, verdict: 'INCONCLUSIVE', reason: 'non-plateau shape without uniform sustained growth' };
+}
+
+export function parseBurstArgs(args: string[]): { label: string; executable: string; evidenceRoot: string } {
+    const values = new Map<string, string>();
+    for (let index = 0; index < args.length; index += 2) {
+        const key = args[index], value = args[index + 1];
+        if (!key || !['--label', '--browser-executable', '--evidence-root'].includes(key) || !value || values.has(key))
+            throw Error('unknown, duplicate or incomplete arguments');
+        values.set(key, value);
+    }
+    const label = values.get('--label') ?? '', executable = values.get('--browser-executable') ?? '';
+    if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(label) || !path.isAbsolute(executable)) throw Error('safe label and absolute browser executable required');
+    const evidenceRoot = path.resolve(values.get('--evidence-root') ?? path.join(ROOT, '.codexclaw/evidence/native-activity-burst'));
+    const allowed = path.join(ROOT, '.codexclaw/evidence');
+    if (evidenceRoot !== allowed && !evidenceRoot.startsWith(allowed + path.sep)) throw Error('evidence root must be repository-owned');
+    return { label, executable, evidenceRoot };
+}
+
+export type BrowserOracleSample = Pick<BurstBrowserSnapshot, 'receivedCount' | 'ingestedCount' | 'retiredCallbackHits'
+    | 'suppressedIngestions' | 'terminal' | 'activeEventSources' | 'maxEventSources' | 'errors' | 'bulk' | 'final'
+    | 'binding' | 'finalText' | 'finalDomRaw' | 'finalDomText' | 'answerCount' | 'controls'>;
+export function browserFailures(value: BrowserOracleSample): string[] {
+    const failures: string[] = [];
+    const check = (condition: boolean, name: string) => { if (!condition) failures.push(name); };
+    check(value.receivedCount === 643, 'received-count'); check(value.ingestedCount === 643, 'ingested-count');
+    check(value.retiredCallbackHits === 0, 'retired-subscriber'); check(value.suppressedIngestions === 0, 'suppressed-ingestion');
+    check(value.terminal, 'terminal'); check(value.activeEventSources === 1 && value.maxEventSources === 1, 'event-source-count');
+    check(value.errors.length === 0, 'browser-errors');
+    const bulk = value.bulk, final = value.final;
+    check(!!bulk && bulk.entryCount === 16 && bulk.retainedChars === 65536 && bulk.observedFieldChars === 65536
+        && bulk.omittedEntries === 496 && bulk.omittedTextChars === 4608 && bulk.latestAction === 'tool-0511 (done)', 'bulk-bounds');
+    check(!!final && final.entryCount === 128 && final.retainedChars === 1408 && final.observedFieldChars === 1408
+        && final.omittedEntries === 513 && final.omittedTextChars === 4608 && final.latestAction === 'tail-0128 (done)', 'tail-bounds');
+    const expectedIds = Array.from({ length: 128 }, (_, index) => `tail-${String(index + 1).padStart(4, '0')}`);
+    check(JSON.stringify(final?.retainedIds) === JSON.stringify(expectedIds), 'retained-identities');
+    check(final?.visibleRows === 8 && final.omissionVisible, 'latest-page');
+    const expected = value.binding ? `WP29 cycle ${String(value.binding.cycle.index).padStart(2, '0')} final` : null;
+    check(expected !== null && value.finalText === expected && value.finalDomRaw === expected
+        && value.finalDomText === expected && value.answerCount === 1, 'final-owner');
+    check(value.controls.some(control => control.completedAt !== null && control.frameAt !== null
+        && control.completedOrdinal !== null && control.frameOrdinal !== null
+        && control.completedAt >= control.queuedAt && control.frameAt >= control.completedAt
+        && control.completedOrdinal >= control.queuedOrdinal && control.frameOrdinal >= control.completedOrdinal
+        && control.frameOrdinal < 513 && value.receivedCount > control.frameOrdinal), 'control-frame-progress');
+    return failures;
+}
+
+async function bounded<T>(promise: Promise<T>, timeout: number, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    try { return await Promise.race([promise, new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(Error(`${label} timeout`)), timeout);
+    })]); } finally { clearTimeout(timer!); }
+}
+
+interface OwnedChild {
+    child: ChildProcess; owner: OwnedProcess; closed: Promise<void>; didClose: boolean; alive: boolean;
+    code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string; failure: string | null;
+}
+function ownedChild(executable: string, args: string[], env: NodeJS.ProcessEnv, ipc = false): OwnedChild {
+    const child = spawn(executable, args, { cwd: ROOT, env, detached: true,
+        stdio: ipc ? ['ignore', 'pipe', 'pipe', 'ipc'] : ['ignore', 'pipe', 'pipe'] });
+    let alive = true;
+    const owner = new OwnedProcess(child, { terminateTree: (_pid, signal = 'SIGTERM') => {
+        if (alive && child.exitCode === null && child.signalCode === null) child.kill(signal);
+    } });
+    const result = { child, owner, didClose: false, alive: true, code: null, signal: null,
+        stdout: '', stderr: '', failure: null } as Omit<OwnedChild, 'closed'> & { closed?: Promise<void> };
+    const retire = () => { alive = false; result.alive = false; owner.complete(); };
+    child.once('exit', retire); child.once('error', error => { result.failure = error.message; retire(); });
+    result.closed = new Promise(resolve => child.once('close', (code, signal) => {
+        result.didClose = true; result.code = code; result.signal = signal;
+        if ((code !== 0 || signal !== null) && result.failure === null) result.failure = `unsuccessful child exit:${code}:${signal}`;
+        retire(); resolve();
+    }));
+    for (const name of ['stdout', 'stderr'] as const) {
+        let bytes = 0;
+        child[name]!.on('data', (chunk: Buffer) => {
+            bytes += chunk.length;
+            if (bytes <= LOG_BYTES) result[name] += chunk.toString();
+            else { result.failure = `${name} output limit`; owner.terminate('output-limit'); }
+        });
+    }
+    return result as OwnedChild;
+}
+
+function safeEvidenceDirectory(parent: string, label: string): string {
+    let cursor = ROOT;
+    for (const part of path.relative(ROOT, parent).split(path.sep)) {
+        cursor = path.join(cursor, part);
+        if (!fs.existsSync(cursor)) fs.mkdirSync(cursor);
+        const stat = fs.lstatSync(cursor);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) throw Error('unsafe evidence ancestor');
+    }
+    const directory = path.join(parent, label); fs.mkdirSync(directory); return fs.realpathSync(directory);
+}
+
+function sourceHashes(): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const directory of ['src', 'public/js', 'public/css', 'types'])
+        for (const entry of fs.readdirSync(path.join(ROOT, directory), { recursive: true, withFileTypes: true })) {
+            if (!entry.isFile()) continue;
+            const filename = path.join(entry.parentPath, entry.name);
+            result[path.relative(ROOT, filename)] = createHash('sha256').update(fs.readFileSync(filename)).digest('hex');
+        }
+    for (const relative of ['package.json', 'package-lock.json', 'public/index.html',
+        'tests/fixtures/native-activity-burst-server.mts', 'tests/fixtures/web-activity-burst.ts',
+        'tests/smoke/native-activity-burst.mts', 'tests/unit/native-activity-burst-fixture.test.ts',
+        ...['playwright-core', 'vite', 'tsx', 'express', 'better-sqlite3'].map(name => `node_modules/${name}/package.json`)])
+        result[relative] = createHash('sha256').update(fs.readFileSync(path.join(ROOT, relative))).digest('hex');
+    return Object.fromEntries(Object.entries(result).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+interface Sample {
+    node: number; renderer: number | null; rendererIdentity: string | null;
+    rendererIssue: string | null; heap: unknown; dom: unknown; producer: BurstMetrics;
+}
+
+export async function runBurst(args: string[]): Promise<number> {
+    const options = parseBurstArgs(args);
+    if (!['darwin', 'linux'].includes(process.platform)) throw Error('this OS RSS probe supports darwin/linux only');
+    if (!fs.statSync(options.executable).isFile()) throw Error('browser executable is not a file');
+    const output = safeEvidenceDirectory(options.evidenceRoot, options.label);
+    const scratch = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'jaw-burst-')));
+    const env: NodeJS.ProcessEnv = { PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin:/usr/sbin:/sbin`, LANG: 'C',
+        NO_COLOR: '1', CLI_JAW_SKIP_AUTOMATION_PRIME: '1', JAW_OPEN_BROWSER: '0', JAW_DASHBOARD_OPEN: '0', JAW_SKILLS_SOURCE: 'local' };
+    for (const [key, relative] of Object.entries({ HOME: 'home', CLI_JAW_HOME: 'jaw', CLI_JAW_DASHBOARD_HOME: 'dashboard',
+        TMPDIR: 'tmp', XDG_CONFIG_HOME: 'config', XDG_CACHE_HOME: 'cache', XDG_DATA_HOME: 'data', XDG_STATE_HOME: 'state',
+        CODEX_HOME: 'codex', CLAUDE_CONFIG_DIR: 'claude', PI_CODING_AGENT_DIR: 'pi', npm_config_cache: 'npm' })) {
+        env[key] = path.join(scratch, relative); fs.mkdirSync(env[key]!);
+    }
+    const project = path.join(scratch, 'project'), profile = path.join(scratch, 'browser');
+    fs.mkdirSync(project); fs.mkdirSync(profile);
+    fs.writeFileSync(path.join(env['CLI_JAW_HOME']!, 'settings.json'), JSON.stringify({ workingDir: project,
+        messaging: { enabledChannels: [], homeChannel: null }, memory: { enabled: false }, locale: 'en' }));
+    fs.writeFileSync(path.join(env['CLI_JAW_HOME']!, 'mcp.json'), '{"servers":{}}');
+    fs.writeFileSync(path.join(env['CLI_JAW_HOME']!, 'heartbeat.json'), '{"jobs":[]}');
+    // Import-time config, DB, Vite and Playwright all see only this owned environment.
+    process.env = env;
+    const nonce = randomBytes(32).toString('hex');
+    const outputStat = fs.statSync(output);
+    const write = (name: string, value: unknown) => {
+        const now = fs.lstatSync(output);
+        assert.ok(now.isDirectory() && !now.isSymbolicLink() && now.dev === outputStat.dev && now.ino === outputStat.ino);
+        fs.writeFileSync(path.join(output, name), typeof value === 'string' ? value : JSON.stringify(value, null, 2), { flag: 'wx' });
+    };
+    const sourceBefore = sourceHashes();
+    const commit = execFileSync('git', ['--work-tree=' + ROOT, 'rev-parse', 'HEAD'], { cwd: ROOT, env: { ...env, GIT_OPTIONAL_LOCKS: '0' }, encoding: 'utf8', timeout: 3000 }).trim();
+    const dirty = execFileSync('git', ['--work-tree=' + ROOT, 'status', '--porcelain', '--untracked-files=all'],
+        { cwd: ROOT, env: { ...env, GIT_OPTIONAL_LOCKS: '0' }, encoding: 'utf8', timeout: 3000 }).trim() !== '';
+    write('source-before.json', { commit, dirty, sources: sourceBefore, node: process.versions.node, platform: process.platform, scratch });
+    const pageBytes = Number(execFileSync('getconf', ['PAGESIZE'], { env, encoding: 'utf8', timeout: 3000 }).trim());
+    assert.ok(Number.isSafeInteger(pageBytes) && pageBytes > 0);
+    const abort = new AbortController();
+    const watchdog = setTimeout(() => abort.abort(Error('whole invocation watchdog')), LIMIT_MS);
+    const interrupt = () => abort.abort(Error('operator signal'));
+    process.once('SIGINT', interrupt); process.once('SIGTERM', interrupt);
+    let producer: OwnedChild | undefined, chrome: OwnedChild | undefined, browser: Browser | undefined;
+    let context: BrowserContext | undefined, page: Page | undefined, browserCdp: CDPSession | undefined, pageCdp: CDPSession | undefined;
+    let vite: Awaited<ReturnType<typeof import('vite')['createServer']>> | undefined;
+    let server: http.Server | undefined, uiOrigin = '', producerOrigin = '', closing = false;
+    let fatal: string | null = null, nodeMemory: MemoryVerdict | null = null, rendererMemory: MemoryVerdict | null = null;
+    let rendererIdentity: string | null = null, rendererStable = true;
+    let producerStopped: Record<string, unknown> | null = null;
+    const unexpected: string[] = [], cycles: unknown[] = [], preflight: unknown[] = [];
+    const initial: Sample[][] = [], measured: Sample[][] = [], final: Sample[][] = [];
+    const sockets = new Set<import('node:net').Socket>(), upstream = new Set<http.ClientRequest>();
+    const activeSseRequests = new Set<BrowserRequest>(), retiredSseRequests = new WeakSet<BrowserRequest>();
+    const fail = (message: string) => { if (unexpected.length < 64) unexpected.push(message.slice(0, 500)); };
+    const ensureLive = () => {
+        abort.signal.throwIfAborted();
+        if (producer && (!producer.alive || producer.failure)) throw Error(`producer retired:${producer.failure ?? producer.code}`);
+        if (chrome && (!chrome.alive || chrome.failure)) throw Error(`browser retired:${chrome.failure ?? chrome.code}`);
+    };
+    async function control<T>(route: string, body?: unknown, overrideNonce = nonce): Promise<T> {
+        ensureLive();
+        const response = await fetch(producerOrigin + route, { method: body === undefined ? 'GET' : 'POST',
+            headers: { [HEADER]: overrideNonce, 'content-type': 'application/json' },
+            ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+            signal: AbortSignal.any([abort.signal, AbortSignal.timeout(5000)]) });
+        const reader = response.body?.getReader(); if (!reader) throw Error('control response has no body');
+        const chunks: Uint8Array[] = []; let bytes = 0;
+        try { while (true) {
+            const next = await reader.read(); if (next.done) break;
+            bytes += next.value.byteLength; if (bytes > 32768) throw Error('control response bound'); chunks.push(next.value);
+        } } finally { await reader.cancel().catch(() => {}); reader.releaseLock(); }
+        if (!response.ok) throw Error(`control HTTP${response.status}`);
+        const value = JSON.parse(Buffer.concat(chunks).toString()) as { ok?: boolean; data?: T };
+        if (value.ok !== true || (value.data === undefined && !['/__probe/start', '/__probe/settle', '/__probe/stop'].includes(route))) throw Error('control envelope');
+        // Only acknowledgement routes permit an absent payload; typed consumers
+        // validate their concrete fields after this JSON-envelope boundary.
+        return value.data as T;
+    }
+    const snapshot = async () => {
+        const value = await bounded(page!.evaluate(() => window.__wp29Probe.snapshot()), 5000, 'browser snapshot');
+        if (Buffer.byteLength(JSON.stringify(value)) > 32768) throw Error('browser snapshot bound');
+        return value;
+    };
+    async function waitFor(predicate: () => Promise<boolean>, name: string, timeout = 5000): Promise<void> {
+        const until = Date.now() + timeout;
+        while (!await predicate()) {
+            ensureLive(); if (Date.now() >= until) throw Error(`${name} timeout`);
+            await new Promise<void>(resolve => setTimeout(resolve, 20));
+        }
+    }
+    async function barriers(): Promise<void> {
+        ensureLive();
+        await bounded(page!.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))), 5000, 'browser scheduling barriers');
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    async function sampleCheckpoint(): Promise<Sample[]> {
+        const samples: Sample[] = [];
+        for (let index = 0; index < 5; index++) {
+            await barriers(); const metrics = await control<BurstMetrics>('/__probe/metrics');
+            assert.equal(metrics.resources.traceRuns, 0); assert.equal(metrics.resources.traceEvents, 0);
+            assert.equal(metrics.resources.runtimeRows, 0); assert.equal(metrics.resources.runtimeBytes, 0);
+            assert.equal(metrics.resources.busListeners, 1); assert.equal(metrics.resources.heartbeatIntervals, 0);
+            assert.equal(metrics.sse.activeConnections, 0); assert.equal(metrics.resources.pendingBatches, 0);
+            assert.equal(metrics.resources.ringCount, 1000); assert.equal(metrics.resources.watermarkCount, 3);
+            const info = await browserCdp!.send('SystemInfo.getProcessInfo');
+            const pids = info.processInfo.filter(value => value.type === 'renderer').map(value => value.id).sort((a, b) => a - b);
+            let rss: number | null = null, identity: string | null = null, rendererIssue: string | null = null;
+            if (pids.length && pids.every(pid => Number.isSafeInteger(pid) && pid > 0)) {
+                try {
+                const rows = execFileSync('/bin/ps', ['-p', pids.join(','), '-o', 'pid=,rss=,lstart='],
+                    { env, encoding: 'utf8', timeout: 3000 }).trim().split('\n').map(line => line.trim().split(/\s+/));
+                if (rows.length === pids.length && rows.every(row => pids.includes(Number(row[0])) && Number(row[1]) > 0 && row.length >= 7)) {
+                    rss = rows.reduce((total, row) => total + Number(row[1]) * 1024, 0);
+                    identity = rows.map(row => `${row[0]}:${row.slice(2).join(' ')}`).sort().join('|');
+                }
+                } catch (error) { rendererIssue = String(error).slice(0, 300); }
+            }
+            if (!identity) rendererStable = false;
+            else if (rendererIdentity === null) rendererIdentity = identity;
+            else if (rendererIdentity !== identity) rendererStable = false;
+            samples.push({ node: metrics.memory.rss, renderer: rss, rendererIdentity: identity, rendererIssue,
+                heap: await pageCdp!.send('Runtime.getHeapUsage'), dom: await pageCdp!.send('Memory.getDOMCounters'), producer: metrics });
+        }
+        return samples;
+    }
+    try {
+        const { createServer } = await import('vite');
+        const indexHtml = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+        const styles = [...indexHtml.matchAll(/href="(\/css\/[^" ]+\.css)"/g)].map(match => '/public' + match[1]);
+        const header = indexHtml.slice(indexHtml.indexOf('<div class="chat-header">'), indexHtml.indexOf('<div class="pabc-roadmap"'));
+        const html = `<!doctype html><html lang="en" data-theme="dark"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Activity burst fixture</title>
+            ${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}
+            <body><nav class="sidebar-left">Burst fixture</nav><main class="chat-area">${header}<div id="statusBadge"></div>
+            <div id="chatMessages" class="chat-messages"></div><div id="typingIndicator"><span class="label"></span></div>
+            <div class="chat-input-area"><textarea id="chatInput" aria-label="Fixture composer" disabled></textarea><button id="btnSend" disabled>Fixture only</button></div>
+            </main><aside class="sidebar-right">Controlled canonical events</aside>
+            <script type="module" src="/tests/fixtures/web-activity-burst.ts"></script></body></html>`;
+        const cacheDir = path.join(scratch, 'vite-cache');
+        vite = await createServer({ configFile: false, envFile: false, root: ROOT, publicDir: false, appType: 'custom', cacheDir,
+            logLevel: 'silent', server: { middlewareMode: true, hmr: false, ws: false, watch: null, cors: false,
+                fs: { strict: true, allow: [ROOT, cacheDir] } }, optimizeDeps: { entries: [path.join(ROOT, 'tests/fixtures/web-activity-burst.ts')] } });
+        server = http.createServer((req, res) => {
+            const requestUrl = new URL(req.url ?? '/', uiOrigin || 'http://127.0.0.1');
+            const pathname = requestUrl.pathname;
+            const reply = (status: number, value: unknown) => { res.writeHead(status, { 'content-type': 'application/json' }); res.end(JSON.stringify(value)); };
+            if (requestUrl.origin !== uiOrigin || req.headers.host !== new URL(uiOrigin).host) return reply(403, { error: 'fixture_origin' });
+            if (pathname === '/api/auth/token') return reply(200, { token: '' });
+            if (/^\/api\/i18n\/(en|ko)$/.test(pathname)) return reply(200,
+                JSON.parse(fs.readFileSync(path.join(ROOT, 'public/locales', pathname.split('/').at(-1)! + '.json'), 'utf8')));
+            if (pathname.startsWith('/api/') || pathname.startsWith('/__probe/')) {
+                if (!producerOrigin) return reply(503, { error: 'producer_pending' });
+                if (!(pathname === '/api/events' || pathname.startsWith('/api/traces/') || pathname.startsWith('/__probe/'))
+                    || !['GET', 'POST'].includes(req.method ?? '')) return reply(403, { error: 'fixture_api' });
+                const target = new URL(req.url!, producerOrigin);
+                const headers: http.OutgoingHttpHeaders = { host: target.host };
+                for (const key of ['cookie', 'origin', 'content-type', 'last-event-id', HEADER]) if (req.headers[key] !== undefined) headers[key] = req.headers[key];
+                let cancelled = false;
+                const outgoing = http.request(target, { method: req.method, headers, agent: false }, response => {
+                    res.writeHead(response.statusCode ?? 502, response.headers); response.pipe(res);
+                    response.once('error', () => { if (!res.destroyed) res.destroy(); });
+                });
+                upstream.add(outgoing); outgoing.once('close', () => upstream.delete(outgoing));
+                outgoing.once('error', error => { if (!closing && !cancelled) fail(`proxy:${error.message}`); if (!res.headersSent) reply(502, { error: 'proxy' }); else res.destroy(); });
+                req.once('aborted', () => { cancelled = true; outgoing.destroy(); });
+                res.once('close', () => { cancelled = true; outgoing.destroy(); }); req.pipe(outgoing); return;
+            }
+            if (!['GET', 'HEAD'].includes(req.method ?? '')) return reply(405, { error: 'fixture_method' });
+            if (pathname === '/burst-fixture') { res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' }); res.end(html); return; }
+            if (pathname === '/favicon.ico') { res.writeHead(204).end(); return; }
+            let relative = pathname;
+            if (/^\/(css|assets|fonts|images|vendor)\//.test(relative)) relative = '/public' + relative;
+            const candidate = path.resolve(relative.startsWith('/@fs/') ? relative.slice(4) : path.join(ROOT, relative));
+            const allowed = (file: string) => file === path.join(ROOT, 'tests/fixtures/web-activity-burst.ts')
+                || ['public', 'src/shared', 'node_modules'].some(root => file.startsWith(path.join(ROOT, root) + path.sep))
+                || file.startsWith(cacheDir + path.sep);
+            const special = ['/@vite/client', '/@id/__x00__vite-browser-external'].includes(pathname);
+            if (!special && (!allowed(candidate) || !/\.(?:[cm]?jsx?|tsx?|css|map|svg|png|jpe?g|webp|ico|woff2?|ttf)$/.test(candidate)
+                || (fs.existsSync(candidate) && !allowed(fs.realpathSync(candidate))))) return reply(403, { error: 'fixture_source' });
+            req.url = relative + requestUrl.search; vite!.middlewares(req, res, () => reply(404, { error: 'fixture_missing' }));
+        });
+        server.on('connection', socket => { sockets.add(socket); socket.once('close', () => sockets.delete(socket)); });
+        await new Promise<void>((resolve, reject) => { server!.once('error', reject); server!.listen(0, '127.0.0.1', resolve); });
+        const address = server.address(); assert.ok(address && typeof address !== 'string'); uiOrigin = `http://127.0.0.1:${address.port}`;
+        producer = ownedChild(process.execPath, ['--import', 'tsx', path.join(ROOT, 'tests/fixtures/native-activity-burst-server.mts')], env, true);
+        producer.child.on('message', message => {
+            if (message && typeof message === 'object' && 'kind' in message && message.kind === 'stopped')
+                producerStopped = message as Record<string, unknown>;
+        });
+        const ready = bounded(new Promise<Record<string, unknown>>((resolve, reject) => {
+            producer!.child.once('error', reject);
+            producer!.child.once('close', () => reject(Error('producer closed before ready')));
+            producer!.child.on('message', message => {
+                if (!message || typeof message !== 'object' || !('kind' in message)) return;
+                if (message.kind === 'ready') resolve(message as Record<string, unknown>);
+                else if (message.kind === 'failed') reject(Error('producer startup failed'));
+            });
+        }), 15000, 'producer ready');
+        producer.child.send!({ protocol: PROTOCOL, nonce, uiOrigin }, error => { if (error) { producer!.failure = error.message; abort.abort(error); } });
+        const info = await ready;
+        assert.equal(info['pid'], producer.child.pid); assert.equal(info['protocol'], PROTOCOL);
+        const origin = new URL(String(info['origin'])); assert.equal(origin.protocol, 'http:'); assert.equal(origin.hostname, '127.0.0.1'); assert.ok(Number(origin.port) > 0);
+        producerOrigin = origin.origin;
+        assert.equal(fs.realpathSync(String(info['home'])), fs.realpathSync(env['CLI_JAW_HOME']!));
+        write('producer-ready.json', info);
+        chrome = ownedChild(options.executable, [`--user-data-dir=${profile}`, '--headless=new', '--remote-debugging-port=0',
+            '--no-first-run', '--no-default-browser-check', '--disable-background-networking', '--disable-component-update',
+            '--disable-sync', '--disable-extensions', '--disable-default-apps', '--password-store=basic', '--use-mock-keychain', 'about:blank'], env);
+        const portFile = path.join(profile, 'DevToolsActivePort');
+        await waitFor(async () => fs.existsSync(portFile), 'browser endpoint', 15000);
+        const [port, id] = fs.readFileSync(portFile, 'utf8').trim().split('\n');
+        assert.ok(Number.isInteger(Number(port)) && Number(port) > 0 && Number(port) < 65536 && /^\/devtools\/browser\/[a-z0-9-]+$/i.test(id ?? ''));
+        const endpoint = `ws://127.0.0.1:${port}${id}`;
+        const { chromium } = await import('playwright-core');
+        browser = await chromium.connectOverCDP(endpoint, { timeout: 15000 }); ensureLive();
+        context = await bounded(browser.newContext({ viewport: { width: 1280, height: 720 }, serviceWorkers: 'block' }), 15000, 'browser context');
+        await context.route('**/*', route => {
+            const value = route.request().url();
+            if (value.startsWith(uiOrigin + '/') || /^(data:|blob:)/.test(value)) return route.continue();
+            fail('blocked foreign browser request:' + new URL(value).origin); return route.abort('blockedbyclient');
+        });
+        await context.addCookies([{ name: COOKIE, value: nonce, url: uiOrigin, httpOnly: true, sameSite: 'Strict' }]);
+        page = await bounded(context.newPage(), 15000, 'browser page');
+        page.setDefaultTimeout(5000); page.setDefaultNavigationTimeout(15000);
+        page.on('pageerror', error => fail('page:' + error.message));
+        page.on('crash', () => { fail('renderer crashed'); abort.abort(Error('renderer crashed')); });
+        page.on('console', message => { if (message.type() === 'error') fail('console:' + message.text()); });
+        page.on('request', request => { if (request.url().startsWith(uiOrigin + '/api/events?')) activeSseRequests.add(request); });
+        page.on('requestfinished', request => activeSseRequests.delete(request));
+        page.on('requestfailed', request => {
+            activeSseRequests.delete(request);
+            if (retiredSseRequests.has(request) && request.url().startsWith(uiOrigin + '/api/events?')) return;
+            if (!closing) fail('request:' + request.url().slice(0, 200) + ':' + request.failure()?.errorText);
+        });
+        await page.goto(uiOrigin + '/burst-fixture', { waitUntil: 'domcontentloaded', timeout: 15000 });
+        await page.waitForFunction(() => typeof window.__wp29Probe?.prepare === 'function', undefined, { timeout: 15000 });
+        browserCdp = await browser.newBrowserCDPSession(); pageCdp = await context.newCDPSession(page);
+        write('spec.json', { protocol: PROTOCOL, workload: '512x4096+129-small-v1', preflight: 5, warmup: 5, measured: 20,
+            initialIdle: 5, finalIdle: 5, pageBytes, cycleMs: CYCLE_MS, limitMs: LIMIT_MS, fixtureOrigin: uiOrigin,
+            producerOrigin, producerPid: producer.child.pid, browserPid: chrome.child.pid, browserExecutable: fs.realpathSync(options.executable),
+            versions: { node: process.versions.node, browser: await browser.version() }, scope: 'canonical writer/store/SSE/Activity, not actual providers or packaged Electron' });
+        await assert.rejects(control('/__probe/metrics', undefined, 'invalid'), /HTTP403/);
+        const beforeInvalid = await control<BurstMetrics>('/__probe/metrics');
+        await assert.rejects(control('/__probe/prepare', { cycle: { phase: 'unknown', index: 1 } }), /HTTP400/);
+        assert.equal((await control<BurstMetrics>('/__probe/metrics')).committed, beforeInvalid.committed);
+        const runCycle = async (cycle: BurstCycle): Promise<void> => {
+            const started = Date.now();
+            const binding = await control<BurstBinding>('/__probe/prepare', { cycle });
+            assert.equal(binding.protocol, PROTOCOL); assert.deepEqual(binding.cycle, cycle);
+            await bounded(page!.evaluate(binding => window.__wp29Probe.prepare(binding), binding), 15000, 'browser prepare');
+            await waitFor(async () => (await control<BurstMetrics>('/__probe/metrics')).sse.activeConnections === 1, 'SSE open');
+            await control('/__probe/start', { cycle });
+            if (cycle.phase === 'preflight' && cycle.index === 1) {
+                await page!.waitForFunction(() => window.__wp29Probe.snapshot().receivedCount >= 64, undefined, { timeout: CYCLE_MS });
+                const beforeCapture = await snapshot();
+                write('preflight-capture-start.json', { browser: beforeCapture, producer: await control<BurstMetrics>('/__probe/metrics') });
+                if (beforeCapture.terminal) throw Error('preflight bulk visual window missed');
+                const summary = page!.locator('.activity-disclosure > summary'); await summary.focus();
+                if (!await page!.locator('.activity-disclosure').evaluate(element => (element as HTMLDetailsElement).open)) await page!.keyboard.press('Enter');
+                await page!.screenshot({ path: path.join(output, 'preflight-bulk.png') });
+                write('preflight-capture-window.json', { before: beforeCapture.receivedCount, after: (await snapshot()).receivedCount });
+            }
+            await page!.waitForFunction(() => window.__wp29Probe.snapshot().terminal, undefined, { timeout: CYCLE_MS });
+            const value = await snapshot(), problems = browserFailures(value);
+            if (cycle.phase === 'preflight' && cycle.index === 3) {
+                assert.deepEqual(problems, ['retired-subscriber']); assert.equal(value.receivedCount, 643); assert.equal(value.ingestedCount, 643);
+            } else if (cycle.phase === 'preflight' && cycle.index === 4) {
+                assert.ok(problems.includes('ingested-count')); assert.equal(value.receivedCount, 643); assert.equal(value.ingestedCount, 642);
+            } else assert.deepEqual(problems, [], 'functional browser oracles');
+            const metrics = await control<BurstMetrics>('/__probe/metrics');
+            for (const key of ['attempted', 'committed', 'published'] as const) assert.equal(metrics[key], 643);
+            assert.equal(metrics.submittedOutputBytes, OUTPUT_BYTES + 258); assert.ok(metrics.committedCanonicalBytes >= 1048576);
+            assert.ok(metrics.storedRuntimeBytes < 4 * 1024 * 1024); assert.equal(metrics.resources.runtimeRows, 643);
+            assert.equal(metrics.resources.traceEvents, 644); assert.equal(metrics.sse.slowClientClosed, 0); assert.equal(metrics.sse.replayGapCount, 0);
+            await page!.getByRole('button', { name: 'Inspect retained activity in Trace' }).click();
+            await waitFor(async () => (await snapshot()).rawProof.length === 2, 'raw proof');
+            const withRaw = await snapshot();
+            const early = withRaw.rawProof.find(row => row.seq === metrics.firstBulkTraceSeq);
+            const late = withRaw.rawProof.find(row => row.seq === metrics.lastTailTraceSeq);
+            assert.equal(early?.runId, binding.runId); assert.equal(early?.outputBytes, 4096);
+            assert.equal(early?.prefix, `C${String(cycle.index).padStart(2, '0')}B0000|`); assert.equal(early?.suffix, '|END0000');
+            assert.equal(late?.runId, binding.runId); assert.equal(late?.outputBytes, 2);
+            if (cycle.phase === 'preflight' && cycle.index === 1) {
+                const summary = page!.locator('.activity-disclosure > summary'); await summary.focus();
+                if (!await page!.locator('.activity-disclosure').evaluate(element => (element as HTMLDetailsElement).open)) await page!.keyboard.press('Enter');
+                await page!.getByRole('button', { name: 'Earlier activity', exact: true }).click();
+                assert.equal(await page!.locator('.activity-item').count(), 40);
+                await page!.screenshot({ path: path.join(output, 'preflight-earlier.png') });
+                await page!.getByRole('button', { name: 'Later activity', exact: true }).click();
+                assert.equal(await page!.locator('.activity-item').count(), 8);
+                await page!.locator('.activity-item > summary').last().click();
+                assert.equal(await page!.locator('.activity-item-text').last().innerText(), 'ok');
+                await page!.screenshot({ path: path.join(output, 'preflight-latest.png') });
+                await assert.rejects(control(`/api/traces/${binding.runId}/events/${metrics.firstBulkTraceSeq}?session=wrong-session`), /HTTP404/);
+            }
+            for (const request of activeSseRequests) retiredSseRequests.add(request);
+            const disposal = await bounded(page!.evaluate(() => window.__wp29Probe.disposeCycle()), 5000, 'browser disposal');
+            assert.equal(disposal.activeEventSources, 0); assert.equal(disposal.rootConnected, false); assert.equal(disposal.handlerCount, 0);
+            assert.deepEqual(disposal.errors, []);
+            assert.equal(disposal.retiredPending, cycle.phase === 'preflight' && cycle.index === 2);
+            await waitFor(async () => (await control<BurstMetrics>('/__probe/metrics')).sse.activeConnections === 0, 'SSE closed');
+            await control('/__probe/settle', { cycle, lastObservedTraceSeq: metrics.terminalTraceSeq, receivedCount: value.receivedCount });
+            assert.ok(Date.now() - started <= CYCLE_MS, 'cycle deadline');
+            const record = { cycle, binding, browser: withRaw, producer: metrics, disposal, problems, elapsedMs: Date.now() - started };
+            if (cycle.phase === 'preflight') preflight.push(record);
+            else cycles.push({ cycle, problems, elapsedMs: record.elapsedMs, artifact: `${cycle.phase}-${String(cycle.index).padStart(2, '0')}.json` });
+            write(`${cycle.phase}-${String(cycle.index).padStart(2, '0')}.json`, record);
+            console.log(`${cycle.phase} ${cycle.index}: ${cycle.phase === 'preflight' && [3, 4].includes(cycle.index) ? 'expected oracle rejection' : 'functional PASS'}`);
+        };
+        for (let index = 1; index <= 5; index++) await runCycle({ phase: 'preflight', index });
+        for (let index = 1; index <= 5; index++) await runCycle({ phase: 'warmup', index });
+        for (let index = 0; index < 5; index++) initial.push(await sampleCheckpoint());
+        for (let index = 1; index <= 20; index++) { await runCycle({ phase: 'measured', index }); measured.push(await sampleCheckpoint()); }
+        for (let index = 0; index < 5; index++) final.push(await sampleCheckpoint());
+        const medians = (groups: Sample[][], key: 'node' | 'renderer') => groups.map(group => median(group.map(row => row[key] ?? NaN)));
+        nodeMemory = classifyMemory({ initial: medians(initial, 'node'), measured: medians(measured, 'node'), final: medians(final, 'node'), pageBytes, identityStable: true });
+        rendererMemory = rendererStable ? classifyMemory({ initial: medians(initial, 'renderer'), measured: medians(measured, 'renderer'), final: medians(final, 'renderer'), pageBytes, identityStable: true })
+            : classifyMemory({ initial: [], measured: [], final: [], pageBytes, identityStable: false });
+        assert.deepEqual(unexpected, [], 'unexpected page/network errors');
+    } catch (error) { fatal = error instanceof Error ? error.message : String(error); }
+    finally {
+        clearTimeout(watchdog); closing = true;
+        for (const request of activeSseRequests) retiredSseRequests.add(request);
+        const cleanupErrors: string[] = [];
+        const clean = async (name: string, action: () => Promise<unknown>) => { try { await bounded(action(), 5000, name); } catch (error) { cleanupErrors.push(`${name}:${String(error)}`.slice(0, 500)); } };
+        if (page && !page.isClosed()) await clean('page disposal', async () => { await page!.evaluate(() => window.__wp29Probe?.disposeCycle()); });
+        if (context) await clean('context close', () => context!.close());
+        if (chrome?.alive && browserCdp) await clean('Browser.close', () => browserCdp!.send('Browser.close').catch(error => {
+            if (chrome!.alive) throw error;
+        }));
+        if (browser) await clean('CDP disconnect', () => browser!.close());
+        if (producer?.alive && producer.child.connected) producer.child.send!({ kind: 'stop' }, error => { if (error) cleanupErrors.push('producer stop IPC:' + error.message); });
+        for (const [name, owned] of [['producer', producer], ['browser', chrome]] as const) if (owned) {
+            try { await bounded(owned.closed, 5000, `${name} cooperative close`); }
+            catch { owned.owner.terminate('shutdown'); await clean(`${name} retained close`, () => owned.closed); }
+        }
+        for (const request of upstream) request.destroy();
+        if (server) { server.closeAllConnections(); await clean('UI server close', () => new Promise<void>(resolve => server!.close(() => resolve()))); }
+        if (vite) await clean('Vite close', () => vite!.close());
+        for (const owned of [producer, chrome]) if (owned && !owned.didClose) {
+            if (owned.child.connected) owned.child.disconnect();
+            owned.child.stdout?.destroy(); owned.child.stderr?.destroy(); owned.child.unref();
+        }
+        process.removeListener('SIGINT', interrupt); process.removeListener('SIGTERM', interrupt);
+        const children = [producer, chrome].filter((value): value is OwnedChild => !!value).map(owned => {
+            let groupAbsent = false;
+            try { process.kill(-owned.child.pid!, 0); } catch (error) { groupAbsent = (error as NodeJS.ErrnoException).code === 'ESRCH'; }
+            return { pid: owned.child.pid, closed: owned.didClose, code: owned.code, signal: owned.signal, groupAbsent, failure: owned.failure };
+        });
+        let sourcesStable = false;
+        try { const after = sourceHashes(); write('source-after.json', { sources: after }); sourcesStable = JSON.stringify(sourceBefore) === JSON.stringify(after); }
+        catch (error) { cleanupErrors.push('source check:' + String(error)); }
+        for (const [name, owned] of [['producer', producer], ['browser', chrome]] as const) if (owned) {
+            write(`${name}.stdout.log`, owned.stdout); write(`${name}.stderr.log`, owned.stderr);
+        }
+        const stopped = producerStopped as Record<string, unknown> | null;
+        if (stopped) write('producer-stop.json', stopped);
+        const producerResources = stopped?.['resources'];
+        const dbClosed = stopped?.['kind'] === 'stopped' && stopped['protocol'] === PROTOCOL && stopped['pid'] === producer?.child.pid
+            && stopped['closed'] === true && stopped['httpClosed'] === true && stopped['dbOpen'] === false
+            && producerResources !== null && typeof producerResources === 'object' && !Array.isArray(producerResources)
+            && Object.keys(producerResources).length === 5
+            && ['activeSse', 'busListeners', 'heartbeatIntervals', 'sockets', 'pendingBatches']
+                .every(key => (producerResources as Record<string, unknown>)[key] === 0);
+        const certified = dbClosed && cleanupErrors.length === 0 && children.length === 2 && children.every(row => row.closed && row.groupAbsent && !row.failure)
+            && !server?.listening && sockets.size === 0 && upstream.size === 0;
+        write('teardown.json', { children, cleanupErrors, certified, scratch, rootDisposition: 'retained-by-policy',
+            dbClosed, uiListening: server?.listening ?? false, sockets: sockets.size, upstream: upstream.size, sourcesStable, at: new Date().toISOString() });
+        write('samples.json', { initial, measured, final, rendererIdentity, rendererStable });
+        write('preflight.json', preflight); write('cycles.json', cycles);
+        const summary = { functional: fatal || unexpected.length ? 'FAIL' : 'PASS', fatal, unexpected,
+            nodeRss: nodeMemory, rendererRss: rendererMemory, rendererScope: 'dedicated browser renderer RSS sum, not inferred page RSS',
+            cleanup: certified ? 'CERTIFIED' : 'UNCERTIFIED', sourcesStable, output,
+            limits: 'canonical writer/store/SSE/Activity fixture; no provider/SDK-process/full-ws/MESSAGE/packaged-Electron or universal leak-free claim' };
+        write('summary.json', summary); console.log(JSON.stringify(summary));
+        if (fatal || unexpected.length || !certified || !sourcesStable) return 1;
+        return nodeMemory?.verdict === 'PLATEAU_OBSERVED' && rendererMemory?.verdict === 'PLATEAU_OBSERVED' ? 0 : 3;
+    }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+    if (process.env.NODE_TEST_CONTEXT) {
+        const { test } = await import('node:test');
+        const args = ['--label', process.env.CLI_JAW_BURST_LABEL ?? '',
+            '--browser-executable', process.env.CLI_JAW_BURST_BROWSER ?? ''];
+        test('canonical Activity burst, concurrency, cleanup and RSS conformance', async () => {
+            assert.equal(await runBurst(args), 0, 'inspect retained summary.json for separate functional, cleanup and RSS verdicts');
+        });
+    } else if (process.argv.slice(2).includes('--help')) console.log('node --import tsx tests/smoke/native-activity-burst.mts --label NAME --browser-executable ABSOLUTE_PATH [--evidence-root REPO_EVIDENCE_ROOT]\nUnder node --test, set CLI_JAW_BURST_LABEL and CLI_JAW_BURST_BROWSER.');
+    else runBurst(process.argv.slice(2)).then(code => { process.exitCode = code; }).catch(error => { console.error(String(error)); process.exitCode = 2; });
+}

--- a/tests/smoke/native-activity-burst.mts
+++ b/tests/smoke/native-activity-burst.mts
@@ -79,6 +79,28 @@ export function parseBurstArgs(args: string[]): { label: string; executable: str
 export type BrowserOracleSample = Pick<BurstBrowserSnapshot, 'receivedCount' | 'ingestedCount' | 'retiredCallbackHits'
     | 'suppressedIngestions' | 'terminal' | 'activeEventSources' | 'maxEventSources' | 'errors' | 'bulk' | 'final'
     | 'binding' | 'finalText' | 'finalDomRaw' | 'finalDomText' | 'answerCount' | 'controls'>;
+// Exact request identities cross disposal; URL similarity alone never retires a failure.
+export function probeRequestTracker<T extends { url(): string; method(): string }>(origin: string) {
+    const active = new Set<T>(), retired = new WeakSet<T>();
+    let disposing = false;
+    const owned = (request: T) => {
+        const url = new URL(request.url());
+        return request.method() === 'GET' && url.origin === origin
+            && (/^\/(?:__probe\/metrics|api\/events|api\/auth\/token|api\/i18n\/(?:en|ko))$/.test(url.pathname)
+                || /^\/api\/traces\/tr_[A-Za-z0-9_-]+\/events\/[1-9]\d*$/.test(url.pathname));
+    };
+    return {
+        started(request: T) { if (owned(request)) { active.add(request); if (disposing) retired.add(request); } },
+        finished(request: T) { active.delete(request); },
+        beginDisposal() { disposing = true; for (const request of active) retired.add(request); },
+        endDisposal() { disposing = false; },
+        failed(request: T, error: string | undefined) {
+            active.delete(request);
+            return { retired: retired.has(request), duringDisposal: disposing,
+                expected: retired.has(request) && error === 'net::ERR_ABORTED' };
+        },
+    };
+}
 export function browserFailures(value: BrowserOracleSample): string[] {
     const failures: string[] = [];
     const check = (condition: boolean, name: string) => { if (!condition) failures.push(name); };
@@ -224,7 +246,8 @@ export async function runBurst(args: string[]): Promise<number> {
     const unexpected: string[] = [], cycles: unknown[] = [], preflight: unknown[] = [];
     const initial: Sample[][] = [], measured: Sample[][] = [], final: Sample[][] = [];
     const sockets = new Set<import('node:net').Socket>(), upstream = new Set<http.ClientRequest>();
-    const activeSseRequests = new Set<BrowserRequest>(), retiredSseRequests = new WeakSet<BrowserRequest>();
+    let requests: ReturnType<typeof probeRequestTracker<BrowserRequest>> | undefined;
+    const requestFailures: unknown[] = [];
     const fail = (message: string) => { if (unexpected.length < 64) unexpected.push(message.slice(0, 500)); };
     const ensureLive = () => {
         abort.signal.throwIfAborted();
@@ -398,12 +421,14 @@ export async function runBurst(args: string[]): Promise<number> {
         page.on('pageerror', error => fail('page:' + error.message));
         page.on('crash', () => { fail('renderer crashed'); abort.abort(Error('renderer crashed')); });
         page.on('console', message => { if (message.type() === 'error') fail('console:' + message.text()); });
-        page.on('request', request => { if (request.url().startsWith(uiOrigin + '/api/events?')) activeSseRequests.add(request); });
-        page.on('requestfinished', request => activeSseRequests.delete(request));
+        requests = probeRequestTracker<BrowserRequest>(uiOrigin);
+        page.on('request', request => requests!.started(request));
+        page.on('requestfinished', request => requests!.finished(request));
         page.on('requestfailed', request => {
-            activeSseRequests.delete(request);
-            if (retiredSseRequests.has(request) && request.url().startsWith(uiOrigin + '/api/events?')) return;
-            if (!closing) fail('request:' + request.url().slice(0, 200) + ':' + request.failure()?.errorText);
+            const error = request.failure()?.errorText;
+            const classification = requests!.failed(request, error);
+            if (requestFailures.length < 64) requestFailures.push({ url: request.url().slice(0, 200), error, ...classification });
+            if (!classification.expected) fail('request:' + request.url().slice(0, 200) + ':' + error);
         });
         await page.goto(uiOrigin + '/burst-fixture', { waitUntil: 'domcontentloaded', timeout: 15000 });
         await page.waitForFunction(() => typeof window.__wp29Probe?.prepare === 'function', undefined, { timeout: 15000 });
@@ -423,16 +448,6 @@ export async function runBurst(args: string[]): Promise<number> {
             await bounded(page!.evaluate(binding => window.__wp29Probe.prepare(binding), binding), 15000, 'browser prepare');
             await waitFor(async () => (await control<BurstMetrics>('/__probe/metrics')).sse.activeConnections === 1, 'SSE open');
             await control('/__probe/start', { cycle });
-            if (cycle.phase === 'preflight' && cycle.index === 1) {
-                await page!.waitForFunction(() => window.__wp29Probe.snapshot().receivedCount >= 64, undefined, { timeout: CYCLE_MS });
-                const beforeCapture = await snapshot();
-                write('preflight-capture-start.json', { browser: beforeCapture, producer: await control<BurstMetrics>('/__probe/metrics') });
-                if (beforeCapture.terminal) throw Error('preflight bulk visual window missed');
-                const summary = page!.locator('.activity-disclosure > summary'); await summary.focus();
-                if (!await page!.locator('.activity-disclosure').evaluate(element => (element as HTMLDetailsElement).open)) await page!.keyboard.press('Enter');
-                await page!.screenshot({ path: path.join(output, 'preflight-bulk.png') });
-                write('preflight-capture-window.json', { before: beforeCapture.receivedCount, after: (await snapshot()).receivedCount });
-            }
             await page!.waitForFunction(() => window.__wp29Probe.snapshot().terminal, undefined, { timeout: CYCLE_MS });
             const value = await snapshot(), problems = browserFailures(value);
             if (cycle.phase === 'preflight' && cycle.index === 3) {
@@ -454,6 +469,20 @@ export async function runBurst(args: string[]): Promise<number> {
             assert.equal(early?.prefix, `C${String(cycle.index).padStart(2, '0')}B0000|`); assert.equal(early?.suffix, '|END0000');
             assert.equal(late?.runId, binding.runId); assert.equal(late?.outputBytes, 2);
             if (cycle.phase === 'preflight' && cycle.index === 1) {
+                // Frozen actual checkpoint DOM, not a screenshot racing live delivery.
+                const capture = await page!.evaluate(() => window.__wp29Probe.takeBulkCapture());
+                assert.equal(capture.receivedCount, 513);
+                assert.ok(capture.html.length > 0 && Buffer.byteLength(capture.html) <= 131072);
+                const capturePage = await context!.newPage();
+                try {
+                    await capturePage.setContent(`<base href="${uiOrigin}/">${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}<main>${capture.html}</main>`);
+                    await capturePage.locator('.activity-disclosure > summary').focus();
+                    if (!await capturePage.locator('.activity-disclosure').evaluate(element => (element as HTMLDetailsElement).open)) await capturePage.keyboard.press('Enter');
+                    await capturePage.locator('.activity-item > summary').first().click();
+                    assert.equal(await capturePage.locator('.activity-item').count(), 16);
+                    await capturePage.screenshot({ path: path.join(output, 'preflight-bulk.png') });
+                } finally { await capturePage.close(); }
+                write('preflight-capture-window.json', { receivedCount: capture.receivedCount, mode: 'frozen bulk checkpoint DOM; not live presentation timing' });
                 const summary = page!.locator('.activity-disclosure > summary'); await summary.focus();
                 if (!await page!.locator('.activity-disclosure').evaluate(element => (element as HTMLDetailsElement).open)) await page!.keyboard.press('Enter');
                 await page!.getByRole('button', { name: 'Earlier activity', exact: true }).click();
@@ -466,8 +495,9 @@ export async function runBurst(args: string[]): Promise<number> {
                 await page!.screenshot({ path: path.join(output, 'preflight-latest.png') });
                 await assert.rejects(control(`/api/traces/${binding.runId}/events/${metrics.firstBulkTraceSeq}?session=wrong-session`), /HTTP404/);
             }
-            for (const request of activeSseRequests) retiredSseRequests.add(request);
-            const disposal = await bounded(page!.evaluate(() => window.__wp29Probe.disposeCycle()), 5000, 'browser disposal');
+            requests!.beginDisposal();
+            const disposal = await bounded(page!.evaluate(() => window.__wp29Probe.disposeCycle()), 5000, 'browser disposal')
+                .finally(() => requests!.endDisposal());
             assert.equal(disposal.activeEventSources, 0); assert.equal(disposal.rootConnected, false); assert.equal(disposal.handlerCount, 0);
             assert.deepEqual(disposal.errors, []);
             assert.equal(disposal.retiredPending, cycle.phase === 'preflight' && cycle.index === 2);
@@ -493,7 +523,7 @@ export async function runBurst(args: string[]): Promise<number> {
     } catch (error) { fatal = error instanceof Error ? error.message : String(error); }
     finally {
         clearTimeout(watchdog); closing = true;
-        for (const request of activeSseRequests) retiredSseRequests.add(request);
+        requests?.beginDisposal();
         const cleanupErrors: string[] = [];
         const clean = async (name: string, action: () => Promise<unknown>) => { try { await bounded(action(), 5000, name); } catch (error) { cleanupErrors.push(`${name}:${String(error)}`.slice(0, 500)); } };
         if (page && !page.isClosed()) await clean('page disposal', async () => { await page!.evaluate(() => window.__wp29Probe?.disposeCycle()); });
@@ -541,6 +571,7 @@ export async function runBurst(args: string[]): Promise<number> {
             dbClosed, uiListening: server?.listening ?? false, sockets: sockets.size, upstream: upstream.size, sourcesStable, at: new Date().toISOString() });
         write('samples.json', { initial, measured, final, rendererIdentity, rendererStable });
         write('preflight.json', preflight); write('cycles.json', cycles);
+        write('request-failures.json', requestFailures);
         const summary = { functional: fatal || unexpected.length ? 'FAIL' : 'PASS', fatal, unexpected,
             nodeRss: nodeMemory, rendererRss: rendererMemory, rendererScope: 'dedicated browser renderer RSS sum, not inferred page RSS',
             cleanup: certified ? 'CERTIFIED' : 'UNCERTIFIED', sourcesStable, output,
@@ -556,7 +587,8 @@ if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === imp
         const { test } = await import('node:test');
         const args = ['--label', process.env.CLI_JAW_BURST_LABEL ?? '',
             '--browser-executable', process.env.CLI_JAW_BURST_BROWSER ?? ''];
-        test('canonical Activity burst, concurrency, cleanup and RSS conformance', async () => {
+        test('canonical Activity burst, concurrency, cleanup and RSS conformance',
+            { skip: !process.env.CLI_JAW_BURST_BROWSER && !process.env.CLI_JAW_BURST_LABEL ? 'opt-in diagnostic: set CLI_JAW_BURST_BROWSER and CLI_JAW_BURST_LABEL' : false }, async () => {
             assert.equal(await runBurst(args), 0, 'inspect retained summary.json for separate functional, cleanup and RSS verdicts');
         });
     } else if (process.argv.slice(2).includes('--help')) console.log('node --import tsx tests/smoke/native-activity-burst.mts --label NAME --browser-executable ABSOLUTE_PATH [--evidence-root REPO_EVIDENCE_ROOT]\nUnder node --test, set CLI_JAW_BURST_LABEL and CLI_JAW_BURST_BROWSER.');

--- a/tests/smoke/native-activity-burst.mts
+++ b/tests/smoke/native-activity-burst.mts
@@ -248,6 +248,17 @@ export async function runBurst(args: string[]): Promise<number> {
     const sockets = new Set<import('node:net').Socket>(), upstream = new Set<http.ClientRequest>();
     let requests: ReturnType<typeof probeRequestTracker<BrowserRequest>> | undefined;
     const requestFailures: unknown[] = [];
+    let diagnosticCycle: BurstCycle | null = null;
+    const disposalWindows: Array<{ cycle: BurstCycle | null; openedAt: number; closedAt: number | null }> = [];
+    let browserReadDiagnostics: unknown = null;
+    const requestStarts = new WeakMap<BrowserRequest, { at: number; cycle: BurstCycle | null }>();
+    const beginDisposal = () => {
+        const window = { cycle: diagnosticCycle && { ...diagnosticCycle }, openedAt: performance.now(), closedAt: null as number | null };
+        disposalWindows.push(window); requests?.beginDisposal(); return window;
+    };
+    const endDisposal = (window: typeof disposalWindows[number]) => {
+        requests?.endDisposal(); window.closedAt = performance.now();
+    };
     const fail = (message: string) => { if (unexpected.length < 64) unexpected.push(message.slice(0, 500)); };
     const ensureLive = () => {
         abort.signal.throwIfAborted();
@@ -422,12 +433,17 @@ export async function runBurst(args: string[]): Promise<number> {
         page.on('crash', () => { fail('renderer crashed'); abort.abort(Error('renderer crashed')); });
         page.on('console', message => { if (message.type() === 'error') fail('console:' + message.text()); });
         requests = probeRequestTracker<BrowserRequest>(uiOrigin);
-        page.on('request', request => requests!.started(request));
+        page.on('request', request => {
+            requestStarts.set(request, { at: performance.now(), cycle: diagnosticCycle && { ...diagnosticCycle } });
+            requests!.started(request);
+        });
         page.on('requestfinished', request => requests!.finished(request));
         page.on('requestfailed', request => {
             const error = request.failure()?.errorText;
             const classification = requests!.failed(request, error);
-            if (requestFailures.length < 64) requestFailures.push({ url: request.url().slice(0, 200), error, ...classification });
+            if (requestFailures.length < 64) requestFailures.push({ url: request.url().slice(0, 200), error, ...classification,
+                failedAt: performance.now(), cycle: diagnosticCycle && { ...diagnosticCycle },
+                started: requestStarts.get(request), readId: request.headers()['x-wp29-read-id'] ?? null });
             if (!classification.expected) fail('request:' + request.url().slice(0, 200) + ':' + error);
         });
         await page.goto(uiOrigin + '/burst-fixture', { waitUntil: 'domcontentloaded', timeout: 15000 });
@@ -442,6 +458,7 @@ export async function runBurst(args: string[]): Promise<number> {
         await assert.rejects(control('/__probe/prepare', { cycle: { phase: 'unknown', index: 1 } }), /HTTP400/);
         assert.equal((await control<BurstMetrics>('/__probe/metrics')).committed, beforeInvalid.committed);
         const runCycle = async (cycle: BurstCycle): Promise<void> => {
+            diagnosticCycle = { ...cycle };
             const started = Date.now();
             const binding = await control<BurstBinding>('/__probe/prepare', { cycle });
             assert.equal(binding.protocol, PROTOCOL); assert.deepEqual(binding.cycle, cycle);
@@ -495,9 +512,9 @@ export async function runBurst(args: string[]): Promise<number> {
                 await page!.screenshot({ path: path.join(output, 'preflight-latest.png') });
                 await assert.rejects(control(`/api/traces/${binding.runId}/events/${metrics.firstBulkTraceSeq}?session=wrong-session`), /HTTP404/);
             }
-            requests!.beginDisposal();
+            const disposalWindow = beginDisposal();
             const disposal = await bounded(page!.evaluate(() => window.__wp29Probe.disposeCycle()), 5000, 'browser disposal')
-                .finally(() => requests!.endDisposal());
+                .finally(() => endDisposal(disposalWindow));
             assert.equal(disposal.activeEventSources, 0); assert.equal(disposal.rootConnected, false); assert.equal(disposal.handlerCount, 0);
             assert.deepEqual(disposal.errors, []);
             assert.equal(disposal.retiredPending, cycle.phase === 'preflight' && cycle.index === 2);
@@ -523,11 +540,17 @@ export async function runBurst(args: string[]): Promise<number> {
     } catch (error) { fatal = error instanceof Error ? error.message : String(error); }
     finally {
         clearTimeout(watchdog); closing = true;
-        requests?.beginDisposal();
+        const teardownWindow = beginDisposal();
         const cleanupErrors: string[] = [];
         const clean = async (name: string, action: () => Promise<unknown>) => { try { await bounded(action(), 5000, name); } catch (error) { cleanupErrors.push(`${name}:${String(error)}`.slice(0, 500)); } };
         if (page && !page.isClosed()) await clean('page disposal', async () => { await page!.evaluate(() => window.__wp29Probe?.disposeCycle()); });
+        if (page && !page.isClosed()) await clean('read diagnostics', async () => {
+            const before = performance.now();
+            const browser = await page!.evaluate(() => window.__wp29Probe?.readDiagnostics());
+            browserReadDiagnostics = { nodeBefore: before, nodeAfter: performance.now(), browser };
+        });
         if (context) await clean('context close', () => context!.close());
+        endDisposal(teardownWindow);
         if (chrome?.alive && browserCdp) await clean('Browser.close', () => browserCdp!.send('Browser.close').catch(error => {
             if (chrome!.alive) throw error;
         }));
@@ -572,6 +595,7 @@ export async function runBurst(args: string[]): Promise<number> {
         write('samples.json', { initial, measured, final, rendererIdentity, rendererStable });
         write('preflight.json', preflight); write('cycles.json', cycles);
         write('request-failures.json', requestFailures);
+        write('request-diagnostics.json', { nodeTimeOrigin: performance.timeOrigin, disposalWindows, browserReadDiagnostics });
         const summary = { functional: fatal || unexpected.length ? 'FAIL' : 'PASS', fatal, unexpected,
             nodeRss: nodeMemory, rendererRss: rendererMemory, rendererScope: 'dedicated browser renderer RSS sum, not inferred page RSS',
             cleanup: certified ? 'CERTIFIED' : 'UNCERTIFIED', sourcesStable, output,

--- a/tests/unit/native-activity-burst-fixture.test.ts
+++ b/tests/unit/native-activity-burst-fixture.test.ts
@@ -1,12 +1,31 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { median, classifyMemory, parseBurstArgs, browserFailures,
+import { median, classifyMemory, parseBurstArgs, browserFailures, probeRequestTracker,
     type MemorySeriesInput, type BrowserOracleSample } from '../smoke/native-activity-burst.mts';
 import { burstBodies, isBurstCycle, nextBurstCycle, BURST_PROTOCOL } from '../fixtures/native-activity-burst-server.mts';
 
 const series = (measured = Array(20).fill(10_000_000)): MemorySeriesInput => ({ initial: Array(5).fill(10_000_000),
     measured, final: Array(5).fill(measured.at(-1)), pageBytes: 16384, identityStable: true });
+
+test('probe abort retirement is request-identity scoped and only applies at disposal', () => {
+    const origin = 'http://127.0.0.1:12345';
+    const request = (route = '/__probe/metrics', method = 'GET') => ({ url: () => origin + route, method: () => method });
+    const tracker = probeRequestTracker<ReturnType<typeof request>>(origin);
+    const live = request(); tracker.started(live);
+    assert.equal(tracker.failed(live, 'net::ERR_ABORTED').expected, false);
+    const pending = request(), done = request(); tracker.started(pending); tracker.started(done); tracker.finished(done);
+    tracker.beginDisposal();
+    const during = request('/api/traces/tr_owned/events/2'); tracker.started(during);
+    const foreign = request('/api/unrelated'); tracker.started(foreign);
+    const post = request('/__probe/metrics', 'POST'); tracker.started(post);
+    assert.equal(tracker.failed(pending, 'net::ERR_CONNECTION_RESET').expected, false);
+    tracker.endDisposal();
+    assert.equal(tracker.failed(during, 'net::ERR_ABORTED').expected, true, 'late disposal notification retains exact identity');
+    for (const value of [done, foreign, post, request()]) assert.equal(tracker.failed(value, 'net::ERR_ABORTED').expected, false);
+    const next = request(); tracker.started(next);
+    assert.equal(tracker.failed(next, 'net::ERR_ABORTED').expected, false, 'next cycle is not retired');
+});
 
 test('median is independent of input order and does not mutate observations', () => {
     const values = [8, 2, 6, 4]; assert.equal(median(values), 5); assert.deepEqual(values, [8, 2, 6, 4]);

--- a/tests/unit/native-activity-burst-fixture.test.ts
+++ b/tests/unit/native-activity-burst-fixture.test.ts
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { median, classifyMemory, parseBurstArgs, browserFailures,
+    type MemorySeriesInput, type BrowserOracleSample } from '../smoke/native-activity-burst.mts';
+import { burstBodies, isBurstCycle, nextBurstCycle, BURST_PROTOCOL } from '../fixtures/native-activity-burst-server.mts';
+
+const series = (measured = Array(20).fill(10_000_000)): MemorySeriesInput => ({ initial: Array(5).fill(10_000_000),
+    measured, final: Array(5).fill(measured.at(-1)), pageBytes: 16384, identityStable: true });
+
+test('median is independent of input order and does not mutate observations', () => {
+    const values = [8, 2, 6, 4]; assert.equal(median(values), 5); assert.deepEqual(values, [8, 2, 6, 4]);
+    assert.equal(median([9, 3, 7]), 7); assert.throws(() => median([])); assert.throws(() => median([NaN]));
+});
+test('constant same-identity memory is a bounded local plateau', () => {
+    const result = classifyMemory(series());
+    assert.equal(result.verdict, 'PLATEAU_OBSERVED'); assert.equal(result.noise, 16384);
+    assert.deepEqual(result.windows, [10_000_000, 10_000_000, 10_000_000, 10_000_000]); assert.equal(result.nineSlope, 0);
+});
+test('hand-worked increasing windows and Theil-Sen slope report growth', () => {
+    const result = classifyMemory(series(Array.from({ length: 20 }, (_, index) => 1_000_000 + index * 131072)));
+    assert.equal(result.verdict, 'GROWTH_OBSERVED');
+    assert.deepEqual(result.windows, [1_262_144, 1_917_504, 2_572_864, 3_228_224]);
+    assert.equal(result.lateSlope, 131072); assert.equal(result.nineSlope, 1_179_648); assert.equal(result.lateChange, 655360);
+});
+test('noise uses within-block variation, never the initial-to-final drift', () => {
+    const input = series(Array.from({ length: 20 }, (_, index) => 10_000_000 + index * 100_000));
+    input.final = Array(5).fill(90_000_000);
+    const result = classifyMemory(input); assert.equal(result.noise, 16384); assert.equal(result.verdict, 'GROWTH_OBSERVED');
+});
+test('noise equal to a complete bulk submission is inconclusive before plateau', () => {
+    const input = series(); input.initial = [10_000_000, 10_000_000, 10_000_000, 10_000_000, 12_097_152];
+    const result = classifyMemory(input); assert.equal(result.noise, 2_097_152); assert.equal(result.verdict, 'INCONCLUSIVE');
+});
+test('an early allocation step is not a fabricated sustained leak', () => {
+    const result = classifyMemory(series([...Array(5).fill(10_000_000), ...Array(15).fill(12_000_000)]));
+    assert.equal(result.verdict, 'PLATEAU_OBSERVED'); assert.equal(result.totalChange, 2_000_000); assert.equal(result.lateChange, 0);
+});
+test('late-only positive drift stays inconclusive, not plateau or attributed growth', () => {
+    const result = classifyMemory(series([...Array(15).fill(10_000_000), 10_100_000, 10_200_000, 10_300_000, 10_400_000, 10_500_000]));
+    assert.equal(result.verdict, 'INCONCLUSIVE');
+});
+for (const [name, change] of [
+    ['identity', (value: MemorySeriesInput) => { value.identityStable = false; }],
+    ['missing sample', (value: MemorySeriesInput) => { value.measured.pop(); }],
+    ['NaN', (value: MemorySeriesInput) => { value.measured[0] = NaN; }],
+    ['zero', (value: MemorySeriesInput) => { value.measured[0] = 0; }],
+    ['negative', (value: MemorySeriesInput) => { value.measured[0] = -1; }],
+    ['invalid page', (value: MemorySeriesInput) => { value.pageBytes = 0; }],
+] as const) test(`missing/invalid ${name} never becomes a zero memory pass`, () => {
+    const input = series(); change(input); assert.equal(classifyMemory(input).verdict, 'INCONCLUSIVE');
+});
+
+test('CLI parser is strict and does not start a browser on import', () => {
+    const result = parseBurstArgs(['--label', 'fixture-01', '--browser-executable', process.execPath]);
+    assert.equal(result.label, 'fixture-01'); assert.equal(result.executable, process.execPath);
+    assert.ok(result.evidenceRoot.endsWith(path.join('.codexclaw', 'evidence', 'native-activity-burst')));
+    for (const args of [[], ['--unknown', '1'], ['--label', '../escape', '--browser-executable', process.execPath],
+        ['--label', 'ok', '--browser-executable', 'relative'], ['--label', 'a', '--label', 'b', '--browser-executable', process.execPath],
+        ['--label', 'ok', '--browser-executable', process.execPath, '--evidence-root', path.parse(process.execPath).root]])
+        assert.throws(() => parseBurstArgs(args));
+});
+test('cycle shape and progression reject malformed and out-of-range values', () => {
+    assert.equal(BURST_PROTOCOL, 'wp29-burst-v2');
+    assert.ok(isBurstCycle({ phase: 'preflight', index: 5 })); assert.ok(isBurstCycle({ phase: 'measured', index: 20 }));
+    for (const value of [null, [], { phase: 'unknown', index: 1 }, { phase: 'warmup', index: 6 },
+        { phase: 'measured', index: 0 }, { phase: 'measured', index: '1' }, { phase: 'measured', index: 1, extra: true }])
+        assert.equal(isBurstCycle(value), false);
+    assert.deepEqual(nextBurstCycle(null), { phase: 'preflight', index: 1 });
+    assert.deepEqual(nextBurstCycle({ phase: 'preflight', index: 5 }), { phase: 'warmup', index: 1 });
+    assert.deepEqual(nextBurstCycle({ phase: 'warmup', index: 5 }), { phase: 'measured', index: 1 });
+    assert.equal(nextBurstCycle({ phase: 'measured', index: 20 }), null);
+});
+test('fixed generator supplies643 legal-shaped bodies and exact independent byte totals', () => {
+    const bodies = [...burstBodies({ phase: 'measured', index: 7 })];
+    assert.equal(bodies.length, 643); assert.equal(bodies[0]?.kind, 'turn-start');
+    const first = bodies[1], lastBulk = bodies[512], firstTail = bodies[513], end = bodies[642];
+    assert.ok(first?.kind === 'tool' && lastBulk?.kind === 'tool' && firstTail?.kind === 'tool' && end?.kind === 'turn-end');
+    assert.equal(first.itemId, 'bulk-0000'); assert.equal(first.name, 'tool-0000');
+    assert.equal(first.output, 'C07B0000|' + 'x'.repeat(4079) + '|END0000');
+    assert.equal(lastBulk.itemId, 'bulk-0511'); assert.equal(lastBulk.output?.length, 4096);
+    assert.equal(firstTail.itemId, 'tail-0000'); assert.equal(firstTail.output, 'ok');
+    assert.equal(end.finalText, 'WP29 cycle 07 final');
+    assert.equal(bodies.reduce((sum, body) => sum + (body.kind === 'tool' ? Buffer.byteLength(body.output ?? '') : 0), 0), 2_097_410);
+});
+
+function healthyBrowser(): BrowserOracleSample {
+    const binding = { protocol: 'wp29-burst-v2', cycle: { phase: 'measured', index: 1 }, sessionId: 'owned', scope: 'wp29:owned',
+        runId: 'tr_0123456789abcdef', turnId: 'tr_0123456789abcdef', specId: '512x4096+129-small-v1' } as const;
+    return { binding, receivedCount: 643, ingestedCount: 643, retiredCallbackHits: 0, suppressedIngestions: 0,
+        terminal: true, activeEventSources: 1, maxEventSources: 1, errors: [],
+        bulk: { entryCount: 16, retainedChars: 65536, observedFieldChars: 65536, omittedEntries: 496, omittedTextChars: 4608,
+            latestAction: 'tool-0511 (done)', retainedIds: Array.from({ length: 16 }, (_, i) => `bulk-${String(i + 496).padStart(4, '0')}`), visibleRows: 16, omissionVisible: true },
+        final: { entryCount: 128, retainedChars: 1408, observedFieldChars: 1408, omittedEntries: 513, omittedTextChars: 4608,
+            latestAction: 'tail-0128 (done)', retainedIds: Array.from({ length: 128 }, (_, i) => `tail-${String(i + 1).padStart(4, '0')}`), visibleRows: 8, omissionVisible: true },
+        finalText: 'WP29 cycle 01 final', finalDomRaw: 'WP29 cycle 01 final', finalDomText: 'WP29 cycle 01 final', answerCount: 1,
+        controls: [{ queuedAt: 1, completedAt: 2, frameAt: 3, queuedOrdinal: 65, completedOrdinal: 70, frameOrdinal: 80, open: true }] };
+}
+test('independent browser oracle accepts the hand-authored healthy result', () => {
+    assert.deepEqual(browserFailures(healthyBrowser()), []);
+});
+test('retired callback and suppressed ingest counterexamples cannot be swallowed as green', () => {
+    const retired = healthyBrowser(); retired.retiredCallbackHits = 1;
+    assert.ok(browserFailures(retired).includes('retired-subscriber'));
+    const dropped = healthyBrowser(); dropped.ingestedCount = 642; dropped.suppressedIngestions = 1;
+    assert.ok(browserFailures(dropped).includes('ingested-count'));
+});
+test('a frame during only the compact tail is not evidence of later bulk progress', () => {
+    const value = healthyBrowser(); value.controls[0]!.frameOrdinal = 640;
+    assert.ok(browserFailures(value).includes('control-frame-progress'));
+});
+test('preview counters cannot hide a different observed field sum or duplicate final', () => {
+    const value = healthyBrowser(); value.bulk!.observedFieldChars = 65537; value.answerCount = 2;
+    assert.ok(browserFailures(value).includes('bulk-bounds')); assert.ok(browserFailures(value).includes('final-owner'));
+});


### PR DESCRIPTION
## Summary

Isolated canonical Activity writer/SQLite/SSE and browser burst diagnostics with a pure unit-test CI gate. Browser smoke is env-gated; enabled diagnostics keep the original functional, cleanup and RSS thresholds. No production code, package scripts or dependencies changed.

Harness fixes: cancel response readers only on early exit, retain exact request identities across disposal, capture frozen actual bulk-checkpoint DOM without pausing delivery, and correlate browser read outcomes with Node request failures using per-read IDs, monotonic clocks and explicit disposal windows. Retired abort exemptions remain narrow; active-run aborts still fail.

## Latest verification: instr-05

- Unit tests: 21 passed, 0 failed, exit 0.
- Strict four-file TypeScript check: exit 0.
- Count checker: exit 0, 540 matching items.
- Exactly one enabled instrumented smoke run: functional PASS, cleanup CERTIFIED, sources stable; all 20 measured cycles completed.
- All 90 browser reads, including 30 metrics reads, reached EOF. No read timeout, cycle-abort or exception. All 30 requestfailed records were expected retired SSE aborts. Unexpected metrics abort did not reproduce; original root cause remains unproven.
- Disposal was already opened before page.evaluate and closed after resolution; observed browser disposal-abort timestamps fell within those windows. No ordering fix or second smoke rerun was performed.
- Node RSS: INCONCLUSIVE; noise 32768, windows [260521984,260521984,260620288,260636672], lateSlope 4096, totalChange 114688, lateChange 16384, nineSlope 36864.
- Renderer sum RSS: GROWTH_OBSERVED; noise 49152, windows [1202143232,1215463424,1228914688,1244823552], lateSlope 2747050.6666666665, totalChange 42680320, lateChange 15908864, nineSlope 24723456.
- Enabled node:test result remains 0 passed, 1 failed, exit 1 because the diagnostic returns 3 for non-plateau RSS. This is not an overall performance PASS.

Ready for review under the maintainer decision that the unit test is the CI gate and functional PASS permits readiness. RSS acceptance and the intermittent metrics-abort cause remain open; instrumentation changes timing and does not itself prove a fix. No forced GC, threshold weakening, choose-best rerun, full suite, provider invocation, merge or release.