### PR TITLE
ci(desktop): upload sidecar smoke reports when the Windows bundle fails

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -89,7 +89,22 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build server and bundle sidecar
+        id: bundle-sidecar
         run: bash scripts/bundle-sidecar.sh "${{ matrix.sidecar_platform }}" "${{ matrix.sidecar_arch }}"
+
+      # Failed smoke probes retain their issues/output in the owned build root.
+      # Upload only the reports, never the source, dependencies or fixture homes.
+      - name: Upload sidecar smoke evidence on failure
+        if: failure() && steps.bundle-sidecar.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sidecar-smoke-${{ matrix.platform }}-${{ github.run_attempt }}
+          path: |
+            electron/sidecar/.server-build.*/smoke-report.json
+            electron/sidecar/.server-build.*/smoke-report.json.cleanup.json
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Install Electron dependencies
         run: npm ci --prefix electron


### PR DESCRIPTION
## Scope: diagnostic fallback, not a verified Windows runtime fix

The requested Windows failure cannot be attributed to specific probes from the available log. This PR implements the explicitly requested fallback: retain `smoke-report.json` and its cleanup receipt as Actions artifacts on a failed sidecar bundle. It does not change or relax smoke behavior on Windows, macOS, or Linux.

## Evidence

Failing [run 34126626985, Windows job 101756710481](https://github.com/lidge-jun/cli-jaw/actions/runs/34126626985/job/101756710481), head `cc66fc4b35c96d129b31cdb5dec96652d64f8d0d`. Retrieved the full job with:

```sh
gh run view 34126626985 --repo lidge-jun/cli-jaw --json jobs
gh run view 34126626985 --repo lidge-jun/cli-jaw --job 101756710481 --log
gh api repos/lidge-jun/cli-jaw/actions/runs/34126626985/artifacts
```

Exact relevant log output:

```text
2026-09-07T13:20:28.2493480Z   better-sqlite3 OK
2026-09-07T13:21:52.3907705Z Sidecar smoke FAIL: 3 critical surfaces; report D:\a\cli-jaw\cli-jaw\electron\sidecar\.server-build.vcVPKNX8\smoke-report.json
2026-09-07T13:21:52.4102795Z Build retained (exit 1); supervisor must prove quiescence before recovery:
```

No per-probe issues are printed. The artifact API returned `{"total_count":0,"artifacts":[]}`. Therefore the exact probe issues are **unavailable**, not inferred from the aggregate verdict.

Inspected a fresh clone at stable `783c22a00b09c5f8bb714d8ebd13c16d328d00a1`. Its smoke parent/child, bundler and desktop workflow are byte-identical to the failing preview head.

- [`scripts/sidecar-smoke-probe.mjs:10`](https://github.com/lidge-jun/cli-jaw/blob/783c22a00b09c5f8bb714d8ebd13c16d328d00a1/scripts/sidecar-smoke-probe.mjs#L10-L14): the three attempted surfaces are Telegram import, worker server, and Manager server. Which failed is unknown.
- [`scripts/check-sidecar-smoke.mjs:260`](https://github.com/lidge-jun/cli-jaw/blob/783c22a00b09c5f8bb714d8ebd13c16d328d00a1/scripts/check-sidecar-smoke.mjs#L259-L261): `3 critical surfaces` is `result.probes.length`, **not a count of failed probes**.
- [`scripts/check-sidecar-smoke.mjs:225`](https://github.com/lidge-jun/cli-jaw/blob/783c22a00b09c5f8bb714d8ebd13c16d328d00a1/scripts/check-sidecar-smoke.mjs#L222-L234): issues, captured output and receipts are written to JSON; cleanup failure can also make the overall result fail. The CLI does not print those details.
- [`scripts/bundle-sidecar.sh:438`](https://github.com/lidge-jun/cli-jaw/blob/783c22a00b09c5f8bb714d8ebd13c16d328d00a1/scripts/bundle-sidecar.sh#L437-L439): explicitly selects the retained build-root report.
- The old desktop workflow uploads only packaged desktop outputs after successful preceding steps; it has no failure-report upload.

## Remaining hypotheses

1. Spawn/bootstrap or IPC identity/path failure: disprove using successful import receipts and captured child output in the missing report.
2. Listener/HTTP readiness failure: disprove using `listening`, `httpReady`, health identity and boundary records.
3. Stop/physical-close or cleanup failure: disprove using `stopAcknowledged`, `exitCode`, `signal`, `portsAbsent` and the cleanup receipt.

The successful native database load rules out a failure at the explicit pre-smoke better-sqlite3 load gate, but does not certify later runtime behavior. No Windows-specific root cause is claimed.

## Change

- Add a bundle step ID and a failure-only report upload immediately afterward.
- Select only `.server-build.*/smoke-report.json` and `.server-build.*/smoke-report.json.cleanup.json`; never upload source snapshots, dependencies or fixture homes.
- Enable hidden-file inclusion because the owned build directory begins with a dot (upload-artifact v4 excludes hidden files by default; [upstream documentation](https://github.com/actions/upload-artifact/blob/v4/README.md#inputs)).
- Unique per-platform/attempt artifact name; seven-day retention. Missing reports warn if bundling failed before smoke. The original build failure remains a failure.

## Verification

On macOS, Node v24.17.0:

```sh
./node_modules/.bin/tsx --experimental-test-module-mocks tests/run.mts tests/unit/sidecar-smoke.test.ts tests/unit/windows-service-path.test.ts tests/unit/path-guards-windows.test.ts tests/unit/windows-launch-spec.test.ts tests/unit/windows-spawn-primitives.test.ts
```

**113 passed, 0 failed, 2 skipped** (the two actual Windows `.cmd` process tests). This includes real local smoke fixture execution and injected Windows path semantics, not an actual Windows sidecar reproduction.

- `actionlint .github/workflows/desktop-release.yml`: PASS.
- Parsed YAML comparison: removing only the new upload step and bundle ID gives the exact original workflow configuration; report-only glob positive/negative checks PASS.
- `bash structure/verify-counts.sh`: PASS, 540 items.
- `git diff --check`: PASS.
- Actual Windows desktop build, GitHub failure-artifact transport and original failure resolution: **NOT VERIFIED**. No release workflow dispatched; no merge, release, service changes or protected-branch pushes.

The next authorized desktop build must use a checkout containing this workflow change. Re-running the immutable old stable tag still uses its old workflow and cannot recover the missing historical report.
