### PR TITLE
test(runner): deterministic --shard/--scope in tests/run.mts with per-file test homes

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "pretest:smoke": "npm run ensure:native",
     "test": "tsx --experimental-test-module-mocks tests/run.mts",
     "test:all": "tsx --experimental-test-module-mocks tests/run.mts --all",
+    "test:shard": "tsx --experimental-test-module-mocks tests/run.mts --scope root,unit --shard",
+    "test:integration:all": "tsx --experimental-test-module-mocks tests/run.mts --scope integration,manager,bin",
     "test:integration": "tsx --experimental-test-module-mocks --test tests/integration/*.test.ts",
     "test:coverage": "tsx --experimental-test-module-mocks --experimental-test-coverage tests/run.mts --all",
     "test:watch": "tsx --experimental-test-module-mocks tests/run.mts --watch",

--- a/tests/run.mts
+++ b/tests/run.mts
@@ -4,20 +4,31 @@
 // recursively" and produces ZERO output (even a trivial zero-import test). A
 // programmatic node:test run() from plain tsx (no --test flag) avoids that.
 //
-//   tsx --experimental-test-module-mocks tests/run.mts [--all|--watch|<paths...>]
+//   tsx --experimental-test-module-mocks tests/run.mts [--all|--scope root,unit|<paths...>] [--shard i/N] [--list] [--watch]
 // --experimental-test-module-mocks must stay a node flag so mock.module works.
+//
+// Scopes: root (tests/*.test.ts), unit (tests/unit/*.test.ts) — both flat — and
+// integration/manager/browser/bin (recursive under tests/<scope>/). Default is
+// root,unit, which is what `npm test` has always meant. --shard i/N keeps the
+// sorted-round-robin slice i of the selected files (see tests/setup/shard.ts);
+// --list prints the selection and exits without running.
 //
 // isolation:'process' runs each file in its own subprocess (matching the old
 // `--test` default). This keeps real-process/timing tests (bgtask spawn, session
 // probes) from contending in one shared event loop — in-process concurrency made
 // them flaky. CLI_JAW_HOME (set by setup/test-home.ts here) is inherited by the
 // child processes via env; --experimental-test-module-mocks propagates too.
+//
+// Coverage: node:test only collects coverage when run() receives { coverage: true }
+// (v22.10+); the --experimental-test-coverage flag alone is filtered out of the
+// programmatic path, so it is bridged from execArgv here.
 import './setup/test-home.ts';
 import { run } from 'node:test';
 import { spec } from 'node:test/reporters';
 import { readdirSync, statSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import process from 'node:process';
+import { parseArgs, partitionFiles, type RunnerOptions } from './setup/shard.ts';
 
 const TESTS_DIR = resolve(import.meta.dirname);
 function list(dir: string, recursive: boolean): string[] {
@@ -28,17 +39,35 @@ function list(dir: string, recursive: boolean): string[] {
         if (e.isDirectory()) { if (recursive) out.push(...list(full, true)); }
         else if (e.name.endsWith('.test.ts')) out.push(full);
     }
-    return out.sort();
+    return out;
 }
-const argv = process.argv.slice(2);
-const all = argv.includes('--all');
-const watch = argv.includes('--watch');
-const explicit = argv.filter(a => !a.startsWith('--'));
+function collectFiles({ explicit, all, scopes }: RunnerOptions): string[] {
+    if (explicit.length) return explicit.flatMap(p => {
+        const absolute = resolve(p);
+        return existsSync(absolute) && statSync(absolute).isDirectory() ? list(absolute, true) : [absolute];
+    });
+    if (all) return list(TESTS_DIR, true);
+    const selected = scopes.length ? scopes : ['root', 'unit'];
+    return selected.flatMap(scope => list(
+        scope === 'root' ? TESTS_DIR : join(TESTS_DIR, scope),
+        scope !== 'root' && scope !== 'unit',
+    ));
+}
+let options: RunnerOptions;
 let files: string[];
-if (explicit.length > 0) files = explicit.flatMap(p => { const a = resolve(p); return (existsSync(a) && statSync(a).isDirectory()) ? list(a, true) : [a]; });
-else if (all) files = list(TESTS_DIR, true);
-else files = [...list(TESTS_DIR, false), ...list(join(TESTS_DIR, 'unit'), false)];
+try {
+    options = parseArgs(process.argv.slice(2));
+    files = partitionFiles(collectFiles(options).map(p => p.split(sep).join('/')), options.shard);
+} catch (error) {
+    console.error(`[tests/run] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+}
+const { watch, list: listOnly } = options;
 if (files.length === 0) { console.error('[tests/run] no test files matched'); process.exit(1); }
+if (listOnly) { for (const f of files) console.log(f); process.exit(0); }
+const scopeLabel = options.explicit.length ? 'explicit' : options.all ? 'all' : (options.scopes.length ? options.scopes : ['root', 'unit']).join(',');
+console.log(`[tests/run] ${files.length} files (scope=${scopeLabel}, shard=${options.shard ? `${options.shard.index}/${options.shard.total}` : 'none'})`);
+const coverage = process.execArgv.includes('--experimental-test-coverage');
 let failures = 0;
-run({ files, concurrency: true, watch, isolation: 'process' }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
+run({ files, concurrency: true, watch, isolation: 'process', coverage }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
 if (!watch) process.on('beforeExit', () => { if (failures > 0 && !process.exitCode) process.exitCode = 1; });

--- a/tests/run.mts
+++ b/tests/run.mts
@@ -16,8 +16,15 @@
 // isolation:'process' runs each file in its own subprocess (matching the old
 // `--test` default). This keeps real-process/timing tests (bgtask spawn, session
 // probes) from contending in one shared event loop — in-process concurrency made
-// them flaky. CLI_JAW_HOME (set by setup/test-home.ts here) is inherited by the
-// child processes via env; --experimental-test-module-mocks propagates too.
+// them flaky.
+//
+// Every child re-imports setup/test-home.ts through the run() execArgv option, so
+// each FILE gets its own fresh CLI_JAW_HOME and jaw.db. Without that, children
+// inherit the parent's single home and two files can race the same first-open
+// migration (SqliteError: duplicate column name) — a failure that only shows up
+// when enough DB-touching files land in one batch, i.e. exactly what sharding
+// changes. The old CI invocation (--import test-home.ts --test) had per-file homes
+// for the same reason; this keeps that behavior inside the driver.
 //
 // Coverage: node:test only collects coverage when run() receives { coverage: true }
 // (v22.10+); the --experimental-test-coverage flag alone is filtered out of the
@@ -27,6 +34,7 @@ import { run } from 'node:test';
 import { spec } from 'node:test/reporters';
 import { readdirSync, statSync, existsSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import process from 'node:process';
 import { parseArgs, partitionFiles, type RunnerOptions } from './setup/shard.ts';
 
@@ -68,6 +76,7 @@ if (listOnly) { for (const f of files) console.log(f); process.exit(0); }
 const scopeLabel = options.explicit.length ? 'explicit' : options.all ? 'all' : (options.scopes.length ? options.scopes : ['root', 'unit']).join(',');
 console.log(`[tests/run] ${files.length} files (scope=${scopeLabel}, shard=${options.shard ? `${options.shard.index}/${options.shard.total}` : 'none'})`);
 const coverage = process.execArgv.includes('--experimental-test-coverage');
+const execArgv = ['--import', pathToFileURL(join(TESTS_DIR, 'setup', 'test-home.ts')).href];
 let failures = 0;
-run({ files, concurrency: true, watch, isolation: 'process', coverage }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
+run({ files, concurrency: true, watch, isolation: 'process', coverage, execArgv }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
 if (!watch) process.on('beforeExit', () => { if (failures > 0 && !process.exitCode) process.exitCode = 1; });

--- a/tests/setup/shard.ts
+++ b/tests/setup/shard.ts
@@ -1,0 +1,73 @@
+// Pure helpers for tests/run.mts: argv parsing and deterministic shard partitioning.
+//
+// Kept free of side effects (no test-home setup, no node:test import) so a unit
+// test can import it without starting a run. Partitioning is sorted round-robin:
+// files are byte-ordered (LC_ALL=C semantics, Buffer.compare) and shard i of N
+// takes every index where index % N === i - 1 — the same rule as Node's own
+// --test-shard and the opencodex CI helper, so every runner computes the same
+// disjoint, complete partition from the same file set.
+import { Buffer } from 'node:buffer';
+
+export const SCOPES = ['root', 'unit', 'integration', 'manager', 'browser', 'bin'] as const;
+export type Scope = typeof SCOPES[number];
+export interface Shard { index: number; total: number }
+export interface RunnerOptions {
+    all: boolean;
+    watch: boolean;
+    list: boolean;
+    explicit: string[];
+    scopes: Scope[];
+    shard?: Shard;
+}
+
+function validateShard({ index, total }: Shard): void {
+    if (!Number.isSafeInteger(index) || !Number.isSafeInteger(total)
+        || index < 1 || total < 1 || index > total) {
+        throw new Error('--shard requires integers 1 <= i <= N');
+    }
+}
+
+export function parseArgs(argv: readonly string[]): RunnerOptions {
+    const options: RunnerOptions = { all: false, watch: false, list: false, explicit: [], scopes: [] };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--') { options.explicit.push(...argv.slice(i + 1)); break; }
+        if (arg === '--all') { options.all = true; continue; }
+        if (arg === '--watch') { options.watch = true; continue; }
+        if (arg === '--list') { options.list = true; continue; }
+        if (arg === '--shard' || arg === '--scope') {
+            const value = argv[++i];
+            if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+            if (arg === '--shard') {
+                if (options.shard) throw new Error('--shard may appear only once');
+                const match = /^([1-9][0-9]*)\/([1-9][0-9]*)$/.exec(value);
+                if (!match) throw new Error('--shard requires i/N');
+                options.shard = { index: Number(match[1]), total: Number(match[2]) };
+                validateShard(options.shard);
+            } else {
+                for (const name of value.split(',')) {
+                    const scope = SCOPES.find(s => s === name);
+                    if (!scope) throw new Error(`unknown scope: ${name}; expected one of ${SCOPES.join(',')}`);
+                    if (!options.scopes.includes(scope)) options.scopes.push(scope);
+                }
+            }
+            continue;
+        }
+        if (arg.startsWith('-')) throw new Error(`unknown option: ${arg}`);
+        options.explicit.push(arg);
+    }
+    if (options.scopes.length && (options.all || options.explicit.length)) {
+        throw new Error('--scope cannot be combined with --all or explicit paths');
+    }
+    if (options.watch && options.shard) throw new Error('--shard cannot be combined with --watch');
+    if (options.watch && options.list) throw new Error('--list cannot be combined with --watch');
+    return options;
+}
+
+// Inputs are '/'-separated paths (the caller normalizes). Returns a new array.
+export function partitionFiles(files: readonly string[], shard?: Shard): string[] {
+    if (shard) validateShard(shard);
+    const sorted = [...new Set(files)].sort((a, b) => Buffer.compare(Buffer.from(a), Buffer.from(b)));
+    return shard ? sorted.filter((_, i) => i % shard.total === shard.index - 1) : sorted;
+}
+

--- a/tests/unit/test-runner-shard.test.ts
+++ b/tests/unit/test-runner-shard.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { parseArgs, partitionFiles, SCOPES } from '../setup/shard.ts';
+
+const SAMPLE = ['tests/z.test.ts', 'tests/unit/b.test.ts', 'tests/a.test.ts', 'tests/unit/a.test.ts',
+    'tests/unit/c.test.ts', 'tests/unit/B.test.ts', 'tests/m.test.ts', 'tests/unit/a-b.test.ts',
+    'tests/unit/a_b.test.ts', 'tests/unit/d.test.ts'];
+
+function partitions(files: readonly string[], total: number): string[][] {
+    return Array.from({ length: total }, (_, i) => partitionFiles(files, { index: i + 1, total }));
+}
+
+test('SHARD-001: shards are disjoint, complete and balanced for N=1..4', () => {
+    const whole = partitionFiles(SAMPLE);
+    assert.equal(whole.length, SAMPLE.length);
+    for (const total of [1, 2, 3, 4]) {
+        const parts = partitions(SAMPLE, total);
+        const union = parts.flat();
+        assert.deepEqual([...union].sort(), [...whole].sort(), `N=${total} union`);
+        assert.equal(new Set(union).size, union.length, `N=${total} disjoint`);
+        const sizes = parts.map(p => p.length);
+        assert.ok(Math.max(...sizes) - Math.min(...sizes) <= 1, `N=${total} balanced: ${sizes}`);
+    }
+});
+
+test('SHARD-002: partition is stable under permutation and duplicates, and never mutates input', () => {
+    const shuffled = [...SAMPLE].reverse();
+    const duplicated = [...SAMPLE, ...SAMPLE.slice(0, 3)];
+    const frozen = Object.freeze([...SAMPLE]);
+    for (const total of [2, 3]) {
+        for (let i = 1; i <= total; i++) {
+            const expected = partitionFiles(SAMPLE, { index: i, total });
+            assert.deepEqual(partitionFiles(shuffled, { index: i, total }), expected);
+            assert.deepEqual(partitionFiles(duplicated, { index: i, total }), expected);
+            assert.deepEqual(partitionFiles(frozen, { index: i, total }), expected);
+        }
+    }
+    assert.deepEqual([...frozen], SAMPLE);
+});
+
+test('SHARD-003: ordering is byte order (LC_ALL=C), not locale collation', () => {
+    assert.deepEqual(partitionFiles(['b', 'B', 'a-', 'a']), ['B', 'a', 'a-', 'b']);
+    assert.deepEqual(partitionFiles(['tests/unit/a_b', 'tests/unit/a-b', 'tests/unit/a.b']),
+        ['tests/unit/a-b', 'tests/unit/a.b', 'tests/unit/a_b']);
+});
+
+test('SHARD-004: real tree — 4 shards of root+unit reproduce the collection exactly', () => {
+    const testsDir = resolve(import.meta.dirname, '..');
+    const flat = (dir: string) => readdirSync(dir, { withFileTypes: true })
+        .filter(e => e.isFile() && e.name.endsWith('.test.ts'))
+        .map(e => join(dir, e.name).split(sep).join('/'));
+    const collection = [...flat(testsDir), ...flat(join(testsDir, 'unit'))];
+    assert.ok(collection.length > 100, 'collector saw the real tree');
+    const parts = partitions(collection, 4);
+    const union = parts.flat();
+    assert.equal(union.length, collection.length);
+    assert.equal(new Set(union).size, collection.length);
+    assert.deepEqual([...union].sort(), [...collection].sort());
+    assert.ok(union.includes(import.meta.filename.split(sep).join('/')), 'this file is in the partition');
+});
+
+test('SHARD-005: parseArgs accepts the documented grammar', () => {
+    const o = parseArgs(['--scope', 'unit,root', '--scope', 'unit', '--shard', '2/4', '--list']);
+    assert.deepEqual(o.scopes, ['unit', 'root']);
+    assert.deepEqual(o.shard, { index: 2, total: 4 });
+    assert.equal(o.list, true);
+    assert.deepEqual(parseArgs(['--', '--weird', 'x']).explicit, ['--weird', 'x']);
+    assert.deepEqual(parseArgs(['tests/unit/a.test.ts', '--all']).explicit, ['tests/unit/a.test.ts']);
+    assert.deepEqual([...SCOPES], ['root', 'unit', 'integration', 'manager', 'browser', 'bin']);
+});
+
+test('SHARD-006: parseArgs rejects malformed and conflicting arguments', () => {
+    const bad: string[][] = [
+        ['--shard', '0/4'], ['--shard', '5/4'], ['--shard', 'a/b'], ['--shard'], ['--shard', '--list'],
+        ['--shard', '1/2', '--shard', '2/2'], ['--scope', 'nope'], ['--scope', 'unit', '--all'],
+        ['--scope', 'unit', 'tests/x.test.ts'], ['--watch', '--shard', '1/2'], ['--watch', '--list'], ['--bogus'],
+    ];
+    for (const argv of bad) assert.throws(() => parseArgs(argv), `should reject: ${argv.join(' ')}`);
+    assert.throws(() => partitionFiles(['a'], { index: 2, total: 1 }), /1 <= i <= N/);
+});
+


### PR DESCRIPTION
## Problem

`tests/run.mts` parsed argv by hand and treated every non-flag token as a path, so there was no way to hand a runner a slice of the suite. CI runs the whole 1,225-file root+unit set in one 345 s step (run 34128612867), and `test:coverage` never produced a report because node:test's programmatic `run()` ignores `--experimental-test-coverage` unless it also receives `{ coverage: true }`.

## Change

- `tests/setup/shard.ts` (new, pure): `parseArgs` + `partitionFiles`. Files are byte-ordered (`Buffer.compare`, LC_ALL=C semantics) and shard *i* of *N* keeps `index % N === i-1` — the same rule as `node --test-shard` and the opencodex CI helper, so every runner computes the same disjoint, complete partition.
- `tests/run.mts`: `--scope root|unit|integration|manager|browser|bin` (default `root,unit` unchanged), `--shard i/N`, `--list` (print selection, exit 0), coverage bridged from execArgv, one `[tests/run] N files (scope=…, shard=…)` log line.
- Every `isolation:'process'` child now re-imports `tests/setup/test-home.ts` through `run({ execArgv })`, so each file gets its own `CLI_JAW_HOME`/`jaw.db`. Children previously inherited the parent's single home and two DB-touching files in one batch could race the first-open migration (`SqliteError: duplicate column name`, seen on shards 1/4 and 2/4 before this fix). The old `--import test-home.ts --test` CI invocation already had per-file homes; the driver now matches it.
- `tests/unit/test-runner-shard.test.ts` (new): disjoint/complete/balanced partitions for N=1..4, stability under permutation/duplicates, byte ordering, the real root+unit tree, and rejection of malformed `--shard`/`--scope`/`--watch` combinations.
- `package.json`: `test:shard` (`npm run test:shard -- 1/4`), `test:integration:all`.

No workflow change here; the sharded test.yml lands in the dependent PR.

## Validation (local, macOS / Node 24.17.0)

- `tests/unit/test-runner-shard.test.ts` + `test-home-contract.test.ts`: 10/10.
- `--list` inventory: 1,226 files; union of shards 1..4 == unsharded list, no duplicates.
- Full shards at 65004c7f1: 1/4 2881 tests, 2/4 2785, 3/4 2608, 4/4 2854 — 0 failures, 42 skipped (11,128 total vs. 11,072 on the current dev run).
- Invalid shard / empty partition / unknown scope exit 1; coverage report emitted with `--experimental-test-coverage`; `npm run typecheck` clean.

Part of devlog `260907_test_sharding_modernization` (wp1 of 5).
