### PR TITLE
ci(tests): shard the suite across four runners and run integration/manager/bin in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
       - preview
       - main
   pull_request:
+  # Manual runs also start the advisory coverage job. publish.yml and the
+  # release scripts only accept `--event push` runs, so a dispatch never
+  # certifies a release.
+  workflow_dispatch:
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
@@ -119,16 +123,189 @@ jobs:
             emit false
           fi
 
-  node-tests:
-    name: node-tests
+      # A missing or malformed classifier output must fail this job instead of
+      # silently reading as "nothing changed" in every `== 'true'` condition.
+      - name: Assert the scope output is usable
+        env:
+          CODE_SCOPE: ${{ steps.scope.outputs.code }}
+        run: |
+          case "$CODE_SCOPE" in
+            true|false) echo "changes.outputs.code=$CODE_SCOPE" ;;
+            *) echo "::error::changes.outputs.code was '$CODE_SCOPE', expected true or false"; exit 1 ;;
+          esac
+
+  # The suite, split by file across four Linux runners.
+  #
+  # tests/run.mts --shard i/N sorts the selected files in byte order and keeps
+  # index % N === i-1 (tests/setup/shard.ts), so every runner computes the same
+  # disjoint, complete partition without any coordination. Only the suite lives
+  # here: typecheck, gates, build and the scans run once in `gates` and
+  # `integration`, not four times. Ported from opencodex's ci.yml
+  # (`test ${{ matrix.shard }}/4`, fail-fast: false); Bun batching and crash
+  # retries were deliberately not carried — a shard that fails here failed a
+  # test.
+  test:
+    name: test ${{ matrix.shard }}/4
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # A quarter of a suite that took 345s serially. A shard that needs longer
+    # than this is wedged, not slow.
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Checkout public submodules
+        run: |
+          git submodule update --init skills_ref
+          git submodule update --init officecli
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build native modules
+        run: npm rebuild better-sqlite3
+
+      # Several unit tests execute dist/bin/cli-jaw.js (clone, launchd-multi,
+      # electron-jaw-spawn …), so the compiled tree has to exist in every shard.
+      - name: Build TypeScript
+        run: npx tsc
+
+      - name: Run shard
+        shell: bash {0}
+        env:
+          TEST_SHARD: "${{ matrix.shard }}/4"
+        run: |
+          started=$(date +%s)
+          npx tsx --experimental-test-module-mocks tests/run.mts --scope root,unit --shard "$TEST_SHARD"
+          status=$?
+          echo "shard $TEST_SHARD wall time: $(( $(date +%s) - started ))s (step limit: 300s)"
+          exit $status
+        timeout-minutes: 5
+
+  # Everything that needs a built package or a live server: the integration,
+  # manager and bin suites (never run in CI before this job existed), the CLI
+  # and API smokes that used to be separate steps, and the fresh-install smoke.
+  #
+  # Quarantined (self-skipping unless opted in; they need real provider auth
+  # and inference, which CI does not have):
+  #   tests/integration/agy-print-smoke.test.ts               JAW_AGY_SMOKE=1
+  #   tests/integration/codex-app-multiplex-activation.test.ts  activation flag + CODEX_HOME auth
+  integration:
+    name: integration
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_ENV: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Checkout public submodules
+        run: |
+          git submodule update --init skills_ref
+          git submodule update --init officecli
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build native modules
+        run: npm rebuild better-sqlite3
+
+      # `npm run build` (not bare tsc): graceful-shutdown boots dist/bin/cli-jaw.js,
+      # which reads dist/src/prompt/templates — atomic-build.sh copies those,
+      # tsc does not.
+      - name: Build (atomic dist with assets)
+        run: npm run build
+
+      - name: Build frontend
+        run: npm run build:frontend
+
+      - name: Check frontend build output
+        run: npm run check:frontend-build-output
+
+      # api-smoke fails closed under CI when this server is missing
+      # (tests/integration/api-smoke.test.ts), so a startup failure can never
+      # turn into a green skip.
+      - name: Start test server (port 3457)
+        run: |
+          node dist/server.js > server.log 2>&1 &
+          echo $! > server.pid
+          for i in $(seq 1 40); do
+            if curl -sf http://localhost:3457/api/session > /dev/null 2>&1; then
+              echo "✅ Server ready after $((i/2))s"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "::error::server did not become ready on :3457"
+          cat server.log
+          exit 1
+
+      - name: Integration, manager and bin suites
+        env:
+          TEST_PORT: "3457"
+          CI: "true"
+        run: npx tsx --experimental-test-module-mocks tests/run.mts --scope integration,manager,bin
+
+      - name: Stop test server
+        if: always()
+        run: kill "$(cat server.pid)" 2>/dev/null || true
+
+      - name: Fresh install smoke (safe mode)
+        run: npm run test:fresh-install
+
+  # Fixed-cost checks, run exactly once: gate:all (which already includes
+  # tsc --noEmit for server + frontend and the strict-baseline checker), the
+  # dependency gates, the devlog audit, and the repo scans.
+  gates:
+    name: gates
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SUBMODULE_PAT: ${{ secrets.SUBMODULE_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Checkout public submodules
         run: |
@@ -154,72 +331,23 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Install system test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ripgrep
-          rg --version
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
       - name: Build native modules
         run: npm rebuild better-sqlite3
 
-      - name: Build TypeScript
-        run: npx tsc
-
-      - name: Run tests
-        # `-e` is off for this step so the elapsed time is reported even when
-        # the suite fails; the original exit status is re-raised at the end.
-        shell: bash {0}
-        run: |
-          started=$(date +%s)
-          npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test-force-exit --test tests/*.test.ts tests/unit/*.test.ts
-          status=$?
-          elapsed=$(( $(date +%s) - started ))
-          echo "suite wall time: ${elapsed}s (step limit: 480s)"
-          # Warn while there is still room to act. The old limit was reached
-          # with no warning at all, because nothing reported how close the
-          # suite was running to it: the last green run had 9 seconds of
-          # headroom and looked exactly like a healthy one.
-          if [ "$elapsed" -gt 360 ]; then
-            echo "::warning::test suite took ${elapsed}s, within 2 minutes of the 480s step limit — split it or trim the slow suites before it starts timing out"
-          fi
-          exit $status
-        # The 3-minute limit was already being met by 9 seconds: the last green
-        # run (30162036088, 2026-07-25) spent 2m51s here. 5581 lines of tests
-        # landed after it, and the step started dying with ~1270 tests still
-        # unreported — no single slow test, just a suite that outgrew its box.
-        #
-        # 8 minutes is roughly 2.5x the current runtime rather than a number
-        # picked to make today pass, so ordinary growth does not put this back
-        # in the same position. The limit still exists to catch a genuine hang;
-        # subprocess-spawning suites carry their own per-process timeouts well
-        # under it, so a stuck case fails with a name instead of killing the
-        # step silently.
-        timeout-minutes: 8
+      - name: Validate windows-unit manifest
+        run: node scripts/ci/windows-unit-manifest.mjs
 
       - name: Release gates (gate:all)
         run: npm run gate:all
-
-      - name: Build frontend
-        run: npm run build:frontend
-
-      - name: Check frontend build output
-        run: npm run check:frontend-build-output
-
-      - name: Fresh install smoke (safe mode)
-        run: npm run test:fresh-install
 
       - name: Deps security check
         run: npm run check:deps
 
       - name: Dependency advisory gate
         run: npm run check:deps:audit
-
-      - name: Strict-baseline regression gate
-        run: npm run check:strict-baseline
 
       - name: Verify devlog submodule
         id: devlog-check
@@ -252,35 +380,77 @@ jobs:
           find . \( -name '*.js' -o -name '*.ts' \) -not -path './node_modules/*' -not -path './skills_ref/*' -not -name '*.d.ts' \
             | xargs wc -l | sort -rn | awk '$1 > 500 && !/total/ { print "⚠️ " $0; found=1 } END { if (!found) print "✅ All files under 500 lines" }'
 
-      - name: CLI basic tests
-        run: npx tsx --test tests/integration/cli-basic.test.ts
+  # Advisory coverage over the root+unit suite. Runs on dev pushes and manual
+  # dispatch only, never on preview/main or pull requests, and is not in
+  # ci-aggregate's needs — it can neither delay nor spoil release certification.
+  # tests/run.mts turns --experimental-test-coverage into run({ coverage:true }),
+  # which node:test added in 22.10; the version check makes that explicit.
+  coverage:
+    name: coverage (advisory)
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
-      - name: API smoke tests
+      - name: Checkout public submodules
         run: |
-          npx tsx server.ts &
-          SERVER_PID=$!
-          # Wait for server to be ready (max 10s)
-          for i in $(seq 1 20); do
-            if curl -sf http://localhost:3457/api/session > /dev/null 2>&1; then
-              echo "✅ Server ready after $((i/2))s"
-              break
-            fi
-            sleep 0.5
-          done
-          TEST_PORT=3457 npx tsx --test tests/integration/api-smoke.test.ts || SMOKE_EXIT=$?
-          kill $SERVER_PID 2>/dev/null || true
-          exit ${SMOKE_EXIT:-0}
-        env:
-          NODE_ENV: test
+          git submodule update --init skills_ref
+          git submodule update --init officecli
 
-  # The single required status check for the `main` ruleset.
-  #
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build native modules
+        run: npm rebuild better-sqlite3
+
+      - name: Require node:test coverage support (>= 22.10)
+        run: node -e "const [a,b]=process.versions.node.split('.').map(Number); if (a<22||(a===22&&b<10)) { console.error('node '+process.versions.node+' lacks run({coverage})'); process.exit(1) }"
+
+      - name: Build TypeScript
+        run: npx tsc
+
+      - name: Run suite with coverage
+        shell: bash {0}
+        run: |
+          npx tsx --experimental-test-module-mocks --experimental-test-coverage tests/run.mts --scope root,unit 2>&1 | tee coverage.txt
+          status=${PIPESTATUS[0]}
+          grep -A3 'start of coverage report' coverage.txt | head -5 || true
+          exit $status
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-${{ github.sha }}
+          path: coverage.txt
+          if-no-files-found: warn
 
   # Fast Windows unit lane on every code PR (#384). Before this, Windows tests
   # ran only in postinstall-platform.yml behind a literal paths: allowlist, so
   # a PR touching Windows behavior in unlisted files merged with zero Windows
-  # CI. Explicit file list - pwsh does not expand globs. Windows flakes in
-  # these suites block merge by design; that is the lane's purpose.
+  # CI. The file list lives in scripts/ci/windows-unit-manifest.txt and is
+  # validated by scripts/ci/windows-unit-manifest.mjs on Linux (gates job +
+  # tests/unit/windows-unit-manifest.test.ts) and here, so a renamed test breaks
+  # CI instead of silently vanishing from the lane. Windows flakes in these
+  # suites block merge by design; that is the lane's purpose.
   windows-unit:
     name: windows-unit
     needs: changes
@@ -290,6 +460,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -309,72 +481,60 @@ jobs:
       - name: Ensure native modules are loadable
         run: node scripts/ensure-native-modules.cjs
 
-      - name: Run Windows-relevant unit tests
-        run: npx tsx --import ./tests/setup/test-home.ts --experimental-test-module-mocks --test tests/unit/windows-service-esm.test.ts tests/unit/service-windows-branch.test.ts tests/unit/windows-service-lifecycle-honesty.test.ts tests/unit/windows-installer-shims.test.ts tests/unit/windows-spawn-primitives.test.ts tests/unit/manager-browser-open.test.ts tests/unit/eaddrinuse-diagnostics-contract.test.ts tests/unit/tui-env-flags.test.ts tests/unit/windows-launch-spec.test.ts tests/unit/service-lifecycle-cli.test.ts tests/unit/claude-sdk-windows-launch.test.ts tests/unit/claude-sdk-session.test.ts tests/unit/claude-sdk-control.test.ts tests/unit/claude-sdk-core-hardening.test.ts tests/unit/claude-sdk-deferred-core.test.ts
+      # The validator prints the list; $LASTEXITCODE is checked immediately
+      # because pwsh does not turn a native non-zero exit into a terminating
+      # error, and any later native call would overwrite it. Arguments go
+      # through one array so nothing is re-parsed by a shell.
+      - name: Run Windows-relevant unit tests (manifest)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = @(& node scripts/ci/windows-unit-manifest.mjs --print)
+          if ($LASTEXITCODE -ne 0) { throw "windows-unit manifest validation failed ($LASTEXITCODE)" }
+          if ($files.Count -eq 0) { throw 'windows-unit manifest is empty' }
+          $tsx = (& node -p "require.resolve('tsx/cli')").Trim()
+          if ($LASTEXITCODE -ne 0 -or -not $tsx) { throw 'cannot resolve the installed tsx' }
+          $nodeArgs = @($tsx, '--import', './tests/setup/test-home.ts', '--experimental-test-module-mocks', '--test') + $files
+          Write-Host "windows-unit: $($files.Count) files"
+          & node @nodeArgs
+          exit $LASTEXITCODE
 
+  # The single required status check for the `main` ruleset.
+  #
   # The check name is the job `name:` below and is load-bearing: the branch
-  # ruleset and the publish gate both match on the literal string
-  # `ci-aggregate`. Renaming this job silently detaches both of them, so the
-  # name is pinned explicitly instead of being inherited from the job id.
+  # ruleset matches on the literal string `ci-aggregate`. (publish.yml and the
+  # release scripts select the whole run by workflow file, SHA, push event and
+  # branch, not by this job name — but the ruleset does.) Renaming this job
+  # silently detaches the ruleset, so the name is pinned explicitly instead of
+  # being inherited from the job id.
   #
   # It runs on every event this workflow accepts — including docs-only pull
-  # requests, where `node-tests` is legitimately skipped — so a required check
-  # always has a run to wait for.
+  # requests, where the producers are legitimately skipped — so a required
+  # check always has a run to wait for. The decision table lives in
+  # scripts/ci/aggregate-check.sh so tests/unit/ci-aggregate-rules.test.ts can
+  # drive it; the checkout below is unconditional for that reason.
   ci-aggregate:
     name: ci-aggregate
-    needs: [changes, node-tests, windows-unit]
+    needs: [changes, test, integration, gates, windows-unit]
     # `always()` rather than the default success() semantics: the point of this
     # job is to report on upstream failures, so it must still run after one.
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout aggregate script
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/ci
+          sparse-checkout-cone-mode: false
+
       - name: Verify producers
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          NODE_TESTS_RESULT: ${{ needs.node-tests.result }}
-          WINDOWS_UNIT_RESULT: ${{ needs.windows-unit.result }}
           CODE_CHANGED: ${{ needs.changes.outputs.code }}
-        run: |
-          set -uo pipefail
-          failed=0
-
-          # `success` and `skipped` pass; `failure`, `cancelled`, an empty
-          # result, and anything unrecognised fail. Skipped and failed are
-          # deliberately NOT collapsed together: a docs-only change skips
-          # node-tests on purpose, a broken one does not.
-          check() {
-            job="$1"
-            result="$2"
-            case "$result" in
-              success)  echo "PASS  $job: success" ;;
-              skipped)  echo "PASS  $job: skipped (not required for this change)" ;;
-              failure)  echo "FAIL  $job: failure"; failed=1 ;;
-              cancelled) echo "FAIL  $job: cancelled"; failed=1 ;;
-              '')       echo "FAIL  $job: no result reported"; failed=1 ;;
-              *)        echo "FAIL  $job: unexpected result '$result'"; failed=1 ;;
-            esac
-          }
-
-          check changes "$CHANGES_RESULT"
-          check node-tests "$NODE_TESTS_RESULT"
-          check windows-unit "$WINDOWS_UNIT_RESULT"
-
-          # A skip is only legitimate when change detection actually said the
-          # change was docs-only. If it said "code" and the suite still did not
-          # run, something dropped the job and the check must not go green.
-          if [ "$CHANGES_RESULT" = "success" ] && [ "$CODE_CHANGED" = "true" ] && [ "$NODE_TESTS_RESULT" = "skipped" ]; then
-            echo "FAIL  node-tests was skipped even though change detection reported code changes"
-            failed=1
-          fi
-
-          if [ "$CHANGES_RESULT" = "success" ] && [ "$CODE_CHANGED" = "true" ] && [ "$WINDOWS_UNIT_RESULT" = "skipped" ]; then
-            echo "FAIL  windows-unit was skipped even though change detection reported code changes"
-            failed=1
-          fi
-
-          if [ "$failed" -ne 0 ]; then
-            echo "::error::ci-aggregate failed — see the per-job results above"
-            exit 1
-          fi
-          echo "ci-aggregate: all required jobs succeeded or were legitimately skipped"
+          TEST_RESULT: ${{ needs.test.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+          GATES_RESULT: ${{ needs.gates.result }}
+          WINDOWS_UNIT_RESULT: ${{ needs.windows-unit.result }}
+        run: bash scripts/ci/aggregate-check.sh

--- a/scripts/ci/aggregate-check.sh
+++ b/scripts/ci/aggregate-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# The ci-aggregate decision for .github/workflows/test.yml, kept in a script so
+# tests/unit/ci-aggregate-rules.test.ts can drive its truth table. Inputs are the
+# producer job results and the change classifier's output, all through env.
+#
+#   changes must be success and CODE_CHANGED exactly true|false
+#   code=true : every producer must be success (a skip is a dropped job, not a pass)
+#   code=false: every producer may be success or skipped (docs-only change)
+#   failure, cancelled, empty, or anything unrecognised always fails
+set -uo pipefail
+
+failed=0
+require_code=""
+
+case "${CHANGES_RESULT:-}" in
+  success) echo "PASS  changes: success" ;;
+  *)       echo "FAIL  changes: ${CHANGES_RESULT:-<empty>}"; failed=1 ;;
+esac
+
+case "${CODE_CHANGED:-}" in
+  true|false) require_code="${CODE_CHANGED}"; echo "INFO  changes.outputs.code=${CODE_CHANGED}" ;;
+  *)          echo "FAIL  changes.outputs.code was '${CODE_CHANGED:-}', expected true or false"; failed=1 ;;
+esac
+
+check() {
+  local job="$1" result="$2"
+  case "$result" in
+    success)
+      echo "PASS  $job: success" ;;
+    skipped)
+      if [ "$require_code" = "false" ]; then
+        echo "PASS  $job: skipped (docs-only change)"
+      else
+        echo "FAIL  $job: skipped although change detection reported code changes"; failed=1
+      fi ;;
+    failure)   echo "FAIL  $job: failure"; failed=1 ;;
+    cancelled) echo "FAIL  $job: cancelled"; failed=1 ;;
+    '')        echo "FAIL  $job: no result reported"; failed=1 ;;
+    *)         echo "FAIL  $job: unexpected result '$result'"; failed=1 ;;
+  esac
+}
+
+check test         "${TEST_RESULT:-}"
+check integration  "${INTEGRATION_RESULT:-}"
+check gates        "${GATES_RESULT:-}"
+check windows-unit "${WINDOWS_UNIT_RESULT:-}"
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::ci-aggregate failed — see the per-job results above"
+  exit 1
+fi
+echo "ci-aggregate: all required jobs succeeded or were legitimately skipped"
+

--- a/scripts/ci/windows-unit-manifest.mjs
+++ b/scripts/ci/windows-unit-manifest.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Validates scripts/ci/windows-unit-manifest.txt — the list of unit test files
+// the windows-unit job runs on windows-latest. One repo-relative POSIX path per
+// line; blank lines and full-line '#' comments are ignored; no globs, duplicates,
+// traversal, or paths outside tests/unit/. Consumed by the Windows job (--print)
+// and by tests/unit/windows-unit-manifest.test.ts, so a renamed test breaks on
+// Linux before it silently vanishes from the Windows lane.
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+export const MANIFEST_PATH = 'scripts/ci/windows-unit-manifest.txt';
+const ENTRY = /^tests\/unit\/[A-Za-z0-9_-]+\.test\.ts$/;
+
+/** @returns {string[]} validated entries in manifest order; throws with the reason */
+export function readManifest(manifestPath, { root } = {}) {
+    const repoRoot = root ?? resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+    const abs = resolve(repoRoot, manifestPath);
+    if (!existsSync(abs)) throw new Error(`manifest missing: ${manifestPath}`);
+    const lines = readFileSync(abs, 'utf8').split(/\r?\n/);
+    const entries = [];
+    const seen = new Set();
+    lines.forEach((raw, i) => {
+        const line = raw.trim();
+        if (!line || line.startsWith('#')) return;
+        const where = `${manifestPath}:${i + 1}`;
+        if (!ENTRY.test(line)) throw new Error(`${where}: invalid entry '${line}' (expected tests/unit/<name>.test.ts)`);
+        if (seen.has(line)) throw new Error(`${where}: duplicate entry '${line}'`);
+        const file = join(repoRoot, line);
+        if (!existsSync(file) || !statSync(file).isFile()) throw new Error(`${where}: missing file '${line}'`);
+        seen.add(line);
+        entries.push(line);
+    });
+    if (entries.length === 0) throw new Error(`${manifestPath}: empty manifest`);
+    return entries;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    const args = process.argv.slice(2);
+    const print = args.includes('--print');
+    const target = args.find(a => !a.startsWith('--')) ?? MANIFEST_PATH;
+    try {
+        const entries = readManifest(target);
+        if (print) process.stdout.write(entries.join('\n') + '\n');
+        else console.log(`windows-unit manifest ok: ${entries.length} files`);
+    } catch (error) {
+        console.error(`[windows-unit-manifest] ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+    }
+}
+

--- a/scripts/ci/windows-unit-manifest.txt
+++ b/scripts/ci/windows-unit-manifest.txt
@@ -1,0 +1,19 @@
+# Unit test files the windows-unit job runs on windows-latest (.github/workflows/test.yml).
+# One repo-relative path per line, tests/unit/<name>.test.ts only; no globs.
+# Validated by scripts/ci/windows-unit-manifest.mjs and tests/unit/windows-unit-manifest.test.ts.
+tests/unit/windows-service-esm.test.ts
+tests/unit/service-windows-branch.test.ts
+tests/unit/windows-service-lifecycle-honesty.test.ts
+tests/unit/windows-installer-shims.test.ts
+tests/unit/windows-spawn-primitives.test.ts
+tests/unit/manager-browser-open.test.ts
+tests/unit/eaddrinuse-diagnostics-contract.test.ts
+tests/unit/tui-env-flags.test.ts
+tests/unit/windows-launch-spec.test.ts
+tests/unit/service-lifecycle-cli.test.ts
+tests/unit/claude-sdk-windows-launch.test.ts
+tests/unit/claude-sdk-session.test.ts
+tests/unit/claude-sdk-control.test.ts
+tests/unit/claude-sdk-core-hardening.test.ts
+tests/unit/claude-sdk-deferred-core.test.ts
+

--- a/tests/integration/api-smoke.test.ts
+++ b/tests/integration/api-smoke.test.ts
@@ -18,6 +18,10 @@ async function checkServer() {
 test('API Smoke Tests', async (t) => {
     const alive = await checkServer();
     if (!alive) {
+        // A missing server is a skip on a developer box, but in CI the integration
+        // job owns the server on TEST_PORT — silently skipping there would turn a
+        // broken startup into a green run.
+        if (process.env.CI) assert.fail(`Server not running on port ${PORT} under CI — the integration job must start it`);
         t.skip(`Server not running on port ${PORT}`);
         return;
     }

--- a/tests/manager/dashboard-memory-routes.test.ts
+++ b/tests/manager/dashboard-memory-routes.test.ts
@@ -79,7 +79,7 @@ test('routes: /read rejects path traversal', async () => {
     const base = freshTmp();
     const home = join(base, '.cli-jaw-3457');
     mkdirSync(join(home, 'memory', 'structured'), { recursive: true });
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(`http://127.0.0.1:${srv.port}/api/dashboard/memory/read?instance=3457&path=${encodeURIComponent('../../etc/passwd')}`);
         assert.ok([400, 404].includes(res.status), `unexpected status ${res.status}`);
@@ -94,7 +94,7 @@ test('routes: /read rejects symlinks (symlink_forbidden)', async () => {
     const decoy = join(base, 'outside.md');
     writeFileSync(decoy, '# secret');
     symlinkSync(decoy, join(memDir, 'evil.md'));
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(`http://127.0.0.1:${srv.port}/api/dashboard/memory/read?instance=3457&path=evil.md`);
         assert.equal(res.status, 400);
@@ -109,7 +109,7 @@ test('routes: /read rejects non-md extension', async () => {
     const memDir = join(home, 'memory', 'structured');
     mkdirSync(memDir, { recursive: true });
     writeFileSync(join(memDir, 'index.sqlite'), '');
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(`http://127.0.0.1:${srv.port}/api/dashboard/memory/read?instance=3457&path=index.sqlite`);
         assert.equal(res.status, 400);
@@ -124,7 +124,7 @@ test('routes: /read reads valid .md file', async () => {
     const memDir = join(home, 'memory', 'structured');
     mkdirSync(memDir, { recursive: true });
     writeFileSync(join(memDir, 'profile.md'), '# Profile\n\nContent.');
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(`http://127.0.0.1:${srv.port}/api/dashboard/memory/read?instance=3457&path=profile.md`);
         assert.equal(res.status, 200);
@@ -137,7 +137,7 @@ test('routes: /instances returns shape', async () => {
     const base = freshTmp();
     const home = join(base, '.cli-jaw-3457');
     mkdirSync(home);
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(`http://127.0.0.1:${srv.port}/api/dashboard/memory/instances`);
         assert.equal(res.status, 200);
@@ -229,7 +229,7 @@ test('FED-12b: a real default /chat/search hit carries no session field', async 
         ).run('fed12buniquetoken row');
     } finally { db.close(); }
 
-    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home }]);
+    const srv = await startServer(async () => [{ port: 3457, profileId: null, homeDisplay: home, ok: true }]);
     try {
         const res = await fetch(
             `http://127.0.0.1:${srv.port}/api/dashboard/memory/chat/search?q=fed12buniquetoken`,

--- a/tests/run.mts
+++ b/tests/run.mts
@@ -26,6 +26,13 @@
 // changes. The old CI invocation (--import test-home.ts --test) had per-file homes
 // for the same reason; this keeps that behavior inside the driver.
 //
+// forceExit mirrors the --test-force-exit the CI invocation always carried: a
+// file whose test left a handle open (a spawned child, a server) would otherwise
+// keep its process alive after the last test and stall the whole shard — shard 3/4
+// of run 34138235928 went silent for 4.5 minutes after ~half its files finished
+// and was killed by the step timeout. Node rejects forceExit together with watch,
+// so watch mode keeps the old behavior.
+//
 // Coverage: node:test only collects coverage when run() receives { coverage: true }
 // (v22.10+); the --experimental-test-coverage flag alone is filtered out of the
 // programmatic path, so it is bridged from execArgv here.
@@ -78,5 +85,5 @@ console.log(`[tests/run] ${files.length} files (scope=${scopeLabel}, shard=${opt
 const coverage = process.execArgv.includes('--experimental-test-coverage');
 const execArgv = ['--import', pathToFileURL(join(TESTS_DIR, 'setup', 'test-home.ts')).href];
 let failures = 0;
-run({ files, concurrency: true, watch, isolation: 'process', coverage, execArgv }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
+run({ files, concurrency: true, watch, isolation: 'process', coverage, execArgv, forceExit: !watch }).on('test:fail', () => { failures += 1; }).compose(spec).pipe(process.stdout);
 if (!watch) process.on('beforeExit', () => { if (failures > 0 && !process.exitCode) process.exitCode = 1; });

--- a/tests/unit/ci-aggregate-rules.test.ts
+++ b/tests/unit/ci-aggregate-rules.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const script = resolve(import.meta.dirname, '..', '..', 'scripts', 'ci', 'aggregate-check.sh');
+type Env = Partial<Record<'CHANGES_RESULT' | 'CODE_CHANGED' | 'TEST_RESULT' | 'INTEGRATION_RESULT' | 'GATES_RESULT' | 'WINDOWS_UNIT_RESULT', string>>;
+const allGreen: Env = { CHANGES_RESULT: 'success', CODE_CHANGED: 'true', TEST_RESULT: 'success', INTEGRATION_RESULT: 'success', GATES_RESULT: 'success', WINDOWS_UNIT_RESULT: 'success' };
+
+function run(env: Env) {
+    const r = spawnSync('bash', [script], { env: { PATH: process.env.PATH ?? '', ...env }, encoding: 'utf8' });
+    return { status: r.status, out: r.stdout + r.stderr };
+}
+
+test('AGG-001: every producer success with code=true passes', () => {
+    const r = run(allGreen);
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /all required jobs succeeded/);
+});
+
+test('AGG-002: docs-only (code=false) accepts skipped producers', () => {
+    const r = run({ ...allGreen, CODE_CHANGED: 'false', TEST_RESULT: 'skipped', INTEGRATION_RESULT: 'skipped', GATES_RESULT: 'skipped', WINDOWS_UNIT_RESULT: 'skipped' });
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /docs-only change/);
+});
+
+test('AGG-003: a skipped producer under code=true is a dropped job, not a pass', () => {
+    for (const job of ['TEST_RESULT', 'INTEGRATION_RESULT', 'GATES_RESULT', 'WINDOWS_UNIT_RESULT'] as const) {
+        const r = run({ ...allGreen, [job]: 'skipped' });
+        assert.equal(r.status, 1, `${job}: ${r.out}`);
+        assert.match(r.out, /skipped although change detection reported code changes/);
+    }
+});
+
+test('AGG-004: failure, cancelled, empty, and unknown results always fail', () => {
+    for (const value of ['failure', 'cancelled', '', 'bogus']) {
+        for (const job of ['TEST_RESULT', 'INTEGRATION_RESULT', 'GATES_RESULT', 'WINDOWS_UNIT_RESULT'] as const) {
+            const env = { ...allGreen, [job]: value };
+            if (value === '') delete (env as Record<string, string>)[job];
+            const r = run(env);
+            assert.equal(r.status, 1, `${job}=${value}: ${r.out}`);
+        }
+    }
+});
+
+test('AGG-005: changes must be success and code must be exactly true|false', () => {
+    assert.equal(run({ ...allGreen, CHANGES_RESULT: 'failure' }).status, 1);
+    assert.equal(run({ ...allGreen, CHANGES_RESULT: 'skipped' }).status, 1);
+    for (const code of ['', 'yes', 'TRUE', 'null']) {
+        const env = { ...allGreen, CODE_CHANGED: code };
+        if (code === '') delete (env as Record<string, string>).CODE_CHANGED;
+        const r = run(env);
+        assert.equal(r.status, 1, `code=${code}`);
+        assert.match(r.out, /expected true or false/);
+    }
+});
+

--- a/tests/unit/windows-unit-manifest.test.ts
+++ b/tests/unit/windows-unit-manifest.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readManifest, MANIFEST_PATH } from '../../scripts/ci/windows-unit-manifest.mjs';
+
+const projectRoot = resolve(import.meta.dirname, '..', '..');
+
+function fixture(content: string, files: string[] = []): string {
+    const root = mkdtempSync(join(tmpdir(), 'cli-jaw-wum-'));
+    mkdirSync(join(root, 'tests', 'unit'), { recursive: true });
+    mkdirSync(join(root, 'scripts', 'ci'), { recursive: true });
+    for (const f of files) writeFileSync(join(root, f), '');
+    writeFileSync(join(root, MANIFEST_PATH), content);
+    return root;
+}
+
+test('WUM-001: the committed manifest validates and lists only existing tests/unit files', () => {
+    const entries = readManifest(MANIFEST_PATH, { root: projectRoot });
+    assert.ok(entries.length >= 15, `expected the 15 Windows lane files, got ${entries.length}`);
+    assert.equal(new Set(entries).size, entries.length);
+    for (const e of entries) assert.match(e, /^tests\/unit\/[A-Za-z0-9_-]+\.test\.ts$/);
+});
+
+test('WUM-002: comments and blank lines are ignored, order is preserved', () => {
+    const root = fixture('# header\n\ntests/unit/b.test.ts\n  tests/unit/a.test.ts  \n', ['tests/unit/a.test.ts', 'tests/unit/b.test.ts']);
+    assert.deepEqual(readManifest(MANIFEST_PATH, { root }), ['tests/unit/b.test.ts', 'tests/unit/a.test.ts']);
+});
+
+test('WUM-003: empty, duplicate, out-of-tree, and missing entries each throw with the reason', () => {
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('# only comments\n') }), /empty manifest/);
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('tests/unit/a.test.ts\ntests/unit/a.test.ts\n', ['tests/unit/a.test.ts']) }), /duplicate entry/);
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('tests/integration/x.test.ts\n') }), /invalid entry/);
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('tests/unit/../../package.json\n') }), /invalid entry/);
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('tests/unit/*.test.ts\n') }), /invalid entry/);
+    assert.throws(() => readManifest(MANIFEST_PATH, { root: fixture('tests/unit/gone.test.ts\n') }), /missing file/);
+    assert.throws(() => readManifest('scripts/ci/nope.txt', { root: fixture('') }), /manifest missing/);
+});
+
+test('WUM-004: CLI --print emits the validated list and exits 1 on a defect', () => {
+    const ok = spawnSync(process.execPath, ['scripts/ci/windows-unit-manifest.mjs', '--print'], { cwd: projectRoot, encoding: 'utf8' });
+    assert.equal(ok.status, 0, ok.stderr);
+    const printed = ok.stdout.trim().split('\n');
+    assert.deepEqual(printed, readManifest(MANIFEST_PATH, { root: projectRoot }));
+    const bad = fixture('tests/unit/gone.test.ts\n');
+    const fail = spawnSync(process.execPath, [join(projectRoot, 'scripts/ci/windows-unit-manifest.mjs'), '--print', join(bad, MANIFEST_PATH)], { cwd: bad, encoding: 'utf8' });
+    assert.equal(fail.status, 1);
+    assert.match(fail.stderr, /missing file/);
+    assert.equal(fail.stdout, '');
+});
+


### PR DESCRIPTION
## Problem

`test.yml` ran everything in one serial `node-tests` job: 345 s of root+unit tests followed by gates, frontend, fresh-install, deps and smokes — 9m51s wall time on the last dev run (34128612867). `tests/integration`, `tests/manager` and `tests/bin` were never run in CI at all; only `cli-basic`, `api-smoke` and (via `gate:all`) `promotion-checkout` were.

## Change

Job graph is now `changes → { test 1..4/4, integration, gates, windows-unit, coverage (advisory) } → ci-aggregate`, ported from opencodex's `ci.yml` (validated `true|false` scope output, `fail-fast: false` shard matrix, `persist-credentials: false`, an `always()` aggregate that names every producer). Deliberately not ported: Bun batching, crash/timeout retries, self-hosted Windows, the push `paths:` allowlist.

- **test i/4** — `tsc` + `tests/run.mts --scope root,unit --shard i/4` (driver from #564).
- **integration** — `npm run build` (a real dist with templates; `graceful-shutdown` boots it), frontend build/check, a live server on :3457, then `--scope integration,manager,bin` with `CI=1`, then fresh-install smoke. The old cli-basic/api-smoke steps are subsumed. Two opt-in provider smokes stay self-skipping and are listed as quarantined in the job comment.
- **gates** — `gate:all` + deps/advisory/devlog/copilot/file-size, once. The standalone strict-baseline step is dropped (`gate:all` already runs that checker).
- **coverage (advisory)** — dev push + `workflow_dispatch` only, `continue-on-error`, not in the aggregate's `needs`, uploads `coverage.txt`.
- **windows-unit** — reads `scripts/ci/windows-unit-manifest.txt` through `scripts/ci/windows-unit-manifest.mjs --print` (pwsh checks `$LASTEXITCODE` immediately, one argument array). The same validator runs in `gates` and in `tests/unit/windows-unit-manifest.test.ts`, so a renamed Windows test fails on Linux instead of silently leaving the lane.
- **ci-aggregate** — name kept (the ruleset matches it); the decision moved to `scripts/ci/aggregate-check.sh` with an unconditional sparse checkout, and `tests/unit/ci-aggregate-rules.test.ts` drives its truth table (skipped producers pass only when the classifier said docs-only; failure/cancelled/empty/unknown always fail).

Test repairs needed to make the integration job green:

- `tests/manager/dashboard-memory-routes.test.ts`: fixtures carry `ok: true` (instance-discovery filters on it; 4 tests failed without it).
- `tests/integration/api-smoke.test.ts`: a missing server fails under `CI` instead of skipping, so a broken startup cannot read as green.

Contracts preserved verbatim: `name: Tests`, the multiline `dev/preview/main` push list, unfiltered `pull_request:`, `name: ci-aggregate`, `npm run check:deps:audit`. `workflow_dispatch` is added; publish.yml and the release scripts still require `--event push` runs on preview/main.

## Validation

- `actionlint -shellcheck='' .github/workflows/test.yml`: clean.
- release-scripts-contract, deps-audit-gate, release-gate-skip-semantics, windows-unit-manifest, ci-aggregate-rules, test-runner-shard, test-home-contract, dashboard-memory-routes: 59/59 locally.
- `CI=1 TEST_PORT=19999 npx tsx --test tests/integration/api-smoke.test.ts` → exit 1 with the CI diagnostic; without `CI` → skip, exit 0.
- `npm run typecheck`, `check-strict-baseline`, `check:path-length`: clean.
- The PR run of this workflow is the real evidence; per-shard wall times from it feed the next PR (rebalance/quarantine).

Stacked on #564. Part of devlog `260907_test_sharding_modernization` (wp2 of 5).
