### PR TITLE
feat(web): select permission policy from sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,8 @@ git add devlog && git commit -m "chore: update devlog ref" && git push
 
 ### Native decisions
 
+The Classic permission selector saves explicit Auto/Safe choices. Server startup preserves the saved policy; never reintroduce the obsolete safe-to-auto coercion. Existing runtime-specific policy support and settings invalidation still apply.
+
 Pi capability preparation owns one asynchronous, completed-close version probe
 per RPC instance; preparing input is not dispatched or treated as legacy yet.
 Keep both capability getters live and typed finality unchanged. Direct Stop and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ This repository is a Node.js ESM orchestration runtime for boss/employee dispatc
 
 ## Current Runtime Notes
 
+The Classic permission selector saves explicit Auto/Safe choices. Server startup preserves the saved policy; never reintroduce the obsolete safe-to-auto coercion. Existing runtime-specific policy support and settings invalidation still apply.
+
 - Classic history restoration uses bounded targeted replay and preserves recorded
   scope; unrelated live runs continue. Exact saved answers come from the run+chat
   MESSAGE lookup, not redacted journal finals. Resolved-session loading and captured

--- a/public/css/sidebar.css
+++ b/public/css/sidebar.css
@@ -208,8 +208,10 @@
 }
 
 .perm-btn {
+    position: relative;
+    display: block;
     flex: 1;
-    padding: 6px;
+    padding: 0;
     border: 1px solid var(--border);
     border-radius: 6px;
     background: none;
@@ -220,18 +222,52 @@
     text-align: center;
 }
 
+.perm-btn select {
+    width: 100%;
+    margin: 0;
+    padding: 6px 18px 6px 22px;
+    border: 0;
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.perm-btn > :first-child {
+    position: absolute;
+    left: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.perm-btn:focus-within {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.perm-save-error {
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--text-dim);
+}
+
 .perm-btn.active {
     border-color: var(--accent);
     color: var(--accent);
     background: color-mix(in oklch, var(--accent) 10%, var(--bg));
 }
 
-.perm-btn:disabled {
+.perm-btn:has(select:disabled) {
     border-color: var(--border);
     background: none;
     color: var(--text-dim);
     cursor: not-allowed;
     opacity: 0.55;
+}
+
+.perm-btn select:disabled {
+    cursor: not-allowed;
 }
 
 .channel-transport-status .transport-status-block + .transport-status-block {

--- a/public/css/sidebar.css
+++ b/public/css/sidebar.css
@@ -208,10 +208,8 @@
 }
 
 .perm-btn {
-    position: relative;
-    display: block;
     flex: 1;
-    padding: 0;
+    padding: 6px;
     border: 1px solid var(--border);
     border-radius: 6px;
     background: none;
@@ -222,7 +220,13 @@
     text-align: center;
 }
 
-.perm-btn select {
+.perm-selector {
+    position: relative;
+    display: block;
+    padding: 0;
+}
+
+.perm-selector select {
     width: 100%;
     margin: 0;
     padding: 6px 18px 6px 22px;
@@ -233,7 +237,7 @@
     cursor: pointer;
 }
 
-.perm-btn > :first-child {
+.perm-selector > :first-child {
     position: absolute;
     left: 6px;
     top: 50%;
@@ -241,7 +245,7 @@
     pointer-events: none;
 }
 
-.perm-btn:focus-within {
+.perm-selector:focus-within {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }
@@ -258,7 +262,8 @@
     background: color-mix(in oklch, var(--accent) 10%, var(--bg));
 }
 
-.perm-btn:has(select:disabled) {
+.perm-btn:disabled,
+.perm-selector:has(select:disabled) {
     border-color: var(--border);
     background: none;
     color: var(--text-dim);
@@ -266,7 +271,7 @@
     opacity: 0.55;
 }
 
-.perm-btn select:disabled {
+.perm-selector select:disabled {
     cursor: not-allowed;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -346,7 +346,7 @@
                         data-i18n-aria="help.permissions.aria" aria-label="권한 도움말">?</button>
                 </label>
                 <div class="perm-toggle">
-                    <span class="perm-btn" id="configuredPerm">
+                    <span class="perm-btn perm-selector" id="configuredPerm">
                         <span data-icon="exec" aria-hidden="true"></span>
                         <span id="configuredPermText" hidden>Configured policy: Not provided</span>
                         <select id="selPerm" aria-labelledby="permissionsLabel" aria-describedby="configuredPermText permSaveError" disabled>

--- a/public/index.html
+++ b/public/index.html
@@ -341,13 +341,22 @@
 
             <div>
                 <label class="label-with-help">
-                    <span data-i18n="label.permissions">권한</span>
+                    <span id="permissionsLabel" data-i18n="label.permissions">권한</span>
                     <button class="help-trigger" type="button" data-help-topic="permissions"
                         data-i18n-aria="help.permissions.aria" aria-label="권한 도움말">?</button>
                 </label>
                 <div class="perm-toggle">
-                    <span class="perm-btn" id="configuredPerm"><span data-icon="exec"></span> <span id="configuredPermText">Configured policy: Not provided</span></span>
+                    <span class="perm-btn" id="configuredPerm">
+                        <span data-icon="exec" aria-hidden="true"></span>
+                        <span id="configuredPermText" hidden>Configured policy: Not provided</span>
+                        <select id="selPerm" aria-labelledby="permissionsLabel" aria-describedby="configuredPermText permSaveError" disabled>
+                            <option value="" disabled hidden>Configured policy: Not provided</option>
+                            <option value="auto">Configured policy: Auto</option>
+                            <option value="safe">Configured policy: Safe</option>
+                        </select>
+                    </span>
                 </div>
+                <div id="permSaveError" role="alert" class="perm-save-error" hidden></div>
             </div>
 
             <div>

--- a/public/js/features/settings-core.ts
+++ b/public/js/features/settings-core.ts
@@ -19,7 +19,7 @@ import { formatProjectLabel } from './project-label.js';
 import { loadHeaderGitStatus, refreshHeaderGitStatusFromSettingsChange } from './project-git-status.js';
 import { applyPresentationSettings, beginPresentationRead } from './presentation-preference.js';
 
-let activeSettingsSave: Promise<void> | null = null;
+const activeSettingsSaves = new Set<Promise<void>>();
 let configuredPermission: unknown;
 let permissionSavePending = false;
 let permissionRevision = 0;
@@ -156,15 +156,14 @@ function cliDisplayLabel(cli: string): string {
 
 function trackSettingsSave(promise: Promise<void>): Promise<void> {
     const tracked = promise.finally(() => {
-        if (activeSettingsSave === tracked) activeSettingsSave = null;
+        activeSettingsSaves.delete(tracked);
     });
-    activeSettingsSave = tracked;
+    activeSettingsSaves.add(tracked);
     return tracked;
 }
 
 export async function waitForSettingsSaveIdle(): Promise<void> {
-    const pending = activeSettingsSave;
-    if (pending) await pending;
+    while (activeSettingsSaves.size) await Promise.all(activeSettingsSaves);
 }
 
 function toDomSuffix(cli: string): string {

--- a/public/js/features/settings-core.ts
+++ b/public/js/features/settings-core.ts
@@ -20,6 +20,9 @@ import { loadHeaderGitStatus, refreshHeaderGitStatusFromSettingsChange } from '.
 import { applyPresentationSettings, beginPresentationRead } from './presentation-preference.js';
 
 let activeSettingsSave: Promise<void> | null = null;
+let configuredPermission: unknown;
+let permissionSavePending = false;
+let permissionRevision = 0;
 
 type MigrationResponse = SettingsData | { ok?: boolean; data?: SettingsData; settings?: SettingsData };
 
@@ -426,6 +429,7 @@ function syncCliProviderControl(settings: SettingsData | null, cli: string): str
 }
 
 export async function loadSettings(): Promise<void> {
+    const permissionRead = permissionRevision;
     await loadCliRegistry();
     const presentationRead = beginPresentationRead();
     let s = await api<SettingsData>('/api/settings');
@@ -459,7 +463,7 @@ export async function loadSettings(): Promise<void> {
     }
     setHeaderProject(s.projectDirs);
     await loadHeaderGitStatus();
-    setPerm(s.permissions, false);
+    if (permissionRead === permissionRevision && !permissionSavePending) setPerm(s.permissions, false);
 
     if (s.perCli) {
         for (const [cli, cfg] of Object.entries(s.perCli) as [string, PerCliConfig][]) {
@@ -549,15 +553,52 @@ function configuredPermLabel(value: unknown): string {
     return 'Unrecognized';
 }
 
-export function setPerm(p: unknown, save = true): void {
-    if (!save) {
-        const label = document.getElementById('configuredPermText');
-        if (label) label.textContent = `Configured policy: ${configuredPermLabel(p)}`;
-        const badge = document.getElementById('configuredPerm');
-        badge?.classList.toggle('active', p === 'auto');
-        badge?.classList.toggle('perm-auto', p === 'auto');
+function renderConfiguredPermission(): void {
+    const p = configuredPermission;
+    const label = configuredPermLabel(p);
+    const text = document.getElementById('configuredPermText');
+    if (text) text.textContent = `Configured policy: ${label}`;
+    const badge = document.getElementById('configuredPerm');
+    badge?.classList.toggle('active', p === 'auto');
+    badge?.classList.toggle('perm-auto', p === 'auto');
+    const select = document.getElementById('selPerm') as HTMLSelectElement | null;
+    if (select) {
+        select.options[0].textContent = `Configured policy: ${label}`;
+        select.value = p === 'auto' || p === 'safe' ? p : '';
+        select.disabled = permissionSavePending;
+        select.setAttribute('aria-busy', String(permissionSavePending));
     }
-    if (save) apiFire('/api/settings', 'PUT', { permissions: 'auto' });
+}
+
+export async function setPerm(p: unknown, save = true): Promise<void> {
+    if (!save) {
+        configuredPermission = p;
+        renderConfiguredPermission();
+        return;
+    }
+    if ((p !== 'auto' && p !== 'safe') || p === configuredPermission || permissionSavePending) return;
+    permissionSavePending = true;
+    permissionRevision++;
+    renderConfiguredPermission();
+    const error = document.getElementById('permSaveError');
+    if (error) { error.hidden = true; error.textContent = ''; }
+    return trackSettingsSave((async () => {
+        try {
+            const result = await apiJson<SettingsData>('/api/settings', 'PUT', { permissions: p });
+            if (!result) throw new Error('Permission settings save failed');
+            configuredPermission = result.permissions;
+        } catch {
+            if (error) {
+                error.textContent = 'Could not save permissions. Please try again.';
+                error.hidden = false;
+            }
+        } finally {
+            permissionSavePending = false;
+            // Also invalidate reads started during the write, before it committed.
+            permissionRevision++;
+            renderConfiguredPermission();
+        }
+    })());
 }
 
 export function getModelValue(cli: string): string {

--- a/public/js/main.ts
+++ b/public/js/main.ts
@@ -47,7 +47,7 @@ import {
 } from './features/slash-commands.js';
 import { toggleSkill, filterSkills, searchSkills } from './features/skills.js';
 import {
-    loadSettings, handleModelSelect, applyCustomModel, onCliChange,
+    loadSettings, setPerm, handleModelSelect, applyCustomModel, onCliChange,
     onPerCliProviderChange, saveActiveCliSettings, savePerCli, openPromptModal,
     onFlushCliChange, loadFlushAgentSidebar,
     closePromptModal, savePromptFromModal, syncMcpServers, installMcpGlobal,
@@ -207,6 +207,9 @@ document.getElementById('selCliProvider')?.addEventListener('change', (event) =>
 });
 document.getElementById('selModel')?.addEventListener('change', () => saveActiveCliSettings());
 document.getElementById('selEffort')?.addEventListener('change', () => saveActiveCliSettings());
+document.getElementById('selPerm')?.addEventListener('change', (event) => {
+    void setPerm((event.target as HTMLSelectElement).value);
+});
 document.getElementById('flushCli')?.addEventListener('change', () => onFlushCliChange());
 document.getElementById('flushModel')?.addEventListener('change', () => onFlushCliChange());
 document.querySelector('[data-action="addEmployee"]')?.addEventListener('click', addEmployee);

--- a/server.ts
+++ b/server.ts
@@ -223,13 +223,6 @@ try {
     console.warn('[jaw:toolchain]', (e as Error).message);
 }
 
-// Phase 3.1: safe → auto 강제 마이그레이션 (기존 사용자 대응)
-if (settings["permissions"] === 'safe') {
-    settings["permissions"] = 'auto';
-    saveSettings(settings);
-    console.log('[jaw:migrate] permissions: safe → auto');
-}
-
 initPromptFiles();
 regenerateB();
 

--- a/structure/AGENTS.md
+++ b/structure/AGENTS.md
@@ -79,3 +79,5 @@ When refreshing docs from recent non-strict commits, check these first:
 - `src/cli/handlers-skill-invoke.ts`: dynamic `/skill:<id>` — `commands.md`, `INDEX.md`.
 - `src/browser/adaptive-fetch/scheduler.ts` / `src/browser/web-ai/session-artifacts.ts`: adaptive-fetch P0 + web-ai parity wave — `infra.md`, `str_func.md` counts (web-ai 96, adaptive-fetch 34).
 - Keep root `AGENTS.md`, `CLAUDE.md`, `README.md`, and public `docs/dev/` pages aligned with this folder when the architecture map changes.
+
+- The Classic permission selector saves explicit Auto/Safe choices. Server startup preserves the saved policy; never reintroduce the obsolete safe-to-auto coercion. Existing runtime-specific policy support and settings invalidation still apply.

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -17,7 +17,7 @@ Legacy TUI output in `bin/commands/tui/ws-handler.ts` separates turn-clock start
 
 ### Classic permission selector
 
-The sidebar permission badge opens a native Auto/Safe dropdown. `settings-core.ts` keeps the configured-policy readout separate from the pending selection and saves only the selected literal through the existing settings API. Identical selections do not write. Custom arrays, missing values and unrecognized settings remain explicit readouts until the user chooses a supported policy. A failed save restores the confirmed selection and shows an inline error; reads begun before or during a save cannot overwrite its result. This control does not change runtime policy support or active-run invalidation.
+The sidebar permission badge opens a native Auto/Safe dropdown. `settings-core.ts` keeps the configured-policy readout separate from the pending selection and saves only the selected literal through the existing settings API. Identical selections do not write. Custom arrays, missing values and unrecognized settings remain explicit readouts until the user chooses a supported policy. A failed save restores the confirmed selection and shows an inline error; reads begun before or during a save cannot overwrite its result. Server startup preserves the saved policy without coercing Safe to Auto. This control does not change runtime policy support or active-run invalidation.
 
 ### Interactive TUI Activity
 

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -15,6 +15,10 @@ aliases: [CLI-JAW Frontend, public architecture, frontend.md]
 
 Legacy TUI output in `bin/commands/tui/ws-handler.ts` separates turn-clock startup from answer-sink startup. Activity-native output uses the scoped owners below; piped raw remains unchanged.
 
+### Classic permission selector
+
+The sidebar permission badge opens a native Auto/Safe dropdown. `settings-core.ts` keeps the configured-policy readout separate from the pending selection and saves only the selected literal through the existing settings API. Identical selections do not write. Custom arrays, missing values and unrecognized settings remain explicit readouts until the user chooses a supported policy. A failed save restores the confirmed selection and shows an inline error; reads begun before or during a save cannot overwrite its result. This control does not change runtime policy support or active-run invalidation.
+
 ### Interactive TUI Activity
 
 `src/cli/tui/activity.ts` groups live work, defaults collapsed and preserves explicit

--- a/structure/infra.md
+++ b/structure/infra.md
@@ -1508,3 +1508,7 @@ Copilot 할당량 조회 + 인증 토큰 관리. env → file cache → `gh auth
 
 - `getServerUrl(undefined)` 패턴: PORT env 우선, 없으면 DEFAULT_PORT(`3457`)
 - memory.ts: init 경로 `${JAW_HOME}/memory/` (하드코딩 `~/.cli-jaw` 제거)
+
+### Saved permission policy at startup
+
+Server startup loads and preserves the configured `permissions` value (Auto, Safe or a custom list). The obsolete Safe-to-Auto coercion is removed so an explicit sidebar choice survives a restart. `tests/unit/server-permission-startup.test.ts` executes the startup source with isolated persistence and stubbed external effects across two starts.

--- a/tests/unit/phase31-runtime.test.ts
+++ b/tests/unit/phase31-runtime.test.ts
@@ -1,5 +1,5 @@
 import { readSource } from './source-normalize.js';
-// Phase 3.1 runtime safeguards: startup migration + workingDir artifact regeneration
+// Phase 3.1 runtime safeguards: workingDir artifact regeneration
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -8,7 +8,6 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..', '..');
-const serverSrc = readSource(join(projectRoot, 'server.ts'), 'utf8');
 const runtimeSettingsSrc = readSource(join(projectRoot, 'src/core/runtime-settings.ts'), 'utf8');
 const builderSrc = readSource(join(projectRoot, 'src/prompt/builder.ts'), 'utf8');
 
@@ -19,12 +18,8 @@ function section(src: string, startMarker: string, endMarker: string) {
     return src.slice(start, end);
 }
 
-test('P31-001: startup migrates permissions safe -> auto', () => {
-    assert.match(
-        serverSrc,
-        /if\s*\(\s*settings\.permissions\s*===\s*['"]safe['"]\s*\)\s*{[\s\S]*settings\.permissions\s*=\s*['"]auto['"][\s\S]*saveSettings\(settings\)/,
-    );
-});
+// Startup policy preservation is exercised against the actual bootstrap source
+// in server-permission-startup.test.ts, including repeated starts.
 
 // The literal used to be `settings.workingDir`; it now reads from the snapshot
 // taken before the merge, which is the same guarantee expressed more precisely.

--- a/tests/unit/server-permission-startup.test.ts
+++ b/tests/unit/server-permission-startup.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+// Like electron-isolated-qa-startup.test.ts, execute actual startup source with
+// explicit side-effect boundaries. This covers server.ts startup sequencing and
+// settings persistence, not the imported config implementation or HTTP listening.
+const source = readFileSync(new URL('../../server.ts', import.meta.url), 'utf8');
+const parsed = ts.createSourceFile('server.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+function callStatement(name: string) {
+    const statement = parsed.statements.find(node => ts.isExpressionStatement(node)
+        && ts.isCallExpression(node.expression) && ts.isIdentifier(node.expression.expression)
+        && node.expression.expression.text === name);
+    assert.ok(statement, `actual startup ${name} boundary must exist`);
+    return statement;
+}
+const start = callStatement('loadSettings').getStart(parsed);
+const end = callStatement('regenerateB').end;
+assert.ok(end > start, 'startup settings load precedes prompt generation');
+const startup = ts.transpileModule(source.slice(start, end), {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+}).outputText;
+
+type SavedSettings = { permissions: string | string[]; cli: string; workingDir: string };
+for (const permission of ['safe', 'auto', ['read']] as const) {
+    test(`actual server startup preserves saved ${JSON.stringify(permission)} through restart`, async () => {
+        const root = mkdtempSync(join(tmpdir(), 'jaw-permission-startup-'));
+        const settingsPath = join(root, 'settings.json');
+        const initial = { permissions: permission, cli: 'claude', workingDir: root };
+        const original = JSON.stringify(initial);
+        writeFileSync(settingsPath, original);
+        try {
+            for (let boot = 0; boot < 2; boot++) {
+                const settings: Partial<SavedSettings> = {};
+                const generated: unknown[] = [];
+                let saves = 0;
+                let loaded = false;
+                const noop = () => {};
+                const context = {
+                    settings, process: { env: {} },
+                    loadSettings() { Object.assign(settings, JSON.parse(readFileSync(settingsPath, 'utf8'))); loaded = true; },
+                    saveSettings(value: SavedSettings) { saves++; writeFileSync(settingsPath, JSON.stringify(value)); },
+                    db: { prepare: () => ({ pluck: () => ({ get: () => 'ok' }) }) },
+                    readDatabaseStorageStats: () => ({ pageCount: 0, freeRatio: 0, freelistCount: 0 }),
+                    clearAllEmployeeSessions: { run: () => ({ changes: 0 }) },
+                    // No real orphan cleanup or provider/toolchain access is admitted.
+                    fs: { readdirSync: () => [], rmSync() { assert.fail('unexpected orphan deletion'); } },
+                    join, console: { log: noop, warn: noop, error: noop },
+                    syncMainSessionToSettings: noop, ensureMemoryRuntimeReady: noop,
+                    hasSoulFile: () => false, refreshHostToolchain: noop,
+                    initPromptFiles: noop,
+                    regenerateB() {
+                        assert.equal(loaded, true, 'prompt generation must follow persisted settings load');
+                        generated.push(structuredClone(settings.permissions));
+                    },
+                };
+                // Replace only the OS tmpdir import with a contained boundary. All
+                // statements including any permission coercion run verbatim after TS erasure.
+                const code = startup.replace("await import('node:os')", '({ tmpdir: () => fixtureTmp })');
+                await runInNewContext(`(async () => { ${code} })()`, { ...context, fixtureTmp: root }, { timeout: 1000 });
+                assert.deepEqual(settings.permissions, permission, `boot ${boot}: configured policy must survive startup`);
+                assert.deepEqual(generated, [permission], `boot ${boot}: prompts must see the saved policy`);
+                assert.equal(readFileSync(settingsPath, 'utf8'), original, `boot ${boot}: startup must not rewrite the saved policy`);
+                assert.equal(saves, 0, `boot ${boot}: no forced permission migration`);
+            }
+        } finally { rmSync(root, { recursive: true, force: true }); }
+    });
+}

--- a/tests/unit/settings-save-race-contract.test.ts
+++ b/tests/unit/settings-save-race-contract.test.ts
@@ -10,17 +10,8 @@ const CHAT = path.join(ROOT, 'public/js/features/chat.ts');
 const settingsSrc = fs.readFileSync(SETTINGS_CORE, 'utf8');
 const chatSrc = fs.readFileSync(CHAT, 'utf8');
 
-test('SSR-001: settings-core tracks active settings save promise', () => {
-    assert.match(settingsSrc, /let\s+activeSettingsSave:\s*Promise<void>\s*\|\s*null\s*=\s*null/);
-    assert.match(settingsSrc, /function\s+trackSettingsSave\(/);
-    assert.match(settingsSrc, /activeSettingsSave\s*=\s*tracked/);
-});
-
-test('SSR-002: settings-core exports waitForSettingsSaveIdle', () => {
-    assert.match(settingsSrc, /export\s+async\s+function\s+waitForSettingsSaveIdle\(\):\s*Promise<void>/);
-    assert.match(settingsSrc, /const\s+pending\s*=\s*activeSettingsSave/);
-    assert.match(settingsSrc, /if\s*\(\s*pending\s*\)\s*await\s+pending/);
-});
+// Save tracking and idle waiting are exercised with real overlapping promises in
+// web-policy-readout.test.ts; do not lock those behaviors to a singleton's syntax.
 
 test('SSR-003: updateSettings restores confirmed server state on failure', () => {
     assert.match(settingsSrc, /const\s+result\s*=\s*await\s+apiJson<SettingsData>\('\/api\/settings',\s*'PUT',\s*s\)/);

--- a/tests/unit/web-policy-readout.test.ts
+++ b/tests/unit/web-policy-readout.test.ts
@@ -2,36 +2,247 @@ import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { setupWebUiDom, resetWebUiDom } from './web-ui-test-dom.ts';
-const writes: Array<{path:string;method:string;body:unknown}> = [];
-mock.module('../../public/js/provider-icons.js',{namedExports:{providerIcon(){return '';},providerLabel(value:string){return value;}}});
-mock.module('../../public/js/api.js',{namedExports:{API_BASE:'',async api(){return null;},async apiJson(){return null;},
-    async getAuthToken(){return '';},async apiFire(path:string,method:string,body:unknown){writes.push({path,method,body});}}});
-let setPerm:typeof import('../../public/js/features/settings-core.ts')['setPerm'];
-test.before(async()=>{setupWebUiDom();({setPerm}=await import('../../public/js/features/settings-core.ts'));});
-test.beforeEach(()=>{
-    writes.length=0;document.querySelector('.perm-toggle')?.remove();
-    const page=new window.DOMParser().parseFromString(readFileSync(new URL('../../public/index.html',import.meta.url),'utf8'),'text/html');
-    document.body.append(document.importNode(page.querySelector('.perm-toggle')!,true));
+import type { SettingsData } from '../../public/js/features/settings-types.ts';
+
+const writes: Array<{ path: string; method: string; body: unknown }> = [];
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(done => { resolve = done; });
+    return { promise, resolve };
+}
+function settings(permissions: string): SettingsData {
+    return { cli: 'claude', workingDir: '/fixture/project', permissions, perCli: {}, projectDirs: [],
+        messaging: { enabledChannels: [] }, runtimeDefaultMigration: null, multiSessionDefaultMigration: null };
+}
+let readSettings: () => Promise<SettingsData | null>;
+let saveSettings: (body: unknown) => Promise<SettingsData | null>;
+mock.module('../../public/js/provider-icons.js', { namedExports: {
+    providerIcon() { return ''; }, providerLabel(value: string) { return value; },
+} });
+mock.module('../../public/js/api.js', { namedExports: {
+    API_BASE: '',
+    async api(path: string) {
+        if (path === '/api/settings') return readSettings();
+        if (path === '/api/cli-registry') return { claude: { label: 'Claude', models: ['sonnet'], efforts: [] } };
+        return null;
+    },
+    async apiJson(path: string, method: string, body: unknown) {
+        writes.push({ path, method, body });
+        return saveSettings(body);
+    },
+    async getAuthToken() { return ''; },
+    async apiFire(path: string, method: string, body: unknown) { writes.push({ path, method, body }); },
+} });
+let setPerm: typeof import('../../public/js/features/settings-core.ts')['setPerm'];
+let loadSettings: typeof import('../../public/js/features/settings-core.ts')['loadSettings'];
+let updateSettings: typeof import('../../public/js/features/settings-core.ts')['updateSettings'];
+let waitForSettingsSaveIdle: typeof import('../../public/js/features/settings-core.ts')['waitForSettingsSaveIdle'];
+function select() {
+    const el = document.querySelector<HTMLSelectElement>('#selPerm');
+    assert.ok(el, 'permission control exists');
+    return el;
+}
+function readout() { return document.getElementById('configuredPermText')!.textContent; }
+function errorAlert() { return document.getElementById('permSaveError')!; }
+
+test.before(async () => {
+    setupWebUiDom();
+    ({ setPerm, loadSettings, updateSettings, waitForSettingsSaveIdle } = await import('../../public/js/features/settings-core.ts'));
 });
-test.after(()=>{resetWebUiDom();mock.restoreAll();});
-for(const [value,label] of [
-    ['auto','Auto'],['safe','Safe'],[[],'Custom (0 entries)'],[['auto'],'Custom (1 entry)'],
-    [[' read ',''],'Custom (2 entries)'],[null,'Not provided'],[undefined,'Not provided'],
-    ['AUTO','Unrecognized'],['<img src=x onerror=alert(1)>','Unrecognized'],[{secret:'DO_NOT_SHOW'},'Unrecognized'],[['read',1],'Unrecognized'],
-] as const)test(`Classic configured-policy readout ${label}: ${JSON.stringify(value)}`,()=>{
-    const before=structuredClone(value);
-    setPerm(value,false);
-    assert.match(document.querySelector('.perm-toggle')!.textContent!,new RegExp('Configured policy: '+label.replace(/[()]/g,'\\$&')));
-    assert.equal(document.querySelector('.perm-btn')!.classList.contains('perm-auto'),value==='auto');
-    assert.deepEqual(value,before);assert.deepEqual(writes,[]);
-    assert.equal(document.querySelector('.perm-toggle img'),null);
-    assert.doesNotMatch(document.querySelector('.perm-toggle')!.textContent!,/DO_NOT_SHOW|onerror/);
+test.beforeEach(() => {
+    writes.length = 0;
+    readSettings = async () => settings('auto');
+    saveSettings = async () => settings('safe');
+    document.getElementById('policyFixture')?.remove();
+    const page = new window.DOMParser().parseFromString(readFileSync(new URL('../../public/index.html', import.meta.url), 'utf8'), 'text/html');
+    const fixture = document.importNode(page.querySelector('.perm-toggle')!.parentElement!, true);
+    fixture.id = 'policyFixture';
+    document.body.append(fixture);
 });
-test('Classic missing readout is a no-op and does not write',()=>{
-    document.querySelector('.perm-toggle')!.remove();setPerm('safe',false);assert.deepEqual(writes,[]);
+test.after(() => { resetWebUiDom(); mock.restoreAll(); });
+
+for (const [value, label] of [
+    ['auto', 'Auto'], ['safe', 'Safe'], [[], 'Custom (0 entries)'], [['auto'], 'Custom (1 entry)'],
+    [[' read ', ''], 'Custom (2 entries)'], [null, 'Not provided'], [undefined, 'Not provided'],
+    ['AUTO', 'Unrecognized'], ['<img src=x onerror=alert(1)>', 'Unrecognized'],
+    [{ secret: 'DO_NOT_SHOW' }, 'Unrecognized'], [['read', 1], 'Unrecognized'],
+] as const) test(`Classic configured-policy readout ${label}: ${JSON.stringify(value)}`, () => {
+    const before = structuredClone(value);
+    void setPerm(value, false);
+    assert.equal(readout(), `Configured policy: ${label}`, 'hydration updates synchronously');
+    assert.equal(document.querySelector('.perm-btn')!.classList.contains('perm-auto'), value === 'auto');
+    assert.equal(select().value, value === 'auto' || value === 'safe' ? value : '');
+    if (select().value === '') assert.equal(select().selectedOptions[0]!.disabled, true);
+    assert.equal(select().disabled, false);
+    assert.deepEqual(value, before);
+    assert.deepEqual(writes, []);
+    assert.equal(document.querySelector('.perm-toggle img'), null);
+    assert.doesNotMatch(document.querySelector('.perm-toggle')!.textContent!, /DO_NOT_SHOW|onerror/);
 });
-test('Classic explicit legacy save keeps literal-auto payload and does not optimistically change saved readout',()=>{
-    setPerm('safe',false);const before=document.querySelector('.perm-toggle')!.textContent;
-    setPerm('safe');assert.deepEqual(writes,[{path:'/api/settings',method:'PUT',body:{permissions:'auto'}}]);
-    assert.equal(document.querySelector('.perm-toggle')!.textContent,before);
+
+test('Classic missing readout is a no-op and does not write', () => {
+    document.getElementById('policyFixture')!.remove();
+    void setPerm('safe', false);
+    assert.deepEqual(writes, []);
 });
+
+test('Classic native select has accessible label, disabled placeholder, and no initial write', () => {
+    assert.equal(select().tagName, 'SELECT');
+    assert.equal(select().disabled, true);
+    const labelId = select().getAttribute('aria-labelledby');
+    assert.ok(labelId && document.getElementById(labelId)?.textContent?.trim());
+    assert.deepEqual(Array.from(select().options).filter(option => !option.disabled).map(option => option.value), ['auto', 'safe']);
+    assert.equal(errorAlert().getAttribute('role'), 'alert');
+    assert.deepEqual(writes, []);
+});
+
+for (const [from, to] of [['auto', 'safe'], ['safe', 'auto']] as const) {
+    test(`Classic saves ${from} to ${to} exactly and waits for confirmation`, async () => {
+        void setPerm(from, false);
+        const pending = deferred<SettingsData | null>();
+        saveSettings = () => pending.promise;
+        select().value = to;
+        const saving = setPerm(to);
+        try {
+            assert.deepEqual(writes, [{ path: '/api/settings', method: 'PUT', body: { permissions: to } }]);
+            assert.equal(select().disabled, true);
+            assert.equal(readout(), `Configured policy: ${from === 'auto' ? 'Auto' : 'Safe'}`);
+            await setPerm(to);
+            await setPerm(from);
+            assert.equal(writes.length, 1, 'pending choices do not enqueue another save');
+        } finally { pending.resolve(settings(to)); await saving; }
+        assert.equal(readout(), `Configured policy: ${to === 'auto' ? 'Auto' : 'Safe'}`);
+        assert.equal(select().value, to);
+        assert.equal(select().disabled, false);
+    });
+}
+
+test('Classic same-value and invalid selections never write', async () => {
+    void setPerm('safe', false);
+    for (const value of ['safe', '', 'AUTO', null, undefined, ['auto'], { permissions: 'auto' }]) await setPerm(value);
+    assert.deepEqual(writes, []);
+    assert.equal(readout(), 'Configured policy: Safe');
+    assert.equal(select().value, 'safe');
+});
+
+test('Classic displays the confirmed response rather than the submitted choice', async () => {
+    void setPerm('auto', false);
+    saveSettings = async () => settings('auto');
+    await setPerm('safe');
+    assert.equal(writes.length, 1);
+    assert.equal(readout(), 'Configured policy: Auto');
+    assert.equal(select().value, 'auto');
+});
+
+for (const prior of ['auto', ['read']] as const) {
+    test(`Classic failed save restores ${JSON.stringify(prior)} and later success clears the alert`, async () => {
+        void setPerm(prior, false);
+        const before = readout();
+        saveSettings = async () => null;
+        select().value = 'safe';
+        await setPerm('safe');
+        assert.equal(readout(), before);
+        assert.equal(select().value, prior === 'auto' ? 'auto' : '');
+        assert.equal(select().disabled, false);
+        assert.equal(errorAlert().getAttribute('role'), 'alert');
+        assert.equal(errorAlert().hidden, false);
+        assert.ok(errorAlert().textContent?.trim());
+        saveSettings = async () => settings('safe');
+        await setPerm('safe');
+        assert.equal(readout(), 'Configured policy: Safe');
+        assert.ok(errorAlert().hidden || !errorAlert().textContent?.trim());
+    });
+}
+
+test('Classic permission saves participate in the shared save-idle barrier', async () => {
+    void setPerm('auto', false);
+    const pending = deferred<SettingsData | null>();
+    saveSettings = () => pending.promise;
+    const saving = setPerm('safe');
+    let idle = false;
+    const waiting = waitForSettingsSaveIdle().then(() => { idle = true; });
+    try { await Promise.resolve(); assert.equal(idle, false); }
+    finally { pending.resolve(settings('safe')); await saving; await waiting; }
+    assert.equal(idle, true);
+});
+
+for (const timing of ['before PUT', 'during PUT'] as const) {
+    test(`Classic GET begun ${timing} cannot overwrite a completed permission save`, async () => {
+        void setPerm('auto', false);
+        const stale = deferred<SettingsData | null>();
+        const readStarted = deferred<void>();
+        const put = deferred<SettingsData | null>();
+        readSettings = () => { readStarted.resolve(); return stale.promise; };
+        saveSettings = () => put.promise;
+        let saving: ReturnType<typeof setPerm> = Promise.resolve();
+        if (timing === 'during PUT') saving = setPerm('safe');
+        const loading = loadSettings();
+        await readStarted.promise;
+        if (timing === 'before PUT') saving = setPerm('safe');
+        put.resolve(settings('safe'));
+        await saving;
+        stale.resolve(settings('auto'));
+        await loading;
+        assert.equal(readout(), 'Configured policy: Safe');
+        assert.equal(select().value, 'safe');
+        assert.equal(select().disabled, false);
+        assert.equal(writes.length, 1);
+        readSettings = async () => settings('auto');
+        await loadSettings();
+        assert.equal(readout(), 'Configured policy: Auto', 'fresh reads still hydrate after the save');
+        assert.equal(writes.length, 1);
+    });
+}
+
+test('Classic GET completing while PUT is pending does not hydrate permissions', async () => {
+    void setPerm('safe', false);
+    const put = deferred<SettingsData | null>();
+    saveSettings = () => put.promise;
+    const saving = setPerm('auto');
+    try {
+        await loadSettings();
+        assert.equal(readout(), 'Configured policy: Safe');
+        assert.equal(select().disabled, true);
+    } finally { put.resolve(settings('auto')); await saving; }
+    assert.equal(readout(), 'Configured policy: Auto');
+});
+
+for (const first of ['CLI settings', 'permissions'] as const) {
+    test(`Classic save-idle barrier waits for both writes when ${first} completes first`, async () => {
+        void setPerm('auto', false);
+        const permissionResponse = deferred<SettingsData | null>();
+        const cliResponse = deferred<SettingsData | null>();
+        saveSettings = body => {
+            assert.ok(body && typeof body === 'object');
+            return 'permissions' in body ? permissionResponse.promise : cliResponse.promise;
+        };
+        const permissionSaving = setPerm('safe');
+        const cliSaving = updateSettings();
+        let idle = false;
+        let waiting: Promise<void> = Promise.resolve();
+        try {
+            assert.deepEqual(writes, [
+                { path: '/api/settings', method: 'PUT', body: { permissions: 'safe' } },
+                { path: '/api/settings', method: 'PUT', body: { cli: 'claude' } },
+            ]);
+            if (first === 'CLI settings') {
+                cliResponse.resolve(settings('auto'));
+                await cliSaving;
+            } else {
+                permissionResponse.resolve(settings('safe'));
+                await permissionSaving;
+            }
+            waiting = waitForSettingsSaveIdle().then(() => { idle = true; });
+            // An already-resolved barrier schedules its callback before this continuation;
+            // a correct barrier remains blocked by the explicitly unresolved response.
+            await Promise.resolve();
+            assert.equal(idle, false, 'save-idle must remain pending until the other write settles');
+        } finally {
+            permissionResponse.resolve(settings('safe'));
+            cliResponse.resolve(settings('safe'));
+            await Promise.all([permissionSaving, cliSaving, waiting]);
+        }
+        assert.equal(idle, true);
+        assert.equal(readout(), 'Configured policy: Safe');
+    });
+}


### PR DESCRIPTION
The Classic sidebar's permission badge now opens an Auto/Safe dropdown and saves the selected policy. It preserves custom and unknown configured values until an explicit choice, waits for server confirmation, and restores the prior selection with an inline error when saving fails.

Overlapping CLI and permission saves now share a complete save barrier so chat cannot start while a policy change is still pending. Delayed settings reads cannot overwrite a completed policy change.

Validation: 99 focused tests passed, including 25 permission/control regressions and a reproduced RED→GREEN overlapping-save case; frontend typecheck and production build passed. Built-page browser smoke covered mouse/keyboard selection, exact request payloads, failed save recovery, and reload. Independent plan and code review completed with all findings resolved. Runtime-specific policy support is unchanged. The obsolete server-start Safe-to-Auto coercion is removed so the selection survives restart.

Permission-specific styles are scoped to the selector; existing onboarding button styles remain intact.

Startup validation: regression reproduced RED before removing the coercion, then Safe/Auto/Custom bootstrap checks passed. Two real compiled server starts in an isolated home both returned Safe over HTTP and preserved Safe on disk; each child closed with exit0. Server build and dist asset verification passed.
