### PR TITLE
fix(quota): bound provider responses and normalize wire values

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 CLI-Jaw Contributors
+Copyright (c) 2026 opencodex contributors (quota reader portions)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/migration/quota-reader-parity.md
+++ b/docs/migration/quota-reader-parity.md
@@ -1,0 +1,59 @@
+# Quota reader migration from OpenCodex
+
+This migration uses OpenCodex source revision
+`b94051fe91e745806102988f6dff2fec8de078ef` as the provider protocol reference.
+It preserves cli-jaw's CLI-keyed `/api/quota` response and native authentication
+ownership. The design below is the implementation contract; verification and
+completion are recorded with the individual pull requests.
+
+| Reader | Required behavior |
+| --- | --- |
+| Claude | Canonical five-hour/weekly/model windows, including Fable and weekly-scoped limits; preserve fractional readings and distinguish unknown from exhausted. Cache only by credential identity; 429 can reuse only that identity's measured snapshot. |
+| Codex | Classify declared short, weekly and monthly windows; preserve Go/Free policy, Spark weekly windows and read-only reset-credit counts. Honor `CODEX_HOME`; never infer zero from missing usage. |
+| Grok | Prefer the JSON weekly credits response, retain gRPC weekly compatibility and validated monthly fallback. Isolate failed attempts and keep session usage separate. |
+| Cursor | Read the native selected credential store and the three current usage endpoints. Direct auth token takes precedence; an overriding API key suppresses stored OAuth quota reads. Explicit dashboard cookie support remains separately sourced. |
+| Kiro | Read the selected native token and region/profile metadata without mutation, use the management usage endpoint, select agentic/credit allowance, preserve trial and overage semantics. |
+| OpenCode Go | Read rolling/weekly/monthly usage directly before any optional models authentication fallback; retain supported legacy shapes. |
+| Antigravity | Read the active native account and project, request summary then available-model quotas, and preserve native IDE-local availability. Never mix local and selected remote accounts. |
+| Copilot | Keep cli-jaw's native Premium quota reader: the reference has no equivalent subscription probe. |
+
+## Compatibility and boundaries
+
+Existing reader exports, `account`, `windows`, wrapper delegation and response keys
+remain compatible. Window percentages are finite and clamped to 0–100 without
+parser rounding. Unknown measurements do not become numeric zero. Reset dates
+are ISO strings; seconds and milliseconds follow the reference threshold
+`10_000_000_000`, except the WHAM seconds-only field. Existing native `raw`
+response fields remain for compatibility and are not described as sanitized.
+
+Provider bodies are limited to 512 KiB and bounded by a deadline. Credentials go
+only to their fixed provider destinations. Google quota redirects are inspected
+without following them, allowing explicit redirect-stop behavior to remain
+distinct from a retryable network failure. No reader imports OAuth refresh,
+account rotation, persisted proxy quotas, automatic reset-credit consumption or
+inference machinery from the reference.
+
+The shared wire boundary is a leaf dependency; native/provider adapters consume
+it and the settings route consumes adapters. Each adapter includes synthetic
+success, malformed input, absent input, authentication, timeout and fallback
+fixtures. The route isolates provider failures and starts Grok concurrently with
+its peers. A rejected provider must not suppress successful rows.
+
+## Delivery and verification
+
+Implement the shared wire foundation first, native account windows next, then
+provider-specific slices, followed by aggregation and architecture documentation.
+Publish ordinary dependent PRs with each layer's own behavioral tests and build.
+Source attribution accompanies adapted code and the distributed MIT license.
+
+Use the repository's programmatic test runner with explicit quota test paths.
+The baseline before this migration passed 44 quota tests, TypeScript, the server
+build and asset check, and all 540 architecture count entries. Build using
+`npm run ensure:native`, `npm --ignore-scripts run build`, then
+`bash scripts/verify-dist-assets.sh`; suppressing npm lifecycle scripts for this
+build avoids the unrelated postbuild that reassigns global NVM package links.
+These baseline results are not proof that later implementation changes pass.
+
+Final delivery requires current branch-tip tests/builds, architecture count sync,
+a synthetic HTTP smoke through the real registered route, and current per-PR CI.
+Merging, releasing and restarting an installed service are separate operations.

--- a/src/routes/quota-wire.ts
+++ b/src/routes/quota-wire.ts
@@ -1,0 +1,81 @@
+/** Quota wire normalization adapted from OpenCodex src/providers/quota-wire.ts.
+ * Reference b94051fe91e745806102988f6dff2fec8de078ef; MIT, see LICENSE.
+ */
+const QUOTA_RESPONSE_MAX_BYTES = 512 * 1024;
+const QUOTA_BODY_TIMEOUT_MS = 8_000;
+
+export function asQuotaRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown> : null;
+}
+
+export function quotaNumber(value: unknown): number | undefined {
+    if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+    if (typeof value !== 'string' || !value.trim()) return undefined;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : undefined;
+}
+
+export function quotaPercent(value: unknown): number | undefined {
+    const number = quotaNumber(value);
+    return number === undefined ? undefined : Math.max(0, Math.min(100, number));
+}
+
+export function quotaResetIso(value: unknown): string | null {
+    let milliseconds: number;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || value <= 0) return null;
+        milliseconds = value > 10_000_000_000 ? value : value * 1000;
+    } else if (typeof value === 'string' && value.trim()) {
+        const trimmed = value.trim();
+        if (/^[+-]?\d+(\.\d+)?$/.test(trimmed)) return quotaResetIso(Number(trimmed));
+        milliseconds = Date.parse(trimmed);
+    } else return null;
+    if (!Number.isFinite(milliseconds) || milliseconds <= 0) return null;
+    const date = new Date(milliseconds);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+export async function readQuotaBytes(response: Response, timeoutMs = QUOTA_BODY_TIMEOUT_MS): Promise<Uint8Array> {
+    const length = Number(response.headers.get('content-length'));
+    if (Number.isFinite(length) && length > QUOTA_RESPONSE_MAX_BYTES) {
+        void response.body?.cancel().catch(() => undefined);
+        throw new Error('Quota response exceeds size limit');
+    }
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Quota response has no body');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('Quota response body timed out')), timeoutMs);
+    });
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+        while (true) {
+            const { done, value } = await Promise.race([reader.read(), timeout]);
+            if (done) break;
+            total += value.byteLength;
+            if (total > QUOTA_RESPONSE_MAX_BYTES) throw new Error('Quota response exceeds size limit');
+            chunks.push(value);
+        }
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
+        return bytes;
+    } catch (error) {
+        // Cancellation is best effort; a broken producer must not extend the deadline.
+        void reader.cancel().catch(() => undefined);
+        throw error;
+    } finally {
+        clearTimeout(timer);
+        reader.releaseLock();
+    }
+}
+
+export async function readQuotaJson(response: Response, timeoutMs = QUOTA_BODY_TIMEOUT_MS): Promise<unknown> {
+    const bytes = await readQuotaBytes(response, timeoutMs);
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown;
+}

--- a/src/routes/quota-wire.ts
+++ b/src/routes/quota-wire.ts
@@ -44,6 +44,7 @@ export async function readQuotaBytes(response: Response, timeoutMs = QUOTA_BODY_
     }
     const reader = response.body?.getReader();
     if (!reader) throw new Error('Quota response has no body');
+    const deadline = performance.now() + timeoutMs;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(() => reject(new Error('Quota response body timed out')), timeoutMs);
@@ -52,7 +53,9 @@ export async function readQuotaBytes(response: Response, timeoutMs = QUOTA_BODY_
     let total = 0;
     try {
         while (true) {
+            if (performance.now() >= deadline) throw new Error('Quota response body timed out');
             const { done, value } = await Promise.race([reader.read(), timeout]);
+            if (performance.now() >= deadline) throw new Error('Quota response body timed out');
             if (done) break;
             total += value.byteLength;
             if (total > QUOTA_RESPONSE_MAX_BYTES) throw new Error('Quota response exceeds size limit');

--- a/tests/unit/quota-wire.test.ts
+++ b/tests/unit/quota-wire.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { asQuotaRecord, quotaNumber, quotaPercent, quotaResetIso, readQuotaBytes, readQuotaJson } from '../../src/routes/quota-wire.ts';
+
+test('quota values preserve observed fractions and reject absent/nonfinite readings', () => {
+    for (const value of [undefined, null, '', ' ', true, {}, NaN, Infinity, 'wat']) {
+        assert.equal(quotaNumber(value), undefined);
+        assert.equal(quotaPercent(value), undefined);
+    }
+    assert.equal(quotaNumber('0'), 0);
+    assert.equal(quotaPercent('12.345'), 12.345);
+    assert.equal(quotaPercent(-1), 0);
+    assert.equal(quotaPercent(101), 100);
+    assert.equal(asQuotaRecord([]), null);
+    assert.equal(asQuotaRecord(null), null);
+    assert.deepEqual(asQuotaRecord({ n: 0 }), { n: 0 });
+});
+
+test('reset dates normalize epoch strings and follow reference threshold', () => {
+    const expected = '2030-01-01T00:00:00.000Z';
+    for (const value of [1893456000, '1893456000', 1893456000000, '1893456000000', expected]) {
+        assert.equal(quotaResetIso(value), expected);
+    }
+    assert.equal(quotaResetIso(10000000001), '1970-04-26T17:46:40.001Z');
+    for (const value of [0, -1, NaN, Infinity, 1e30, '', 'garbage', null, {}, '1970-01-01']) {
+        assert.equal(quotaResetIso(value), null);
+    }
+});
+
+test('JSON reader accepts the exact byte boundary and rejects streamed overflow', async () => {
+    const exact = '"' + 'a'.repeat(512 * 1024 - 2) + '"';
+    assert.equal((await readQuotaJson(new Response(exact)) as string).length, 512 * 1024 - 2);
+    await assert.rejects(readQuotaJson(new Response(exact + ' ')), /size limit/);
+    await assert.rejects(readQuotaJson(new Response('not-json')), SyntaxError);
+    await assert.rejects(readQuotaJson(new Response(new Uint8Array([0xff]))), TypeError);
+    await assert.rejects(readQuotaJson(new Response(null)), /no body/);
+});
+
+test('declared oversize and dishonest streaming sizes cancel the producer', async () => {
+    let declaredCancelled = false;
+    const declared = new Response(new ReadableStream({
+        cancel() { declaredCancelled = true; },
+    }), { headers: { 'content-length': String(512 * 1024 + 1) } });
+    await assert.rejects(readQuotaBytes(declared), /size limit/);
+    assert.equal(declaredCancelled, true);
+
+    let streamedCancelled = false;
+    const streamed = new Response(new ReadableStream({
+        start(controller) {
+            controller.enqueue(new Uint8Array(512 * 1024));
+            controller.enqueue(new Uint8Array(1));
+        },
+        cancel() { streamedCancelled = true; },
+    }), { headers: { 'content-length': '1' } });
+    await assert.rejects(readQuotaBytes(streamed), /size limit/);
+    assert.equal(streamedCancelled, true);
+});
+
+test('stalled stream rejects by deadline even when producer cancellation never resolves', async () => {
+    let cancelled = false;
+    const response = new Response(new ReadableStream({
+        cancel() {
+            cancelled = true;
+            return new Promise<void>(() => undefined);
+        },
+    }));
+    await assert.rejects(readQuotaJson(response, 5), /timed out/);
+    assert.equal(cancelled, true);
+});
+
+test('byte reader preserves protobuf bytes and joins chunks without text conversion', async () => {
+    const response = new Response(new ReadableStream({
+        start(controller) {
+            controller.enqueue(new Uint8Array([0, 255]));
+            controller.enqueue(new Uint8Array([128, 1]));
+            controller.close();
+        },
+    }));
+    assert.deepEqual(await readQuotaBytes(response), new Uint8Array([0, 255, 128, 1]));
+});

--- a/tests/unit/quota-wire.test.ts
+++ b/tests/unit/quota-wire.test.ts
@@ -78,3 +78,14 @@ test('byte reader preserves protobuf bytes and joins chunks without text convers
     }));
     assert.deepEqual(await readQuotaBytes(response), new Uint8Array([0, 255, 128, 1]));
 });
+
+
+test('continuously ready chunks cannot starve the total deadline timer', async () => {
+    const response = new Response(new ReadableStream({
+        start(controller) {
+            for (let i = 0; i < 50000; i++) controller.enqueue(new Uint8Array([32]));
+            controller.close();
+        },
+    }));
+    await assert.rejects(readQuotaBytes(response, 1), /timed out/);
+});


### PR DESCRIPTION
Quota readers currently accept unbounded response bodies and inconsistent numeric/reset values. Add a shared 512 KiB body limit with a read deadline, finite percentage normalization, and source-aligned epoch conversion for the provider migrations above this layer.

Adapted from OpenCodex `b94051fe91e745806102988f6dff2fec8de078ef`; preserve its MIT copyright for quota portions. Includes the migration contract.

Validation: six behavioral wire tests pass, including cancellation and a producer whose cancel never resolves. Raising the body cap makes the regression test fail. Restored server build and asset verification pass. Hosted checks certify this branch tip separately.

Stack: foundation (this PR) → native Claude/Codex → provider adapters → HTTP integration. Base: preview. Subsequent layers consume this helper; merge bottom-up.
