### PR TITLE
fix(quota): prefer Grok weekly JSON with isolated fallbacks

### DIFF
--- a/src/routes/quota.ts
+++ b/src/routes/quota.ts
@@ -8,7 +8,7 @@ import { probeGrokModels } from '../core/probe-exec.js';
 import { stripUndefined } from '../core/strip-undefined.js';
 import { createHash } from 'node:crypto';
 import { parseClaudeUsageWindows, parseCodexUsageWindows, type NativeUsageWindows } from './quota-native-window.js';
-import { readQuotaJson } from './quota-wire.js';
+import { asQuotaRecord, quotaNumber, quotaPercent, quotaResetIso, readQuotaBytes, readQuotaJson } from './quota-wire.js';
 
 interface GrokSessionUsage {
     sourcePath: string;
@@ -319,16 +319,19 @@ interface GrokBillingData {
     limit: number;
     used: number;
     percent: number;
-    limitUsd: number;
-    usedUsd: number;
+    limitUsd?: number;
+    usedUsd?: number;
     periodLabel: string;
     periodStart?: string | null;
-    periodEnd: string;
+    periodEnd?: string;
     email: string | null;
     source: string;
 }
 
 const GROK_BILLING_URL = 'https://cli-chat-proxy.grok.com/v1/billing';
+const GROK_JSON_CREDITS_URL = `${GROK_BILLING_URL}?format=credits`;
+// OpenCodex b94051fe91e745806102988f6dff2fec8de078ef xai-transport compatibility.
+const GROK_QUOTA_CLIENT_VERSION = '0.2.93';
 const GROK_USER_URL = 'https://cli-chat-proxy.grok.com/v1/user';
 const GROK_WEB_CREDITS_URL = 'https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig';
 
@@ -342,37 +345,50 @@ interface GrokTokenCandidate {
     token: string;
     source: string;
     email?: string | null;
+    userId?: string;
+}
+
+function grokUserIdFromAccessToken(token: string): string | undefined {
+    const payload = token.split('.')[1];
+    if (!payload) return undefined;
+    try {
+        const sub = asQuotaRecord(JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')))?.['sub'];
+        return typeof sub === 'string' && sub.trim() ? sub.trim() : undefined;
+    } catch { return undefined; }
 }
 
 function readGrokTokenCandidates(homeDir = os.homedir()): GrokTokenCandidate[] {
     const candidates: GrokTokenCandidate[] = [];
     try {
         const authPath = join(homeDir, '.grok', 'auth.json');
-        const data = JSON.parse(fs.readFileSync(authPath, 'utf8')) as Record<string, unknown>;
-        const entries = Object.entries(data)
-            .filter(([, entry]) => entry && typeof entry === 'object' && typeof (entry as Record<string, unknown>)['key'] === 'string')
-            .map(([scope, entry]) => {
-                const obj = entry as Record<string, unknown>;
-                return {
-                    token: obj['key'] as string,
-                    source: scope.startsWith('https://auth.x.ai::') ? 'grok:auth-json-oidc' : 'grok:auth-json',
-                    email: typeof obj['email'] === 'string' ? obj['email'] as string : null,
-                    priority: scope.startsWith('https://auth.x.ai::') ? 0 : 1,
-                };
-            })
-            .sort((a, b) => a.priority - b.priority);
-        for (const entry of entries) candidates.push({ token: entry.token, source: entry.source, email: entry.email });
-    } catch { /* best effort */ }
-    try {
-        const authPath = join(homeDir, '.progrok', 'auth.json');
-        const data = JSON.parse(fs.readFileSync(authPath, 'utf8')) as { accessToken?: string };
-        if (typeof data.accessToken === 'string' && data.accessToken.trim()) {
-            candidates.push({ token: data.accessToken, source: 'progrok:auth-json', email: null });
+        const data = asQuotaRecord(JSON.parse(fs.readFileSync(authPath, 'utf8')));
+        const entries = Object.entries(data ?? {})
+            .sort(([a], [b]) => Number(!a.startsWith('https://auth.x.ai::')) - Number(!b.startsWith('https://auth.x.ai::')));
+        for (const [scope, value] of entries) {
+            const entry = asQuotaRecord(value);
+            if (!entry || typeof entry['key'] !== 'string' || !entry['key'].trim()) continue;
+            const token = entry['key'].trim();
+            const userId = typeof entry['user_id'] === 'string' && entry['user_id'].trim()
+                ? entry['user_id'].trim() : grokUserIdFromAccessToken(token);
+            candidates.push({
+                token,
+                source: scope.startsWith('https://auth.x.ai::') ? 'grok:auth-json-oidc' : 'grok:auth-json',
+                email: typeof entry['email'] === 'string' ? entry['email'] : null,
+                ...(userId ? { userId } : {}),
+            });
         }
-    } catch { /* best effort */ }
+    } catch { /* native auth is optional */ }
+    try {
+        const data = asQuotaRecord(JSON.parse(fs.readFileSync(join(homeDir, '.progrok', 'auth.json'), 'utf8')));
+        if (typeof data?.['accessToken'] === 'string' && data['accessToken'].trim()) {
+            const token = data['accessToken'].trim();
+            const userId = grokUserIdFromAccessToken(token);
+            candidates.push({ token, source: 'progrok:auth-json', email: null, ...(userId ? { userId } : {}) });
+        }
+    } catch { /* legacy auth is optional */ }
     const seen = new Set<string>();
-    return candidates.filter((candidate) => {
-        if (!candidate.token || seen.has(candidate.token)) return false;
+    return candidates.filter(candidate => {
+        if (seen.has(candidate.token)) return false;
         seen.add(candidate.token);
         return true;
     });
@@ -476,79 +492,114 @@ export function parseGrokCreditsGrpcWeb(buf: Buffer, now = new Date()): Pick<Gro
     };
 }
 
-async function fetchGrokWeeklyCredits(token: string): Promise<Pick<GrokBillingData, 'percent' | 'periodEnd' | 'periodLabel' | 'source'> | null> {
-    const resp = await fetch(GROK_WEB_CREDITS_URL, {
-        method: 'POST',
-        headers: {
-            'Authorization': `Bearer ${token}`,
-            'X-XAI-Token-Auth': 'xai-grok-cli',
-            'Origin': 'https://grok.com',
-            'Referer': 'https://grok.com/?_s=usage',
-            'Accept': 'application/grpc-web+proto',
-            'Content-Type': 'application/grpc-web+proto',
-            'x-grpc-web': '1',
-            'x-user-agent': 'connect-es/2.1.1',
-        },
-        body: Buffer.from([0, 0, 0, 0, 0]),
-        signal: AbortSignal.timeout(8000),
-    });
-    if (!resp.ok) return null;
-    return parseGrokCreditsGrpcWeb(Buffer.from(await resp.arrayBuffer()));
+export function parseGrokCreditsResponse(value: unknown): {
+    percent: number; periodEnd?: string;
+} | null {
+    const config = asQuotaRecord(asQuotaRecord(value)?.['config']);
+    const period = asQuotaRecord(config?.['currentPeriod']);
+    if (!config || period?.['type'] !== 'USAGE_PERIOD_TYPE_WEEKLY') return null;
+    const percent = config['creditUsagePercent'] === undefined
+        ? 0 : quotaPercent(config['creditUsagePercent']);
+    if (percent === undefined) return null;
+    const periodEnd = quotaResetIso(period['end']);
+    return { percent, ...(periodEnd ? { periodEnd } : {}) };
 }
 
-async function fetchGrokBilling(): Promise<GrokBillingData | null> {
-    const tokens = readGrokTokenCandidates();
-    if (!tokens.length) return null;
+type GrokWeeklyCredits = Pick<GrokBillingData, 'percent' | 'periodEnd' | 'periodLabel' | 'source'>;
+
+async function fetchGrokWeeklyCreditsJson(candidate: GrokTokenCandidate): Promise<GrokWeeklyCredits | null> {
+    if (!candidate.userId) return null;
     try {
-        for (const candidate of tokens) {
-            const weekly = await fetchGrokWeeklyCredits(candidate.token);
-            if (weekly) {
-                return {
-                    tier: 'SuperGrok',
-                    limit: 100,
-                    used: weekly.percent,
-                    percent: weekly.percent,
-                    limitUsd: 0,
-                    usedUsd: 0,
-                    periodLabel: weekly.periodLabel,
-                    periodEnd: weekly.periodEnd,
-                    email: candidate.email ?? null,
-                    source: weekly.source,
-                };
-            }
+        const response = await fetch(GROK_JSON_CREDITS_URL, {
+            redirect: 'error',
+            headers: {
+                Accept: 'application/json', Authorization: `Bearer ${candidate.token}`,
+                'x-userid': candidate.userId,
+                'x-xai-token-auth': 'xai-grok-cli',
+                'x-authenticateresponse': 'authenticate-response',
+                'x-grok-client-version': GROK_QUOTA_CLIENT_VERSION,
+            },
+            signal: AbortSignal.timeout(8000),
+        });
+        if (!response.ok) return null;
+        const parsed = parseGrokCreditsResponse(await readQuotaJson(response));
+        return parsed ? { ...parsed, periodLabel: 'weekly', source: 'grok:cli-chat-proxy-billing-credits' } : null;
+    } catch { return null; }
+}
+
+async function fetchGrokWeeklyCredits(token: string): Promise<Pick<GrokBillingData, 'percent' | 'periodEnd' | 'periodLabel' | 'source'> | null> {
+    try {
+        const resp = await fetch(GROK_WEB_CREDITS_URL, {
+            method: 'POST',
+            redirect: 'error',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'X-XAI-Token-Auth': 'xai-grok-cli',
+                'Origin': 'https://grok.com',
+                'Referer': 'https://grok.com/?_s=usage',
+                'Accept': 'application/grpc-web+proto',
+                'Content-Type': 'application/grpc-web+proto',
+                'x-grpc-web': '1',
+                'x-user-agent': 'connect-es/2.1.1',
+            },
+            body: Buffer.from([0, 0, 0, 0, 0]),
+            signal: AbortSignal.timeout(8000),
+        });
+        if (!resp.ok) return null;
+        return parseGrokCreditsGrpcWeb(Buffer.from(await readQuotaBytes(resp)));
+    } catch { return null; }
+}
+
+async function fetchGrokMonthlyBilling(candidate: GrokTokenCandidate): Promise<GrokBillingData | null> {
+    try {
+        const headers = { Accept: 'application/json', Authorization: `Bearer ${candidate.token}` };
+        const [billingRes, userRes] = await Promise.allSettled([
+            fetch(GROK_BILLING_URL, { headers, redirect: 'error', signal: AbortSignal.timeout(8000) }),
+            fetch(GROK_USER_URL, { headers, redirect: 'error', signal: AbortSignal.timeout(5000) }),
+        ]);
+        if (billingRes.status !== 'fulfilled' || !billingRes.value.ok) return null;
+        const billing = asQuotaRecord(asQuotaRecord(await readQuotaJson(billingRes.value))?.['config']);
+        if (!billing) return null;
+        const limit = quotaNumber(asQuotaRecord(billing['monthlyLimit'])?.['val']);
+        const used = quotaNumber(asQuotaRecord(billing['used'])?.['val']);
+        if (limit === undefined || used === undefined || limit <= 0) return null;
+        const percent = quotaPercent(used / limit * 100);
+        if (percent === undefined) return null;
+        let email = candidate.email ?? null;
+        if (userRes.status === 'fulfilled' && userRes.value.ok) {
+            try {
+                const user = asQuotaRecord(await readQuotaJson(userRes.value, 5000));
+                if (typeof user?.['email'] === 'string') email = user['email'];
+            } catch { /* optional identity metadata must not discard valid billing */ }
         }
+        const periodEnd = quotaResetIso(billing['billingPeriodEnd']);
+        return {
+            tier: grokTierFromLimit(limit), limit, used, percent,
+            limitUsd: limit / 100, usedUsd: used / 100,
+            periodLabel: 'monthly', periodStart: quotaResetIso(billing['billingPeriodStart']),
+            ...(periodEnd ? { periodEnd } : {}), email,
+            source: candidate.source === 'progrok:auth-json' ? 'progrok:billing-api' : 'grok:cli-chat-proxy-billing-api',
+        };
+    } catch { return null; }
+}
+
+export async function fetchGrokBilling(homeDir = os.homedir()): Promise<GrokBillingData | null> {
+    const tokens = readGrokTokenCandidates(homeDir);
+    const weeklyReaders = [fetchGrokWeeklyCreditsJson, (candidate: GrokTokenCandidate) => fetchGrokWeeklyCredits(candidate.token)];
+    for (const read of weeklyReaders) {
         for (const candidate of tokens) {
-            const headers = { Authorization: `Bearer ${candidate.token}` };
-            const [billingRes, userRes] = await Promise.allSettled([
-                fetch(GROK_BILLING_URL, { headers, signal: AbortSignal.timeout(8000) }),
-                fetch(GROK_USER_URL, { headers, signal: AbortSignal.timeout(5000) }),
-            ]);
-            if (billingRes.status !== 'fulfilled' || !billingRes.value.ok) continue;
-            const billing = (await billingRes.value.json() as {
-                config: { monthlyLimit: { val: number }; used: { val: number }; billingPeriodStart?: string; billingPeriodEnd: string };
-            }).config;
-            const limit = billing.monthlyLimit.val;
-            const used = billing.used.val;
-            let email: string | null = candidate.email ?? null;
-            if (userRes.status === 'fulfilled' && userRes.value.ok) {
-                const user = await userRes.value.json() as { email?: string };
-                email = user.email ?? email;
-            }
-            return {
-                tier: grokTierFromLimit(limit),
-                limit, used,
-                percent: limit > 0 ? Math.round((used / limit) * 100) : 0,
-                limitUsd: limit / 100,
-                usedUsd: used / 100,
-                periodLabel: 'monthly',
-                periodStart: billing.billingPeriodStart ?? null,
-                periodEnd: billing.billingPeriodEnd,
-                email,
-                source: candidate.source === 'progrok:auth-json' ? 'progrok:billing-api' : 'grok:cli-chat-proxy-billing-api',
+            const weekly = await read(candidate);
+            if (weekly) return {
+                tier: 'SuperGrok', limit: 100, used: weekly.percent,
+                ...weekly, email: candidate.email ?? null,
             };
         }
-        return null;
-    } catch { return null; }
+    }
+    for (const candidate of tokens) {
+        const monthly = await fetchGrokMonthlyBilling(candidate);
+        if (monthly) return monthly;
+    }
+    return null;
 }
 
 export async function fetchGrokStatus(binary = 'grok') {

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -322,7 +322,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 - `agy`는 `src/routes/quota-agy-reverse.ts`의 `fetchAgyUsage()`를 통해 Antigravity quota snapshot을 읽는다.
 - `antigravity-usage --json`이 `remainingPercentage`를 정밀 소수점 대신 `0`/`1`로만 반환하면 AGY window는 `precision: "binary"`와 `status: "available" | "exhausted"`를 포함한다. backend의 `percent`는 호환 필드일 뿐이며, UI는 exact percent bar 대신 `Available` / `Exhausted` 상태 텍스트를 표시해야 한다. upstream이 다시 정밀 퍼센트를 주면 기존 fractional path가 그대로 사용된다.
 - `cursor`는 `src/routes/quota-cursor-dashboard.ts`의 `fetchCursorUsage()`를 통해 dashboard session/usage를 읽는다.
-- `grok`은 `~/.grok/auth.json`의 OIDC `key`를 우선 읽고 `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig` gRPC-web 응답으로 SuperGrok weekly usage pool window를 만든다. 실패하면 legacy `cli-chat-proxy.grok.com/v1/billing` monthly credits window로 fallback한다.
+- `grok` reads native OIDC key/user identity, then requests JSON `/v1/billing?format=credits` weekly usage. It preserves fractional and omitted-zero readings, with bounded gRPC weekly compatibility and validated monthly fallback. Each failed request is isolated; session usage remains separate.
 - `kiro-code`는 `src/routes/quota-kiro-reverse.ts`의 `fetchKiroUsage()`를 통해 CodeWhisperer `GetUsageLimits` API를 reverse-engineer 호출한다.
 
 ### Wiki lifecycle ownership

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -394,7 +394,7 @@ cli-jaw/
 │   │   ├── settings.ts       ← settings/prompt/project pick/git summary/heartbeat-md/MCP/registry/status/quota/copilot + Pi profile register/model discovery 라우트 + CLI_KEYS 기반 quota parity/status-only metadata (754L)
 │   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (513L)
 │   │   ├── avatar.ts         ← Agent/User 아바타 이미지 업로드/서빙/삭제 + settings.json 메타 저장 + safeResolveUnder 경로 보호 (147L)
-│   │   ├── quota.ts          ← Copilot/Claude/Codex/Grok/OpenCode quota helper readers + Grok weekly credits + credential-scoped Claude cache (583L)
+│   │   ├── quota.ts          ← Copilot/Claude/Codex/Grok/OpenCode quota helper readers + Grok weekly credits + credential-scoped Claude cache (634L)
 │   │   ├── quota-native-window.ts ← Codex duration-aware and Claude model-scoped quota parsers (122L)
 │   │   ├── quota-wire.ts ← Bounded upstream bodies, finite percentages and reset normalization (84L)
 │   │   ├── quota-kiro-reverse.ts ← Kiro/CodeWhisperer quota reader (239L)

--- a/tests/unit/quota-grok-parity.test.ts
+++ b/tests/unit/quota-grok-parity.test.ts
@@ -1,0 +1,227 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { fetchGrokBilling, parseGrokCreditsResponse } from '../../src/routes/quota.ts';
+
+const billingUrl = 'https://cli-chat-proxy.grok.com/v1/billing';
+const weekly = (percent?: unknown, end: unknown = '2026-10-01T00:00:00Z') => ({
+    config: { ...(percent === undefined ? {} : { creditUsagePercent: percent }),
+        currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end } },
+});
+const monthly = { config: { monthlyLimit: { val: '10000' }, used: { val: '2500' },
+    billingPeriodEnd: '2026-10-01T00:00:00Z' } };
+
+test('Grok JSON weekly schema, numeric values and optional reset', () => {
+    assert.equal(parseGrokCreditsResponse(weekly(57.4))?.percent, 57.4);
+    assert.equal(parseGrokCreditsResponse(weekly())?.percent, 0);
+    assert.equal(parseGrokCreditsResponse(weekly('12.5'))?.percent, 12.5);
+    assert.equal(parseGrokCreditsResponse(weekly(150))?.percent, 100);
+    assert.equal(parseGrokCreditsResponse(weekly(-1))?.percent, 0);
+    assert.deepEqual(parseGrokCreditsResponse(weekly(42, 1e20)), { percent: 42 });
+    for (const value of [null, false, '', 'invalid', {}, []]) {
+        assert.equal(parseGrokCreditsResponse(weekly(value)), null);
+    }
+    for (const value of [null, [], {}, { config: {} }, {
+        config: { creditUsagePercent: 12, currentPeriod: { type: 'USAGE_PERIOD_TYPE_MONTHLY' } },
+    }]) assert.equal(parseGrokCreditsResponse(value), null);
+});
+
+test('Grok real coordinator uses native identity and isolated fallback', async (t) => {
+    const home = fs.mkdtempSync(join(os.tmpdir(), 'jaw-grok-parity-'));
+    const originalFetch = globalThis.fetch;
+    fs.mkdirSync(join(home, '.grok'));
+    const writeAuth = (entries: Record<string, unknown>) => fs.writeFileSync(
+        join(home, '.grok', 'auth.json'), JSON.stringify(entries));
+    const native = (key = 'fixture-access', user_id?: string) => ({ key, user_id, email: 'fixture@example.invalid' });
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const install = (handler: (url: string, init?: RequestInit) => Response | Promise<Response>) => {
+        calls.length = 0;
+        globalThis.fetch = (async (input, init) => {
+            const url = String(input); calls.push({ url, init });
+            return handler(url, init);
+        }) as typeof fetch;
+    };
+    try {
+        await t.test('native user_id first, complete headers, no secret serialization', async () => {
+            const jwt = `e30.${Buffer.from(JSON.stringify({ sub: 'jwt-id' })).toString('base64url')}.fixture`;
+            writeAuth({ 'https://auth.x.ai::fixture': native(jwt, 'native-id') });
+            install(() => Response.json(weekly(31)));
+            const result = await fetchGrokBilling(home);
+            assert.equal(result?.source, 'grok:cli-chat-proxy-billing-credits');
+            assert.equal(result?.percent, 31);
+            assert.equal(result?.limitUsd, undefined);
+            assert.equal(calls.length, 1);
+            const call = calls[0]!;
+            assert.equal(call.url, `${billingUrl}?format=credits`);
+            assert.equal(call.init?.method ?? 'GET', 'GET');
+            assert.equal(call.init?.body, undefined);
+            assert.equal(call.init?.redirect, 'error');
+            assert.ok(call.init?.signal);
+            const headers = new Headers(call.init?.headers);
+            for (const [key, value] of Object.entries({ authorization: `Bearer ${jwt}`,
+                accept: 'application/json', 'x-userid': 'native-id', 'x-xai-token-auth': 'xai-grok-cli',
+                'x-authenticateresponse': 'authenticate-response', 'x-grok-client-version': '0.2.93' })) {
+                assert.equal(headers.get(key), value);
+            }
+            assert.ok(!JSON.stringify(result).includes(jwt));
+            assert.ok(!JSON.stringify(result).includes('native-id'));
+            writeAuth({ 'https://auth.x.ai::fixture': native(jwt) });
+            await fetchGrokBilling(home);
+            assert.equal(new Headers(calls.at(-1)?.init?.headers).get('x-userid'), 'jwt-id');
+        });
+        for (const failure of ['throw', '503', 'malformed', 'oversize', 'wrong-period'] as const) {
+            await t.test(`${failure} weekly failure still reaches monthly`, async () => {
+                writeAuth({ 'https://auth.x.ai::fixture': native('fixture-access', 'fixture-user') });
+                install((url) => {
+                    if (url.endsWith('format=credits')) {
+                        if (failure === 'throw') throw new Error('fixture timeout');
+                        if (failure === '503') return new Response('', { status: 503 });
+                        if (failure === 'malformed') return new Response('{');
+                        if (failure === 'oversize') return new Response('{}', { headers: { 'content-length': String(512 * 1024 + 1) } });
+                        return Response.json({ config: { currentPeriod: { type: 'MONTHLY' } } });
+                    }
+                    if (url.includes('GetGrokCreditsConfig')) throw new Error('fixture gRPC unavailable');
+                    if (url === billingUrl) return Response.json(monthly);
+                    return new Response('{'); // user parse must not discard billing
+                });
+                const result = await fetchGrokBilling(home);
+                assert.equal(result?.periodLabel, 'monthly');
+                assert.equal(result?.percent, 25);
+                assert.equal(result?.email, 'fixture@example.invalid');
+                assert.ok(calls.some(c => c.url === billingUrl));
+            });
+        }
+        await t.test('opaque token skips JSON; invalid monthly limit is unavailable', async () => {
+            writeAuth({ 'https://auth.x.ai::fixture': native() });
+            install(url => url === billingUrl ? Response.json({ config: {
+                monthlyLimit: { val: 0 }, used: { val: 0 },
+            } }) : new Response('', { status: 404 }));
+            assert.equal(await fetchGrokBilling(home), null);
+            assert.ok(!calls.some(c => c.url.includes('format=credits')));
+        });
+        await t.test('one candidate throw does not suppress the next native candidate', async () => {
+            writeAuth({ 'https://auth.x.ai::one': native('fixture-one', 'one'),
+                'https://auth.x.ai::two': native('fixture-two', 'two') });
+            install((_url, init) => {
+                if (new Headers(init?.headers).get('x-userid') === 'one') throw new Error('fixture failure');
+                return Response.json(weekly(0));
+            });
+            assert.equal((await fetchGrokBilling(home))?.percent, 0);
+            assert.equal(calls.length, 2);
+        });
+        await t.test('gRPC compatibility success precedes monthly and preserves wire headers', async () => {
+            writeAuth({ 'https://auth.x.ai::fixture': native('fixture-access', 'fixture-user') });
+            // protobuf: config(field 1) contains usage float(field 1) and reset timestamp(field 5.1).
+            const reset = Math.floor(Date.now() / 1000) + 7 * 86400;
+            const varint = (input: number) => {
+                const bytes: number[] = [];
+                do { const rest = Math.floor(input / 128); bytes.push(input % 128 + (rest ? 128 : 0)); input = rest; } while (input);
+                return Buffer.from(bytes);
+            };
+            const used = Buffer.alloc(5); used[0] = 13; used.writeFloatLE(27.5, 1);
+            const timestamp = Buffer.concat([Buffer.from([8]), varint(reset)]);
+            const config = Buffer.concat([used, Buffer.from([42, timestamp.length]), timestamp]);
+            const payload = Buffer.concat([Buffer.from([10, config.length]), config]);
+            const frame = Buffer.alloc(5); frame.writeUInt32BE(payload.length, 1);
+            install(url => url.includes('GetGrokCreditsConfig')
+                ? new Response(Buffer.concat([frame, payload])) : new Response('', { status: 503 }));
+            const result = await fetchGrokBilling(home);
+            assert.equal(result?.source, 'grok:grok-build-billing-grpc-web');
+            assert.equal(result?.percent, 28); // retained gRPC rounding contract
+            assert.equal(result?.periodEnd, new Date(reset * 1000).toISOString());
+            assert.equal(result?.usedUsd, undefined);
+            assert.equal(calls.length, 2);
+            const call = calls[1]!;
+            assert.equal(call.init?.method, 'POST');
+            assert.equal(call.init?.redirect, 'error');
+            assert.deepEqual(call.init?.body, Buffer.alloc(5));
+            const headers = new Headers(call.init?.headers);
+            assert.equal(headers.get('content-type'), 'application/grpc-web+proto');
+            assert.equal(headers.get('x-grpc-web'), '1');
+            assert.equal(headers.get('authorization'), 'Bearer fixture-access');
+            assert.equal(headers.get('origin'), 'https://grok.com');
+        });
+        for (const declared of [true, false]) await t.test(`gRPC ${declared ? 'declared' : 'chunked'} overflow cancels and falls back`, async () => {
+            writeAuth({ 'https://auth.x.ai::fixture': native() });
+            let canceled = 0;
+            install(url => {
+                if (url.includes('GetGrokCreditsConfig')) return new Response(new ReadableStream<Uint8Array>({
+                    start(controller) { if (!declared) controller.enqueue(new Uint8Array(512 * 1024 + 1)); },
+                    cancel() { canceled += 1; },
+                }), declared ? { headers: { 'content-length': String(512 * 1024 + 1) } } : {});
+                return url === billingUrl ? Response.json(monthly) : Response.json({ email: 'upstream@example.invalid' });
+            });
+            const result = await fetchGrokBilling(home);
+            assert.equal(result?.periodLabel, 'monthly');
+            assert.equal(result?.email, 'upstream@example.invalid');
+            assert.equal(canceled, 1);
+        });
+        await t.test('native OIDC priority, deduplication and legacy order apply per stage', async () => {
+            const legacy = `e30.${Buffer.from('{"sub":"legacy-id"}').toString('base64url')}.fixture`;
+            fs.mkdirSync(join(home, '.progrok'), { recursive: true });
+            fs.writeFileSync(join(home, '.progrok', 'auth.json'), JSON.stringify({ accessToken: legacy }));
+            writeAuth({ other: native('other', 'other-id'),
+                'https://auth.x.ai::first': native('oidc', 'oidc-id'),
+                'https://auth.x.ai::duplicate': native('oidc', 'duplicate-id') });
+            install(url => url === billingUrl ? Response.json({ config: { monthlyLimit: { val: 0 } } }) : new Response('', { status: 404 }));
+            assert.equal(await fetchGrokBilling(home), null);
+            const expected = ['Bearer oidc', 'Bearer other', `Bearer ${legacy}`];
+            for (const match of ['format=credits', 'GetGrokCreditsConfig', '/v1/billing']) {
+                assert.deepEqual(calls.filter(c => c.url.endsWith(match)).map(c => new Headers(c.init?.headers).get('authorization')), expected);
+            }
+            install((url, init) => url === billingUrl && new Headers(init?.headers).get('authorization') === `Bearer ${legacy}`
+                ? Response.json(monthly) : new Response('', { status: 404 }));
+            assert.equal((await fetchGrokBilling(home))?.source, 'progrok:billing-api');
+            fs.rmSync(join(home, '.progrok'), { recursive: true });
+        });
+        for (const value of [undefined, null, false, '', 'bad', 0, -1]) await t.test(`monthly rejects limit ${String(value)}`, async () => {
+            writeAuth({ 'https://auth.x.ai::fixture': native() });
+            install(url => url === billingUrl ? Response.json({ config: { monthlyLimit: { val: value }, used: { val: 0 } } })
+                : new Response('', { status: 404 }));
+            assert.equal(await fetchGrokBilling(home), null);
+        });
+        await t.test('monthly numeric strings, clamping and invalid reset; malformed first candidate continues', async () => {
+            writeAuth({ 'https://auth.x.ai::one': native('one'), 'https://auth.x.ai::two': native('two') });
+            install((url, init) => {
+                if (url === billingUrl) return new Headers(init?.headers).get('authorization') === 'Bearer one'
+                    ? new Response('{') : Response.json({ config: { monthlyLimit: { val: '100' }, used: { val: '250' }, billingPeriodEnd: 1e20 } });
+                if (url.endsWith('/user')) return Response.json({ email: { secret: 'must-not-escape' } });
+                return new Response('', { status: 404 });
+            });
+            const result = await fetchGrokBilling(home);
+            assert.equal(result?.percent, 100);
+            assert.equal(result?.limitUsd, 1);
+            assert.equal(result?.usedUsd, 2.5);
+            assert.equal(result?.periodEnd, undefined);
+            assert.equal(result?.email, 'fixture@example.invalid');
+            assert.ok(!JSON.stringify(result).includes('must-not-escape'));
+        });
+        for (const mode of ['401', 'reject', 'malformed']) await t.test(`optional user ${mode} cannot discard monthly`, async () => {
+            writeAuth({ 'https://auth.x.ai::fixture': native() });
+            install(url => {
+                if (url === billingUrl) return Response.json(monthly);
+                if (url.endsWith('/user')) {
+                    if (mode === 'reject') throw new Error('fixture user timeout');
+                    return mode === '401' ? new Response('', { status: 401 }) : new Response('{');
+                }
+                return new Response('', { status: 404 });
+            });
+            assert.equal((await fetchGrokBilling(home))?.percent, 25);
+        });
+        await t.test('missing and malformed native stores make no requests', async () => {
+            fs.rmSync(join(home, '.grok', 'auth.json'));
+            install(() => { throw new Error('unexpected network'); });
+            assert.equal(await fetchGrokBilling(home), null);
+            for (const raw of ['{', 'null', '[]', '{"scope":{"key":"  "}}']) {
+                fs.writeFileSync(join(home, '.grok', 'auth.json'), raw);
+                assert.equal(await fetchGrokBilling(home), null);
+            }
+            assert.equal(calls.length, 0);
+        });
+    } finally {
+        globalThis.fetch = originalFetch;
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
Grok quota falls back incorrectly when the weekly request throws and misses the current JSON credits response. Prefer JSON weekly billing with native user identity, preserve fractional and omitted-zero usage, then retain bounded gRPC weekly and validated monthly compatibility paths. Isolate each failed attempt so later candidates still run.

Validation: 52 Grok/status tests pass; independent Grok review and 26 dedicated tests pass; server build passes. Existing gRPC fixtures and Windows-safe native status probe remain intact. Reference: OpenCodex b94051fe.

Stack: #569 wire → #570 native accounts → this Grok layer → remaining providers → HTTP integration. Depends on #570. Review the layer-only diff; merge bottom-up.
