### PR TITLE
fix(quota): consume current OpenCode Go usage directly

### DIFF
--- a/src/routes/quota-opencode-go-api.ts
+++ b/src/routes/quota-opencode-go-api.ts
@@ -1,10 +1,12 @@
-// OpenCode Go subscription quota via Bearer API key (zen/go/v1/usage).
+// OpenCode Go quota, adapted from OpenCodex src/providers/quota.ts at
+// b94051fe91e745806102988f6dff2fec8de078ef (MIT; see LICENSE).
 
 import fs from 'fs';
 import os from 'os';
 import { join } from 'path';
 import { JAW_HOME, SETTINGS_PATH } from '../core/config.js';
 import { stripUndefined } from '../core/strip-undefined.js';
+import { asQuotaRecord as asRecord, quotaNumber, quotaPercent, quotaResetIso, readQuotaJson } from './quota-wire.js';
 
 const OPENCODE_GO_USAGE_URL = 'https://opencode.ai/zen/go/v1/usage';
 const OPENCODE_GO_MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
@@ -12,29 +14,6 @@ const OPENCODE_AUTH_FILE = join(os.homedir(), '.local/share/opencode/auth.json')
 const OPENCODE_GO_API_KEY_FILE = join(JAW_HOME, 'quota', 'opencode-go-api-key');
 
 type QuotaRecord = Record<string, unknown>;
-
-interface UsageWindowInput {
-    usagePercent?: number;
-    usage_percent?: number;
-    percent?: number;
-    resetInSec?: number;
-    resetInSeconds?: number;
-    resets_in_seconds?: number;
-    limitDollars?: number;
-    limit_dollars?: number;
-    usedDollars?: number;
-    used_dollars?: number;
-}
-
-function asRecord(value: unknown): QuotaRecord | null {
-    return value && typeof value === 'object' && !Array.isArray(value)
-        ? value as QuotaRecord
-        : null;
-}
-
-function numberField(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
 
 function readTrimmedEnv(name: string): string | null {
     const value = process.env[name]?.trim();
@@ -81,23 +60,20 @@ function readApiKeyFromAuthFile(): string | null {
     }
 }
 
-function windowFromInput(input: UsageWindowInput | null | undefined): { label: string; percent: number; resetsAt?: string | null } | null {
+function windowFromInput(value: unknown, now: number, canonical: boolean) {
+    const input = asRecord(value);
     if (!input) return null;
-    const percent = numberField(input.usagePercent)
-        ?? numberField(input.usage_percent)
-        ?? numberField(input.percent);
-    if (percent == null) return null;
-    const resetSec = numberField(input.resetInSec)
-        ?? numberField(input.resetInSeconds)
-        ?? numberField(input.resets_in_seconds);
-    const resetsAt = resetSec != null
-        ? new Date(Date.now() + resetSec * 1000).toISOString()
-        : null;
-    return {
-        percent: Math.round(Math.max(0, Math.min(100, percent))),
-        resetsAt,
-        label: '',
-    };
+    const percent = quotaPercent(canonical ? input['percent']
+        : quotaNumber(input['usagePercent']) ?? quotaNumber(input['usage_percent']) ?? input['percent']);
+    if (percent === undefined) return null;
+    let resetsAt = quotaResetIso(input['resetsAt']);
+    if (!resetsAt && !canonical) {
+        const seconds = quotaNumber(input['resetInSec']) ?? quotaNumber(input['resetInSeconds'])
+            ?? quotaNumber(input['resets_in_seconds']);
+        if (seconds !== undefined && seconds >= 0) resetsAt = quotaResetIso(now + seconds * 1000);
+    }
+    // Preserve legacy display rounding; canonical usage carries exact fractions.
+    return { percent: canonical ? percent : Math.round(percent), resetsAt };
 }
 
 export function normalizeOpenCodeGoUsage(data: unknown): QuotaRecord {
@@ -106,21 +82,20 @@ export function normalizeOpenCodeGoUsage(data: unknown): QuotaRecord {
         return { error: true, reason: 'usage_parse_failed' };
     }
 
-    const windows: Array<{ label: string; percent: number; resetsAt?: string | null }> = [];
-    const push = (label: string, input: UsageWindowInput | null | undefined) => {
-        const window = windowFromInput(input);
-        if (!window) return;
-        windows.push({ ...window, label });
-    };
-
+    const canonical = Object.hasOwn(root, 'usage');
+    const usage = asRecord(root['usage']);
+    if (canonical && !usage) return { error: true, reason: 'usage_parse_failed' };
+    const windows: Array<{ label: string; percent: number; resetsAt: string | null }> = [];
+    const now = Date.now();
     const nested = asRecord(root['windows']);
-    push('5h', asRecord(root['rolling5h']) as UsageWindowInput | null
-        ?? asRecord(root['rolling']) as UsageWindowInput | null
-        ?? nested?.['rolling'] as UsageWindowInput | undefined);
-    push('Weekly', asRecord(root['weekly']) as UsageWindowInput | null
-        ?? nested?.['weekly'] as UsageWindowInput | undefined);
-    push('Monthly', asRecord(root['monthly']) as UsageWindowInput | null
-        ?? nested?.['monthly'] as UsageWindowInput | undefined);
+    const inputs = canonical ? [usage?.['rolling'], usage?.['weekly'], usage?.['monthly']]
+        : [asRecord(root['rolling5h']) ?? asRecord(root['rolling']) ?? asRecord(nested?.['rolling']),
+            asRecord(root['weekly']) ?? asRecord(nested?.['weekly']),
+            asRecord(root['monthly']) ?? asRecord(nested?.['monthly'])];
+    for (const [i, label] of ['5h', 'Weekly', 'Monthly'].entries()) {
+        const window = windowFromInput(inputs[i], now, canonical);
+        if (window) windows.push({ ...window, label });
+    }
 
     return stripUndefined({
         authenticated: true,
@@ -138,21 +113,24 @@ export function normalizeOpenCodeGoUsage(data: unknown): QuotaRecord {
     });
 }
 
-export async function probeOpenCodeGoApiKey(apiKey: string): Promise<boolean> {
+type KeyProbe = 'authenticated' | 'rejected' | 'unavailable';
+
+async function probeOpenCodeGoKeyStatus(apiKey: string): Promise<KeyProbe> {
     try {
         const resp = await fetch(OPENCODE_GO_MODELS_URL, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-                Accept: 'application/json',
-            },
-            signal: AbortSignal.timeout(8000),
+            headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' },
+            redirect: 'error', signal: AbortSignal.timeout(8000),
         });
-        if (!resp.ok) return false;
-        const data = await resp.json() as unknown;
-        return asRecord(data)?.['object'] === 'list';
-    } catch {
-        return false;
-    }
+        if (!resp.ok) {
+            void resp.body?.cancel().catch(() => undefined);
+            return resp.status === 401 || resp.status === 403 ? 'rejected' : 'unavailable';
+        }
+        return asRecord(await readQuotaJson(resp))?.['object'] === 'list' ? 'authenticated' : 'unavailable';
+    } catch { return 'unavailable'; }
+}
+
+export async function probeOpenCodeGoApiKey(apiKey: string): Promise<boolean> {
+    return await probeOpenCodeGoKeyStatus(apiKey) === 'authenticated';
 }
 
 export async function fetchOpenCodeGoUsageApi(apiKey: string): Promise<QuotaRecord | null> {
@@ -162,22 +140,25 @@ export async function fetchOpenCodeGoUsageApi(apiKey: string): Promise<QuotaReco
                 Authorization: `Bearer ${apiKey}`,
                 Accept: 'application/json',
             },
+            redirect: 'error',
             signal: AbortSignal.timeout(8000),
         });
+        if (!resp.ok) void resp.body?.cancel().catch(() => undefined);
         if (resp.status === 401 || resp.status === 403) {
             return { authenticated: false, reason: 'api_key_invalid' };
         }
         if (resp.status === 404) {
-            return { usageApiUnavailable: true, reason: 'usage_api_not_deployed' };
+            return { usageApiUnavailable: true, reason: 'usage_api_unavailable' };
         }
         if (!resp.ok) {
             return { error: true, reason: 'usage_fetch_failed' };
         }
         const contentType = resp.headers.get('content-type') || '';
         if (!contentType.includes('json')) {
+            void resp.body?.cancel().catch(() => undefined);
             return { usageApiUnavailable: true, reason: 'usage_api_not_json' };
         }
-        const data = await resp.json() as unknown;
+        const data = await readQuotaJson(resp);
         return normalizeOpenCodeGoUsage(data);
     } catch {
         return { error: true, reason: 'usage_fetch_failed' };
@@ -196,63 +177,22 @@ function buildStatusOnly(): QuotaRecord {
     });
 }
 
-function mergeOpenCodeQuota(base: QuotaRecord, overlay: QuotaRecord | null): QuotaRecord {
-    if (!overlay) return base;
-    if (overlay['authenticated'] === false) {
-        return stripUndefined({
-            ...base,
-            authenticated: false,
-            quotaCapable: false,
-            reason: overlay['reason'] ?? 'api_key_invalid',
-            dashboardHint: 'OpenCode Go API key was rejected. Re-run opencode providers login or update OPENCODE_GO_API_KEY.',
-        });
-    }
-    if (overlay['usageApiUnavailable']) {
-        return stripUndefined({
-            ...base,
-            authenticated: base['authenticated'] !== false,
-            quotaCapable: false,
-            quotaSource: 'opencode-go:usage-api-unavailable',
-            usageApiUnavailable: true,
-            dashboardHint: 'GET /zen/go/v1/usage is not live yet (upstream anomalyco/opencode#16017). API key works for models; quota bar will appear when the endpoint ships.',
-            windows: [],
-        });
-    }
-    if (overlay['error']) {
-        return stripUndefined({
-            ...base,
-            error: true,
-            reason: overlay['reason'] ?? 'usage_fetch_failed',
-        });
-    }
-    return stripUndefined({
-        ...base,
-        ...overlay,
-        authenticated: true,
-        account: { ...(asRecord(base['account']) || {}), ...(asRecord(overlay['account']) || {}) },
-    });
-}
-
 export async function fetchOpenCodeUsage(): Promise<QuotaRecord> {
     const apiKey = readOpenCodeGoApiKey();
     if (!apiKey) return buildStatusOnly();
-
-    const authenticated = await probeOpenCodeGoApiKey(apiKey);
-    const base = stripUndefined({
-        ...buildStatusOnly(),
-        authenticated,
-        displayTier: 'OpenCode Go',
-        account: { type: 'opencode', tier: authenticated ? 'Go' : 'auth/status only' },
-        quotaSource: authenticated ? 'opencode-go:api-key-probed' : 'opencode-go:api-key-invalid',
-    });
-
-    if (!authenticated) {
-        return stripUndefined({
-            ...base,
-            dashboardHint: 'Set OPENCODE_GO_API_KEY or run opencode providers login for OpenCode Go.',
-        });
-    }
-
+    // Presence proves only a configured key; failures must not invent an auth verdict.
+    const base: QuotaRecord = {
+        quotaCapable: false, windows: [], displayTier: 'OpenCode Go',
+        account: { type: 'opencode', tier: 'Go' }, quotaSource: 'opencode-go:usage-api',
+    };
     const usage = await fetchOpenCodeGoUsageApi(apiKey);
-    return mergeOpenCodeQuota(base, usage);
+    if (!usage) return { ...base, error: true, reason: 'usage_fetch_failed' };
+    if (!usage['usageApiUnavailable']) return { ...base, ...usage };
+    const probe = await probeOpenCodeGoKeyStatus(apiKey);
+    return {
+        ...base, ...usage, quotaSource: 'opencode-go:usage-api-unavailable',
+        ...(probe === 'authenticated' ? { authenticated: true }
+            : probe === 'rejected' ? { authenticated: false, reason: 'api_key_invalid' } : { error: true }),
+        dashboardHint: 'OpenCode Go quota endpoint is unavailable for this response; model access and quota availability are checked separately.',
+    };
 }

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -315,6 +315,8 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 
 ### `/api/quota`
 
+- OpenCode Go reads canonical `usage.rolling/weekly/monthly` directly from `/zen/go/v1/usage`, retaining legacy window shapes. A successful usage response needs no models preflight; unavailable usage may probe model authentication without treating transient failure as invalid credentials.
+
 - Native Claude/Codex readers normalize upstream windows with `quota-native-window.ts` and bounded JSON from `quota-wire.ts`. Codex honors `CODEX_HOME`, declared short/monthly durations, Spark weekly limits and additive read-only `resetCredits`; missing readings do not create a zero bar. Claude supports Fable and weekly-scoped model limits; its 30-second fresh and 5-minute 429 fallback caches are credential-scoped. A 429 without a measured same-credential snapshot returns an error with no fabricated quota bar.
 
 - 응답 키: `pi`, `agy`, `ai-e`, `claude`, `claude-e`, `codex`, `codex-app`, `cursor`, `gemini`, `grok`, `opencode`, `copilot`, `kiro-code` (`CLI_KEYS` 순서).

--- a/tests/unit/quota-opencode-parity.test.ts
+++ b/tests/unit/quota-opencode-parity.test.ts
@@ -132,7 +132,7 @@ test('Go key precedence remains env, dedicated file, native auth, settings', t =
     t.after(() => { if (old === undefined) delete process.env.OPENCODE_GO_API_KEY; else process.env.OPENCODE_GO_API_KEY = old; });
     let dedicated = true; let native = true;
     t.mock.method(fs, 'readFileSync', (path: unknown) => {
-        const name = String(path);
+        const name = String(path).replaceAll('\\', '/');
         if (name.endsWith('opencode-go-api-key')) { if (dedicated) return 'file-key'; throw new Error('absent'); }
         if (name.endsWith('opencode/auth.json')) return JSON.stringify(native ? { 'opencode-go': { key: 'native-key' } } : {});
         if (name.endsWith('settings.json')) return JSON.stringify({ quota: { opencodeGoApiKey: 'settings-key' } });

--- a/tests/unit/quota-opencode-parity.test.ts
+++ b/tests/unit/quota-opencode-parity.test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fetchOpenCodeUsage, normalizeOpenCodeGoUsage, readOpenCodeGoApiKey } from '../../src/routes/quota-opencode-go-api.js';
+
+const usageUrl = 'https://opencode.ai/zen/go/v1/usage';
+const modelsUrl = 'https://opencode.ai/zen/go/v1/models';
+const canonical = { usage: {
+    rolling: { percent: 12.5, resetsAt: '2026-09-09T00:00:00Z' },
+    weekly: { percent: '8', resetsAt: 1789430400 },
+    monthly: { percent: 35, resetsAt: '2026-10-01T00:00:00Z' },
+} };
+const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } });
+
+test('canonical Go envelope preserves fractional percentages and absolute resets', () => {
+    const result = normalizeOpenCodeGoUsage(canonical);
+    assert.deepEqual(result.windows, [
+        { label: '5h', percent: 12.5, resetsAt: '2026-09-09T00:00:00.000Z' },
+        { label: 'Weekly', percent: 8, resetsAt: '2026-09-15T00:00:00.000Z' },
+        { label: 'Monthly', percent: 35, resetsAt: '2026-10-01T00:00:00.000Z' },
+    ]);
+});
+
+test('canonical presence cannot resurrect legacy windows; invalid fields remain unknown', () => {
+    const legacy = { weekly: { percent: 99 } };
+    assert.deepEqual(normalizeOpenCodeGoUsage({ ...legacy, usage: {} }).windows, []);
+    assert.equal(normalizeOpenCodeGoUsage({ ...legacy, usage: [] }).error, true);
+    for (const percent of [null, true, '', Infinity, NaN]) {
+        assert.deepEqual(normalizeOpenCodeGoUsage({ usage: { rolling: { percent } } }).windows, []);
+    }
+    assert.deepEqual(normalizeOpenCodeGoUsage({ usage: { rolling: { percent: 150, resetsAt: 1e30 } } }).windows,
+        [{ label: '5h', percent: 100, resetsAt: null }]);
+});
+
+test('legacy relative resets are bounded and absolute reset wins', t => {
+    t.mock.method(Date, 'now', () => Date.parse('2026-09-08T00:00:00Z'));
+    for (const resetInSec of [0, -1, 1e30]) {
+        const result = normalizeOpenCodeGoUsage({ rolling: { percent: 7, resetInSec } });
+        assert.deepEqual(result.windows, [{ label: '5h', percent: 7, resetsAt: resetInSec === 0 ? '2026-09-08T00:00:00.000Z' : null }]);
+    }
+    assert.deepEqual(normalizeOpenCodeGoUsage({ rolling: { percent: 7, resetInSec: 60, resetsAt: '2026-10-01' } }).windows,
+        [{ label: '5h', percent: 7, resetsAt: '2026-10-01T00:00:00.000Z' }]);
+});
+
+test('legacy malformed prefix candidates cannot mask later valid objects', () => {
+    const result = normalizeOpenCodeGoUsage({
+        rolling5h: 'unavailable', rolling: { percent: 17 },
+        weekly: [], monthly: false,
+        windows: { weekly: { percent: 23 }, monthly: { percent: 41 } },
+    });
+    assert.deepEqual(result.windows, [
+        { label: '5h', percent: 17, resetsAt: null },
+        { label: 'Weekly', percent: 23, resetsAt: null },
+        { label: 'Monthly', percent: 41, resetsAt: null },
+    ]);
+    assert.deepEqual(normalizeOpenCodeGoUsage({ usage: {}, rolling: { percent: 17 } }).windows, []);
+});
+
+test('default Go reader uses usage first and never probes models on success or valid empty', async t => {
+    const old = process.env.OPENCODE_GO_API_KEY;
+    process.env.OPENCODE_GO_API_KEY = 'fixture-go-key';
+    t.after(() => { if (old === undefined) delete process.env.OPENCODE_GO_API_KEY; else process.env.OPENCODE_GO_API_KEY = old; });
+    const calls: string[] = [];
+    let body: unknown = canonical;
+    t.mock.method(globalThis, 'fetch', async (url: unknown, init?: RequestInit) => {
+        calls.push(String(url));
+        assert.equal(init?.redirect, 'error');
+        assert.equal(new Headers(init?.headers).get('authorization'), 'Bearer fixture-go-key');
+        assert.equal(String(url), usageUrl);
+        return json(body);
+    });
+    assert.equal((await fetchOpenCodeUsage()).quotaCapable, true);
+    body = { usage: {} };
+    const empty = await fetchOpenCodeUsage();
+    assert.equal(empty.authenticated, true);
+    assert.equal(empty.quotaCapable, false);
+    assert.deepEqual(calls, [usageUrl, usageUrl]);
+    assert.ok(!JSON.stringify(empty).includes('fixture-go-key'));
+});
+
+test('Go failure classes preserve auth evidence and bound the models fallback', async t => {
+    const old = process.env.OPENCODE_GO_API_KEY;
+    process.env.OPENCODE_GO_API_KEY = 'fixture-go-key';
+    t.after(() => { if (old === undefined) delete process.env.OPENCODE_GO_API_KEY; else process.env.OPENCODE_GO_API_KEY = old; });
+    let usageStatus = 401;
+    let modelStatus = 200;
+    const calls: string[] = [];
+    t.mock.method(globalThis, 'fetch', async (url: unknown, init?: RequestInit) => {
+        assert.equal(init?.redirect, 'error');
+        calls.push(String(url));
+        if (String(url) === usageUrl) return new Response('failure', { status: usageStatus });
+        assert.equal(String(url), modelsUrl);
+        return modelStatus === 200 ? json({ object: 'list' }) : new Response(null, { status: modelStatus });
+    });
+    for (const status of [401, 403, 408, 429, 500, 503, 400]) {
+        usageStatus = status; calls.length = 0;
+        const result = await fetchOpenCodeUsage();
+        assert.deepEqual(calls, [usageUrl]);
+        assert.deepEqual(result.windows, []);
+        if (status === 401 || status === 403) assert.equal(result.authenticated, false);
+        else { assert.equal(result.error, true); assert.notEqual(result.authenticated, false); }
+    }
+    usageStatus = 404;
+    for (const status of [200, 401, 429]) {
+        modelStatus = status; calls.length = 0;
+        const result = await fetchOpenCodeUsage();
+        assert.deepEqual(calls, [usageUrl, modelsUrl]);
+        assert.equal(result.quotaCapable, false);
+        if (status === 200) assert.equal(result.authenticated, true);
+        else if (status === 401) assert.equal(result.authenticated, false);
+        else assert.notEqual(result.authenticated, false);
+    }
+});
+
+test('Go malformed and oversized bodies fail without models or secret echo', async t => {
+    const old = process.env.OPENCODE_GO_API_KEY;
+    process.env.OPENCODE_GO_API_KEY = 'fixture-go-key';
+    t.after(() => { if (old === undefined) delete process.env.OPENCODE_GO_API_KEY; else process.env.OPENCODE_GO_API_KEY = old; });
+    let response = new Response('{fixture-go-key', { headers: { 'content-type': 'application/json' } });
+    let calls = 0;
+    t.mock.method(globalThis, 'fetch', async (url: unknown) => { assert.equal(String(url), usageUrl); calls++; return response; });
+    assert.equal((await fetchOpenCodeUsage()).error, true);
+    response = new Response('fixture-go-key', { headers: { 'content-type': 'application/json', 'content-length': '524289' } });
+    const result = await fetchOpenCodeUsage();
+    assert.equal(result.error, true);
+    assert.ok(!JSON.stringify(result).includes('fixture-go-key'));
+    assert.equal(calls, 2);
+});
+
+test('Go key precedence remains env, dedicated file, native auth, settings', t => {
+    const old = process.env.OPENCODE_GO_API_KEY;
+    t.after(() => { if (old === undefined) delete process.env.OPENCODE_GO_API_KEY; else process.env.OPENCODE_GO_API_KEY = old; });
+    let dedicated = true; let native = true;
+    t.mock.method(fs, 'readFileSync', (path: unknown) => {
+        const name = String(path);
+        if (name.endsWith('opencode-go-api-key')) { if (dedicated) return 'file-key'; throw new Error('absent'); }
+        if (name.endsWith('opencode/auth.json')) return JSON.stringify(native ? { 'opencode-go': { key: 'native-key' } } : {});
+        if (name.endsWith('settings.json')) return JSON.stringify({ quota: { opencodeGoApiKey: 'settings-key' } });
+        throw new Error('Unexpected file');
+    });
+    process.env.OPENCODE_GO_API_KEY = 'env-key'; assert.equal(readOpenCodeGoApiKey(), 'env-key');
+    delete process.env.OPENCODE_GO_API_KEY; assert.equal(readOpenCodeGoApiKey(), 'file-key');
+    dedicated = false; assert.equal(readOpenCodeGoApiKey(), 'native-key');
+    native = false; assert.equal(readOpenCodeGoApiKey(), 'settings-key');
+});


### PR DESCRIPTION
OpenCode Go quota parsing misses the canonical usage envelope and requires an unrelated models probe before every usage read. Read rolling/weekly/monthly usage directly, preserve fractional and absolute-reset values, and retain validated legacy fallbacks. Probe models only when usage is unavailable; transient failures remain distinct from rejected credentials.

Validation: 11 focused tests pass, including malformed legacy prefixes that must fall through to valid objects. Independent review PASS; server build passes. Reference: OpenCodex b94051fe.

Stack: #569 wire → #570 native → #571 Grok → this OpenCode layer → remaining providers → integration. Depends on #571; merge bottom-up.
