### PR TITLE
fix(manager): align dashboard top chrome with macOS traffic lights and shorten search

### DIFF
--- a/electron/src/main/lib/window/chrome-options.ts
+++ b/electron/src/main/lib/window/chrome-options.ts
@@ -2,7 +2,7 @@ export const TITLEBAR_OVERLAY_HEIGHT = 40;
 export const TITLEBAR_OVERLAY_COLOR = '#01000000';
 export const TITLEBAR_DARK_SYMBOL_COLOR = '#f8fafc';
 export const TITLEBAR_LIGHT_SYMBOL_COLOR = '#1f2937';
-export const TRAFFIC_LIGHT_POSITION = { x: 16, y: 18 } as const;
+export const TRAFFIC_LIGHT_POSITION = { x: 16, y: 20 } as const;
 
 export type WindowChromePlatform = 'darwin' | 'win32' | 'linux' | string;
 

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -91,7 +91,7 @@ h2 { font-size: 13px; }
 .command-actions { justify-self: end; }
 .is-electron-titlebar {
     -webkit-app-region: drag;
-    padding-left: var(--electron-titlebar-left-reserve, 90px);
+    padding-left: var(--electron-titlebar-left-reserve, 108px);
 }
 .is-electron-titlebar button,
 .is-electron-titlebar input,

--- a/public/manager/src/manager-layout.css
+++ b/public/manager/src/manager-layout.css
@@ -150,7 +150,6 @@
     .dashboard-shell.manager-shell:not(.is-sidebar-collapsed) .manager-workspace.is-side-panel-open {
         --right-panel-width: 50vw;
     }
-    .command-search { width: clamp(260px, 38vw, 620px); }
     .overview-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 @media (max-width: 1023px) {

--- a/public/manager/src/manager-p0-1-1.css
+++ b/public/manager/src/manager-p0-1-1.css
@@ -7,7 +7,8 @@
 }
 .command-center.command-bar.is-electron-titlebar,
 :root[data-cli-jaw-desktop="true"] .command-center.command-bar {
-    --electron-titlebar-left-reserve: 90px;
+    /* 16px inset + 3 * 12px lights + 2 * 8px gaps + 40px clearance (audit-folded: 108px). */
+    --electron-titlebar-left-reserve: 108px;
     padding: 0 10px 0 var(--electron-titlebar-left-reserve);
 }
 :root[data-window-fullscreen="true"] .command-center.command-bar.is-electron-titlebar,
@@ -41,9 +42,16 @@
         grid-template-columns: auto minmax(0, 1fr) auto;
         grid-template-areas: "drawer search actions";
     }
+    .command-primary .command-title { display: none; }
 }
 .command-title { grid-area: title; }
-.command-search { grid-area: search; width: 100%; max-width: none; }
+.command-search { grid-area: search; width: 100%; max-width: 100%; }
+@media (min-width: 1024px) {
+    .command-search {
+        width: clamp(220px, 28vw, 420px);
+        justify-self: start;
+    }
+}
 .command-actions { grid-area: actions; }
 
 .command-title {

--- a/tests/unit/electron-window-titlebar-contract.test.ts
+++ b/tests/unit/electron-window-titlebar-contract.test.ts
@@ -17,10 +17,10 @@ test('resolveWindowChromeOptions uses hiddenInset traffic lights on darwin', () 
     const light = resolveWindowChromeOptions('darwin', false);
 
     assert.equal(dark.titleBarStyle, 'hiddenInset');
-    assert.deepEqual(dark.trafficLightPosition, { x: 16, y: 18 });
+    assert.deepEqual(dark.trafficLightPosition, { x: 16, y: 20 });
     assert.equal(dark.titleBarOverlay, undefined);
     assert.equal(light.titleBarStyle, 'hiddenInset');
-    assert.deepEqual(light.trafficLightPosition, { x: 16, y: 18 });
+    assert.deepEqual(light.trafficLightPosition, { x: 16, y: 20 });
     assert.equal(light.titleBarOverlay, undefined);
 });
 


### PR DESCRIPTION
Fixes two top-chrome problems in the Manager dashboard on macOS desktop: the traffic lights sat 2px above the 52px bar's center and touched the CLI-JAW wordmark at the 90px reserve, and the search field stretched across the whole bar so almost none of it was draggable.

**Before:** lights center at 24px (y=18), wordmark starts at x=90, search width = full track (no-drag).
**After:** lights center at 26px (y=20) matching the bar/title/search center, wordmark starts at x=108, search capped at `clamp(220px, 28vw, 420px)` at ≥1024px and the freed middle track stays `-webkit-app-region: drag`. Mobile (≤1023px) keeps full-width search; ≤767px hides the title under the compact stylesheet (restores the original layout.css intent that the compact sheet was overriding). The superseded 1024–1279px clamp in `manager-layout.css` is removed.

**Manual PR chain** (merge bottom-up; no GitHub native stack):
| Order | PR | Layer | Base | Review focus |
|---|---|---|---|---|
| 1 | this PR ← you are here | Top chrome | dev | Native controls, logo alignment, search width |
| 2 | PR-B (not yet opened) | Session navigation | codex/dash-topbar-chrome | Active disclosure and /0 preview |

No preceding feature dependency. PR-B depends on this PR.

Validation:
- `npm run typecheck:frontend` exit 0; `npm --prefix electron run typecheck` exit 0
- `tests/run.mts` on electron-window-titlebar-contract, manager-electron-desktop-contract, manager-frontend-contract, manager-responsive-contract, manager-activity-title, manager-preview-path-insert-contract, manager-reminders-frontend-contract: 66 pass / 0 fail
- `npm run build:frontend` ok; built CSS contains `--electron-titlebar-left-reserve:108px` and `clamp(220px,28vw,420px)`
- Isolated manager on :24990 with the desktop marker: bar 52px (center 26), title x=108 center 26, search 420px center 26, bar `drag` / search `no-drag` (CDP measurement)
- `bash structure/verify-counts.sh` 540 PASS

Limitations: the native traffic-light geometry (y=20) is verified against the rebuilt Electron app in the follow-up recovery step, not in this PR's CI.
