### PR TITLE
fix(quota): support native Cursor usage and credential precedence

### DIFF
--- a/src/routes/quota-cursor-dashboard.ts
+++ b/src/routes/quota-cursor-dashboard.ts
@@ -1,11 +1,14 @@
 // Reverse-engineered Cursor dashboard quota reader (unofficial API).
 
 import fs from 'fs';
+import os from 'node:os';
+import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join } from 'path';
 import { JAW_HOME, SETTINGS_PATH } from '../core/config.js';
 import { stripUndefined } from '../core/strip-undefined.js';
+import { asQuotaRecord, quotaNumber, quotaPercent, quotaResetIso, readQuotaJson } from './quota-wire.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -27,6 +30,44 @@ async function readCursorJsonCommand(binary: string, command: string, args: stri
     } catch {
         return null;
     }
+}
+
+// Native store contract: Cursor CLI 2026.09.02-c22c1a3 credential manager.
+// Read only; never invoke its login/refresh or write-back paths.
+export function getCursorNativeAuthPath(
+    platform: NodeJS.Platform = process.platform,
+    homeDir = os.homedir(),
+    env: NodeJS.ProcessEnv = process.env,
+): string {
+    if (platform === 'win32') return path.win32.join(
+        env['APPDATA'] || path.win32.join(homeDir, 'AppData', 'Roaming'), 'Cursor', 'auth.json');
+    if (platform === 'darwin') return path.posix.join(homeDir, '.cursor', 'auth.json');
+    return path.posix.join(env['XDG_CONFIG_HOME'] || path.posix.join(homeDir, '.config'), 'cursor', 'auth.json');
+}
+export async function readCursorNativeAccessToken(options: {
+    platform?: NodeJS.Platform; homeDir?: string; env?: NodeJS.ProcessEnv;
+} = {}): Promise<string | null> {
+    const env = options.env ?? process.env;
+    const platform = options.platform ?? process.platform;
+    const token = (value: unknown) => typeof value === 'string' && value.trim() ? value.trim() : null;
+    const direct = token(env['CURSOR_AUTH_TOKEN']);
+    if (direct) return direct;
+    if (token(env['CURSOR_API_KEY'])) return null;
+    if (env['AGENT_CLI_CREDENTIAL_STORE'] === 'memory') return null;
+    if (env['AGENT_CLI_CREDENTIAL_STORE'] === 'file' || platform !== 'darwin') {
+        try {
+            const file = getCursorNativeAuthPath(platform, options.homeDir ?? os.homedir(), env);
+            return token(asQuotaRecord(JSON.parse(fs.readFileSync(file, 'utf8')))?.['accessToken']);
+        } catch { return null; }
+    }
+    try {
+        const { stderr } = await execFileAsync('/usr/bin/security',
+            ['find-generic-password', '-a', 'cursor-user', '-s', 'cursor-access-token', '-g'],
+            { encoding: 'utf8', timeout: 5000, maxBuffer: 64 * 1024 });
+        const hex = stderr.match(/^password: 0x([0-9a-fA-F]+)\s*$/m);
+        if (hex) return hex[1]!.length % 2 === 0 ? token(Buffer.from(hex[1]!, 'hex').toString('utf8')) : null;
+        return token(stderr.match(/^password: "(.*)"\s*$/m)?.[1]);
+    } catch { return null; }
 }
 
 export function readCursorDashboardSessionToken(): string | null {
@@ -107,34 +148,27 @@ export async function readCursorStatus(binary = 'cursor-agent'): Promise<QuotaRe
     });
 }
 
-function asRecord(value: unknown): QuotaRecord | null {
-    return value && typeof value === 'object' && !Array.isArray(value)
-        ? value as QuotaRecord
-        : null;
-}
-
-function numberField(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
 export function normalizeCursorUsageSummary(data: QuotaRecord): QuotaRecord {
-    const individualUsage = asRecord(data["individualUsage"]);
-    const plan = asRecord(individualUsage?.["plan"]);
+    const individualUsage = asQuotaRecord(data["individualUsage"]);
+    const plan = asQuotaRecord(individualUsage?.["plan"]);
     const windows: Array<{ label: string; percent: number; resetsAt?: string | null }> = [];
-    const resetsAt = typeof data["billingCycleEnd"] === 'string' ? data["billingCycleEnd"] : null;
+    const resetsAt = quotaResetIso(data["billingCycleEnd"]);
     const membershipType = typeof data["membershipType"] === 'string' ? data["membershipType"] : undefined;
 
-    const totalPercentUsed = numberField(plan?.["totalPercentUsed"]);
-    const apiPercentUsed = numberField(plan?.["apiPercentUsed"]);
-    const autoPercentUsed = numberField(plan?.["autoPercentUsed"]);
+    const used = quotaNumber(plan?.["used"]);
+    const limit = quotaNumber(plan?.["limit"]);
+    const totalPercentUsed = quotaPercent(plan?.["totalPercentUsed"])
+        ?? (used !== undefined && limit !== undefined && limit > 0 ? quotaPercent(used / limit * 100) : undefined);
+    const apiPercentUsed = quotaPercent(plan?.["apiPercentUsed"]);
+    const autoPercentUsed = quotaPercent(plan?.["autoPercentUsed"]);
 
     if (totalPercentUsed != null) {
-        windows.push({ label: 'Cycle', percent: Math.round(totalPercentUsed), resetsAt });
+        windows.push({ label: 'Cycle', percent: totalPercentUsed, resetsAt });
     } else if (apiPercentUsed != null) {
-        windows.push({ label: 'API', percent: Math.round(apiPercentUsed), resetsAt });
+        windows.push({ label: 'API', percent: apiPercentUsed, resetsAt });
     }
     if (autoPercentUsed != null && autoPercentUsed > 0) {
-        windows.push({ label: 'Auto', percent: Math.round(autoPercentUsed), resetsAt });
+        windows.push({ label: 'Auto', percent: autoPercentUsed, resetsAt });
     }
 
     return stripUndefined({
@@ -148,11 +182,11 @@ export function normalizeCursorUsageSummary(data: QuotaRecord): QuotaRecord {
             plan: membershipType,
         }),
         windows,
-        billingCycleStart: data["billingCycleStart"],
-        billingCycleEnd: data["billingCycleEnd"],
-        planUsed: plan?.["used"],
-        planLimit: plan?.["limit"],
-        planRemaining: plan?.["remaining"],
+        billingCycleStart: quotaResetIso(data["billingCycleStart"]),
+        billingCycleEnd: resetsAt,
+        planUsed: quotaNumber(plan?.["used"]),
+        planLimit: quotaNumber(plan?.["limit"]),
+        planRemaining: quotaNumber(plan?.["remaining"]),
         reverseEngineered: true,
     });
 }
@@ -160,18 +194,111 @@ export function normalizeCursorUsageSummary(data: QuotaRecord): QuotaRecord {
 export async function fetchCursorDashboardUsage(sessionToken: string): Promise<QuotaRecord | null> {
     try {
         const resp = await fetch(CURSOR_USAGE_SUMMARY_URL, {
-            headers: { Cookie: `WorkosCursorSessionToken=${sessionToken}` },
+            headers: { Accept: 'application/json', Cookie: `WorkosCursorSessionToken=${sessionToken}` },
+            redirect: 'error',
             signal: AbortSignal.timeout(8000),
         });
         if (resp.status === 401 || resp.status === 403) {
             return { authenticated: false, reason: 'dashboard_session_expired' };
         }
         if (!resp.ok) return { error: true };
-        const data = await resp.json() as QuotaRecord;
+        const data = asQuotaRecord(await readQuotaJson(resp));
+        if (!data) return { error: true };
         return normalizeCursorUsageSummary(data);
     } catch {
         return { error: true };
     }
+}
+
+// Quota semantics adapted from OpenCodex b94051fe91e745806102988f6dff2fec8de078ef.
+type CursorWindow = { label: string; percent: number; resetsAt: string | null };
+function cursorNativeQuota(source: string, windows: CursorWindow[]): QuotaRecord | null {
+    return windows.length ? { authenticated: true, quotaCapable: true, quotaSource: source,
+        windows, reverseEngineered: true } : null;
+}
+export function normalizeCursorPeriodUsage(value: unknown): QuotaRecord | null {
+    const body = asQuotaRecord(value);
+    const plan = asQuotaRecord(body?.['planUsage']);
+    if (!body || !plan) return null;
+    const resetsAt = quotaResetIso(body['billingCycleEnd'] ?? plan['billingCycleEnd'] ?? body['periodEnd']);
+    const limit = quotaNumber(plan['limit'] ?? plan['limitCents'] ?? plan['totalLimitCents']);
+    const remaining = quotaNumber(plan['remaining'] ?? plan['remainingCents']);
+    const included = quotaNumber(plan['includedSpend'] ?? plan['usedCents'] ?? plan['used']);
+    const totalSpend = quotaNumber(plan['totalSpend']);
+    const used = included !== undefined ? included
+        : limit !== undefined && remaining !== undefined ? Math.max(0, limit - remaining) : totalSpend;
+    const total = quotaPercent(plan['totalPercentUsed'] ?? plan['percentUsed'])
+        ?? (limit !== undefined && limit > 0 && used !== undefined ? quotaPercent(used / limit * 100) : undefined);
+    const auto = quotaPercent(plan['autoPercentUsed']);
+    const api = quotaPercent(plan['apiPercentUsed']);
+    const windows: CursorWindow[] = [];
+    if (total !== undefined) windows.push({ label: 'Cycle', percent: total, resetsAt });
+    if (auto !== undefined) windows.push({ label: 'First-party models', percent: auto, resetsAt });
+    if (api !== undefined) windows.push({ label: 'API usage', percent: api, resetsAt });
+    return cursorNativeQuota('cursor:period-usage', windows);
+}
+export function normalizeCursorNativeSummary(value: unknown): QuotaRecord | null {
+    const body = asQuotaRecord(value);
+    const plan = asQuotaRecord(asQuotaRecord(body?.['individualUsage'])?.['plan']);
+    if (!body || !plan) return null;
+    const used = quotaNumber(plan['used']);
+    const limit = quotaNumber(plan['limit']);
+    const percent = quotaPercent(plan['totalPercentUsed'])
+        ?? (used !== undefined && limit !== undefined && limit > 0 ? quotaPercent(used / limit * 100) : undefined);
+    return percent === undefined ? null : cursorNativeQuota('cursor:usage-summary', [
+        { label: 'Cycle', percent, resetsAt: quotaResetIso(body['billingCycleEnd']) },
+    ]);
+}
+export function normalizeCursorAuthUsage(value: unknown): QuotaRecord | null {
+    const body = asQuotaRecord(value);
+    if (!body) return null;
+    const bucket = (value: unknown) => {
+        const record = asQuotaRecord(value);
+        if (!record) return null;
+        const used = quotaNumber(record['numRequests'] ?? record['used']);
+        const limit = quotaNumber(record['maxRequestUsage'] ?? record['limit'] ?? record['maxRequests']);
+        if (used === undefined || limit === undefined || limit <= 0) return null;
+        const percent = quotaPercent(used / limit * 100);
+        return percent === undefined ? null : { percent };
+    };
+    let selected = bucket(body['gpt-4']);
+    if (!selected) for (const [key, value] of Object.entries(body)) {
+        if (key === 'startOfMonth' || key === 'billingCycleStart') continue;
+        selected = bucket(value);
+        if (selected) break;
+    }
+    if (!selected) return null;
+    const startIso = quotaResetIso(body['startOfMonth'] ?? body['billingCycleStart']);
+    let resetsAt: string | null = null;
+    if (startIso) {
+        const start = new Date(startIso);
+        // Date.UTC overflow behavior matches reference; do not clamp to month end.
+        resetsAt = quotaResetIso(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, start.getUTCDate()));
+    }
+    return cursorNativeQuota('cursor:auth-usage', [{ label: 'Cycle', percent: selected.percent, resetsAt }]);
+}
+export async function fetchCursorNativeUsage(accessToken: string): Promise<QuotaRecord | null> {
+    const headers = { Accept: 'application/json', Authorization: `Bearer ${accessToken}`,
+        'User-Agent': 'cli-jaw-quota' };
+    const stages = [
+        { url: 'https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage',
+            parse: normalizeCursorPeriodUsage, post: true },
+        { url: 'https://api2.cursor.sh/api/usage/summary', parse: normalizeCursorNativeSummary, post: false },
+        { url: 'https://api2.cursor.sh/auth/usage', parse: normalizeCursorAuthUsage, post: false },
+    ];
+    for (const stage of stages) {
+        try {
+            const response = await fetch(stage.url, {
+                method: stage.post ? 'POST' : 'GET', redirect: 'error',
+                headers: stage.post ? { ...headers, 'Content-Type': 'application/json', 'Connect-Protocol-Version': '1' } : headers,
+                ...(stage.post ? { body: '{}' } : {}), signal: AbortSignal.timeout(8000),
+            });
+            if (!response.ok) continue;
+            const quota = stage.parse(await readQuotaJson(response));
+            if (quota) return quota;
+        } catch { /* next fixed endpoint; never return raw errors or refresh credentials */ }
+    }
+    return null;
 }
 
 function mergeCursorQuota(base: QuotaRecord, overlay: QuotaRecord | null): QuotaRecord {
@@ -189,15 +316,19 @@ function mergeCursorQuota(base: QuotaRecord, overlay: QuotaRecord | null): Quota
     return stripUndefined({
         ...base,
         ...overlay,
-        authenticated: base["authenticated"] !== false,
-        account: { ...(asRecord(base["account"]) || {}), ...(asRecord(overlay["account"]) || {}) },
+        authenticated: overlay["authenticated"] === true || base["authenticated"] === true,
+        account: { ...(asQuotaRecord(base["account"]) || {}), ...(asQuotaRecord(overlay["account"]) || {}) },
     });
 }
 
 export async function fetchCursorUsage(binary = 'cursor-agent'): Promise<QuotaRecord> {
     const base = await readCursorStatus(binary);
+    const accessToken = await readCursorNativeAccessToken();
+    if (accessToken) {
+        const native = await fetchCursorNativeUsage(accessToken);
+        if (native) return mergeCursorQuota(base, native);
+    }
     const sessionToken = readCursorDashboardSessionToken();
-    if (!sessionToken) return base;
-    const dashboard = await fetchCursorDashboardUsage(sessionToken);
-    return mergeCursorQuota(base, dashboard);
+    if (sessionToken) return mergeCursorQuota(base, await fetchCursorDashboardUsage(sessionToken));
+    return accessToken ? { ...base, error: true, reason: 'native_quota_unavailable' } : base;
 }

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -323,7 +323,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 - `pi`는 Settings의 Pi profile registration을 통해 endpoint/model/key를 검증하고, quota 자체는 auth/status-only로 표시한다.
 - `agy`는 `src/routes/quota-agy-reverse.ts`의 `fetchAgyUsage()`를 통해 Antigravity quota snapshot을 읽는다.
 - `antigravity-usage --json`이 `remainingPercentage`를 정밀 소수점 대신 `0`/`1`로만 반환하면 AGY window는 `precision: "binary"`와 `status: "available" | "exhausted"`를 포함한다. backend의 `percent`는 호환 필드일 뿐이며, UI는 exact percent bar 대신 `Available` / `Exhausted` 상태 텍스트를 표시해야 한다. upstream이 다시 정밀 퍼센트를 주면 기존 fractional path가 그대로 사용된다.
-- `cursor`는 `src/routes/quota-cursor-dashboard.ts`의 `fetchCursorUsage()`를 통해 dashboard session/usage를 읽는다.
+- `cursor` reads its selected native OAuth store (or direct auth token), probes period usage → summary → legacy usage, then retains explicitly configured dashboard-cookie fallback. An API-key override suppresses unrelated stored OAuth reads. Keychain/memory/file selection follows the native CLI; credentials are never returned in quota rows.
 - `grok` reads native OIDC key/user identity, then requests JSON `/v1/billing?format=credits` weekly usage. It preserves fractional and omitted-zero readings, with bounded gRPC weekly compatibility and validated monthly fallback. Each failed request is isolated; session usage remains separate.
 - `kiro-code`는 `src/routes/quota-kiro-reverse.ts`의 `fetchKiroUsage()`를 통해 CodeWhisperer `GetUsageLimits` API를 reverse-engineer 호출한다.
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -399,7 +399,7 @@ cli-jaw/
 │   │   ├── quota-wire.ts ← Bounded upstream bodies, finite percentages and reset normalization (84L)
 │   │   ├── quota-kiro-reverse.ts ← Kiro/CodeWhisperer quota reader (239L)
 │   │   ├── quota-agy-reverse.ts ← AGY reverse quota reader (153L)
-│   │   ├── quota-cursor-dashboard.ts ← Cursor dashboard quota reader (203L)
+│   │   ├── quota-cursor-dashboard.ts ← Cursor dashboard quota reader (334L)
 │   │   ├── goal.ts           ← goal CRUD + kickGoalContinuation route (registerGoalRoutes) (183L)
 │   │   ├── goal-run.ts       ← goal-run execution routes (83L)
 │   │   ├── runtime-context.ts ← runtime context route helpers (46L)

--- a/tests/unit/quota-cursor-parity.test.ts
+++ b/tests/unit/quota-cursor-parity.test.ts
@@ -1,0 +1,421 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as childProcess from 'node:child_process';
+import fs from 'node:fs';
+import { promisify } from 'node:util';
+
+type Window = { label: string; percent: number; resetsAt: string | null };
+
+test('Cursor native quota, credential precedence and cookie compatibility', async (t) => {
+    const originalFetch = globalThis.fetch;
+    const oldSession = process.env['CURSOR_SESSION_TOKEN'];
+    const oldDashboard = process.env['CURSOR_DASHBOARD_SESSION_TOKEN'];
+    const oldKey = process.env['CURSOR_API_KEY'];
+    const oldAuth = process.env['CURSOR_AUTH_TOKEN'];
+    const oldStore = process.env['AGENT_CLI_CREDENTIAL_STORE'];
+    let keychainStderr = 'password: \"fixture-keychain\"';
+    let cliAuthenticated = false;
+    let keychainCalls = 0;
+    let keychainError: Error | undefined;
+    const cliCalls: Array<{ binary: string; args: string[]; options: Record<string, unknown> }> = [];
+    const fixtureExec = Object.assign(() => { throw new Error('unexpected sync fixture call'); }, {
+        [promisify.custom]: async (_binary: string, args: string[], options: Record<string, unknown>) => {
+            assert.ok(_binary === '/usr/bin/security' || _binary === 'fixture-cursor');
+            cliCalls.push({ binary: _binary, args, options });
+            if (_binary === '/usr/bin/security') {
+                keychainCalls += 1;
+                if (keychainError) throw keychainError;
+            }
+            return { stdout: _binary === '/usr/bin/security' ? '' : JSON.stringify(args[0] === 'status' ? { isAuthenticated: cliAuthenticated } : {}),
+            stderr: _binary === '/usr/bin/security' ? keychainStderr : '',
+            };
+        },
+    });
+    t.mock.module('node:child_process', { namedExports: { ...childProcess, execFile: fixtureExec } });
+    process.env['CURSOR_SESSION_TOKEN'] = 'fixture-cookie';
+    delete process.env['CURSOR_DASHBOARD_SESSION_TOKEN'];
+    delete process.env['CURSOR_API_KEY'];
+    delete process.env['CURSOR_AUTH_TOKEN'];
+    process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'memory';
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    let response: () => Response = () => Response.json({});
+    globalThis.fetch = (async (input, init) => {
+        calls.push({ url: String(input), init }); return response();
+    }) as typeof fetch;
+    try {
+        const { normalizeCursorUsageSummary, fetchCursorDashboardUsage, fetchCursorUsage,
+            readCursorNativeAccessToken, getCursorNativeAuthPath, normalizeCursorPeriodUsage,
+            normalizeCursorAuthUsage, normalizeCursorNativeSummary, readCursorDashboardSessionToken } =
+            await import('../../src/routes/quota-cursor-dashboard.ts');
+        const summarize = (plan: Record<string, unknown>, end: unknown = '1771077734000') =>
+            normalizeCursorUsageSummary({ individualUsage: { plan }, billingCycleEnd: end });
+        await t.test('total precedence, finite strings, derived total and compatible pools', () => {
+            assert.deepEqual(summarize({ totalPercentUsed: '15.48', used: 90, limit: 100,
+                apiPercentUsed: 46.444, autoPercentUsed: 12 }).windows, [
+                { label: 'Cycle', percent: 15.48, resetsAt: new Date(1771077734000).toISOString() },
+                { label: 'Auto', percent: 12, resetsAt: new Date(1771077734000).toISOString() },
+            ]);
+            assert.equal((summarize({ used: '42', limit: '100' }).windows as Window[])[0]!.percent, 42);
+            assert.deepEqual(summarize({ used: 0, limit: 0, autoPercentUsed: 0 }).windows, []);
+            assert.deepEqual(summarize({ apiPercentUsed: 150 }, 'bad-date').windows,
+                [{ label: 'API', percent: 100, resetsAt: null }]);
+            assert.deepEqual(summarize({ totalPercentUsed: -1 }, 1e20).windows,
+                [{ label: 'Cycle', percent: 0, resetsAt: null }]);
+            const clean = summarize({ used: { secret: 'fixture-private' }, limit: [], remaining: false });
+            assert.ok(!JSON.stringify(clean).includes('fixture-private'));
+            assert.equal(clean.planUsed, undefined);
+        });
+        await t.test('successful dashboard proves auth despite failed CLI probe', async () => {
+            response = () => Response.json({ individualUsage: { plan: { totalPercentUsed: 25 } } });
+            const result = await fetchCursorUsage('fixture-cursor');
+            assert.equal(result.authenticated, true);
+            assert.equal(result.quotaCapable, true);
+            const call = calls.at(-1)!;
+            assert.equal(call.url, 'https://cursor.com/api/usage-summary');
+            assert.equal(call.init?.method ?? 'GET', 'GET');
+            assert.equal(call.init?.redirect, 'error');
+            assert.ok(call.init?.signal);
+            const headers = new Headers(call.init?.headers);
+            assert.equal(headers.get('cookie'), 'WorkosCursorSessionToken=fixture-cookie');
+            assert.equal(headers.get('accept'), 'application/json');
+            assert.equal(headers.get('authorization'), null);
+            assert.ok(!JSON.stringify(result).includes('fixture-cookie'));
+        });
+        for (const status of [401, 403]) await t.test(`expired cookie ${status} keeps native status`, async () => {
+            cliAuthenticated = true;
+            response = () => new Response('', { status });
+            const result = await fetchCursorUsage('fixture-cursor');
+            assert.equal(result.authenticated, true);
+            assert.equal(result.dashboardAuth, false);
+            assert.equal(result.quotaCapable, false);
+        });
+        for (const malformed of [null, [], true]) await t.test(`invalid root ${JSON.stringify(malformed)}`, async () => {
+            response = () => Response.json(malformed);
+            assert.deepEqual(await fetchCursorDashboardUsage('fixture-cookie'), { error: true });
+        });
+        for (const kind of ['503', 'malformed', 'oversize', 'throw'] as const) await t.test(kind, async () => {
+            response = () => {
+                if (kind === '503') return new Response('', { status: 503 });
+                if (kind === 'malformed') return new Response('{');
+                if (kind === 'oversize') return new Response('{}', { headers: { 'content-length': String(512 * 1024 + 1) } });
+                throw new Error('fixture failure');
+            };
+            const result = await fetchCursorUsage('fixture-cursor');
+            assert.equal(result.reason, 'dashboard_fetch_failed');
+            assert.equal(result.error, true);
+        });
+        assert.ok(calls.every(call => call.url === 'https://cursor.com/api/usage-summary'));
+        await t.test('native platform paths and selected store only', async () => {
+            assert.equal(getCursorNativeAuthPath('darwin', '/fixture/home', {}), '/fixture/home/.cursor/auth.json');
+            assert.equal(getCursorNativeAuthPath('linux', '/fixture/home', {}), '/fixture/home/.config/cursor/auth.json');
+            assert.equal(getCursorNativeAuthPath('linux', '/fixture/home', { XDG_CONFIG_HOME: '/fixture/xdg' }), '/fixture/xdg/cursor/auth.json');
+            assert.equal(getCursorNativeAuthPath('win32', 'C:/Users/fixture', { APPDATA: 'C:/fixture/roaming' }),
+                String.raw`C:\fixture\roaming\Cursor\auth.json`);
+            assert.equal(await readCursorNativeAccessToken({ env: { CURSOR_AUTH_TOKEN: ' fixture-direct ',
+                AGENT_CLI_CREDENTIAL_STORE: 'memory' } }), 'fixture-direct');
+            assert.equal(await readCursorNativeAccessToken({ env: { AGENT_CLI_CREDENTIAL_STORE: 'memory',
+                CURSOR_API_KEY: 'fixture-api-key' } }), null);
+            const diskPaths: string[] = [];
+            let disk = JSON.stringify({ accessToken: 'fixture-file', refreshToken: 'must-not-return', apiKey: 'not-bearer' });
+            const diskMock = t.mock.method(fs, 'readFileSync', ((path: unknown) => {
+                diskPaths.push(String(path)); return disk;
+            }) as typeof fs.readFileSync);
+            try {
+                const options = { platform: 'linux' as const, homeDir: '/fixture/home', env: {} };
+                assert.equal(await readCursorNativeAccessToken(options), 'fixture-file');
+                assert.deepEqual(diskPaths, ['/fixture/home/.config/cursor/auth.json']);
+                for (const malformed of ['{', '[]', 'null', '{"accessToken":42}', '{"accessToken":"  "}', '{"apiKey":"fixture-key"}']) {
+                    disk = malformed;
+                    assert.equal(await readCursorNativeAccessToken(options), null);
+                }
+                diskPaths.length = 0;
+                keychainStderr = 'password: "fixture-keychain"';
+                assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: {} }), 'fixture-keychain');
+                keychainStderr = 'password: 0x666978747572652d686578';
+                assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: {} }), 'fixture-hex');
+                keychainStderr = 'unrelated "metadata"';
+                assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: {} }), null);
+                assert.equal(diskPaths.length, 0); // default macOS never falls through to stale file
+            } finally { diskMock.mock.restore(); }
+        });
+        await t.test('API key override suppresses stale login; direct token still wins; cookie independent', async () => {
+            let storageReads = 0;
+            const staleRead = t.mock.method(fs, 'readFileSync', (() => {
+                storageReads += 1;
+                return JSON.stringify({ accessToken: 'fixture-stale-login' });
+            }) as typeof fs.readFileSync);
+            const beforeKeychain = keychainCalls;
+            calls.length = 0;
+            try {
+                for (const platform of ['darwin', 'linux', 'win32'] as const) {
+                    for (const store of ['default', 'file']) {
+                        assert.equal(await readCursorNativeAccessToken({ platform, homeDir: '/fixture/home',
+                            env: { CURSOR_API_KEY: ' fixture-api-override ', AGENT_CLI_CREDENTIAL_STORE: store } }), null);
+                    }
+                }
+                assert.equal(await readCursorNativeAccessToken({ env: {
+                    CURSOR_AUTH_TOKEN: 'fixture-direct-wins', CURSOR_API_KEY: 'fixture-api-override',
+                } }), 'fixture-direct-wins');
+                assert.equal(storageReads, 0);
+                assert.equal(keychainCalls, beforeKeychain);
+                assert.equal(calls.length, 0);
+                process.env['CURSOR_API_KEY'] = 'fixture-api-override';
+                delete process.env['CURSOR_AUTH_TOKEN'];
+                process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'file';
+                // Explicit cookie bypasses cookie-file lookup and remains a separate quota source.
+                process.env['CURSOR_SESSION_TOKEN'] = 'fixture-cookie';
+                response = () => Response.json({ individualUsage: { plan: { totalPercentUsed: 7 } } });
+                const result = await fetchCursorUsage('fixture-cursor');
+                assert.equal(result.quotaSource, 'cursor-dashboard-unofficial-api');
+                assert.deepEqual(calls.map(call => call.url), ['https://cursor.com/api/usage-summary']);
+                assert.equal(new Headers(calls[0]?.init?.headers).get('authorization'), null);
+                assert.equal(storageReads, 0);
+                assert.equal(keychainCalls, beforeKeychain);
+            } finally {
+                staleRead.mock.restore();
+                delete process.env['CURSOR_API_KEY'];
+                process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'memory';
+            }
+        });
+        await t.test('native primary total and zero pools match reference', async () => {
+            assert.deepEqual(normalizeCursorPeriodUsage({ planUsage: { totalPercentUsed: 15.48,
+                includedSpend: 23222, limit: 40000, autoPercentUsed: 0, apiPercentUsed: 46.444 },
+                billingCycleEnd: '1771077734000' })?.windows, [
+                { label: 'Cycle', percent: 15.48, resetsAt: new Date(1771077734000).toISOString() },
+                { label: 'First-party models', percent: 0, resetsAt: new Date(1771077734000).toISOString() },
+                { label: 'API usage', percent: 46.444, resetsAt: new Date(1771077734000).toISOString() },
+            ]);
+            assert.deepEqual(normalizeCursorAuthUsage({ 'gpt-4': { numRequests: 150, maxRequestUsage: 500 },
+                startOfMonth: '2026-12-31T00:00:00Z' })?.windows,
+                [{ label: 'Cycle', percent: 30, resetsAt: '2027-01-31T00:00:00.000Z' }]);
+        });
+        for (const stage of [0, 1, 2]) await t.test(`reachable native success stage ${stage}`, async () => {
+            process.env['CURSOR_AUTH_TOKEN'] = 'fixture-native';
+            cliAuthenticated = false;
+            calls.length = 0;
+            const urls = ['https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage',
+                'https://api2.cursor.sh/api/usage/summary', 'https://api2.cursor.sh/auth/usage'];
+            const payloads = [{ planUsage: { totalPercentUsed: 25 } },
+                { individualUsage: { plan: { used: 25, limit: 100 } } },
+                { 'gpt-4': { numRequests: 1, maxRequestUsage: 4 } }];
+            response = () => calls.length - 1 === stage ? Response.json(payloads[stage]) : new Response('{');
+            const result = await fetchCursorUsage('fixture-cursor');
+            assert.equal(result.authenticated, true);
+            assert.equal(result.quotaCapable, true);
+            assert.deepEqual(calls.map(c => c.url), urls.slice(0, stage + 1));
+            for (const [index, call] of calls.entries()) {
+                const headers = new Headers(call.init?.headers);
+                assert.equal(headers.get('authorization'), 'Bearer fixture-native');
+                assert.equal(headers.get('cookie'), null);
+                assert.equal(headers.get('user-agent'), 'cli-jaw-quota');
+                assert.equal(headers.get('accept'), 'application/json');
+                assert.equal(call.init?.redirect, 'error');
+                assert.equal(call.init?.method, index === 0 ? 'POST' : 'GET');
+                assert.equal(call.init?.body, index === 0 ? '{}' : undefined);
+                assert.equal(headers.get('connect-protocol-version'), index === 0 ? '1' : null);
+            }
+            assert.ok(!JSON.stringify(result).includes('fixture-native'));
+        });
+        await t.test('three native failures use existing explicit cookie fallback', async () => {
+            calls.length = 0;
+            response = () => calls.at(-1)?.url === 'https://cursor.com/api/usage-summary'
+                ? Response.json({ individualUsage: { plan: { totalPercentUsed: 12 } } })
+                : new Response('', { status: 503 });
+            const result = await fetchCursorUsage('fixture-cursor');
+            assert.equal(result.quotaSource, 'cursor-dashboard-unofficial-api');
+            assert.equal(calls.length, 4);
+            assert.equal(new Headers(calls.at(-1)?.init?.headers).get('authorization'), null);
+        });
+
+        await t.test('native period aliases, computed precedence and partial pools', () => {
+            const first = (plan: Record<string, unknown>) =>
+                (normalizeCursorPeriodUsage({ planUsage: plan })?.windows as Window[] | undefined)?.[0]?.percent;
+            for (const limit of ['limit', 'limitCents', 'totalLimitCents']) {
+                for (const used of ['includedSpend', 'usedCents', 'used']) assert.equal(first({ [limit]: '100', [used]: '30' }), 30);
+                for (const remaining of ['remaining', 'remainingCents']) assert.equal(first({ [limit]: 100, [remaining]: 40 }), 60);
+            }
+            assert.equal(first({ limit: 100, includedSpend: 10, usedCents: 20, used: 30, remaining: 40, totalSpend: 80 }), 10);
+            assert.equal(first({ limit: 100, remaining: 40, totalSpend: 80 }), 60);
+            assert.equal(first({ limit: 100, totalSpend: 80 }), 80);
+            assert.equal(first({ limit: 100, remaining: 150 }), 0);
+            assert.equal(first({ percentUsed: '13.7' }), 13.7);
+            assert.equal(first({ totalPercentUsed: 15, percentUsed: 40 }), 15);
+            assert.equal(first({ totalPercentUsed: 'bad', limit: 100, includedSpend: 27 }), 27);
+            assert.equal(first({ totalPercentUsed: 200 }), 100);
+            assert.equal(first({ totalPercentUsed: -10 }), 0);
+            assert.equal(first({ limit: 0, includedSpend: 0 }), undefined);
+            assert.equal(first({ limit: 100, includedSpend: {} }), undefined);
+            assert.deepEqual(normalizeCursorPeriodUsage({ planUsage: { autoPercentUsed: 0, apiPercentUsed: 12 } })?.windows,
+                [{ label: 'First-party models', percent: 0, resetsAt: null }, { label: 'API usage', percent: 12, resetsAt: null }]);
+            for (const body of [{ planUsage: { totalPercentUsed: 1, billingCycleEnd: 1771077734000 } },
+                { planUsage: { totalPercentUsed: 1 }, periodEnd: 1771077734 }]) {
+                assert.equal((normalizeCursorPeriodUsage(body)?.windows as Window[])[0]!.resetsAt, '2026-02-14T14:02:14.000Z');
+            }
+            for (const parser of [normalizeCursorPeriodUsage, normalizeCursorNativeSummary, normalizeCursorAuthUsage]) {
+                for (const invalid of [null, [], true, 'body', {}, { planUsage: [] }]) assert.equal(parser(invalid), null);
+            }
+        });
+        await t.test('native summary total and auth bucket selection are independent', () => {
+            const result = normalizeCursorNativeSummary({ individualUsage: { plan: { totalPercentUsed: '12.5', used: 99, limit: 100 } } });
+            assert.equal((result?.windows as Window[])[0]!.percent, 12.5);
+            assert.equal(normalizeCursorNativeSummary({ individualUsage: { plan: { apiPercentUsed: 99 } } }), null);
+            const meter = (body: unknown) => (normalizeCursorAuthUsage(body)?.windows as Window[] | undefined)?.[0];
+            assert.equal(meter({ other: { used: 80, limit: 100 }, 'gpt-4': { numRequests: 2, maxRequestUsage: 10 } })?.percent, 20);
+            assert.equal(meter({ 'gpt-4': { used: 50, limit: 0 }, invalid: { used: 4 }, other: { used: 3, maxRequests: '10' } })?.percent, 30);
+            assert.equal(meter({ startOfMonth: { used: 1, limit: 2 }, billingCycleStart: { used: 1, limit: 2 } }), undefined);
+            assert.equal(meter({ model: { used: 1, limit: 4 }, startOfMonth: '2026-01-31T12:45:00Z' })?.resetsAt, '2026-03-03T00:00:00.000Z');
+            assert.equal(meter({ model: { used: 1, limit: 4 }, startOfMonth: 'garbage' })?.resetsAt, null);
+        });
+        await t.test('empty cookie response differs from valid zero quota', () => {
+            const empty = normalizeCursorUsageSummary({});
+            assert.equal(empty.authenticated, true);
+            assert.equal(empty.quotaCapable, false);
+            assert.deepEqual(empty.windows, []);
+            assert.deepEqual(summarize({ totalPercentUsed: 0 }, 'bad').windows, [{ label: 'Cycle', percent: 0, resetsAt: null }]);
+        });
+        await t.test('file and Keychain source failures do not fall through or write', async () => {
+            let reads = 0;
+            const fileMock = t.mock.method(fs, 'readFileSync', (() => { reads += 1; throw new Error('fixture missing'); }) as typeof fs.readFileSync);
+            const before = keychainCalls;
+            try {
+                assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: { AGENT_CLI_CREDENTIAL_STORE: 'file' } }), null);
+                assert.equal(reads, 1);
+                assert.equal(keychainCalls, before);
+                reads = 0;
+                keychainError = new Error('fixture keychain locked');
+                assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: {} }), null);
+                assert.equal(reads, 0);
+                const security = cliCalls.at(-1)!;
+                assert.equal(security.binary, '/usr/bin/security');
+                assert.deepEqual(security.args, ['find-generic-password', '-a', 'cursor-user', '-s', 'cursor-access-token', '-g']);
+                assert.equal(security.options.timeout, 5000);
+                assert.equal(security.options.maxBuffer, 64 * 1024);
+                keychainError = undefined;
+                for (const malformed of ['password: 0xabc', 'password: ""', 'metadata: "private"']) {
+                    keychainStderr = malformed;
+                    assert.equal(await readCursorNativeAccessToken({ platform: 'darwin', env: {} }), null);
+                }
+                assert.equal(reads, 0);
+            } finally { fileMock.mock.restore(); keychainError = undefined; }
+        });
+        await t.test('cookie precedence uses env then quota file then settings, without native token conversion', () => {
+            delete process.env['CURSOR_AUTH_TOKEN'];
+            delete process.env['CURSOR_SESSION_TOKEN'];
+            process.env['CURSOR_DASHBOARD_SESSION_TOKEN'] = 'dashboard-env';
+            let quotaFile = true;
+            const reads: string[] = [];
+            const fileMock = t.mock.method(fs, 'readFileSync', ((file: unknown) => {
+                reads.push(String(file));
+                if (String(file).endsWith('cursor-session-token')) {
+                    if (quotaFile) return ' quota-file ';
+                    throw new Error('fixture missing');
+                }
+                assert.ok(String(file).endsWith('settings.json'));
+                return JSON.stringify({ quota: { cursorSessionToken: 'settings-cookie' } });
+            }) as typeof fs.readFileSync);
+            try {
+                assert.equal(readCursorDashboardSessionToken(), 'dashboard-env');
+                process.env['CURSOR_SESSION_TOKEN'] = 'primary-env';
+                assert.equal(readCursorDashboardSessionToken(), 'primary-env');
+                assert.equal(reads.length, 0);
+                delete process.env['CURSOR_SESSION_TOKEN'];
+                delete process.env['CURSOR_DASHBOARD_SESSION_TOKEN'];
+                assert.equal(readCursorDashboardSessionToken(), 'quota-file');
+                quotaFile = false;
+                assert.equal(readCursorDashboardSessionToken(), 'settings-cookie');
+            } finally { fileMock.mock.restore(); process.env['CURSOR_SESSION_TOKEN'] = 'fixture-cookie'; }
+        });
+        await t.test('API-key-only source makes no native request even with stale file; missing sources stay status-only', async () => {
+            delete process.env['CURSOR_AUTH_TOKEN'];
+            delete process.env['CURSOR_SESSION_TOKEN'];
+            delete process.env['CURSOR_DASHBOARD_SESSION_TOKEN'];
+            process.env['CURSOR_API_KEY'] = 'api-override';
+            process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'file';
+            const reads: string[] = [];
+            const fileMock = t.mock.method(fs, 'readFileSync', ((file: unknown) => {
+                reads.push(String(file));
+                if (String(file).endsWith('auth.json')) return '{"accessToken":"stale"}';
+                throw new Error('fixture absent cookie');
+            }) as typeof fs.readFileSync);
+            const before = keychainCalls;
+            calls.length = 0;
+            try {
+                const result = await fetchCursorUsage('fixture-cursor');
+                assert.equal(result.authenticated, true);
+                assert.equal(result.quotaCapable, false);
+                assert.deepEqual(result.windows, []);
+                assert.equal(calls.length, 0);
+                assert.equal(reads.some(file => file.endsWith('auth.json')), false);
+                assert.equal(keychainCalls, before);
+                delete process.env['CURSOR_API_KEY'];
+                process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'memory';
+                cliAuthenticated = false;
+                const absent = await fetchCursorUsage('fixture-cursor');
+                assert.equal(absent.authenticated, false);
+                assert.deepEqual(absent.windows, []);
+                assert.equal(calls.length, 0);
+                process.env['CURSOR_AUTH_TOKEN'] = 'native-failed';
+                response = () => new Response('', { status: 401 });
+                const failed = await fetchCursorUsage('fixture-cursor');
+                assert.equal(failed.reason, 'native_quota_unavailable');
+                assert.equal(failed.authenticated, false);
+                assert.equal(calls.length, 3);
+            } finally { fileMock.mock.restore(); process.env['CURSOR_SESSION_TOKEN'] = 'fixture-cookie'; }
+        });
+        for (const kind of ['declared', 'chunked', 'stall', '401', '403', '429', 'throw', 'empty'] as const) {
+            await t.test(`native ${kind} failure reaches summary`, async () => {
+                calls.length = 0;
+                process.env['CURSOR_AUTH_TOKEN'] = 'fixture-native';
+                let canceled = 0;
+                const realTimeout = globalThis.setTimeout;
+                const timeoutMock = kind === 'stall' ? t.mock.method(globalThis, 'setTimeout',
+                    ((fn: (...args: unknown[]) => void, ms?: number, ...args: unknown[]) => realTimeout(fn, ms === 8000 ? 5 : ms, ...args)) as typeof setTimeout) : null;
+                response = () => {
+                    if (calls.at(-1)?.url.endsWith('/api/usage/summary')) return Response.json({ individualUsage: { plan: { totalPercentUsed: 42 } } });
+                    if (kind === 'throw') throw new Error('fixture request failed');
+                    if (kind === 'empty') return Response.json({});
+                    if (kind === '401' || kind === '403' || kind === '429') return new Response('', { status: Number(kind) });
+                    return new Response(new ReadableStream<Uint8Array>({
+                        start(controller) { if (kind === 'chunked') controller.enqueue(new Uint8Array(512 * 1024 + 1)); },
+                        cancel() { canceled += 1; },
+                    }), kind === 'declared' ? { headers: { 'content-length': String(512 * 1024 + 1) } } : {});
+                };
+                try {
+                    const result = await fetchCursorUsage('fixture-cursor');
+                    assert.equal(result.quotaSource, 'cursor:usage-summary');
+                    assert.equal(calls.length, 2);
+                    if (['declared', 'chunked', 'stall'].includes(kind)) assert.equal(canceled, 1);
+                } finally { timeoutMock?.mock.restore(); }
+            });
+        }
+        await t.test('native secondary-only zero stops fallback and rereads file token on the next call', async () => {
+            delete process.env['CURSOR_AUTH_TOKEN'];
+            process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'file';
+            let token = 'file-generation-one';
+            const fileMock = t.mock.method(fs, 'readFileSync', (() => JSON.stringify({ accessToken: token })) as typeof fs.readFileSync);
+            calls.length = 0;
+            response = () => Response.json({ planUsage: { autoPercentUsed: 0 } });
+            try {
+                assert.equal((await fetchCursorUsage('fixture-cursor')).quotaSource, 'cursor:period-usage');
+                token = 'file-generation-two';
+                await fetchCursorUsage('fixture-cursor');
+                assert.equal(calls.length, 2);
+                assert.deepEqual(calls.map(c => new Headers(c.init?.headers).get('authorization')),
+                    ['Bearer file-generation-one', 'Bearer file-generation-two']);
+            } finally { fileMock.mock.restore(); process.env['AGENT_CLI_CREDENTIAL_STORE'] = 'memory'; }
+        });
+    } finally {
+        globalThis.fetch = originalFetch;
+        if (oldSession === undefined) delete process.env['CURSOR_SESSION_TOKEN'];
+        else process.env['CURSOR_SESSION_TOKEN'] = oldSession;
+        if (oldDashboard === undefined) delete process.env['CURSOR_DASHBOARD_SESSION_TOKEN'];
+        else process.env['CURSOR_DASHBOARD_SESSION_TOKEN'] = oldDashboard;
+        if (oldKey === undefined) delete process.env['CURSOR_API_KEY'];
+        else process.env['CURSOR_API_KEY'] = oldKey;
+        if (oldAuth === undefined) delete process.env['CURSOR_AUTH_TOKEN'];
+        else process.env['CURSOR_AUTH_TOKEN'] = oldAuth;
+        if (oldStore === undefined) delete process.env['AGENT_CLI_CREDENTIAL_STORE'];
+        else process.env['AGENT_CLI_CREDENTIAL_STORE'] = oldStore;
+        t.mock.restoreAll();
+    }
+});


### PR DESCRIPTION
Cursor quota currently requires a dashboard cookie despite a native authenticated session. Read the native selected credential store and current period/summary/legacy usage endpoints, preserving total/secondary pools and reset units. Direct auth token takes precedence; an API-key override prevents quota reads from an unrelated saved OAuth account. Retain explicitly configured dashboard-cookie fallback with separate source metadata.

Validation: 36 native/cookie/parser tests pass; server build passes; independent source/security review PASS. Native store behavior is grounded in installed Cursor 2026.09.02-c22c1a3 source, usage semantics in OpenCodex b94051fe. No token refresh, key exchange or credential writes added.

Stack: #569 → #570 → #571 → #572 → this Cursor layer → Kiro/AGY → integration. Depends on #572; merge bottom-up.
