### PR TITLE
fix(quota): upgrade Kiro management quota and native selection

### DIFF
--- a/src/agent/kiro-auth.ts
+++ b/src/agent/kiro-auth.ts
@@ -63,6 +63,67 @@ export function readKiroAuthFromStore(dataPath = resolveKiroDataPath()): {
     }
 }
 
+export interface KiroQuotaToken extends KiroSocialToken {
+    apiRegion?: string;
+    ssoRegion?: string;
+}
+
+/** Read-only quota selection adapted from OpenCodex oauth/kiro-credentials.ts
+ * b94051fe91e745806102988f6dff2fec8de078ef (MIT; see LICENSE).
+ * The runtime social-token reader above intentionally retains its original contract.
+ */
+export function readKiroQuotaAuthFromStore(dataPath = resolveKiroDataPath()): {
+    token: KiroQuotaToken | null; profile: KiroProfile | null; reason?: string;
+} {
+    const missing = (reason: string) => ({ token: null, profile: null, reason });
+    let db: Database.Database | undefined;
+    try {
+        db = new Database(dataPath, { readonly: true, fileMustExist: true });
+        const store = db;
+        return store.transaction(() => {
+            const rows = store.prepare("SELECT key, value FROM auth_kv WHERE key LIKE ? ORDER BY key ASC")
+                .all('%:token') as Array<{ key: string; value: string | Buffer }>;
+            const selected = process.env['KIROCLI_TOKEN_KEY']?.trim();
+            const priorities = ['kirocli:odic:token', 'kirocli:oidc:token', 'kirocli:social:token', 'codewhisperer:odic:token'];
+            const row = selected ? rows.find(entry => entry.key === selected)
+                : priorities.map(key => rows.find(entry => entry.key === key)).find(Boolean)
+                    ?? (rows.length === 1 ? rows[0] : undefined);
+            if (!row) return missing(selected ? 'kiro_token_key_missing'
+                : rows.length > 1 ? 'kiro_token_ambiguous' : 'kiro_token_missing');
+            const raw = typeof row.value === 'string' ? row.value : row.value.toString('utf8');
+            const data: unknown = JSON.parse(raw);
+            if (!data || typeof data !== 'object' || Array.isArray(data)) return missing('kiro_token_invalid');
+            const record = data as Record<string, unknown>;
+            const field = (...keys: string[]): string | undefined => keys.map(key => record[key])
+                .find((value): value is string => typeof value === 'string' && !!value.trim())?.trim();
+            const accessToken = field('accessToken', 'access_token');
+            if (!accessToken) return missing('kiro_token_invalid');
+            const token: KiroQuotaToken = { accessToken };
+            const profileArn = field('profileArn', 'profile_arn');
+            const apiRegion = field('apiRegion', 'api_region');
+            const ssoRegion = field('region');
+            if (profileArn) token.profileArn = profileArn;
+            if (apiRegion) token.apiRegion = apiRegion;
+            if (ssoRegion) token.ssoRegion = ssoRegion;
+            const profileRaw = readKv(store, 'state', 'api.codewhisperer.profile');
+            let profile: KiroProfile | null = null;
+            if (profileRaw) {
+                let state: unknown;
+                try { state = JSON.parse(profileRaw); }
+                catch { /* Optional profile corruption must not discard the selected access token. */ }
+                if (state && typeof state === 'object' && !Array.isArray(state)) {
+                    const rec = state as Record<string, unknown>;
+                    const arn = [rec['arn'], rec['profileArn'], rec['profile_arn']]
+                        .find((value): value is string => typeof value === 'string' && !!value.trim());
+                    if (arn) profile = { arn: arn.trim(), ...(typeof rec['name'] === 'string' ? { name: rec['name'] } : {}) };
+                }
+            }
+            return { token, profile };
+        })();
+    } catch { return missing('kiro_auth_store_unavailable'); }
+    finally { db?.close(); }
+}
+
 function parseKiroSocialToken(raw: string | null): KiroSocialToken | null {
     if (!raw?.trim()) return null;
     try {

--- a/src/routes/quota-kiro-reverse.ts
+++ b/src/routes/quota-kiro-reverse.ts
@@ -3,133 +3,91 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import {
-    readKiroAuthFromStore,
-    regionFromProfileArn,
+    readKiroQuotaAuthFromStore,
     resolveKiroProfileArn,
 } from '../agent/kiro-auth.js';
 import { detectCli } from '../core/cli-detection.js';
 import { stripUndefined } from '../core/strip-undefined.js';
+import { asQuotaRecord as asRecord, quotaNumber, quotaPercent, quotaResetIso, readQuotaJson } from './quota-wire.js';
 
 const execFileAsync = promisify(execFile);
 
 type QuotaRecord = Record<string, unknown>;
 
-interface KiroUsageBreakdown {
-    displayName?: string;
-    displayNamePlural?: string;
-    currentUsage?: number;
-    currentUsageWithPrecision?: number;
-    usageLimit?: number;
-    usageLimitWithPrecision?: number;
-    nextDateReset?: number;
-    currentOverages?: number;
-    overageCap?: number;
-    resourceType?: string;
+function textField(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-interface KiroUsageLimitsResponse {
-    daysUntilReset?: number;
-    nextDateReset?: number;
-    subscriptionInfo?: {
-        subscriptionTitle?: string;
-        type?: string;
-        overageCapability?: string;
-    };
-    usageBreakdownList?: KiroUsageBreakdown[];
-    limits?: Array<{
-        type?: string;
-        currentUsage?: number;
-        totalUsageLimit?: number;
-        percentUsed?: number;
-    }>;
+function allowance(row: QuotaRecord | null) {
+    if (!row) return null;
+    const used = quotaNumber(row['currentUsageWithPrecision']) ?? quotaNumber(row['currentUsage']);
+    const limit = quotaNumber(row['usageLimitWithPrecision']) ?? quotaNumber(row['usageLimit']);
+    if (used === undefined || used < 0 || limit === undefined || limit <= 0) return null;
+    const percent = quotaPercent(used / limit * 100);
+    return percent === undefined ? null : { used, limit, percent };
 }
 
-function asRecord(value: unknown): QuotaRecord | null {
-    return value && typeof value === 'object' && !Array.isArray(value)
-        ? value as QuotaRecord
-        : null;
-}
-
-function numberField(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function isoFromEpochSeconds(value: unknown): string | null {
-    const seconds = numberField(value);
-    if (seconds == null) return null;
-    const ms = seconds > 1e12 ? seconds : seconds * 1000;
-    const date = new Date(ms);
-    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function usedPercent(current?: number, limit?: number): number {
-    if (current == null || limit == null || limit <= 0) return 0;
-    return Math.max(0, Math.min(100, Math.round((current / limit) * 100)));
-}
-
-export function normalizeKiroUsageLimits(data: KiroUsageLimitsResponse): QuotaRecord {
-    const windows: Array<{ label: string; percent: number; resetsAt?: string | null }> = [];
-    const subscription = data.subscriptionInfo || {};
-    const resetsAt = isoFromEpochSeconds(data.nextDateReset);
-
-    for (const breakdown of data.usageBreakdownList || []) {
-        const current = breakdown.currentUsageWithPrecision ?? breakdown.currentUsage;
-        const limit = breakdown.usageLimitWithPrecision ?? breakdown.usageLimit;
-        const label = breakdown.displayName || breakdown.resourceType || 'Usage';
-        if (current == null && limit == null) continue;
-        windows.push(stripUndefined({
-            label,
-            percent: usedPercent(current, limit),
-            resetsAt: isoFromEpochSeconds(breakdown.nextDateReset) ?? resetsAt,
-        }) as { label: string; percent: number; resetsAt?: string | null });
+/** Allowance selection adapted from OpenCodex providers/kiro-usage.ts,
+ * b94051fe91e745806102988f6dff2fec8de078ef (MIT; see LICENSE).
+ */
+export function normalizeKiroUsageLimits(value: unknown): QuotaRecord {
+    const data = asRecord(value);
+    if (!data) return { error: true, reason: 'kiro_usage_parse_failed', quotaCapable: false, windows: [] };
+    const windows: Array<{ label: string; percent: number; resetsAt: string | null }> = [];
+    const subscription = asRecord(data['subscriptionInfo']);
+    const resetsAt = quotaResetIso(data['nextDateReset']);
+    const list = Array.isArray(data['usageBreakdownList']) ? data['usageBreakdownList'].map(asRecord) : [];
+    const selected = ['AGENTIC_REQUEST', 'CREDIT'].map(type => list.find(row =>
+        textField(row?.['resourceType'])?.toUpperCase() === type)).find(Boolean) ?? null;
+    const primary = allowance(selected);
+    const overageStatus = textField(asRecord(data['overageConfiguration'])?.['overageStatus']);
+    if (primary && selected) {
+        windows.push({ label: textField(selected['displayName']) || textField(selected['resourceType']) || 'Usage',
+            percent: primary.percent, resetsAt: quotaResetIso(selected['nextDateReset']) ?? resetsAt });
+        const trialRow = asRecord(selected['freeTrialInfo']);
+        const trial = allowance(trialRow);
+        if (trial) windows.push({ label: 'Free trial', percent: trial.percent, resetsAt: quotaResetIso(trialRow?.['nextDateReset']) });
+    } else if (!Object.hasOwn(data, 'usageBreakdownList') && Array.isArray(data['limits'])) {
+        for (const value of data['limits']) {
+            const row = asRecord(value);
+            if (!row) continue;
+            const current = quotaNumber(row['currentUsage']);
+            const limit = quotaNumber(row['totalUsageLimit']);
+            const percent = quotaPercent(row['percentUsed']) ??
+                (current !== undefined && current >= 0 && limit !== undefined && limit > 0 ? quotaPercent(current / limit * 100) : undefined);
+            if (percent !== undefined) windows.push({ label: textField(row['type']) || 'Usage', percent, resetsAt });
+        }
     }
-
-    for (const limit of data.limits || []) {
-        if (windows.length) break;
-        const label = limit.type || 'Usage';
-        const percent = numberField(limit.percentUsed);
-        windows.push(stripUndefined({
-            label,
-            percent: percent != null ? Math.round(percent) : usedPercent(limit.currentUsage, limit.totalUsageLimit),
-            resetsAt,
-        }) as { label: string; percent: number; resetsAt?: string | null });
-    }
-
-    const primaryBreakdown = data.usageBreakdownList?.[0];
-    const subscriptionTitle = subscription.subscriptionTitle;
-    const subscriptionType = subscription.type;
-
+    const title = textField(subscription?.['subscriptionTitle']);
+    const type = textField(subscription?.['type']);
     return stripUndefined({
-        authenticated: true,
-        quotaCapable: windows.length > 0,
+        authenticated: true, quotaCapable: windows.length > 0,
         quotaSource: 'kiro:codewhisperer-get-usage-limits',
-        displayTier: subscriptionTitle
-            ? `Kiro ${subscriptionTitle}`
-            : subscriptionType
-                ? `Kiro ${subscriptionType}`
-                : 'Kiro',
-        account: stripUndefined({
-            type: 'kiro',
-            tier: subscriptionTitle || subscriptionType || 'authenticated',
-            plan: subscriptionType,
-        }),
-        windows,
-        daysUntilReset: data.daysUntilReset,
-        nextDateReset: resetsAt,
-        currentUsage: primaryBreakdown?.currentUsageWithPrecision ?? primaryBreakdown?.currentUsage,
-        usageLimit: primaryBreakdown?.usageLimitWithPrecision ?? primaryBreakdown?.usageLimit,
-        usageUnit: primaryBreakdown?.displayNamePlural || primaryBreakdown?.displayName,
-        overageStatus: asRecord(primaryBreakdown as unknown)?.['overageStatus'],
+        displayTier: title || type ? `Kiro ${title || type}` : 'Kiro',
+        account: stripUndefined({ type: 'kiro', tier: title || type || 'authenticated', plan: type }),
+        windows, daysUntilReset: quotaNumber(data['daysUntilReset']), nextDateReset: resetsAt,
+        currentUsage: primary?.used, usageLimit: primary?.limit,
+        usageUnit: primary ? textField(selected?.['displayNamePlural']) || textField(selected?.['displayName']) : undefined,
+        overageStatus, exhausted: primary ? primary.used >= primary.limit && overageStatus?.toUpperCase() !== 'ENABLED' : undefined,
         reverseEngineered: true,
     });
 }
 
+function kiroUsageRegion(profileArn?: string, regions?: { apiRegion?: string; ssoRegion?: string }): string {
+    return [profileArn?.split(':')[3], regions?.apiRegion, regions?.ssoRegion]
+        .find((region): region is string => !!region && /^[a-z0-9-]{1,32}$/.test(region)) ?? 'us-east-1';
+}
+
 export async function fetchKiroUsageLimits(
     accessToken: string,
-    profileArn: string,
-): Promise<KiroUsageLimitsResponse | QuotaRecord> {
-    const region = regionFromProfileArn(profileArn);
-    const url = `https://codewhisperer.${region}.amazonaws.com/`;
+    profileArn?: string,
+    regions?: { apiRegion?: string; ssoRegion?: string },
+): Promise<unknown> {
+    const region = kiroUsageRegion(profileArn, regions);
+    const url = new URL(`https://management.${region}.kiro.dev/`);
+    url.searchParams.set('origin', 'AI_EDITOR');
+    url.searchParams.set('isEmailRequired', 'true');
+    if (profileArn) url.searchParams.set('profileArn', profileArn);
 
     try {
         const resp = await fetch(url, {
@@ -139,17 +97,20 @@ export async function fetchKiroUsageLimits(
                 'Content-Type': 'application/x-amz-json-1.0',
                 Accept: 'application/json',
                 'X-Amz-Target': 'AmazonCodeWhispererService.GetUsageLimits',
+                'x-amzn-codewhisperer-optout': 'true',
             },
-            body: JSON.stringify({ profileArn }),
-            signal: AbortSignal.timeout(12000),
+            body: JSON.stringify({ origin: 'AI_EDITOR', isEmailRequired: true, ...(profileArn ? { profileArn } : {}) }),
+            redirect: 'error',
+            signal: AbortSignal.timeout(8000),
         });
 
+        if (!resp.ok) void resp.body?.cancel().catch(() => undefined);
         if (resp.status === 401 || resp.status === 403) {
             return { authenticated: false, reason: 'kiro_token_expired' };
         }
         if (!resp.ok) return { error: true, reason: `kiro_usage_http_${resp.status}` };
 
-        return await resp.json() as KiroUsageLimitsResponse;
+        return await readQuotaJson(resp);
     } catch {
         return { error: true, reason: 'kiro_usage_fetch_failed' };
     }
@@ -173,14 +134,15 @@ async function readKiroWhoamiEmail(binary?: string): Promise<string | undefined>
 
 export async function fetchKiroUsage(binary?: string): Promise<QuotaRecord> {
     const resolvedBinary = binary || detectCli('kiro-code').path;
-    const { token, profile } = readKiroAuthFromStore();
+    const { token, profile, reason: authReason } = readKiroQuotaAuthFromStore();
     const profileArn = resolveKiroProfileArn(token, profile);
 
-    if (!token?.accessToken || !profileArn) {
+    if (!token?.accessToken) {
         return stripUndefined({
             authenticated: false,
             quotaCapable: false,
             quotaSource: 'kiro:auth-store-missing',
+            reason: authReason,
             displayTier: 'Kiro',
             account: { type: 'kiro', tier: 'not logged in' },
             windows: [],
@@ -188,7 +150,7 @@ export async function fetchKiroUsage(binary?: string): Promise<QuotaRecord> {
     }
 
     const [usageResult, email] = await Promise.all([
-        fetchKiroUsageLimits(token.accessToken, profileArn),
+        fetchKiroUsageLimits(token.accessToken, profileArn ?? undefined, token),
         readKiroWhoamiEmail(resolvedBinary || undefined),
     ]);
 
@@ -227,7 +189,7 @@ export async function fetchKiroUsage(binary?: string): Promise<QuotaRecord> {
         });
     }
 
-    const normalized = normalizeKiroUsageLimits(usageResult as KiroUsageLimitsResponse);
+    const normalized = normalizeKiroUsageLimits(usageResult);
     return stripUndefined({
         ...normalized,
         account: {

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -325,7 +325,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 - `antigravity-usage --json`이 `remainingPercentage`를 정밀 소수점 대신 `0`/`1`로만 반환하면 AGY window는 `precision: "binary"`와 `status: "available" | "exhausted"`를 포함한다. backend의 `percent`는 호환 필드일 뿐이며, UI는 exact percent bar 대신 `Available` / `Exhausted` 상태 텍스트를 표시해야 한다. upstream이 다시 정밀 퍼센트를 주면 기존 fractional path가 그대로 사용된다.
 - `cursor` reads its selected native OAuth store (or direct auth token), probes period usage → summary → legacy usage, then retains explicitly configured dashboard-cookie fallback. An API-key override suppresses unrelated stored OAuth reads. Keychain/memory/file selection follows the native CLI; credentials are never returned in quota rows.
 - `grok` reads native OIDC key/user identity, then requests JSON `/v1/billing?format=credits` weekly usage. It preserves fractional and omitted-zero readings, with bounded gRPC weekly compatibility and validated monthly fallback. Each failed request is isolated; session usage remains separate.
-- `kiro-code`는 `src/routes/quota-kiro-reverse.ts`의 `fetchKiroUsage()`를 통해 CodeWhisperer `GetUsageLimits` API를 reverse-engineer 호출한다.
+- `kiro-code` reads a selected native social/OIDC token in a read-only SQLite snapshot and calls `management.<validated-region>.kiro.dev` GetUsageLimits. Profile is optional; malformed optional profile data does not discard a valid token. Allowance selection prefers AGENTIC_REQUEST then CREDIT and keeps free-trial pools separate.
 
 ### Wiki lifecycle ownership
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -152,7 +152,7 @@ cli-jaw/
 │   │   ├── pi-runtime.ts     ← Pi profile 정규화 + isolated `PI_CODING_AGENT_DIR` models/settings 생성 + `pi --offline --list-models` discovery + `pi --mode rpc` JSONL parser/spawner (1118L) ✨
 │   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1393L)
 │   │   ├── jwc-runtime.ts    ← resident/in-process JWC runtime bridge and event handling (222L)
-│   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (253L)
+│   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (314L)
 │   │   ├── kiro-models.ts    ← Kiro live model inventory (KiroModelEntry, KiroModelInventory, parseKiroModelListJson, fetchKiroModelInventory) (98L)
 │   │   ├── kiro-runtime.ts   ← Kiro plain-text stdout parser + session capture (isKiroPlainTextCli, processKiroStdoutChunk, flushKiroStdoutContext, appendKiroStdoutChunk, captureKiroSessionIdAfterExit, stripKiroAnsi, parseKiroAssistantText, isKiroStaleSessionOutput, isKiroResumeDegradedOutput, KiroStreamEvent, KiroStdoutContext) (460L)
 │   │   ├── cursor-runtime.ts ← Cursor CLI event adapter + session management (395L) ✨
@@ -397,7 +397,7 @@ cli-jaw/
 │   │   ├── quota.ts          ← Copilot/Claude/Codex/Grok/OpenCode quota helper readers + Grok weekly credits + credential-scoped Claude cache (634L)
 │   │   ├── quota-native-window.ts ← Codex duration-aware and Claude model-scoped quota parsers (122L)
 │   │   ├── quota-wire.ts ← Bounded upstream bodies, finite percentages and reset normalization (84L)
-│   │   ├── quota-kiro-reverse.ts ← Kiro/CodeWhisperer quota reader (239L)
+│   │   ├── quota-kiro-reverse.ts ← Kiro/CodeWhisperer quota reader (201L)
 │   │   ├── quota-agy-reverse.ts ← AGY reverse quota reader (153L)
 │   │   ├── quota-cursor-dashboard.ts ← Cursor dashboard quota reader (334L)
 │   │   ├── goal.ts           ← goal CRUD + kickGoalContinuation route (registerGoalRoutes) (183L)

--- a/tests/unit/quota-kiro-parity.test.ts
+++ b/tests/unit/quota-kiro-parity.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { mock } from 'node:test';
+
+// Never invoke a native CLI or probe the operator's installations.
+mock.module('node:child_process', { namedExports: { execFile: (...args: unknown[]) => {
+    const callback = args.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+    callback(null, 'fixture@example.test', '');
+} } });
+mock.module('../../src/core/cli-detection.js', { namedExports: { detectCli: () => ({ path: '/fixture/kiro' }) } });
+const { fetchKiroUsage, fetchKiroUsageLimits, normalizeKiroUsageLimits } = await import('../../src/routes/quota-kiro-reverse.js');
+const { readKiroQuotaAuthFromStore, readKiroAuthFromStore } = await import('../../src/agent/kiro-auth.js');
+
+const usage = { nextDateReset: 1788220800, overageConfiguration: { overageStatus: 'ENABLED' }, usageBreakdownList: [
+    { resourceType: 'STORAGE', currentUsage: 99, usageLimit: 100 },
+    { resourceType: 'CREDIT', currentUsage: 20, usageLimit: 100 },
+    { resourceType: 'AGENTIC_REQUEST', displayName: 'Requests', currentUsage: 99, currentUsageWithPrecision: '100.5', usageLimit: 100,
+        freeTrialInfo: { currentUsageWithPrecision: 5, usageLimitWithPrecision: 20 } },
+] };
+const json = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } });
+
+test('Kiro selects resource priority, precise values and independent trial/overage', () => {
+    const result = normalizeKiroUsageLimits(usage);
+    assert.deepEqual(result.windows, [
+        { label: 'Requests', percent: 100, resetsAt: '2026-09-01T00:00:00.000Z' },
+        { label: 'Free trial', percent: 25, resetsAt: null },
+    ]);
+    assert.equal(result.currentUsage, 100.5);
+    assert.equal(result.usageLimit, 100);
+    assert.equal(result.exhausted, false);
+    assert.equal(normalizeKiroUsageLimits({ ...usage, overageConfiguration: {} }).exhausted, true);
+    const justBelow = { usageBreakdownList: [{ resourceType: 'CREDIT', currentUsage: 99.9, usageLimit: 100 }] };
+    assert.equal(normalizeKiroUsageLimits(justBelow).exhausted, false);
+});
+
+test('Kiro malformed canonical data never becomes fabricated zero or legacy fallback', () => {
+    for (const list of [null, {}, [], [null], [{ resourceType: 'STORAGE', currentUsage: 1, usageLimit: 2 }],
+        [{ resourceType: 'CREDIT', currentUsage: 1 }], [{ resourceType: 'CREDIT', currentUsage: -1, usageLimit: 2 }],
+        [{ resourceType: 'CREDIT', currentUsage: 0, usageLimit: 0 }]]) {
+        const result = normalizeKiroUsageLimits({ usageBreakdownList: list, limits: [{ percentUsed: 99 }] });
+        assert.deepEqual(result.windows, []);
+        assert.equal(result.quotaCapable, false);
+        assert.equal(result.currentUsage, undefined);
+    }
+    assert.deepEqual(normalizeKiroUsageLimits({ limits: [{ percentUsed: '25', type: 'A' }, { currentUsage: 1, totalUsageLimit: 2, type: 'B' }] }).windows,
+        [{ label: 'A', percent: 25, resetsAt: null }, { label: 'B', percent: 50, resetsAt: null }]);
+});
+
+test('Kiro management request duplicates modeled fields and validates region candidates', async t => {
+    const calls: Array<{ url: URL; init: RequestInit }> = [];
+    t.mock.method(globalThis, 'fetch', async (input: URL, init: RequestInit) => {
+        calls.push({ url: new URL(input), init });
+        return json(usage);
+    });
+    const results = [
+        await fetchKiroUsageLimits('fixture-access', 'arn:aws:service:eu-west-2:acct:profile', { apiRegion: 'us-west-2' }),
+        await fetchKiroUsageLimits('fixture-access', 'arn:aws:service:evil.example/x:acct:p', { apiRegion: 'bad/host', ssoRegion: 'eu-west-1' }),
+        await fetchKiroUsageLimits('fixture-access', undefined, { apiRegion: 'evil@host', ssoRegion: '..' }),
+    ];
+    for (const result of results) {
+        assert.deepEqual(result, usage);
+        assert.equal(normalizeKiroUsageLimits(result).quotaCapable, true);
+    }
+    for (const { url, init } of calls) {
+        const headers = new Headers(init.headers);
+        assert.equal(headers.get('authorization'), 'Bearer fixture-access');
+        assert.equal(headers.get('x-amzn-codewhisperer-optout'), 'true');
+        assert.equal(headers.get('x-amz-target'), 'AmazonCodeWhispererService.GetUsageLimits');
+        assert.equal(init.redirect, 'error');
+        assert.deepEqual(JSON.parse(String(init.body)), { origin: 'AI_EDITOR', isEmailRequired: true,
+            ...(url.searchParams.has('profileArn') ? { profileArn: url.searchParams.get('profileArn') } : {}) });
+        assert.equal(url.searchParams.get('origin'), 'AI_EDITOR');
+        assert.equal(url.searchParams.get('isEmailRequired'), 'true');
+    }
+    assert.deepEqual(calls.map(call => call.url.hostname), ['management.eu-west-2.kiro.dev', 'management.eu-west-1.kiro.dev', 'management.us-east-1.kiro.dev']);
+});
+
+test('quota-only SQLite supplier preserves old reader and activates optional-profile OIDC', async t => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jaw-kiro-quota-'));
+    const file = path.join(dir, 'data.sqlite3');
+    const oldDir = process.env.KIRO_CLI_DATA_DIR;
+    const oldKey = process.env.KIROCLI_TOKEN_KEY;
+    t.after(() => {
+        if (oldDir === undefined) delete process.env.KIRO_CLI_DATA_DIR; else process.env.KIRO_CLI_DATA_DIR = oldDir;
+        if (oldKey === undefined) delete process.env.KIROCLI_TOKEN_KEY; else process.env.KIROCLI_TOKEN_KEY = oldKey;
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+    process.env.KIRO_CLI_DATA_DIR = dir; delete process.env.KIROCLI_TOKEN_KEY;
+    const db = new Database(file);
+    db.exec('CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT); CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)');
+    db.prepare('INSERT INTO auth_kv VALUES (?, ?)').run('kirocli:social:token', JSON.stringify({ accessToken: 'social-fixture' }));
+    db.prepare('INSERT INTO auth_kv VALUES (?, ?)').run('kirocli:oidc:token', JSON.stringify({ access_token: 'oidc-fixture', api_region: 'eu-west-1', region: 'us-east-1', refreshToken: 'never-return', clientSecret: 'never-return' }));
+    db.close();
+    const before = fs.readFileSync(file);
+    assert.equal(readKiroAuthFromStore(file).token?.accessToken, 'social-fixture');
+    assert.deepEqual(readKiroQuotaAuthFromStore(file).token, { accessToken: 'oidc-fixture', apiRegion: 'eu-west-1', ssoRegion: 'us-east-1' });
+    let calls = 0;
+    t.mock.method(globalThis, 'fetch', async (input: URL, init: RequestInit) => {
+        calls++; assert.equal(new URL(input).hostname, 'management.eu-west-1.kiro.dev');
+        assert.equal(new URL(input).searchParams.has('profileArn'), false);
+        assert.equal(new Headers(init.headers).get('authorization'), 'Bearer oidc-fixture');
+        return json(usage);
+    });
+    const result = await fetchKiroUsage();
+    assert.equal(result.quotaCapable, true); assert.equal(calls, 1);
+    assert.ok(!JSON.stringify(result).includes('oidc-fixture'));
+    assert.deepEqual(fs.readFileSync(file), before);
+    process.env.KIROCLI_TOKEN_KEY = 'kirocli:social:token';
+    assert.equal(readKiroQuotaAuthFromStore(file).token?.accessToken, 'social-fixture');
+    process.env.KIROCLI_TOKEN_KEY = 'absent';
+    assert.equal(readKiroQuotaAuthFromStore(file).reason, 'kiro_token_key_missing');
+    const missing = await fetchKiroUsage();
+    assert.equal(missing.authenticated, false); assert.equal(calls, 1);
+});
+
+test('quota SQLite selection handles aliases, sole/ambiguous unknowns and malformed selected token', t => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jaw-kiro-selection-'));
+    const file = path.join(dir, 'data.sqlite3');
+    const old = process.env.KIROCLI_TOKEN_KEY; delete process.env.KIROCLI_TOKEN_KEY;
+    const db = new Database(file);
+    t.after(() => { db.close(); fs.rmSync(dir, { recursive: true, force: true }); if (old !== undefined) process.env.KIROCLI_TOKEN_KEY = old; });
+    db.exec('CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT); CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)');
+    const put = db.prepare('INSERT OR REPLACE INTO auth_kv VALUES (?, ?)');
+    put.run('custom:token', JSON.stringify({ accessToken: 'sole', profile_arn: 'token-profile' }));
+    db.prepare('INSERT INTO state VALUES (?, ?)').run('api.codewhisperer.profile', JSON.stringify({ profile_arn: 'state-profile', name: 'Fixture' }));
+    assert.equal(readKiroQuotaAuthFromStore(file).token?.accessToken, 'sole');
+    assert.equal(readKiroQuotaAuthFromStore(file).profile?.arn, 'state-profile');
+    db.prepare('UPDATE state SET value = ?').run('{invalid-profile');
+    assert.deepEqual(readKiroQuotaAuthFromStore(file), {
+        token: { accessToken: 'sole', profileArn: 'token-profile' }, profile: null,
+    });
+    put.run('kirocli:oidc:token', JSON.stringify({ accessToken: 'valid-oidc', apiRegion: 'eu-west-1' }));
+    assert.deepEqual(readKiroQuotaAuthFromStore(file), {
+        token: { accessToken: 'valid-oidc', apiRegion: 'eu-west-1' }, profile: null,
+    });
+    db.prepare('DELETE FROM auth_kv WHERE key = ?').run('kirocli:oidc:token');
+    put.run('other:token', JSON.stringify({ accessToken: 'other' }));
+    assert.equal(readKiroQuotaAuthFromStore(file).reason, 'kiro_token_ambiguous');
+    put.run('kirocli:odic:token', '{}');
+    assert.equal(readKiroQuotaAuthFromStore(file).reason, 'kiro_token_invalid');
+});
+
+test('Kiro transport/body failures are bounded generic outcomes', async t => {
+    let response = new Response(null, { status: 401 });
+    t.mock.method(globalThis, 'fetch', async () => response);
+    for (const status of [401, 403, 429, 503]) {
+        response = new Response('fixture-secret', { status });
+        const result = await fetchKiroUsageLimits('fixture-access');
+        assert.equal((result as Record<string, unknown>)[status < 429 ? 'authenticated' : 'error'], status < 429 ? false : true);
+        assert.ok(!JSON.stringify(result).includes('fixture-secret'));
+    }
+    response = new Response('{fixture-secret');
+    assert.equal((await fetchKiroUsageLimits('fixture-access') as Record<string, unknown>).error, true);
+    response = new Response('x', { headers: { 'content-length': '524289' } });
+    assert.equal((await fetchKiroUsageLimits('fixture-access') as Record<string, unknown>).error, true);
+});

--- a/tests/unit/quota-kiro-reverse.test.ts
+++ b/tests/unit/quota-kiro-reverse.test.ts
@@ -25,7 +25,7 @@ test('normalizeKiroUsageLimits maps credit breakdown to quota windows', () => {
     assert.equal(normalized['displayTier'], 'Kiro KIRO POWER');
     assert.deepEqual(normalized['windows'], [{
         label: 'Credit',
-        percent: 0,
+        percent: 0.0041,
         resetsAt: '2026-06-01T00:00:00.000Z',
     }]);
     assert.equal(normalized['currentUsage'], 0.41);


### PR DESCRIPTION
Kiro quota reads require a social token/profile and use an outdated endpoint and allowance selection. Read native token selection/metadata without modifying the store, support optional-profile OIDC, call the region-validated management endpoint, and select agentic/credit allowance with a separate trial pool and correct overage fields.

Malformed optional profile JSON preserves the valid token. Transport tests verify returned results and captured options outside production error handling, so broken headers/body cannot pass silently.

Validation: 8 focused tests pass (including selection/ambiguity/profile/transport cases), server build passes, independent review PASS after both findings were fixed. Reference: OpenCodex b94051fe.

Stack: #569 → #570 → #571 → #572 → #574 → this Kiro layer → AGY → integration. Depends on #574; merge bottom-up.
