### PR TITLE
fix(manager): open the default session on instance click and keep Active sessions visible

### DIFF
--- a/public/js/features/session-hub.ts
+++ b/public/js/features/session-hub.ts
@@ -22,6 +22,7 @@ export interface SessionListResponse {
 type SessionViewMode = 'off' | 'hub' | 'session' | 'redirect';
 
 interface SessionViewState {
+    initialized: boolean;
     enabled: boolean;
     mode: SessionViewMode;
     activeId: string | null;
@@ -29,6 +30,7 @@ interface SessionViewState {
 }
 
 const viewState: SessionViewState = {
+    initialized: false,
     enabled: false,
     mode: 'off',
     activeId: null,
@@ -37,6 +39,12 @@ const viewState: SessionViewState = {
 
 let cancelRecordingOnReadonly: (() => void) | null = null;
 let latestList: SessionListResponse | null = null;
+
+export function resetSessionViewForTest(): void {
+    Object.assign(viewState, { initialized: false, enabled: false, mode: 'off', activeId: null, viewed: null });
+    cancelRecordingOnReadonly = null;
+    latestList = null;
+}
 
 const ALLOWED_READONLY_COMMAND = /^\s*(?:\/switch(?:\s|$)|\/sessions(?:\s|$)|\/fork(?:\s|$)|\/\d+(?:\s|$))/i;
 
@@ -59,24 +67,24 @@ function navigationFieldsPresent(response: SessionListResponse): boolean {
 export function configureSessionView(response: SessionListResponse, pathname = window.location.pathname): SessionViewMode {
     latestList = response;
     if (!navigationFieldsPresent(response)) {
-        Object.assign(viewState, { enabled: false, mode: 'off', activeId: null, viewed: null });
+        Object.assign(viewState, { initialized: true, enabled: false, mode: 'off', activeId: null, viewed: null });
         return 'off';
     }
 
     const path = routePath(pathname);
     if (path === '/' || path === '') {
-        Object.assign(viewState, { enabled: true, mode: 'hub', activeId: response.active, viewed: null });
+        Object.assign(viewState, { initialized: true, enabled: true, mode: 'hub', activeId: response.active, viewed: null });
         return 'hub';
     }
 
     const seq = parsedSeq(pathname);
     const viewed = seq === null ? null : response.sessions.find(session => session.seq === seq) || null;
     if (!viewed) {
-        Object.assign(viewState, { enabled: true, mode: 'redirect', activeId: response.active, viewed: null });
+        Object.assign(viewState, { initialized: true, enabled: true, mode: 'redirect', activeId: response.active, viewed: null });
         return 'redirect';
     }
 
-    Object.assign(viewState, { enabled: true, mode: 'session', activeId: response.active, viewed });
+    Object.assign(viewState, { initialized: true, enabled: true, mode: 'session', activeId: response.active, viewed });
     if (!canSendFromCurrentView()) cancelRecordingOnReadonly?.();
     return 'session';
 }
@@ -88,6 +96,8 @@ export function canSendFromCurrentView(commandText = ''): boolean {
     // the guard and write to the GLOBAL active session — the exact
     // cross-session write this guard exists to prevent.
     if (!viewState.enabled) {
+        // Once navigation is known to be off, numeric routes use the legacy session.
+        if (viewState.initialized) return true;
         if (parsedSeq(window.location.pathname) === null) return true;
         return commandText ? ALLOWED_READONLY_COMMAND.test(commandText) : false;
     }

--- a/public/manager/src/App.tsx
+++ b/public/manager/src/App.tsx
@@ -248,8 +248,9 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
         return window.confirm('Discard unsaved Settings changes?');
     }
 
-    function handlePreview(instance: DashboardInstance): void {
+    function handlePreview(instance: DashboardInstance, openDefaultSession = false): void {
         if (!canLeaveDirtySettings()) return;
+        if (openDefaultSession) { setPreviewEnabled(true); setAutoUnloadNotice(false); setPreviewRefreshKey(key => key + 1); }
         setSettingsDirty(false); activityUnread.markPortSeen(instance.port); view.setSelectedPort(instance.port);
         view.setActiveDetailTab('preview'); view.setActivityDockCollapsed(true); view.setDrawerOpen(false);
         void saveUi({ selectedPort: instance.port, selectedTab: 'preview', activityDockCollapsed: true });
@@ -475,8 +476,7 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             busyPorts={messageActivity.busyPorts} showLatestActivityTitles={view.showLatestActivityTitles}
             showInlineLabelEditor={view.showInlineLabelEditor} showSidebarRuntimeLine={view.showSidebarRuntimeLine}
             showSelectedRowActions={view.showSelectedRowActions} profiles={profiles} getLabel={instanceLabel}
-            onRouteToSettings={(port) => { /* 260806 D3: Active-row re-click → Settings */ view.setActiveDetailTab('settings'); void saveUi({ selectedPort: port, selectedTab: 'settings' }); }}
-            formatUptime={formatUptime} onSelect={handleSelectInstance} onPreview={handlePreview}
+            formatUptime={formatUptime} onSelect={handleSelectInstance} onPreview={(instance) => handlePreview(instance, true)}
             onMarkActivitySeen={activityUnread.markPortSeen} onInstanceLabelSave={labelEditor.saveInstanceLabel}
             onLifecycle={(action, instance) => void handleLifecycle(action, instance)} />
     );

--- a/public/manager/src/components/InstanceGroups.tsx
+++ b/public/manager/src/components/InstanceGroups.tsx
@@ -210,7 +210,7 @@ function InstanceGroupSection(section: InstanceGroupSectionProps) {
                         jumpHint,
                     );
                 })}
-                {group.id === 'active' && visible[0] ? props.renderActiveSessionList?.(visible[0].port) : null}
+                {group.id === 'active' && visible[0]?.ok ? props.renderActiveSessionList?.(visible[0].port) : null}
                 {group.id === 'settled' && settledExpanded && hiddenSettled > 0 ? (
                     <button
                         type="button"

--- a/public/manager/src/components/InstanceListContent.tsx
+++ b/public/manager/src/components/InstanceListContent.tsx
@@ -27,9 +27,6 @@ type InstanceListContentProps = {
     showInlineLabelEditor: boolean;
     showSidebarRuntimeLine: boolean;
     showSelectedRowActions: boolean;
-    /** Re-clicking the already selected (Active) row routes here instead of
-     *  onSelect — palette/keyboard selection keeps its meaning (260806 D3). */
-    onRouteToSettings?: (port: number) => void;
     profiles: DashboardProfile[];
     getLabel: (instance: DashboardInstance) => string;
     formatUptime: (seconds: number | null) => string;
@@ -51,14 +48,14 @@ export function InstanceListContent(props: InstanceListContentProps) {
         ? [props.selectedInstance, ...props.filtered]
         : props.filtered;
     const handleSelect = (instance: DashboardInstance): void => {
-        if (props.onRouteToSettings && props.selectedInstance?.port === instance.port) {
-            props.onRouteToSettings(instance.port);
+        if (instance.ok) {
+            props.onPreview(instance);
             return;
         }
         props.onSelect(instance);
     };
     const renderActiveSessionList = (port: number): ReactNode =>
-        <InstanceSessionList port={port} open={sessionsOpen} />;
+        <InstanceSessionList key={port} port={port} open={sessionsOpen} />;
 
     return (
         <>

--- a/public/manager/src/components/InstanceRow.tsx
+++ b/public/manager/src/components/InstanceRow.tsx
@@ -164,7 +164,7 @@ export function InstanceRow(props: InstanceRowProps) {
                         {transitionLabel && <span><em className="instance-row-transition">{transitionLabel}</em></span>}
                     </div>
                     <div className="instance-row-quick" onClick={stopAction}>
-                        {props.priority === 'active' && (props.sessionCount ?? 0) >= 2 && props.onToggleSessions ? (
+                        {props.priority === 'active' && props.instance.ok && (props.sessionCount ?? 0) >= 1 && props.onToggleSessions ? (
                             // Same nested-interactive debt as the stop/open
                             // controls beside it (audit Med#2): aria-expanded +
                             // label only, no aria-controls, restructure tracked

--- a/public/manager/src/components/InstanceSessionList.tsx
+++ b/public/manager/src/components/InstanceSessionList.tsx
@@ -89,7 +89,16 @@ export function InstanceSessionList(props: InstanceSessionListProps) {
         );
     }
 
-    const sessions = snapshot.data?.sessions ?? [];
+    if (snapshot.data === null) {
+        return (
+            <div className="instance-session-list" role="list" aria-label="Chat sessions">
+                <div className="instance-session-empty">Loading sessions…</div>
+            </div>
+        );
+    }
+
+    const sessions = snapshot.data.sessions;
+    if (sessions.length === 0) return null;
     const activeId = snapshot.data?.activeId ?? null;
 
     return (
@@ -125,7 +134,6 @@ export function InstanceSessionList(props: InstanceSessionListProps) {
                     </button>
                 );
             })}
-            {sessions.length === 0 && <div className="instance-session-empty">Loading sessions…</div>}
         </div>
     );
 }

--- a/public/manager/src/hooks/useActiveSessionDisclosure.ts
+++ b/public/manager/src/hooks/useActiveSessionDisclosure.ts
@@ -13,13 +13,13 @@ const EMPTY_SESSIONS_SNAPSHOT: SessionsSnapshot = {
     count: 0,
 };
 
-// Session disclosure state for the Active navigator row:
-// count fetched once per selected instance to decide chevron visibility; the
-// list itself is fetched lazily by InstanceSessionList only while open.
+// Active disclosure defaults open on each selected online port.
+// The hook and list share the same cached/in-flight load; the list also
+// exposes initial loading and failure before any sessions are known.
 // Extracted from App.tsx to honor the 500-line dashboard budget; the WP4
 // hardening cycle replaces the fetch here with the shared session store.
 export function useActiveSessionDisclosure(activeSessionPort: number | null) {
-    const [sessionsOpen, setSessionsOpen] = useState(false);
+    const [sessionsOpen, setSessionsOpen] = useState(true);
     const subscribe = useCallback(
         (callback: () => void) => activeSessionPort == null
             ? () => {}
@@ -35,7 +35,7 @@ export function useActiveSessionDisclosure(activeSessionPort: number | null) {
     const snapshot = useSyncExternalStore(subscribe, getSnapshot);
 
     useEffect(() => {
-        setSessionsOpen(false);
+        setSessionsOpen(true);
         if (activeSessionPort == null) return;
         void loadSessions(activeSessionPort)
             .catch(() => { /* offline or pre-session build: chevron simply stays hidden */ });

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -479,13 +479,19 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
 
 /* ─── Active-row session disclosure ─── */
 .instance-session-list {
+    --instance-session-row-height: 30px;
     display: grid;
+    grid-auto-rows: max-content;
+    align-content: start;
     gap: 2px;
     margin: -2px 0 8px;
     padding: 6px;
     border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background: var(--row-bg);
+    max-height: calc(3 * var(--instance-session-row-height) + 2 * 2px + 2 * 6px + 2 * 1px);
+    overflow: auto;
+    overscroll-behavior-y: contain;
     animation: session-list-in 0.12s ease;
 }
 @keyframes session-list-in {
@@ -506,12 +512,15 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     justify-content: space-between;
     gap: 8px;
     width: 100%;
+    min-height: var(--instance-session-row-height);
+    height: var(--instance-session-row-height);
     padding: 5px 8px;
     border: 0;
     border-radius: 6px;
     background: transparent;
     color: var(--text-secondary);
     font-size: 12px;
+    line-height: 16px;
     text-align: left;
     cursor: pointer;
 }
@@ -544,6 +553,7 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
 .instance-session-meta {
     flex-shrink: 0;
     font-size: 11px;
+    white-space: nowrap;
     color: var(--text-tertiary, var(--text-secondary));
     font-variant-numeric: tabular-nums;
 }

--- a/public/manager/src/preview.ts
+++ b/public/manager/src/preview.ts
@@ -101,9 +101,11 @@ export function buildPreviewState(
         && originPreview.url
         && !prefersLegacyPreviewTransport();
     if (useOriginPort) {
+        const previewUrl = new URL(normalizePreviewUrlForCurrentHost(originPreview.url));
+        previewUrl.pathname = `${previewUrl.pathname.replace(/\/?$/, '/')}0`;
         return {
             canPreview: true,
-            src: appendPreviewTheme(normalizePreviewUrlForCurrentHost(originPreview.url), theme),
+            src: appendPreviewTheme(previewUrl.toString(), theme),
             reason: null,
             transport: 'origin-port',
             warning: 'origin proxy ready',
@@ -112,7 +114,7 @@ export function buildPreviewState(
     const basePath = proxy.basePath || '/i';
     return {
         canPreview: true,
-        src: appendPreviewTheme(`${basePath}/${instance.port}/`, theme),
+        src: appendPreviewTheme(`${basePath}/${instance.port}/0`, theme),
         reason: null,
         transport: 'legacy-path',
         warning: 'legacy proxy fallback',

--- a/tests/unit/manager-preview.test.ts
+++ b/tests/unit/manager-preview.test.ts
@@ -39,7 +39,7 @@ const data: DashboardScanResult = {
 test('preview helper builds proxy preview url', () => {
     assert.deepEqual(buildPreviewState(online, data, 'proxy'), {
         canPreview: true,
-        src: '/i/3457/',
+        src: '/i/3457/0',
         reason: null,
         transport: 'legacy-path',
         warning: 'legacy proxy fallback',
@@ -49,7 +49,7 @@ test('preview helper builds proxy preview url', () => {
 test('preview helper appends theme to proxy preview url', () => {
     const state = buildPreviewState(online, data, 'dark');
 
-    assert.equal(state.src, '/i/3457/?jawTheme=dark');
+    assert.equal(state.src, '/i/3457/0?jawTheme=dark');
     assert.equal(state.transport, 'legacy-path');
 });
 
@@ -83,7 +83,7 @@ test('preview helper prefers origin-port preview url', () => {
         },
     }), {
         canPreview: true,
-        src: 'http://127.0.0.1:24602/',
+        src: 'http://127.0.0.1:24602/0',
         reason: null,
         transport: 'origin-port',
         warning: 'origin proxy ready',
@@ -116,7 +116,7 @@ test('preview helper appends theme to origin-port preview url', () => {
         },
     }, 'light');
 
-    assert.equal(state.src, 'http://127.0.0.1:24602/?x=1&jawTheme=light#frame');
+    assert.equal(state.src, 'http://127.0.0.1:24602/0?x=1&jawTheme=light#frame');
     assert.equal(state.transport, 'origin-port');
 });
 
@@ -146,7 +146,7 @@ test('preview helper can force same-origin proxy as an explicit fallback', () =>
         },
     }, { theme: 'light', transport: 'legacy-path' });
 
-    assert.equal(state.src, '/i/3457/?jawTheme=light');
+    assert.equal(state.src, '/i/3457/0?jawTheme=light');
     assert.equal(state.transport, 'legacy-path');
 });
 
@@ -187,14 +187,14 @@ test('preview helper falls back when origin-port preview is unavailable', () => 
         },
     });
 
-    assert.equal(state.src, '/i/3457/');
+    assert.equal(state.src, '/i/3457/0');
     assert.equal(state.transport, 'legacy-path');
 });
 
 test('preview helper ignores legacy direct mode argument and keeps proxy path', () => {
     const state = buildPreviewState(online, data, 'direct' as any);
 
-    assert.equal(state.src, '/i/3457/');
+    assert.equal(state.src, '/i/3457/0');
     assert.equal(state.transport, 'legacy-path');
     assert.equal(state.warning, 'legacy proxy fallback');
 });
@@ -206,4 +206,69 @@ test('preview helper rejects offline instances', () => {
     assert.equal(state.canPreview, false);
     assert.match(state.reason || '', /online/);
     assert.equal(state.transport, 'none');
+});
+
+function originScan(base: string): DashboardScanResult {
+    const scan = structuredClone(data);
+    assert.ok(scan.manager.proxy);
+    scan.manager.proxy.preview = {
+        enabled: true, kind: 'origin-port', previewFrom: 24602, previewTo: 24651,
+        instances: {
+            '3457': { targetPort: 3457, previewPort: 24602, url: `${base}?x=1#frame`, status: 'ready', reason: null },
+        },
+    };
+    return scan;
+}
+
+test('default-session preview handles origin bases with or without a trailing slash', () => {
+    for (const base of ['http://127.0.0.1:24602', 'http://127.0.0.1:24602/']) {
+        assert.equal(buildPreviewState(online, originScan(base), 'light').src,
+            'http://127.0.0.1:24602/0?x=1&jawTheme=light#frame');
+    }
+});
+
+test('default-session preview normalizes localhost and respects Safari and explicit legacy transport', async () => {
+    const { setupWebUiDom, resetWebUiDom } = await import('./web-ui-test-dom.ts');
+    const globals = Object.getOwnPropertyDescriptors(globalThis);
+    try {
+        setupWebUiDom();
+        // The common DOM fixture uses 127.0.0.1; use a real localhost location
+        // without attempting cross-origin history mutation in JSDOM.
+        const { JSDOM } = await import('jsdom');
+        const localDom = new JSDOM('', { url: 'http://localhost:24576/' });
+        try {
+            Object.defineProperty(globalThis, 'window', { configurable: true, value: localDom.window });
+            const scan = originScan('http://127.0.0.1:24602/');
+            assert.equal(buildPreviewState(online, scan, 'light').src,
+                'http://localhost:24602/0?x=1&jawTheme=light#frame');
+            assert.equal(buildPreviewState(online, scan, { transport: 'legacy-path' }).src, '/i/3457/0');
+            Object.defineProperty(globalThis, 'navigator', {
+                configurable: true, value: { userAgent: 'Mozilla/5.0 Version/18.0 Safari/605.1.15' },
+            });
+            const safari = buildPreviewState(online, scan);
+            assert.equal(safari.src, '/i/3457/0');
+            assert.equal(safari.transport, 'legacy-path');
+        } finally { localDom.window.close(); }
+    } finally {
+        resetWebUiDom();
+        for (const key of Object.getOwnPropertyNames(globalThis)) {
+            if (!(key in globals)) Reflect.deleteProperty(globalThis, key);
+        }
+        Object.defineProperties(globalThis, globals);
+    }
+});
+
+test('default-session navigation preserves all preview eligibility guards', () => {
+    const disabled = structuredClone(data);
+    assert.ok(disabled.manager.proxy);
+    disabled.manager.proxy.enabled = false;
+    for (const [instance, scan] of [
+        [null, data], [{ ...online, ok: false, status: 'offline' }, data],
+        [online, disabled], [{ ...online, port: 3507 }, data],
+    ] as Array<[DashboardInstance | null, DashboardScanResult]>) {
+        const state = buildPreviewState(instance, scan);
+        assert.equal(state.canPreview, false);
+        assert.equal(state.src, null);
+        assert.equal(state.transport, 'none');
+    }
 });

--- a/tests/unit/manager-session-navigation.test.ts
+++ b/tests/unit/manager-session-navigation.test.ts
@@ -1,0 +1,255 @@
+import test, { afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as React from 'react';
+import { act, createElement, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { setupWebUiDom, resetWebUiDom } from './web-ui-test-dom.ts';
+import { InstanceListContent } from '../../public/manager/src/components/InstanceListContent.tsx';
+import { useActiveSessionDisclosure } from '../../public/manager/src/hooks/useActiveSessionDisclosure.ts';
+import { SIDEBAR_GROUP_COLLAPSED_KEY } from '../../public/manager/src/hooks/useSidebarGroupCollapse.ts';
+import {
+    getSessionListenerCountForTest, loadSessions, resetSessionStoreForTest,
+} from '../../public/manager/src/lib/session-store.ts';
+import type { DashboardInstance } from '../../public/manager/src/types.ts';
+
+const online: DashboardInstance = {
+    port: 3457, url: 'http://localhost:3457', status: 'online', ok: true,
+    version: null, uptime: null, instanceId: 'default', homeDisplay: '/fixture',
+    workingDir: '/fixture', currentCli: 'codex', currentModel: null,
+    serviceMode: 'unknown', lastCheckedAt: '2026-09-08T00:00:00Z', healthReason: null,
+};
+const second: DashboardInstance = { ...online, port: 3458, url: 'http://localhost:3458' };
+const offline: DashboardInstance = { ...online, port: 3459, ok: false, status: 'offline' };
+let root: Root | null;
+let container: HTMLDivElement;
+let globals: PropertyDescriptorMap;
+let previousCollapse: string | null;
+let previews: number[];
+let selections: number[];
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(done => { resolve = done; });
+    return { promise, resolve };
+}
+function response(labels: string[]): Response {
+    return Response.json({ ok: true, data: {
+        sessions: labels.map((label, seq) => ({ id: seq === 0 ? 'default' : `s-${seq}`, seq, label: label || null, message_count: 0 })),
+        active: 'default',
+    } });
+}
+function props(selectedInstance: DashboardInstance | null = online): ComponentProps<typeof InstanceListContent> {
+    return {
+        error: null, loading: false, instances: [online, second, offline], filtered: [online, second, offline],
+        selectedInstance, data: null, lifecycleBusyPort: null, transitioningPort: null, transitionAction: null,
+        activityUnreadByPort: {}, latestTitleByPort: {}, showLatestActivityTitles: false,
+        showInlineLabelEditor: false, showSidebarRuntimeLine: false, showSelectedRowActions: true,
+        profiles: [], getLabel: instance => `Jaw ${instance.port}`, formatUptime: () => '—',
+        onSelect: instance => { selections.push(instance.port); },
+        onPreview: instance => { previews.push(instance.port); },
+        onMarkActivitySeen: () => {}, onInstanceLabelSave: async () => {}, onLifecycle: () => {},
+    };
+}
+async function render(selected: DashboardInstance | null = online): Promise<void> {
+    await act(async () => { root!.render(createElement(InstanceListContent, props(selected))); });
+}
+async function click(selector: string): Promise<void> {
+    const target = container.querySelector<HTMLButtonElement>(selector);
+    assert.ok(target, `missing ${selector}`);
+    await act(async () => { target.click(); });
+}
+function items(): string[] {
+    return [...container.querySelectorAll('[aria-label="Chat sessions"] [role="listitem"]')].map(el => el.textContent ?? '');
+}
+function expanded(): string | null | undefined {
+    return container.querySelector('.action-sessions')?.getAttribute('aria-expanded');
+}
+
+beforeEach(() => {
+    globals = Object.getOwnPropertyDescriptors(globalThis);
+    setupWebUiDom();
+    // tests/run uses the root tsconfig (classic JSX); Vite uses automatic JSX.
+    Object.defineProperty(globalThis, 'React', { configurable: true, value: React });
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { configurable: true, writable: true, value: true });
+    previousCollapse = localStorage.getItem(SIDEBAR_GROUP_COLLAPSED_KEY);
+    localStorage.removeItem(SIDEBAR_GROUP_COLLAPSED_KEY);
+    previews = []; selections = [];
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+});
+afterEach(async () => {
+    if (root) await act(async () => { root!.unmount(); });
+    for (const port of [3457, 3458, 3459]) assert.equal(getSessionListenerCountForTest(port), 0);
+    resetSessionStoreForTest();
+    if (previousCollapse === null) localStorage.removeItem(SIDEBAR_GROUP_COLLAPSED_KEY);
+    else localStorage.setItem(SIDEBAR_GROUP_COLLAPSED_KEY, previousCollapse);
+    resetWebUiDom();
+    for (const key of Object.getOwnPropertyNames(globalThis)) {
+        if (!(key in globals)) Reflect.deleteProperty(globalThis, key);
+    }
+    Object.defineProperties(globalThis, globals);
+});
+
+test('one default session opens automatically and hook/list share one GET and release listeners', async () => {
+    const pending = deferred<Response>();
+    let calls = 0;
+    resetSessionStoreForTest({ fetchImpl: async () => { calls++; return pending.promise; } });
+    await render();
+    assert.match(container.querySelector('.instance-session-list')?.textContent ?? '', /Loading sessions/);
+    assert.equal(calls, 1);
+    assert.equal(getSessionListenerCountForTest(3457), 2);
+    await act(async () => { pending.resolve(response([''])); await loadSessions(3457); });
+    assert.equal(items().length, 1);
+    assert.match(items()[0]!, /Default session/);
+    assert.equal(container.querySelector('.action-sessions')?.getAttribute('aria-label'), 'Sessions (1)');
+    assert.equal(expanded(), 'true');
+    await render();
+    assert.equal(calls, 1, 'fresh renders reuse the GET');
+    await act(async () => { root!.unmount(); }); root = null;
+    assert.equal(getSessionListenerCountForTest(3457), 0);
+});
+
+test('five rows stay in DOM; manual collapse and reopen do not select or preview', async () => {
+    let calls = 0;
+    resetSessionStoreForTest({ fetchImpl: async () => { calls++; return response(['one', 'two', 'three', 'four', 'five']); } });
+    await render();
+    assert.equal(items().length, 5);
+    assert.equal(expanded(), 'true');
+    await click('.action-sessions');
+    assert.equal(container.querySelector('.instance-session-list'), null);
+    assert.equal(expanded(), 'false');
+    await click('.action-sessions');
+    assert.equal(items().length, 5);
+    assert.equal(expanded(), 'true');
+    assert.deepEqual(previews, []); assert.deepEqual(selections, []);
+    assert.equal(calls, 1);
+});
+
+test('port change opens B after collapsing A and ignores a late A refresh', async () => {
+    let now = 10_000;
+    let aCalls = 0;
+    const lateA = deferred<Response>();
+    const pendingB = deferred<Response>();
+    resetSessionStoreForTest({ now: () => now, fetchImpl: async url => {
+        if (String(url).includes('/3458/')) return pendingB.promise;
+        return ++aCalls === 1 ? response(['A']) : lateA.promise;
+    } });
+    await render();
+    await click('.action-sessions');
+    now += 2_001;
+    const refreshingA = loadSessions(3457);
+    await render(second);
+    assert.equal(getSessionListenerCountForTest(3457), 0);
+    assert.match(container.querySelector('.instance-session-list')?.textContent ?? '', /Loading/);
+    await act(async () => { pendingB.resolve(response(['B'])); await loadSessions(3458); });
+    assert.equal(expanded(), 'true');
+    assert.match(items()[0]!, /^B/);
+    const bList = container.querySelector('.instance-session-list');
+    await act(async () => { lateA.resolve(response(['late A'])); await refreshingA; });
+    assert.equal(container.querySelector('.instance-session-list'), bList);
+    assert.match(items()[0]!, /^B/);
+    assert.equal(items().length, 1);
+});
+
+test('same-port refreshed count preserves a manually collapsed disclosure', async () => {
+    let now = 10_000;
+    let calls = 0;
+    resetSessionStoreForTest({ now: () => now, fetchImpl: async () => response(++calls === 1 ? ['one'] : ['one', 'two']) });
+    await render();
+    await click('.action-sessions');
+    now += 2_001;
+    await act(async () => { await loadSessions(3457); });
+    assert.equal(expanded(), 'false');
+    assert.equal(container.querySelector('.action-sessions')?.getAttribute('aria-label'), 'Sessions (2)');
+    assert.equal(items().length, 0);
+});
+
+test('loaded empty hides list and chevron', async () => {
+    resetSessionStoreForTest({ fetchImpl: async () => response([]) });
+    await render();
+    assert.equal(container.querySelector('.instance-session-list'), null);
+    assert.equal(container.querySelector('.action-sessions'), null);
+});
+
+test('null or offline selection never requests sessions or exposes disclosure', async () => {
+    let calls = 0;
+    resetSessionStoreForTest({ fetchImpl: async () => { calls++; return response(['unexpected']); } });
+    for (const selected of [null, offline]) {
+        await render(selected);
+        assert.equal(container.querySelector('.instance-session-list'), null);
+        assert.equal(container.querySelector('.action-sessions'), null);
+    }
+    assert.equal(calls, 0);
+});
+
+test('initial load error exposes Retry without chevron and recovers to expanded rows', async () => {
+    let calls = 0;
+    resetSessionStoreForTest({ fetchImpl: async () => ++calls === 1 ? new Response(null, { status: 503 }) : response(['recovered']) });
+    await render();
+    assert.match(container.querySelector('.instance-session-list')?.textContent ?? '', /503.*Retry/);
+    assert.equal(container.querySelector('.action-sessions'), null);
+    await click('.instance-session-retry');
+    assert.equal(expanded(), 'true');
+    assert.match(items()[0]!, /^recovered/);
+    assert.deepEqual(previews, []); assert.deepEqual(selections, []);
+});
+
+test('cached load failure and failed switch retain Retry and successful retries restore rows', async () => {
+    let now = 10_000;
+    let gets = 0;
+    let posts = 0;
+    resetSessionStoreForTest({ now: () => now, fetchImpl: async (_url, init) => {
+        if (init?.method === 'POST') {
+            return ++posts === 1 ? Response.json({ error: 'switch refused' }, { status: 503 }) : new Response(null, { status: 200 });
+        }
+        return ++gets === 2 ? new Response(null, { status: 503 }) : response(['default', 'second']);
+    } });
+    await render();
+    now += 2_001;
+    await act(async () => { await assert.rejects(loadSessions(3457), /503/); });
+    assert.equal(expanded(), 'true');
+    assert.equal(items().length, 0, 'load error takes priority over cached rows');
+    await click('.instance-session-retry');
+    assert.equal(items().length, 2);
+    await click('.instance-session-row:nth-child(2)');
+    assert.match(container.querySelector('.instance-session-error')?.textContent ?? '', /switch refused.*Retry/);
+    assert.equal(items().length, 2, 'switch error keeps cached rows');
+    await click('.instance-session-retry');
+    assert.equal(posts, 2);
+    assert.equal(container.querySelector('.instance-session-error'), null);
+    assert.deepEqual(previews, []); assert.deepEqual(selections, []);
+});
+
+test('Active and Running online row clicks preview exactly once; offline rows select', async () => {
+    let posts = 0;
+    resetSessionStoreForTest({ fetchImpl: async (_url, init) => { if (init?.method === 'POST') posts++; return response(['default']); } });
+    await render();
+    for (const [group, port] of [['active', 3457], ['running', 3457], ['running', 3458]] as const) {
+        previews = []; selections = [];
+        await click(`#instance-group-body-${group} .instance-row-select[data-instance-port="${port}"]`);
+        assert.deepEqual(previews, [port]); assert.deepEqual(selections, []);
+    }
+    previews = []; selections = [];
+    await click('.instance-row-select[data-instance-port="3459"]');
+    assert.deepEqual(previews, []); assert.deepEqual(selections, [3459]);
+    assert.equal(posts, 0);
+});
+
+function HookHarness({ port }: { port: number | null }) {
+    const { activeSessionCount, sessionsOpen, setSessionsOpen } = useActiveSessionDisclosure(port);
+    return createElement('button', { 'aria-expanded': sessionsOpen, onClick: () => setSessionsOpen(open => !open) }, String(activeSessionCount));
+}
+
+test('hook harness resets disclosure only on port changes and hands off subscriptions', async () => {
+    resetSessionStoreForTest({ fetchImpl: async () => response(['default']) });
+    await act(async () => { root!.render(createElement(HookHarness, { port: 3457 })); });
+    assert.equal(container.querySelector('button')?.getAttribute('aria-expanded'), 'true');
+    await click('button');
+    await act(async () => { root!.render(createElement(HookHarness, { port: 3457 })); });
+    assert.equal(container.querySelector('button')?.getAttribute('aria-expanded'), 'false');
+    await act(async () => { root!.render(createElement(HookHarness, { port: 3458 })); });
+    assert.equal(container.querySelector('button')?.getAttribute('aria-expanded'), 'true');
+    assert.equal(getSessionListenerCountForTest(3457), 0);
+    assert.equal(getSessionListenerCountForTest(3458), 1);
+});

--- a/tests/unit/preview-transport.test.ts
+++ b/tests/unit/preview-transport.test.ts
@@ -64,7 +64,7 @@ test('buildPreviewState uses legacy path on Safari even when origin preview is r
     try {
         const state = buildPreviewState(onlineInstance, scanWithOriginPreview, { theme: 'dark' });
         assert.equal(state.transport, 'legacy-path');
-        assert.equal(state.src, '/i/3457/?jawTheme=dark');
+        assert.equal(state.src, '/i/3457/0?jawTheme=dark');
     } finally {
         Object.defineProperty(globalThis, 'navigator', { configurable: true, value: original });
     }

--- a/tests/unit/session-hub-routing.test.ts
+++ b/tests/unit/session-hub-routing.test.ts
@@ -46,7 +46,7 @@ test('digits-only route serves index after static without capturing API, media, 
 
     try {
         await withServer(app, async baseUrl => {
-            for (const path of ['/1', '/1/']) {
+            for (const path of ['/0', '/0/', '/1', '/1/']) {
                 const response = await fetch(baseUrl + path);
                 assert.equal(response.status, 200);
                 assert.match(await response.text(), /session-index-071/);
@@ -57,7 +57,7 @@ test('digits-only route serves index after static without capturing API, media, 
             assert.equal((await fetch(`${baseUrl}/not-a-session`)).status, 404);
 
             rmSync(join(root, 'public', 'dist', 'index.html'));
-            const sourceFallback = await fetch(`${baseUrl}/2`);
+            const sourceFallback = await fetch(`${baseUrl}/0`);
             assert.equal(sourceFallback.status, 200);
             assert.match(await sourceFallback.text(), /source-index-071/);
         });

--- a/tests/unit/session-readonly-guard.test.ts
+++ b/tests/unit/session-readonly-guard.test.ts
@@ -245,11 +245,11 @@ test('render dispatchers call the synchronous shared predicate before mutation o
 // wrote to the GLOBAL active session — the exact cross-session write this
 // guard exists to prevent.
 test('an uninitialized numeric route fails closed, and non-numeric routes stay open', async () => {
-    const { canSendFromCurrentView, configureSessionView } = await import('../../public/js/features/session-hub.ts');
+    const { canSendFromCurrentView, resetSessionViewForTest } = await import('../../public/js/features/session-hub.ts');
     setupWebUiDom();
     // Earlier tests in this file leave viewState enabled; reset to the
-    // pre-initialization shape this test is about by feeding an OFF-mode list.
-    configureSessionView({ active: 'default', sessions: [{ id: 'default', seq: 0, label: null, message_count: 0 }] } as never, '/');
+    // pre-initialization shape without configuring a successful response.
+    resetSessionViewForTest();
     // setupWebUiDom pins the URL, so drive the path directly — the guard reads
     // window.location.pathname to decide whether a numeric route is in play.
     const setPath = (pathname: string) => {
@@ -279,4 +279,23 @@ test('the send button preserves the allow-list and only drops text for stop clic
         'stop detection must be explicit rather than assuming every button click is a stop');
     assert.match(guardCall, /canSendFromCurrentView\(isStopClick \? '' : text\)/,
         'ordinary button sends must pass the typed text so allow-listed commands survive');
+});
+
+test('initialized navigation-off permits /0 sends while inactive navigation-on stays read-only', async () => {
+    setupWebUiDom();
+    const { canSendFromCurrentView, configureSessionView, resetSessionViewForTest } = await import('../../public/js/features/session-hub.ts');
+    resetSessionViewForTest();
+    window.history.replaceState({}, '', '/0');
+    assert.equal(canSendFromCurrentView('hello'), false, 'numeric zero also fails closed before initialization');
+    const offResponse = { active: 'default', sessions: [{ id: 'default', seq: 0, label: null, message_count: 0 }] };
+    assert.equal(configureSessionView(offResponse, '/0'), 'off');
+    assert.equal(canSendFromCurrentView('hello'), true);
+    assert.equal(canSendFromCurrentView(), true);
+    window.history.replaceState({}, '', '/7');
+    configureSessionView({ ...onResponse, sessions: [
+        ...onResponse.sessions,
+        { id: 'local-7', seq: 7, label: null, message_count: 0, source: 'local', remoteKey: null },
+    ] }, '/7');
+    assert.equal(canSendFromCurrentView('hello'), false);
+    resetSessionViewForTest();
 });


### PR DESCRIPTION
Clicking an instance row in the Manager navigator now opens its default session (`/0`) in the preview instead of the session hub, and the Active section's session list is expanded by default with a three-row scroll window.

**Before:** any row click only selected the instance (re-clicking the Active row jumped to Settings); the preview iframe loaded `/i/<port>/` or the origin-port root, which is the session hub; the Active session list was collapsed until the chevron was clicked and only showed a chevron from two sessions.
**After:** clicking an online row (Active or Running) selects it, turns preview on, and loads `…/0` on both transports with theme query/hash preserved; offline rows still just select. The Active list opens by default for the selected online port (manual collapse is kept while on that port), shows the chevron from one session, and is bounded to `3 × 30px` rows with inner scrolling; it renders error → loading → empty(null) → list.

Instance web UI compatibility fix: on a server with multi-session navigation off, `/:seq` used to fail closed for ordinary sends after initialization (`canSendFromCurrentView` treated any numeric route as uninitialized). A `SessionViewState.initialized` flag now lets an initialized navigation-off view send normally while the pre-initialization fail-closed guard is unchanged (`resetSessionViewForTest` added for the guard test). Servers older than the numeric route (pre-43aa08083) reached through the preview proxy remain a documented limitation.

The Active re-click → Settings shortcut is removed on purpose; Settings stays one tab away.

**Manual PR chain** (merge bottom-up; no GitHub native stack):
| Order | PR | Layer | Base | Review focus |
|---|---|---|---|---|
| 1 | #573 | Top chrome | dev | Native controls, logo alignment, search width |
| 2 | this PR ← you are here | Session navigation | codex/dash-topbar-chrome | Active disclosure and /0 preview |

Depends on #573. Review this PR's diff only. Retarget to dev after #573 lands.

Validation:
- `npm run typecheck:frontend` exit 0
- `tests/run.mts` on 12 manager/session/electron unit files: 113 pass / 0 fail (incl. new `manager-session-navigation.test.ts`, 10 mounted cases; updated preview URL expectations; readonly-guard initialized/uninitialized cases; App.tsx stays ≤ 500 lines)
- `npm run build:frontend` ok; `bash structure/verify-counts.sh` 540 PASS
- Browser check on an isolated manager (:24990): row click → iframe `src=/i/3465/0?jawTheme=light`, frame pathname `/0`, preview switch on; Active list expanded (2 rows), `max-height: 108px`, `overflow: auto`

Limitations: root `tsc -p tsconfig.json` reports pre-existing errors from a missing `@anthropic-ai/claude-agent-sdk` install in this checkout (identical on the base commit); not caused by this PR. Session-row clicks still switch the server's active session without navigating the preview (documented follow-up).
