### PR TITLE
fix(files): keep Linux file opening from blocking HTTP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,8 @@ git add devlog && git commit -m "chore: update devlog ref" && git push
 
 ### Architecture Docs Sync
 
+- Linux `/api/file/open` acknowledges asynchronous `xdg-open` launch, not desktop application success. Keep detached/ignored-stdio dispatch and launch-error handling; never wait synchronously for the opener. See `structure/server_api.md`.
+
 - Sidecar builds use exclusive owned staging/source snapshots and retained failure evidence; preserve the existing compiled-asset/prune/native/no-JWC gates. Smoke executes a byte-matched copy outside checkout dependency ancestors with the target Node, strict process/IPC/listener/HTTP/close checks and evidence before cleanup. Never equate timeout/skipped with pass, relabel retained roots as deleted, adopt unknown output, or force-remove locks. Input relative contained symlinks are preserved verbatim; output fingerprinting is local provenance, not a signature. Final builder-filtered native UI remains separate. See `structure/infra.md`.
 
 - Isolated desktop QA is explicit via `CLI_JAW_ISOLATED_QA_ROOT`; `src/shared/isolated-qa.ts` owns fixed role homes, strict W/M/P ports and fresh child environment. The supervisor validates before imports; Electron applies paths before lock/session and suppresses global registration/installer actions. QA Manager rejects foreign scans/peers and lifecycle actions before side effects; ordinary mode is unchanged. Preserve captured policy and lifetime-safe QA cleanup. This is controlled launch containment, not an arbitrary-command sandbox or packaged/native QA certification. Sync `structure/infra.md`, README and root/structure notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ This repository is a Node.js ESM orchestration runtime for boss/employee dispatc
 
 The Classic permission selector saves explicit Auto/Safe choices. Server startup preserves the saved policy; never reintroduce the obsolete safe-to-auto coercion. Existing runtime-specific policy support and settings invalidation still apply.
 
+- Linux `/api/file/open` acknowledges asynchronous `xdg-open` launch, not desktop application success. Keep detached/ignored-stdio dispatch and launch-error handling; never wait synchronously for the opener. See `structure/server_api.md`.
+
 - Classic history restoration uses bounded targeted replay and preserves recorded
   scope; unrelated live runs continue. Exact saved answers come from the run+chat
   MESSAGE lookup, not redacted journal finals. Resolved-session loading and captured

--- a/README.md
+++ b/README.md
@@ -832,6 +832,10 @@ jaw --home "$HOME/jaw/worker-a" service stop --port 3458
 
 ### Remote and headless hosts
 
+On Linux, opening a file from the Web UI dispatches `xdg-open` without waiting for
+the desktop application to exit. A successful response acknowledges launch only;
+a headless host still needs a desktop handler to display the file.
+
 `ssh host 'jaw serve ...'` runs a non-login, non-interactive shell that reads none of the
 files the installer adds `~/.local/bin` to, so `jaw` can work when you log in and still fail
 over SSH with `nohup: failed to run command 'jaw'`. Run `jaw doctor` and check the

--- a/src/routes/messaging.ts
+++ b/src/routes/messaging.ts
@@ -157,7 +157,7 @@ export function registerMessagingRoutes(app: Express, requireAuth: AuthMiddlewar
 
     // Open file in system file manager (Finder reveal)
     // NOTE: cli-jaw is a localhost-only program. No remote access.
-    app.post('/api/file/open', requireAuth, (req, res) => {
+    app.post('/api/file/open', requireAuth, async (req, res) => {
         const { path: rawPath } = req.body;
         if (!rawPath || typeof rawPath !== 'string') {
             return fail(res, 400, 'path_required');
@@ -183,7 +183,16 @@ export function registerMessagingRoutes(app: Express, requireAuth: AuthMiddlewar
                 child.once('error', () => { /* explorer missing is not actionable here */ });
                 child.unref();
             } else {
-                execFileSync('xdg-open', [target.openedPath]);
+                // xdg-open may live as long as the desktop application (#540).
+                // Acknowledge launch, not exit, without retaining server pipes.
+                await new Promise<void>((resolve, reject) => {
+                    const child = spawn('xdg-open', [target.openedPath], { detached: true, stdio: 'ignore' });
+                    child.once('error', reject);
+                    child.once('spawn', () => {
+                        child.unref();
+                        resolve();
+                    });
+                });
             }
             ok(res, {
                 opened: target.openedPath,

--- a/structure/AGENTS.md
+++ b/structure/AGENTS.md
@@ -2,6 +2,8 @@
 
 # structure/ — Sync Guide
 
+- Linux `/api/file/open` acknowledges asynchronous `xdg-open` launch, not desktop application success. Keep detached/ignored-stdio dispatch and launch-error handling; never wait synchronously for the opener. See `server_api.md`.
+
 - Sidecar build/smoke: sync `infra.md` and root notes for transactional source/stage/lock ownership, runtime-candidate/seal matching, outside-checkout target-Node execution, preserved asset/prune/native/no-JWC gates and explicit retained evidence/cleanup. Ordinary import, live server readiness and final packaged native UI are separate proofs; no timeout or skipped green.
 
 - Isolated desktop QA: `src/shared/isolated-qa.ts` owns opt-in role paths/strict ports/child env; Electron, dashboard CLI and Manager enforce the captured launch policy before their owned side effects. Keep the supervisor-before-import boundary, no global registration/installer or foreign scan/peer/lifecycle actions, normal-mode compatibility and lifetime-safe QA cleanup explicit in `infra.md` and root docs. Do not conflate mocked/compiled launch checks with final packaged native UI proof.

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -433,3 +433,9 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 | Jaw CEO (manager) | `/api/jaw-ceo/*` (same sub-router as core server) |
 
 Text responses from the hub outbound relay may include `bodyDelivered`, a server-generated receipt. Native hub-member completions require both `ok === true` and `bodyDelivered === true`; missing/false receipts are unconfirmed and are not automatically resent. Request payloads cannot set the receipt or native guard options. Existing untagged callers retain the prior `ok` contract.
+
+### Linux file-open dispatch
+
+`POST /api/file/open` keeps the existing auth middleware and `{path}` input. Missing/invalid paths return `400 path_required`; nonexistent targets return `404 file_not_found`. Document paths (including supported line/column suffixes) open directly; other files open their parent directory, and directories open themselves. An existing literal filename takes precedence over suffix stripping.
+
+On Linux, `xdg-open` launches asynchronously with detached lifecycle and ignored stdio. The handler returns `200 {ok:true,data:{opened,resolvedTarget,strategy}}` after the process spawns, without waiting for the desktop application's lifetime. Launch failures such as missing executable or execute permission return `500 {ok:false,error:"open_failed"}`. A later opener failure/nonzero exit does not change the completed HTTP response; success confirms dispatch, not a visible desktop window. macOS and Windows behavior is unchanged.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -392,7 +392,7 @@ cli-jaw/
 │   │   ├── orchestrate.ts    ← IPABCD reset/state/workers/worker-runs/snapshot/queue cancel/queue steer async accept/dispatch/virtual dispatch/batch safe summary/worker result/state PUT 라우트 + Phase60 boss-token actor distinction + --attest body gate + single-use pendingAttestation null-clear (1222L)
 │   │   ├── memory.ts         ← memory status/KV/files/settings 라우트 (191L)
 │   │   ├── settings.ts       ← settings/prompt/project pick/git summary/heartbeat-md/MCP/registry/status/quota/copilot + Pi profile register/model discovery 라우트 + CLI_KEYS 기반 quota parity/status-only metadata (754L)
-│   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (513L)
+│   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (522L)
 │   │   ├── avatar.ts         ← Agent/User 아바타 이미지 업로드/서빙/삭제 + settings.json 메타 저장 + safeResolveUnder 경로 보호 (147L)
 │   │   ├── quota.ts          ← Copilot/Claude/Codex/Grok/OpenCode quota helper readers + Grok weekly credits + Claude 429 cache (541L)
 │   │   ├── quota-kiro-reverse.ts ← Kiro/CodeWhisperer quota reader (239L)

--- a/tests/fixtures/file-open-server.ts
+++ b/tests/fixtures/file-open-server.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+const { registerMessagingRoutes } = process.env.FILE_OPEN_TEST_BUILT === '1'
+    ? await import('../../dist/src/routes/messaging.js')
+    : await import('../../src/routes/messaging.ts');
+
+// Imports bind native dependencies using the real platform first. The route's
+// Linux branch can then be exercised on macOS without opening a desktop app.
+Object.defineProperty(process, 'platform', { value: 'linux' });
+process.env.PATH = process.env.FILE_OPEN_TEST_BIN!;
+
+const app = express();
+app.use(express.json());
+app.get('/probe', (_req, res) => res.json({ alive: true }));
+registerMessagingRoutes(app, (req, res, next) => {
+    if (req.headers['x-test-auth'] !== 'allow') {
+        res.status(401).json({ error: 'unauthorized' });
+        return;
+    }
+    next();
+});
+const server = app.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    if (address && typeof address !== 'string') process.send?.({ port: address.port });
+});
+process.on('message', message => {
+    if (message !== 'stop') return;
+    server.closeAllConnections();
+    server.close(() => process.exit(0));
+});

--- a/tests/unit/file-open-route.test.ts
+++ b/tests/unit/file-open-route.test.ts
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { once } from 'node:events';
+import { chmodSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+test('Linux file-open dispatch does not wait for a desktop application', {
+    skip: process.platform === 'win32' ? 'POSIX executable fixture; Linux/macOS exercise the Linux route' : false,
+    timeout: 30_000,
+}, async t => {
+    const root = mkdtempSync(join(tmpdir(), 'jaw-file-open-'));
+    const bin = join(root, 'bin');
+    mkdirSync(bin);
+    const sockets = new Set<Socket>();
+    const control = createServer(socket => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+    });
+    control.listen(0, '127.0.0.1');
+    await once(control, 'listening');
+    const address = control.address();
+    assert.ok(address && typeof address !== 'string');
+    const opener = join(bin, 'xdg-open');
+    writeFileSync(opener, `#!${process.execPath}
+const net = require('node:net');
+const fs = require('node:fs');
+const socket = net.connect(${address.port}, '127.0.0.1', () => {
+    socket.write(JSON.stringify({ pid: process.pid, args: process.argv.slice(2),
+        ignoredStdio: [0, 1, 2].every(fd => fs.fstatSync(fd).isCharacterDevice()) }) + '\\n');
+});
+socket.on('data', () => { socket.end(); });
+socket.on('error', () => { process.exitCode = 1; });
+socket.on('end', () => { socket.end(); });
+`, { mode: 0o755 });
+    const fixture = fileURLToPath(new URL('../fixtures/file-open-server.ts', import.meta.url));
+    const server = fork(fixture, [], {
+        execArgv: ['--import', 'tsx'],
+        env: { ...process.env, CLI_JAW_HOME: join(root, 'home'), NODE_ENV: 'test', FILE_OPEN_TEST_BIN: bin },
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    let output = '';
+    server.stdout!.on('data', chunk => { output += String(chunk); });
+    server.stderr!.on('data', chunk => { output += String(chunk); });
+    const closed = once(server, 'exit');
+    try {
+        const [ready] = await once(server, 'message', { signal: AbortSignal.timeout(10_000) });
+        assert.ok(ready && typeof ready === 'object' && 'port' in ready, output);
+        const base = `http://127.0.0.1:${ready.port}`;
+        const post = (body: unknown, authenticated = true) => fetch(`${base}/api/file/open`, {
+            method: 'POST', headers: { 'content-type': 'application/json', 'x-test-auth': authenticated ? 'allow' : '' },
+            body: JSON.stringify(body), signal: AbortSignal.timeout(3_000),
+        });
+        const document = join(root, 'report ; $safe.md');
+        const binary = join(root, 'archive.bin');
+        writeFileSync(document, 'fixture');
+        writeFileSync(binary, 'fixture');
+        const colonName = join(root, 'literal.md:12');
+        writeFileSync(colonName, 'exact filename wins over line suffix');
+        for (const [input, opened, resolvedTarget, strategy] of [
+            [document + ':12:3', document, document, 'reveal'],
+            [binary, root, binary, 'folder'],
+            [root, root, root, 'directory'],
+            [colonName, root, colonName, 'folder'],
+        ] as const) {
+            await t.test(`responsive while ${strategy} opener is alive`, async () => {
+                const connection = once(control, 'connection', { signal: AbortSignal.timeout(3_000) });
+                // Catch immediately: a regressed synchronous server times out while
+                // the parent is independently probing its event loop.
+                const response = post({ path: input }).then(value => ({ value }), error => ({ error }));
+                const [socket] = await connection as [Socket];
+                try {
+                    const data = await new Promise<string>((resolve, reject) => {
+                        let buffer = '';
+                        const timer = setTimeout(() => finish(new Error('opener handshake timed out')), 3_000);
+                        const onClose = () => finish(new Error('opener closed before handshake'));
+                        const onError = (error: Error) => finish(error);
+                        const onData = (chunk: Buffer) => {
+                            buffer += chunk.toString();
+                            if (buffer.includes('\n')) finish();
+                        };
+                        function finish(error?: Error) {
+                            clearTimeout(timer);
+                            socket.off('data', onData);
+                            socket.off('close', onClose);
+                            socket.off('error', onError);
+                            if (error) reject(error);
+                            else resolve(buffer.slice(0, buffer.indexOf('\n')));
+                        }
+                        socket.on('data', onData);
+                        socket.once('close', onClose);
+                        socket.once('error', onError);
+                    });
+                    const launch = JSON.parse(data) as { pid: number; args: string[]; ignoredStdio: boolean };
+                    process.kill(launch.pid, 0);
+                    const probe = await fetch(`${base}/probe`, { signal: AbortSignal.timeout(3_000) });
+                    assert.deepEqual(await probe.json(), { alive: true });
+                    const result = await response;
+                    if ('error' in result) throw result.error;
+                    assert.equal(result.value.status, 200);
+                    assert.deepEqual(await result.value.json(), {
+                        ok: true, data: { opened: resolve(opened), resolvedTarget: resolve(resolvedTarget), strategy },
+                    });
+                    assert.deepEqual(launch.args, [resolve(opened)]);
+                    assert.equal(launch.ignoredStdio, true, 'opener must not inherit server pipes');
+                    process.kill(launch.pid, 0);
+                } finally {
+                    try {
+                        if (!socket.destroyed) {
+                            const ended = once(socket, 'close', { signal: AbortSignal.timeout(3_000) });
+                            socket.end('stop');
+                            await ended;
+                        }
+                    } finally {
+                        socket.destroy();
+                        await response;
+                    }
+                }
+            });
+        }
+        await t.test('successful dispatch does not claim application exit success', async () => {
+            writeFileSync(opener, `#!${process.execPath}\nprocess.exitCode = 7;\n`, { mode: 0o755 });
+            const response = await post({ path: document });
+            assert.equal(response.status, 200);
+            assert.deepEqual(await response.json(), {
+                ok: true, data: { opened: document, resolvedTarget: document, strategy: 'reveal' },
+            });
+        });
+        await t.test('launch errors and rejected paths preserve HTTP outcomes', async () => {
+            renameSync(opener, opener + '.hidden');
+            const missing = await post({ path: document });
+            assert.equal(missing.status, 500);
+            assert.deepEqual(await missing.json(), { ok: false, error: 'open_failed' });
+            renameSync(opener + '.hidden', opener);
+            chmodSync(opener, 0o600);
+            const denied = await post({ path: document });
+            assert.equal(denied.status, 500);
+            assert.deepEqual(await denied.json(), { ok: false, error: 'open_failed' });
+            for (const [body, status, error] of [
+                [{ path: '' }, 400, 'path_required'],
+                [{ path: 42 }, 400, 'path_required'],
+                [{ path: join(root, 'missing.md') }, 404, 'file_not_found'],
+            ] as const) {
+                const response = await post(body);
+                assert.equal(response.status, status);
+                assert.deepEqual(await response.json(), { ok: false, error });
+            }
+            assert.equal((await post({ path: document }, false)).status, 401);
+            assert.equal((await fetch(`${base}/probe`, { signal: AbortSignal.timeout(3_000) })).status, 200);
+        });
+    } finally {
+        for (const socket of sockets) socket.destroy();
+        if (server.connected) server.send('stop');
+        const killTimer = setTimeout(() => server.kill('SIGKILL'), 2_000);
+        const [code, signal] = await closed;
+        clearTimeout(killTimer);
+        await new Promise<void>(resolve => control.close(() => resolve()));
+        rmSync(root, { recursive: true, force: true });
+        assert.equal(signal, null, output);
+        assert.equal(code, 0, output);
+    }
+});


### PR DESCRIPTION
## Summary

Closes #540.

Linux file opening currently runs `xdg-open` synchronously, so a desktop application that stays alive can stall unrelated HTTP requests. Dispatch the opener asynchronously with detached lifecycle and ignored stdio; acknowledge the spawn event and return the existing `open_failed` error on launch failure. A 200 response confirms dispatch, not eventual desktop success. macOS and Windows behavior is unchanged.

Preserve authentication, path classification, literal-filename precedence and line/column suffix handling. Document the Linux response semantics.

## Verification

- Controlled real opener/isolated Express regression: the original synchronous implementation times out on unrelated HTTP requests; the fix passes all 7 tests.
- Same 7 tests pass against compiled `dist` routes.
- Adjacent route/consumer tests: 25 passed.
- Server TypeScript build and dist asset checks: passed.
- Architecture counts: 540 passed; `git diff --check`: passed.
- The controlled fixture reproduces the blocking mechanism, not the reporter's exact Chrome/nginx incident.
- Independent final review: PASS on `2dcf1776`; no blocking findings.
- Built-route curl QA: three concurrent file opens and unrelated GET return 200 while openers remain alive; validation/launch errors preserve 400/404/500; owned processes/listeners cleaned up.
- Final-head GitHub CI passed on `2dcf177633ca4983e02f430f95bbfbaeace87d3c`: [Tests run 34145490107](https://github.com/lidge-jun/cli-jaw/actions/runs/34145490107). All four Linux shards, integration, gates, Windows units and required aggregate passed. The new regression ran on Linux in shard 4. Advisory coverage and CodeRabbit review were skipped, not counted as verification.

## Checklist

- [x] Focused regression coverage added, including launch failures and preserved response envelopes.
- [x] API and operating documentation updated.
- [x] No dependencies, real desktop launches, release, deployment or service restart.
- [x] Final independent review and current-head GitHub CI passed.
