### PR TITLE
feat(manager): drop Workbench Settings tab, add instance settings side panel (wbui 3/6)

### DIFF
--- a/public/manager/src/App.tsx
+++ b/public/manager/src/App.tsx
@@ -7,7 +7,6 @@ import { ProfileChip } from './components/ProfileChip';
 import { AppChrome } from './AppChrome';
 import { type HelpTopicId } from './help/helpContent';
 import { isHelpShortcutEditableTarget } from './help/help-shortcuts';
-import { WorkbenchHeader } from './components/WorkbenchHeader';
 import { loadPreviewEnabled, savePreviewEnabled } from './lib/preview-prefs';
 import { useHiddenUnload } from './lib/use-hidden-unload';
 import { type DashboardSettingsSection } from './dashboard-settings/DashboardSettingsSidebar';
@@ -23,7 +22,7 @@ import { normalizeSidebarModeForBuild, REMINDERS_WORKSPACE_ENABLED } from './das
 import { readInitialSidebarMode, readTrayRemindersMode } from './dashboard-url-state';
 import { TrayRemindersApp } from './dashboard-reminders/TrayRemindersApp';
 import { useDashboardRegistry } from './hooks/useDashboardRegistry';
-import { useDashboardView } from './hooks/useDashboardView';
+import { useDashboardView, hydrateInstanceSettings, createInstanceSettingsNavigation, useSettingsDirtyState } from './hooks/useDashboardView';
 import { useActivityUnread } from './hooks/useActivityUnread';
 import { useTheme } from './hooks/useTheme';
 import { useCommandPalette } from './hooks/useCommandPalette';
@@ -58,7 +57,7 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
     const [transitioningPort, setTransitioningPort] = useState<number | null>(null);
     const [transitionAction, setTransitionAction] = useState<DashboardLifecycleAction | null>(null);
     const [activeProfileIds, setActiveProfileIds] = useState<string[]>([]);
-    const [settingsDirty, setSettingsDirty] = useState(false);
+    const { settingsDirty, panelSettingsDirty, setSettingsDirty, onSettingsDirtyChange, onPanelSettingsDirtyChange } = useSettingsDirtyState();
     const [notesDirtyPath, setNotesDirtyPath] = useState<string | null>(null);
     const [notesSidebarMode, setNotesSidebarMode] = useState<NotesSidebarMode>('files');
     const [notesSearchFocusToken, setNotesSearchFocusToken] = useState(0);
@@ -194,7 +193,8 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             try {
                 const loaded = await registry.refresh();
                 const ui = loaded.registry.ui;
-                view.setSelectedPort(ui.selectedPort); view.setActiveDetailTab(ui.selectedTab); view.setSidebarCollapsed(ui.sidebarCollapsed);
+                const restored = hydrateInstanceSettings(ui);
+                view.setSelectedPort(ui.selectedPort); view.setActiveDetailTab(restored.selectedTab); view.setInstanceSettingsOpen(restored.instanceSettingsOpen); view.setSidebarCollapsed(ui.sidebarCollapsed);
                 view.setActivityDockCollapsed(ui.activityDockCollapsed); view.setActivityDockHeight(ui.activityDockHeight);
                 const sidebarMode = normalizeSidebarModeForBuild(readInitialSidebarMode(window.location.search) ?? ui.sidebarMode);
                 view.setSidebarMode(sidebarMode);
@@ -243,27 +243,27 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
         setActiveProfileIds(next);
         void registry.save({ activeProfileFilter: next });
     }
-    function canLeaveDirtySettings(): boolean {
-        if (view.activeDetailTab !== 'settings' || !settingsDirty) return true;
-        return window.confirm('Discard unsaved Settings changes?');
-    }
+    const { canLeaveDirtySettings, setInstanceSettingsOpen } = createInstanceSettingsNavigation({
+        view, settingsDirty, panelSettingsDirty, setSettingsDirty, clearPanelDirty: () => onSettingsDirtyChange('panel', false), saveUi, selectedPort: selectedInstance?.port ?? null,
+    });
 
     function handlePreview(instance: DashboardInstance, openDefaultSession = false): void {
-        if (!canLeaveDirtySettings()) return;
+        if (instance.port !== selectedInstance?.port && !canLeaveDirtySettings()) return;
         if (openDefaultSession) { setPreviewEnabled(true); setAutoUnloadNotice(false); setPreviewRefreshKey(key => key + 1); }
-        setSettingsDirty(false); activityUnread.markPortSeen(instance.port); view.setSelectedPort(instance.port);
+        if (instance.port !== selectedInstance?.port) setSettingsDirty(false);
+        activityUnread.markPortSeen(instance.port); view.setSelectedPort(instance.port);
         view.setActiveDetailTab('preview'); view.setActivityDockCollapsed(true); view.setDrawerOpen(false);
         void saveUi({ selectedPort: instance.port, selectedTab: 'preview', activityDockCollapsed: true });
     }
     function handleOpenJawCeoWorker(port: number): void { const instance = instances.find(row => row.port === port); if (instance) handlePreview(instance); }
     function handleSelectInstance(instance: DashboardInstance): void {
-        if (!canLeaveDirtySettings()) return;
-        setSettingsDirty(false); activityUnread.markPortSeen(instance.port); view.setSelectedPort(instance.port); view.setDrawerOpen(false);
+        if (instance.port !== selectedInstance?.port && !canLeaveDirtySettings()) return;
+        if (instance.port !== selectedInstance?.port) setSettingsDirty(false);
+        activityUnread.markPortSeen(instance.port); view.setSelectedPort(instance.port); view.setDrawerOpen(false);
         void saveUi({ selectedPort: instance.port });
     }
     function handleTabChange(tab: DashboardDetailTab): void {
-        if (tab !== 'settings' && !canLeaveDirtySettings()) return;
-        if (tab !== 'settings') setSettingsDirty(false);
+        if (tab === 'settings') { setInstanceSettingsOpen(true); return; }
         if (view.activeDetailTab === 'preview' && tab !== 'preview') {
             const port = view.selectedPort;
             if (port != null) activityUnread.markPortSeen(port);
@@ -385,6 +385,7 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             handleTabChange,
             setPreviewRefreshKey,
             handleSidebarToggle,
+            toggleInstanceSettings: () => setInstanceSettingsOpen(!view.instanceSettingsOpen),
         });
     }
     useEffect(() => {
@@ -394,7 +395,7 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             runManagerShortcut(action);
         });
         return unsubscribe;
-    }, [filtered, selectedInstance, view.dashboardShortcutsEnabled, view.sidebarMode, view.activeDetailTab, settingsDirty]);
+    }, [filtered, selectedInstance, view.dashboardShortcutsEnabled, view.sidebarMode, view.activeDetailTab, view.instanceSettingsOpen, settingsDirty, panelSettingsDirty]);
 
     useEffect(() => {
         function onKeyDown(event: KeyboardEvent): void {
@@ -415,7 +416,7 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
         }
         document.addEventListener('keydown', onKeyDown);
         return () => document.removeEventListener('keydown', onKeyDown);
-    }, [filtered, selectedInstance, view.dashboardShortcutsEnabled, view.dashboardShortcutKeymap, view.sidebarMode, view.activeDetailTab, settingsDirty]);
+    }, [filtered, selectedInstance, view.dashboardShortcutsEnabled, view.dashboardShortcutKeymap, view.sidebarMode, view.activeDetailTab, view.instanceSettingsOpen, settingsDirty, panelSettingsDirty]);
 
     async function handleLifecycle(action: DashboardLifecycleAction, instance: DashboardInstance): Promise<void> {
         const lifecycle = instance.lifecycle;
@@ -480,7 +481,6 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             onMarkActivitySeen={activityUnread.markPortSeen} onInstanceLabelSave={labelEditor.saveInstanceLabel}
             onLifecycle={(action, instance) => void handleLifecycle(action, instance)} />
     );
-    const workbenchHeader = <WorkbenchHeader instance={selectedInstance} previewEnabled={previewEnabled} onPreviewEnabledChange={setPreviewEnabled} onPreviewRefresh={() => setPreviewRefreshKey(key => key + 1)} onOpenHelpTopic={openHelpTopic} onPickProject={(port) => void projectPicker.pick(port)} projectPickBusy={projectPicker.busyPort != null} />;
     const dashboardSettingsUi = dashboardSettingsUiFromView(view, theme.theme), titleSupport = summarizeActivityTitleSupport(messageActivity.titleSupportByPort);
     const profileChipStrip = (chipProfiles: DashboardProfile[]) => chipProfiles.length > 0 ? <div className="profile-chip-strip drawer-chip-strip" aria-label="Profile filters">{chipProfiles.map(profile => <ProfileChip key={profile.profileId} profile={profile} active={activeProfileIds.includes(profile.profileId)} count={profileCounts[profile.profileId] || 0} onToggle={toggleProfile} />)}</div> : null;
 
@@ -489,11 +489,11 @@ export function App() { if (readTrayRemindersMode(window.location.search) && REM
             instance={selectedInstance}
             data={data}
             activeTab={tab}
-            onSettingsDirtyChange={setSettingsDirty}
+            onSettingsDirtyChange={onPanelSettingsDirtyChange}
             onSettingsSaved={() => { if (selectedInstance) void refreshInstance(selectedInstance.port); publishInvalidation({ topics: ['instances'], reason: 'instance:settings-saved', source: 'ui', sourceId: 'app' }); }}
             onRegistryPatch={(port, patch) => { void registry.save({ instances: { [String(port)]: patch } }).then(() => { load(); publishInvalidation({ topics: ['instances'], reason: 'instance:registry-patched', source: 'ui', sourceId: 'app' }); }); }}
         />
     );
 
-    return <AppChrome view={view} palette={palette} theme={theme} query={query} loading={loading} showHidden={showHidden} instances={instances} selectedInstance={selectedInstance} data={data} summary={summary} scheduleGroup={scheduleGroup} boardView={boardView} notesModel={notesModel} notesSelectedNote={notesSelectedNote} notesDirtyPath={notesDirtyPath} notesHighlightedPath={notesHighlightedPath} notesSidebarMode={notesSidebarMode} notesSearchFocusToken={notesSearchFocusToken} settingsSection={dashboardSettingsSection} dashboardSettingsUi={dashboardSettingsUi} titleSupport={titleSupport} activityEvents={activityEvents} busyPorts={messageActivity.busyPorts} titlesByPort={messageActivity.titlesByPort} lifecycleMessage={lifecycleMessage} error={error} registryMessage={registry.error || labelEditor.error || managerEvents.error} workbenchHeader={workbenchHeader} detailContent={detailContent} instanceListContent={instanceListContent} drawerProfileFilters={profileChipStrip(profiles)} jawCeoWorkbenchButton={jawCeoBridge.workbenchButton} jawCeoVoiceOverlay={jawCeoBridge.voiceOverlay} jawCeo={jawCeoBridge.ceo} jawCeoVoice={jawCeoBridge.voice} jawCeoOpen={jawCeoBridge.open} jawCeoSelectedPort={activeJawCeoPort} onJawCeoOpenChange={jawCeoBridge.setOpen} onJawCeoOpenWorker={handleOpenJawCeoWorker} previewEnabled={previewEnabled} previewRefreshKey={previewRefreshKey} autoUnloadNotice={autoUnloadNotice} helpOpen={helpOpen} helpTopic={helpTopic} setQuery={setQuery} setShowHidden={setShowHidden} setPreviewEnabled={setPreviewEnabled} setAutoUnloadNotice={setAutoUnloadNotice} setHelpOpen={setHelpOpen} setHelpTopic={setHelpTopic} onOpenHelpTopic={openHelpTopic} setNotesSidebarMode={setNotesSidebarMode} setBoardView={setBoardView} setScheduleGroup={setScheduleGroup} setDashboardSettingsSection={setDashboardSettingsSection} load={load} cycleTheme={cycleTheme} openSelectedInBrowser={openSelectedInBrowser} handleSelectInstance={handleSelectInstance} handleSidebarModeChange={handleSidebarModeChange} handleSidebarToggle={handleSidebarToggle} handleNotesSelectedPathChange={handleNotesSelectedPathChange} openNotesFromPreview={openNotesFromPreview} handleNotesViewModeChange={handleNotesViewModeChange} handleNotesAuthoringModeChange={handleNotesAuthoringModeChange} handleNotesWordWrapChange={handleNotesWordWrapChange} handleNotesVimModeChange={handleNotesVimModeChange} handleNotesTreeWidthChange={handleNotesTreeWidthChange} handleNotesGraphSettingsChange={handleNotesGraphSettingsChange} openNotesSidebarSearch={openNotesSidebarSearch} setNotesDirtyPath={setNotesDirtyPath} handleTabChange={handleTabChange} handleActivityToggle={handleActivityToggle} handleActivityHeight={handleActivityHeight} onDismissLifecycleMessage={() => setLifecycleMessage(null)} handleDashboardSettingsPatch={handleDashboardSettingsPatch} activityUnreadOpenAndMarkSeen={activityUnread.openAndMarkSeen} panelInitialState={panelInitialState} onPanelStateChange={handlePanelStateChange} onShortcutAction={runManagerShortcut} />;
+    return <AppChrome view={view} palette={palette} theme={theme} query={query} loading={loading} showHidden={showHidden} instances={instances} selectedInstance={selectedInstance} data={data} summary={summary} scheduleGroup={scheduleGroup} boardView={boardView} notesModel={notesModel} notesSelectedNote={notesSelectedNote} notesDirtyPath={notesDirtyPath} notesHighlightedPath={notesHighlightedPath} notesSidebarMode={notesSidebarMode} notesSearchFocusToken={notesSearchFocusToken} settingsSection={dashboardSettingsSection} dashboardSettingsUi={dashboardSettingsUi} titleSupport={titleSupport} activityEvents={activityEvents} busyPorts={messageActivity.busyPorts} titlesByPort={messageActivity.titlesByPort} lifecycleMessage={lifecycleMessage} error={error} registryMessage={registry.error || labelEditor.error || managerEvents.error} onPickProject={(port) => void projectPicker.pick(port)} projectPickBusy={projectPicker.busyPort != null} onRefreshPreview={() => setPreviewRefreshKey(key => key + 1)} onInstanceSettingsOpenChange={setInstanceSettingsOpen} onSettingsDirtyChange={onSettingsDirtyChange} detailContent={detailContent} instanceListContent={instanceListContent} drawerProfileFilters={profileChipStrip(profiles)} jawCeoWorkbenchButton={jawCeoBridge.workbenchButton} jawCeoVoiceOverlay={jawCeoBridge.voiceOverlay} jawCeo={jawCeoBridge.ceo} jawCeoVoice={jawCeoBridge.voice} jawCeoOpen={jawCeoBridge.open} jawCeoSelectedPort={activeJawCeoPort} onJawCeoOpenChange={jawCeoBridge.setOpen} onJawCeoOpenWorker={handleOpenJawCeoWorker} previewEnabled={previewEnabled} previewRefreshKey={previewRefreshKey} autoUnloadNotice={autoUnloadNotice} helpOpen={helpOpen} helpTopic={helpTopic} setQuery={setQuery} setShowHidden={setShowHidden} setPreviewEnabled={setPreviewEnabled} setAutoUnloadNotice={setAutoUnloadNotice} setHelpOpen={setHelpOpen} setHelpTopic={setHelpTopic} onOpenHelpTopic={openHelpTopic} setNotesSidebarMode={setNotesSidebarMode} setBoardView={setBoardView} setScheduleGroup={setScheduleGroup} setDashboardSettingsSection={setDashboardSettingsSection} load={load} cycleTheme={cycleTheme} openSelectedInBrowser={openSelectedInBrowser} handleSelectInstance={handleSelectInstance} handleSidebarModeChange={handleSidebarModeChange} handleSidebarToggle={handleSidebarToggle} handleNotesSelectedPathChange={handleNotesSelectedPathChange} openNotesFromPreview={openNotesFromPreview} handleNotesViewModeChange={handleNotesViewModeChange} handleNotesAuthoringModeChange={handleNotesAuthoringModeChange} handleNotesWordWrapChange={handleNotesWordWrapChange} handleNotesVimModeChange={handleNotesVimModeChange} handleNotesTreeWidthChange={handleNotesTreeWidthChange} handleNotesGraphSettingsChange={handleNotesGraphSettingsChange} openNotesSidebarSearch={openNotesSidebarSearch} setNotesDirtyPath={setNotesDirtyPath} handleTabChange={handleTabChange} handleActivityToggle={handleActivityToggle} handleActivityHeight={handleActivityHeight} onDismissLifecycleMessage={() => setLifecycleMessage(null)} handleDashboardSettingsPatch={handleDashboardSettingsPatch} activityUnreadOpenAndMarkSeen={activityUnread.openAndMarkSeen} panelInitialState={panelInitialState} onPanelStateChange={handlePanelStateChange} onShortcutAction={runManagerShortcut} />;
 }

--- a/public/manager/src/AppChrome.tsx
+++ b/public/manager/src/AppChrome.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type ReactNode, type SetStateAction } from 'react';
 import { CommandBar } from './components/CommandBar';
+import { WorkbenchHeader } from './components/WorkbenchHeader';
 import { CommandPalette } from './components/CommandPalette';
 import { ManagerShell } from './components/ManagerShell';
 import { HelpDrawer } from './help/HelpDrawer';
@@ -50,7 +51,11 @@ type AppChromeProps = {
     lifecycleMessage: string | null;
     error: string | null;
     registryMessage: string | null;
-    workbenchHeader: ReactNode;
+    onPickProject: (port: number) => void;
+    projectPickBusy: boolean;
+    onRefreshPreview: () => void;
+    onInstanceSettingsOpenChange: (open: boolean) => void;
+    onSettingsDirtyChange: (entry: 'panel' | 'dashboard', dirty: boolean) => void;
     detailContent: (tab: DashboardDetailTab) => ReactNode;
     instanceListContent: ReactNode;
     drawerProfileFilters: ReactNode;
@@ -143,7 +148,7 @@ export function AppChrome(props: AppChromeProps) {
                         boardView={props.boardView} onBoardViewChange={props.setBoardView} scheduleGroup={props.scheduleGroup} onScheduleGroupChange={props.setScheduleGroup}
                         instances={props.instances} selectedInstance={props.selectedInstance} data={props.data} titlesByPort={props.titlesByPort}
                         busyPorts={props.busyPorts} activeDetailTab={props.view.activeDetailTab} onDetailTabChange={props.handleTabChange}
-                        workbenchHeader={props.workbenchHeader} detailContent={props.detailContent} previewEnabled={props.previewEnabled}
+                        workbenchHeader={<WorkbenchHeader instance={props.selectedInstance} previewEnabled={props.previewEnabled} onPreviewEnabledChange={props.setPreviewEnabled} onPreviewRefresh={props.onRefreshPreview} onOpenHelpTopic={props.onOpenHelpTopic} onPickProject={props.onPickProject} projectPickBusy={props.projectPickBusy} />} instanceSettingsOpen={props.view.instanceSettingsOpen} onInstanceSettingsOpenChange={props.onInstanceSettingsOpenChange} onSettingsDirtyChange={props.onSettingsDirtyChange} detailContent={props.detailContent} previewEnabled={props.previewEnabled}
                         previewRefreshKey={props.previewRefreshKey} previewTheme={props.theme.resolved} onOpenNotesFromPreview={props.openNotesFromPreview} lifecycleMessage={props.lifecycleMessage}
                         onDismissLifecycleMessage={props.onDismissLifecycleMessage} instanceListContent={props.instanceListContent} loading={props.loading}
                         jawCeoWorkbenchButton={props.jawCeoWorkbenchButton} jawCeoVoiceOverlay={props.jawCeoVoiceOverlay}

--- a/public/manager/src/SidebarRailRouter.tsx
+++ b/public/manager/src/SidebarRailRouter.tsx
@@ -5,6 +5,7 @@ import { InstanceNavigator } from './components/InstanceNavigator';
 import { MobileNav } from './components/MobileNav';
 import { SidebarRail } from './components/SidebarRail';
 import { Workbench } from './components/Workbench';
+import { WorkbenchSettingsToggle } from './components/WorkbenchHeader';
 import { WorkspaceLayout } from './components/WorkspaceLayout';
 import { lazy } from 'react';
 import { RightSidebar } from './panels/RightSidebar';
@@ -139,6 +140,9 @@ type Props = {
     titlesByPort: Record<number, string>;
     busyPorts: Set<number>;
     activeDetailTab: DashboardDetailTab;
+    instanceSettingsOpen: boolean;
+    onInstanceSettingsOpenChange: (open: boolean) => void;
+    onSettingsDirtyChange: (entry: 'panel' | 'dashboard', dirty: boolean) => void;
     onDetailTabChange: (tab: DashboardDetailTab) => void;
     workbenchHeader: ReactNode;
     detailContent: (tab: DashboardDetailTab) => ReactNode;
@@ -569,7 +573,7 @@ export function SidebarRailRouter(props: Props) {
                     )}
                     <div className="workspace-surface-layer">
                         <WorkspaceSurface active={props.sidebarMode === 'instances' && props.viewMode === 'jaw'}>
-                            <Workbench mode={props.activeDetailTab} onModeChange={props.onDetailTabChange} header={props.workbenchHeader} modeActions={props.jawCeoWorkbenchButton} overview={props.detailContent('overview')} preview={(
+                            <Workbench mode={props.activeDetailTab} onModeChange={props.onDetailTabChange} header={props.workbenchHeader} modeActions={<>{props.jawCeoWorkbenchButton}<WorkbenchSettingsToggle open={props.instanceSettingsOpen} onToggle={() => props.onInstanceSettingsOpenChange(!props.instanceSettingsOpen)} /></>} active={props.sidebarMode === 'instances' && props.viewMode === 'jaw'} settingsOpen={props.instanceSettingsOpen} onSettingsClose={() => props.onInstanceSettingsOpenChange(false)} overview={props.detailContent('overview')} preview={(
                                 <InstancePreview instance={props.selectedInstance} data={props.data} enabled={props.previewEnabled} active={props.sidebarMode === 'instances' && props.activeDetailTab === 'preview'} refreshKey={props.previewRefreshKey} theme={props.previewTheme} {...(props.onOpenNotesFromPreview ? { onOpenNotesFromPreview: props.onOpenNotesFromPreview } : {})} onOpenDocFromPreview={handleRightPreviewFile} onPreviewDroppedFiles={handlePreviewDroppedFiles} docPanelCapable={desktopPanelsAvailable} previewInsertTextRequest={previewInsertTextRequest} onPreviewInsertTextResult={handlePreviewInsertTextResult} />
                             )} logs={props.detailContent('logs')} settings={props.detailContent('settings')} />
                         </WorkspaceSurface>
@@ -617,7 +621,7 @@ export function SidebarRailRouter(props: Props) {
                 />
             )}
             sidePanel={(!isElectron && ceoConsoleOpen) ? jawCeoPanel : undefined}
-            mobileNav={<MobileNav activeTab={props.activeDetailTab} onOpenInstances={props.onOpenDrawer} onSelectTab={props.onSelectTab} onToggleActivity={props.onToggleActivityFromMobile} />}
+            mobileNav={<MobileNav activeTab={props.instanceSettingsOpen ? 'settings' : props.activeDetailTab} onOpenInstances={props.onOpenDrawer} onSelectTab={props.onSelectTab} onToggleActivity={props.onToggleActivityFromMobile} />}
             drawer={(
                 <InstanceDrawer open={props.drawerOpen} profileFilters={props.drawerProfileFilters} onClose={props.onCloseDrawer}>
                     {props.instanceListContent}

--- a/public/manager/src/components/InstanceDetailPanel.tsx
+++ b/public/manager/src/components/InstanceDetailPanel.tsx
@@ -51,7 +51,7 @@ export function InstanceDetailPanel(props: InstanceDetailPanelProps) {
                     <SettingsShell
                         key={instance.port}
                         port={instance.port}
-                        instanceUrl={`http://localhost:${instance.port}`}
+                        instanceUrl={instance.url}
                         {...(props.onSettingsDirtyChange !== undefined ? { onDirtyChange: props.onSettingsDirtyChange } : {})}
                         {...(props.onSettingsSaved !== undefined ? { onSaved: props.onSettingsSaved } : {})}
                     />

--- a/public/manager/src/components/Workbench.tsx
+++ b/public/manager/src/components/Workbench.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import type { DashboardDetailTab } from '../types';
 
 type WorkbenchProps = {
@@ -10,17 +10,33 @@ type WorkbenchProps = {
     preview: ReactNode;
     logs: ReactNode;
     settings: ReactNode;
+    settingsOpen: boolean;
+    onSettingsClose: () => void;
+    active: boolean;
 };
 
-const MODES: DashboardDetailTab[] = ['overview', 'preview', 'logs', 'settings'];
+const MODES: DashboardDetailTab[] = ['overview', 'preview', 'logs'];
 
 function modeLabel(mode: DashboardDetailTab): string {
     return mode[0].toUpperCase() + mode.slice(1);
 }
 
 export function Workbench(props: WorkbenchProps) {
+    const panelRef = useRef<HTMLElement>(null);
+    useEffect(() => {
+        if (!props.settingsOpen || !props.active) return;
+        const panel = panelRef.current;
+        const previous = document.activeElement;
+        panel?.querySelector<HTMLButtonElement>('button')?.focus({ preventScroll: true });
+        return () => {
+            if (document.activeElement !== document.body && !panel?.contains(document.activeElement)) return;
+            const target = previous instanceof HTMLElement && previous.isConnected && previous.getClientRects().length
+                ? previous : document.querySelector<HTMLElement>('.workbench-settings-toggle');
+            if (target?.getClientRects().length) target.focus({ preventScroll: true });
+        };
+    }, [props.settingsOpen, props.active]);
     return (
-        <section className={`workbench workbench-${props.mode}`} aria-label="Selected instance workbench">
+        <section className={`workbench workbench-${props.mode}`} data-instance-settings-open={props.settingsOpen} aria-label="Selected instance workbench">
             <div className="workbench-header">
                 {props.header}
                 <div className="workbench-mode-bar">
@@ -57,10 +73,18 @@ export function Workbench(props: WorkbenchProps) {
                 {props.mode === 'logs' && (
                     <div key="logs" className="workbench-panel workbench-panel-logs">{props.logs}</div>
                 )}
-                {props.mode === 'settings' && (
-                    <div key="settings" className="workbench-panel workbench-panel-settings">{props.settings}</div>
-                )}
             </div>
+            {props.settingsOpen && (
+                <aside ref={panelRef} id="workbench-instance-settings" className="workbench-settings-panel"
+                    aria-label="Instance settings" onKeyDown={(event) => {
+                        if (event.key !== 'Escape' || event.defaultPrevented) return;
+                        if ((event.target as Element).closest('[role="dialog"], [role="listbox"]')) return;
+                        event.preventDefault(); event.stopPropagation(); props.onSettingsClose();
+                    }}>
+                    <header><strong>Instance settings</strong><button type="button" aria-label="Close instance settings" onClick={props.onSettingsClose}>Close</button></header>
+                    {props.settings}
+                </aside>
+            )}
         </section>
     );
 }

--- a/public/manager/src/components/WorkbenchHeader.tsx
+++ b/public/manager/src/components/WorkbenchHeader.tsx
@@ -1,4 +1,5 @@
 import { instanceLabel } from '../instance-label';
+import { icon } from '../../../js/icons';
 import { HelpTopicButton } from '../help/HelpTopicButton';
 import type { HelpTopicId } from '../help/helpContent';
 import type { DashboardInstance } from '../types';
@@ -103,4 +104,12 @@ export function WorkbenchHeader(props: WorkbenchHeaderProps) {
             )}
         </div>
     );
+}
+
+export function WorkbenchSettingsToggle(props: { open: boolean; onToggle: () => void }) {
+    return <button type="button" className="workbench-settings-toggle" aria-label="Instance settings"
+        title="Instance settings" aria-pressed={props.open} aria-controls="workbench-instance-settings"
+        onClick={props.onToggle}>
+        <span aria-hidden="true" dangerouslySetInnerHTML={{ __html: icon('settings', 16) }} />
+    </button>;
 }

--- a/public/manager/src/dashboard-settings/DashboardSettingsWorkspace.tsx
+++ b/public/manager/src/dashboard-settings/DashboardSettingsWorkspace.tsx
@@ -95,6 +95,11 @@ const COPY = {
                 scope: '단축키',
                 description: '현재 필터 목록에서 이전 인스턴스를 선택합니다.',
             },
+            shortcutToggleInstanceSettings: {
+                label: '인스턴스 설정',
+                scope: '단축키',
+                description: '설정 패널을 열거나 닫습니다. 미리보기 iframe 안에서는 작동하지 않습니다.',
+            },
             shortcutNextInstance: {
                 label: '다음 인스턴스',
                 scope: '단축키',
@@ -180,6 +185,11 @@ const COPY = {
                 label: 'Previous instance',
                 scope: 'Shortcut',
                 description: 'Select the previous instance in the current filtered list.',
+            },
+            shortcutToggleInstanceSettings: {
+                label: 'Instance settings',
+                scope: 'Shortcut',
+                description: 'Open or close the settings panel in the Manager document; unavailable inside the preview iframe.',
             },
             shortcutNextInstance: {
                 label: 'Next instance',
@@ -267,6 +277,11 @@ const COPY = {
                 scope: '快捷键',
                 description: '选择当前筛选列表中的上一个实例。',
             },
+            shortcutToggleInstanceSettings: {
+                label: '实例设置',
+                scope: '快捷键',
+                description: '打开或关闭设置面板；在预览 iframe 内不可用。',
+            },
             shortcutNextInstance: {
                 label: '下一个实例',
                 scope: '快捷键',
@@ -352,6 +367,11 @@ const COPY = {
                 label: '前のインスタンス',
                 scope: 'ショートカット',
                 description: '現在のフィルタ一覧で前のインスタンスを選択します。',
+            },
+            shortcutToggleInstanceSettings: {
+                label: 'インスタンス設定',
+                scope: 'ショートカット',
+                description: '設定パネルを開閉します。プレビュー iframe 内では使えません。',
             },
             shortcutNextInstance: {
                 label: '次のインスタンス',
@@ -481,6 +501,7 @@ function DashboardShortcutInput(props: DashboardShortcutInputProps) {
 }
 
 function shortcutCopyKey(action: DashboardShortcutAction): keyof typeof COPY.ko.fields {
+    if (action === 'toggleInstanceSettings') return 'shortcutToggleInstanceSettings';
     if (action === 'focusInstances') return 'shortcutFocusInstances';
     if (action === 'focusActiveSession') return 'shortcutFocusActiveSession';
     if (action === 'focusNotes') return 'shortcutFocusNotes';

--- a/public/manager/src/dashboard-settings/dashboard-settings-ui.ts
+++ b/public/manager/src/dashboard-settings/dashboard-settings-ui.ts
@@ -11,6 +11,7 @@ export function dashboardSettingsUiFromView(
     return {
         selectedPort: view.selectedPort,
         selectedTab: view.activeDetailTab,
+        instanceSettingsOpen: view.instanceSettingsOpen,
         sidebarCollapsed: view.sidebarCollapsed,
         activityDockCollapsed: view.activityDockCollapsed,
         activityDockHeight: view.activityDockHeight,

--- a/public/manager/src/hooks/useDashboardView.ts
+++ b/public/manager/src/hooks/useDashboardView.ts
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import type { DashboardRegistryUi } from '../types';
 import { DEFAULT_MANAGER_SHORTCUT_KEYMAP, normalizeManagerShortcutKeymap } from '../manager-shortcuts';
 import type { DashboardDetailTab, DashboardDiffMode, DashboardDiffRootPolicy, DashboardLocale, DashboardNotesAuthoringMode, DashboardNotesGraphSettings, DashboardNotesViewMode, DashboardShortcutKeymap, DashboardSidebarMode, DashboardViewMode } from '../types';
 
 export function useDashboardView() {
     const [selectedPort, setSelectedPort] = useState<number | null>(null);
     const [activeDetailTab, setActiveDetailTab] = useState<DashboardDetailTab>('overview');
+    const [instanceSettingsOpen, setInstanceSettingsOpen] = useState(false);
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     const [activityDockCollapsed, setActivityDockCollapsed] = useState(false);
@@ -40,6 +42,7 @@ export function useDashboardView() {
     return {
         selectedPort,
         setSelectedPort,
+        instanceSettingsOpen, setInstanceSettingsOpen,
         activeDetailTab,
         setActiveDetailTab,
         drawerOpen,
@@ -97,4 +100,62 @@ export function useDashboardView() {
         locale,
         setLocale,
     };
+}
+
+export function hydrateInstanceSettings(ui: Pick<DashboardRegistryUi, 'selectedTab'> & { instanceSettingsOpen?: unknown }) {
+    return { selectedTab: ui.selectedTab === 'settings' ? 'overview' as const : ui.selectedTab,
+        instanceSettingsOpen: ui.selectedTab === 'settings' || ui.instanceSettingsOpen === true };
+}
+
+type SettingsNavigation = {
+    view: Pick<ReturnType<typeof useDashboardView>, 'instanceSettingsOpen' | 'activeDetailTab' |
+        'setSelectedPort' | 'setInstanceSettingsOpen' | 'setSidebarMode' | 'setViewMode' | 'setDrawerOpen'>;
+    selectedPort: number | null;
+    settingsDirty: boolean;
+    panelSettingsDirty: boolean;
+    setSettingsDirty: (dirty: boolean) => void;
+    clearPanelDirty: () => void;
+    saveUi: (patch: Partial<DashboardRegistryUi>) => Promise<void>;
+    confirmDiscard?: () => boolean;
+};
+export function createInstanceSettingsNavigation(args: SettingsNavigation) {
+    const { view, selectedPort } = args;
+    function canLeaveDirtySettings(): boolean {
+        return !args.settingsDirty ||
+            (args.confirmDiscard ?? (() => window.confirm('Discard unsaved Settings changes?')))();
+    }
+    function setInstanceSettingsOpen(open: boolean, port = selectedPort): void {
+        if ((port !== selectedPort || (!open && args.panelSettingsDirty)) && !canLeaveDirtySettings()) return;
+        if (port !== selectedPort) args.setSettingsDirty(false);
+        else if (!open) args.clearPanelDirty();
+        if (open) {
+            view.setSelectedPort(port); view.setSidebarMode('instances');
+            view.setViewMode('jaw'); view.setDrawerOpen(false);
+        }
+        view.setInstanceSettingsOpen(open);
+        void args.saveUi({ instanceSettingsOpen: open,
+            selectedTab: view.activeDetailTab === 'settings' ? 'overview' : view.activeDetailTab,
+            ...(open ? { selectedPort: port, sidebarMode: 'instances' as const } : {}) });
+    }
+    return { canLeaveDirtySettings, setInstanceSettingsOpen };
+}
+
+// Both entry points may remain mounted: a clean hidden Shell cannot clear its peer.
+export function settingsDirtyAfter(current: { panel: boolean; dashboard: boolean },
+    entry: 'panel' | 'dashboard', dirty: boolean) {
+    return { ...current, [entry]: dirty };
+}
+export function useSettingsDirtyState() {
+    const [entries, setEntries] = useState({ panel: false, dashboard: false });
+    const onSettingsDirtyChange = useCallback((entry: 'panel' | 'dashboard', dirty: boolean) => {
+        setEntries(current => settingsDirtyAfter(current, entry, dirty));
+    }, []);
+    // SettingsShell keys its dirty notification and unmount cleanup to this callback.
+    const onPanelSettingsDirtyChange = useCallback((dirty: boolean) => {
+        onSettingsDirtyChange('panel', dirty);
+    }, [onSettingsDirtyChange]);
+    const setSettingsDirty = useCallback((dirty: boolean) => {
+        setEntries({ panel: dirty, dashboard: dirty });
+    }, []);
+    return { settingsDirty: entries.panel || entries.dashboard, panelSettingsDirty: entries.panel, setSettingsDirty, onSettingsDirtyChange, onPanelSettingsDirtyChange };
 }

--- a/public/manager/src/manager-components.css
+++ b/public/manager/src/manager-components.css
@@ -705,11 +705,13 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     height: 100%;
     min-width: 0;
     min-height: 0;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--instance-settings-w, 0px);
+    grid-template-rows: auto minmax(0, 1fr);
     overflow: hidden;
 }
 .workbench-header {
+    grid-column: 1 / -1;
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 10px;
@@ -718,10 +720,9 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     padding: 8px 12px;
 }
 .workbench-mode-tabs {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    justify-content: flex-end;
+    display: inline-flex; flex-wrap: nowrap; align-items: center;
+    background: var(--segment-track); border: 1px solid var(--segment-border);
+    border-radius: 8px; padding: 3px; gap: 2px; min-height: 30px;
 }
 .workbench-mode-bar {
     min-width: 0;
@@ -731,9 +732,12 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     gap: 8px;
 }
 .workbench-mode-tabs button {
-    min-height: 28px;
-    padding: 5px 9px;
-    font-size: 12px;
+    min-height: 24px; height: 24px; padding: 3px 9px;
+    font-size: 12px; font-weight: 500; border-radius: 6px;
+    background: transparent; border: none; box-shadow: none; color: var(--text-dim);
+}
+.workbench-mode-tabs button:hover:not(:disabled) {
+    background: var(--segment-hover); color: var(--text-primary);
 }
 .workbench-mode-tabs button.is-active {
     background: var(--accent-soft);
@@ -741,7 +745,7 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     color: var(--accent);
 }
 .workbench-body {
-    flex: 1;
+    grid-column: 1; grid-row: 2; min-width: 0;
     min-height: 0;
     overflow: hidden;
     position: relative;
@@ -1252,3 +1256,28 @@ button.instance-group-header[aria-expanded="false"] .instance-group-chevron {
     padding: 10px 12px;
 }
 .drawer-body { min-height: 0; overflow: auto; }
+
+.workbench[data-instance-settings-open="true"] { --instance-settings-w: 420px; }
+.workbench-settings-panel {
+    grid-column: 2; grid-row: 2; min-width: 0; min-height: 0;
+    display: flex; flex-direction: column; overflow: hidden;
+    border-left: 1px solid var(--border-subtle); background: var(--surface-base);
+}
+.workbench-settings-panel > header { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 12px; }
+.workbench-settings-panel > .detail-panel { flex: 1; height: auto; min-height: 0; border: 0; border-radius: 0; }
+.workbench-settings-panel .settings-shell { grid-template-columns: minmax(0, 1fr); grid-template-rows: minmax(0, auto) minmax(0, 1fr); min-width: 0; }
+.workbench-settings-panel .settings-sidebar { max-height: 160px; border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+.workbench-settings-panel .settings-sidebar-group-items { flex-direction: row; flex-wrap: wrap; gap: 4px; }
+.workbench-settings-panel .settings-sidebar-item { padding: 6px 10px; }
+.workbench-settings-panel .settings-page { min-width: 0; min-height: 0; }
+.workbench-settings-panel .settings-percli-grid { grid-template-columns: minmax(0, 1fr); }
+.workbench-settings-toggle { min-width: 32px; min-height: 32px; display: inline-flex; align-items: center; justify-content: center; }
+.workbench-settings-toggle svg { width: 16px; height: 16px; stroke-width: 1.8; }
+.workbench-settings-toggle[aria-pressed="true"] { color: var(--accent); background: var(--accent-soft); }
+.workbench-settings-toggle:focus-visible, .workbench-settings-panel button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (min-width: 1440px) { .workbench[data-instance-settings-open="true"] { --instance-settings-w: 480px; } }
+@media (max-width: 1023px) {
+    .workbench[data-instance-settings-open="true"] { --instance-settings-w: 0px; }
+    .workbench-settings-panel { position: fixed; inset-block: 0; right: 0; width: min(92vw, 420px); z-index: 22; padding-bottom: env(safe-area-inset-bottom); }
+}
+@media (pointer: coarse) { .workbench-settings-toggle, .workbench-settings-panel > header button { min-width: 44px; min-height: 44px; } }

--- a/public/manager/src/manager-layout.css
+++ b/public/manager/src/manager-layout.css
@@ -279,12 +279,12 @@
         overflow-x: auto;
         padding-bottom: 1px;
     }
-    .workbench-mode-tabs {
+    .workbench-header .workbench-mode-tabs {
         flex-wrap: nowrap;
         justify-content: stretch;
         overflow-x: auto;
     }
-    .workbench-mode-tabs button { flex: 1 0 auto; }
+    .workbench-header .workbench-mode-tabs button { flex: 1 0 auto; }
     .overview-grid { grid-template-columns: 1fr; }
     .instance-actions { grid-auto-flow: column; grid-auto-columns: minmax(0, 1fr); }
     .workbench-preview .preview-panel {

--- a/public/manager/src/manager-p0-1-1.css
+++ b/public/manager/src/manager-p0-1-1.css
@@ -167,10 +167,7 @@
     padding: 4px 8px;
 }
 
-.workbench-preview .workbench-mode-tabs button {
-    min-height: 24px;
-    padding: 3px 8px;
-}
+/* Workbench mode-tab skin is owned by manager-components.css. */
 
 .workbench-preview .preview-panel {
     gap: 3px;

--- a/public/manager/src/manager-polish.css
+++ b/public/manager/src/manager-polish.css
@@ -112,11 +112,6 @@
     padding: 1px 5px;
 }
 
-.workbench-preview .workbench-mode-tabs button {
-    min-height: 24px;
-    padding: 3px 8px;
-    font-size: 12px;
-}
 
 .workbench-preview .preview-panel {
     gap: 3px;
@@ -322,45 +317,7 @@
     width: 230px;
 }
 
-/* Polish Workbench Mode Tabs (Segmented Control Style) */
-.workbench-mode-tabs {
-    display: inline-flex;
-    align-items: center;
-    background: var(--segment-track);
-    border-radius: 8px;
-    padding: 3px;
-    gap: 2px;
-    min-height: 30px;
-    border: 1px solid var(--segment-border);
-}
-
-.workbench-mode-tabs button {
-    background: transparent;
-    border: none;
-    height: 24px;
-    min-height: 24px;
-    padding: 3px 9px;
-    color: var(--text-dim);
-    font-size: 12px;
-    font-weight: 500;
-    border-radius: 6px;
-    box-shadow: none;
-    transition: all 0.2s ease;
-}
-
-.workbench-mode-tabs button:hover:not(:disabled) {
-    background: var(--segment-hover);
-    color: var(--text-primary);
-    border-color: transparent;
-}
-
-.workbench-mode-tabs button.is-active {
-    background: var(--accent-soft);
-    color: var(--accent);
-    border: none;
-    box-shadow: none;
-    font-weight: 500;
-}
+/* Workbench mode-tab skin is owned by manager-components.css. */
 
 /* Polish Open Link Button */
 .detail-header .open-link {

--- a/public/manager/src/manager-shortcut-runner.ts
+++ b/public/manager/src/manager-shortcut-runner.ts
@@ -10,6 +10,7 @@ import { getInstanceJumpSelector, jumpInstanceIndexFromAction, readRenderedInsta
  * behaviour is identical — App passes current render values on every call.
  */
 export interface ManagerShortcutRunnerDeps {
+    toggleInstanceSettings: () => void;
     selectedInstance: DashboardInstance | null;
     filtered: DashboardInstance[];
     activeDetailTab: DashboardDetailTab;
@@ -23,6 +24,7 @@ export interface ManagerShortcutRunnerDeps {
 }
 
 export function runManagerShortcut(action: DashboardShortcutAction, deps: ManagerShortcutRunnerDeps): void {
+    if (action === 'toggleInstanceSettings') { deps.toggleInstanceSettings(); return; }
     if (panelShortcutBus.dispatch(action)) return;
     const jumpIndex = jumpInstanceIndexFromAction(action);
     if (jumpIndex != null) {
@@ -76,7 +78,7 @@ export function runManagerShortcut(action: DashboardShortcutAction, deps: Manage
     if (action === 'switchTab3') { deps.handleTabChange('logs'); return; }
     if (action === 'switchTab4') { deps.handleTabChange('settings'); return; }
     if (action === 'previousTab' || action === 'nextTab') {
-        const tabs: DashboardDetailTab[] = ['overview', 'preview', 'logs', 'settings'];
+        const tabs: DashboardDetailTab[] = ['overview', 'preview', 'logs'];
         const idx = tabs.indexOf(deps.activeDetailTab);
         const dir = action === 'nextTab' ? 1 : -1;
         deps.handleTabChange(tabs[(idx + dir + tabs.length) % tabs.length]);
@@ -123,6 +125,7 @@ export function runManagerShortcut(action: DashboardShortcutAction, deps: Manage
 }
 
 const CAPTURE_TOGGLE_ACTIONS = new Set<DashboardShortcutAction>([
+    'toggleInstanceSettings',
     'toggleLeftSidebar',
     'toggleRightPanel',
     'resetSidebarWidth',

--- a/public/manager/src/manager-shortcuts.ts
+++ b/public/manager/src/manager-shortcuts.ts
@@ -1,6 +1,7 @@
 import type { DashboardShortcutAction, DashboardShortcutKeymap } from './types';
 
 export const MANAGER_SHORTCUT_ACTIONS: DashboardShortcutAction[] = [
+    'toggleInstanceSettings',
     'focusInstances',
     'focusActiveSession',
     'focusNotes',
@@ -40,6 +41,7 @@ export const MANAGER_SHORTCUT_ACTIONS: DashboardShortcutAction[] = [
 ];
 
 export const DEFAULT_MANAGER_SHORTCUT_KEYMAP: DashboardShortcutKeymap = {
+    toggleInstanceSettings: 'Meta+,',
     focusInstances: 'Alt+I',
     focusActiveSession: 'Alt+P',
     focusNotes: 'Alt+N',

--- a/public/manager/src/types.ts
+++ b/public/manager/src/types.ts
@@ -14,6 +14,7 @@ export type DashboardLocale = 'ko' | 'en' | 'zh' | 'ja';
 export type DashboardSidebarMode = 'instances' | 'board' | 'schedule' | 'reminders' | 'notes' | 'settings';
 export type DashboardViewMode = 'jaw' | 'code';
 export type DashboardShortcutAction =
+    | 'toggleInstanceSettings'
     | 'focusInstances'
     | 'focusActiveSession'
     | 'focusNotes'
@@ -289,6 +290,7 @@ export type DashboardRegistryScan = {
 export type DashboardRegistryUi = {
     selectedPort: number | null;
     selectedTab: DashboardDetailTab;
+    instanceSettingsOpen: boolean;
     sidebarCollapsed: boolean;
     activityDockCollapsed: boolean;
     activityDockHeight: number;

--- a/src/manager/registry.ts
+++ b/src/manager/registry.ts
@@ -51,6 +51,7 @@ const NOTES_GRAPH_SECTIONS = ['filters', 'display', 'forces', 'groups'] as const
 const DIFF_ROOT_POLICIES: DashboardDiffRootPolicy[] = ['project-first', 'working-dir-first', 'manual'];
 const DIFF_MODES: DashboardDiffMode[] = ['unstaged', 'staged', 'head', 'base'];
 const SHORTCUT_ACTIONS: DashboardShortcutAction[] = [
+    'toggleInstanceSettings',
     'focusInstances',
     'focusActiveSession',
     'focusNotes',
@@ -59,6 +60,7 @@ const SHORTCUT_ACTIONS: DashboardShortcutAction[] = [
 ];
 
 export const DEFAULT_DASHBOARD_SHORTCUT_KEYMAP: DashboardShortcutKeymap = {
+    toggleInstanceSettings: 'Meta+,',
     focusInstances: 'Alt+I',
     focusActiveSession: 'Alt+P',
     focusNotes: 'Alt+N',
@@ -274,6 +276,7 @@ function defaultUi(): DashboardRegistryUi {
     return {
         selectedPort: null,
         selectedTab: 'overview',
+        instanceSettingsOpen: false,
         sidebarCollapsed: false,
         activityDockCollapsed: false,
         activityDockHeight: DEFAULT_ACTIVITY_HEIGHT,
@@ -345,6 +348,8 @@ function normalizeUi(value: unknown): DashboardRegistryUi {
     return {
         selectedPort,
         selectedTab,
+        instanceSettingsOpen: typeof input["instanceSettingsOpen"] === 'boolean'
+            ? input["instanceSettingsOpen"] : fallback.instanceSettingsOpen,
         sidebarCollapsed: typeof input["sidebarCollapsed"] === 'boolean' ? input["sidebarCollapsed"] : fallback.sidebarCollapsed,
         activityDockCollapsed: typeof input["activityDockCollapsed"] === 'boolean' ? input["activityDockCollapsed"] : fallback.activityDockCollapsed,
         activityDockHeight: clampInt(input["activityDockHeight"], fallback.activityDockHeight, MIN_ACTIVITY_HEIGHT, MAX_ACTIVITY_HEIGHT),

--- a/src/manager/types.ts
+++ b/src/manager/types.ts
@@ -22,6 +22,7 @@ export type DashboardSidebarMode =
     | 'reminders'
     | 'settings';
 export type DashboardShortcutAction =
+    | 'toggleInstanceSettings'
     | 'focusInstances'
     | 'focusActiveSession'
     | 'focusNotes'
@@ -221,6 +222,7 @@ export type DashboardRegistryScan = {
 export type DashboardRegistryUi = {
     selectedPort: number | null;
     selectedTab: DashboardDetailTab;
+    instanceSettingsOpen: boolean;
     sidebarCollapsed: boolean;
     activityDockCollapsed: boolean;
     activityDockHeight: number;

--- a/tests/browser/manager-layout-smoke.test.ts
+++ b/tests/browser/manager-layout-smoke.test.ts
@@ -72,7 +72,7 @@ async function selectFirstOnlineInstance(page: Page): Promise<void> {
         await fetch('/api/dashboard/registry', {
             method: 'PATCH',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ ui: { sidebarMode: 'instances', selectedPort: selected.port, selectedTab: 'preview' } }),
+            body: JSON.stringify({ ui: { sidebarMode: 'instances', selectedPort: selected.port, selectedTab: 'preview', instanceSettingsOpen: false } }),
         });
         return selected.port;
     });
@@ -193,7 +193,7 @@ test('manager preview iframe survives Workbench tab changes', async (t) => await
     assert.equal(before.hostHidden, false, 'preview host should be visible on Preview tab');
     assert.equal(before.hasFrame, true, 'preview iframe should render for an online selected instance');
 
-    await page.getByRole('tab', { name: 'Settings' }).click();
+    await page.getByRole('button', { name: 'Instance settings', exact: true }).click();
 
     const during = await page.evaluate(() => {
         const host = document.querySelector('[data-preview-host="persistent"]');
@@ -205,10 +205,10 @@ test('manager preview iframe survives Workbench tab changes', async (t) => await
         };
     });
 
-    assert.equal(during.hostHidden, true, 'preview host should be hidden off Preview tab');
-    assert.equal(during.sameFrame, true, 'preview iframe must stay mounted while hidden');
+    assert.equal(during.hostHidden, false, 'opening settings must leave Preview visible');
+    assert.equal(during.sameFrame, true, 'preview iframe must stay mounted beside settings');
 
-    await page.getByRole('tab', { name: 'Preview' }).click();
+    await page.getByRole('button', { name: 'Close instance settings' }).click();
 
     const after = await page.evaluate(() => {
         const host = document.querySelector('[data-preview-host="persistent"]');
@@ -223,6 +223,14 @@ test('manager preview iframe survives Workbench tab changes', async (t) => await
     assert.equal(after.hostHidden, false, 'preview host should show again on Preview tab');
     assert.equal(after.sameFrame, true, 'preview iframe must remain the same DOM node after returning');
     assert.equal(after.src, before.src, 'preview source should not change across tab-only navigation');
+    for (const mode of ['Overview', 'Logs', 'Preview']) {
+        await page.getByRole('tab', { name: mode, exact: true }).click();
+        const state = await page.evaluate(() => ({
+            hidden: document.querySelector('[data-preview-host]')?.hasAttribute('hidden'),
+            same: document.querySelector('iframe.preview-frame') === (window as Window & { __jawPreviewFrame?: Element | null }).__jawPreviewFrame,
+        }));
+        assert.equal(state.hidden, mode !== 'Preview'); assert.equal(state.same, true);
+    }
 }));
 
 test('manager preview header toggles and refreshes the iframe', async (t) => await withManagerBrowserLock(async () => {
@@ -328,3 +336,45 @@ test('manager sidebar shell resizes, persists, resets, and collapses', async (t)
     await page.keyboard.press('Meta+Shift+B');
 }));
 
+
+test('instance settings panel has bounded layout and guarded keyboard close', async (t) => await withManagerBrowserLock(async () => {
+    const page = await pageForManager(t); if (!page) return;
+    let snapshot: import('../../public/manager/src/types').DashboardRegistryLoadResult | undefined;
+    await page.route('**/api/dashboard/registry', async route => {
+        if (!snapshot) {
+            snapshot = await (await route.fetch({ method: 'GET' })).json();
+            snapshot!.registry.ui.instanceSettingsOpen = false;
+        }
+        if (route.request().method() === 'PATCH') Object.assign(snapshot!.registry.ui, route.request().postDataJSON().ui);
+        snapshot!.status.ui = snapshot!.registry.ui;
+        await route.fulfill({ json: snapshot });
+    });
+    await page.goto(MANAGER_URL, { waitUntil: 'domcontentloaded' }); await selectFirstOnlineInstance(page);
+    const toggle = page.getByRole('button', { name: 'Instance settings', exact: true });
+    await toggle.click();
+    const panel = page.locator('aside.workbench-settings-panel');
+    assert.equal(await page.getByRole('tab', { name: 'Settings', exact: true }).count(), 0);
+    for (const width of [1440, 1280, 1024, 1023, 390]) {
+        await page.setViewportSize({ width, height: 900 });
+        const metrics = await panel.evaluate(el => ({ width: el.getBoundingClientRect().width,
+            right: el.getBoundingClientRect().right, position: getComputedStyle(el).position,
+            documentWidth: document.documentElement.scrollWidth }));
+        const expected = width >= 1440 ? 480 : width >= 1024 ? 420 : Math.min(width * .92, 420);
+        assert.ok(Math.abs(metrics.width - expected) <= 1); assert.ok(metrics.right <= width + 1);
+        assert.equal(metrics.documentWidth, width); assert.equal(metrics.position === 'fixed', width < 1024);
+    }
+    await panel.getByRole('tab', { name: 'Display', exact: true }).click();
+    assert.equal(await panel.getByRole('tab', { name: 'Display', exact: true }).getAttribute('aria-selected'), 'true');
+    assert.ok(await panel.locator('.settings-sidebar [role=tab]').count() > 0);
+    const field = panel.locator('#display-pasteCollapseLines');
+    const initial = Number(await field.inputValue()); await field.fill(String(initial + 1));
+    await page.getByRole('button', { name: 'Close instance settings' }).focus();
+    page.once('dialog', dialog => dialog.dismiss()); await page.keyboard.press('Escape');
+    assert.equal(await panel.count(), 1); assert.equal(await field.inputValue(), String(initial + 1));
+    page.once('dialog', dialog => dialog.accept()); await page.keyboard.press('Escape');
+    await panel.waitFor({ state: 'detached' });
+    assert.equal(await toggle.evaluate(el => el === document.activeElement), true);
+    await page.keyboard.press('Meta+,'); await panel.waitFor({ state: 'visible' });
+    assert.equal(await toggle.getAttribute('aria-pressed'), 'true');
+    await page.keyboard.press('Meta+,'); await panel.waitFor({ state: 'detached' });
+}));

--- a/tests/unit/jaw-ceo-frontend-contract.test.ts
+++ b/tests/unit/jaw-ceo-frontend-contract.test.ts
@@ -20,7 +20,7 @@ function sliceBetween(source: string, start: string, end: string): string {
     return source.slice(from, to);
 }
 
-test('jaw-ceo frontend installs workbench launcher outside instance groups', () => {
+test('jaw-ceo frontend installs workbench launcher outside instance groups', async () => {
     const app = read('public/manager/src/App.tsx');
     const bridge = read('public/manager/src/jaw-ceo/useJawCeoDashboardBridge.tsx');
     const router = read('public/manager/src/SidebarRailRouter.tsx');
@@ -38,7 +38,22 @@ test('jaw-ceo frontend installs workbench launcher outside instance groups', () 
     assert.ok(router.includes('<JawCeoConsole'), 'router must render the CEO console in the right panel or sidePanel slot');
     assert.ok(router.includes('jawCeoWorkbenchButton?: ReactNode'), 'router must accept a CEO Workbench button slot');
     assert.ok(workbench.includes('modeActions?: ReactNode'), 'Workbench must expose a tab-bar action slot');
-    assert.ok(workbench.indexOf('workbench-mode-tabs') < workbench.indexOf('props.modeActions'), 'CEO button must render beside the mode tabs');
+    const React = await import('react'), { renderToStaticMarkup } = await import('react-dom/server');
+    const { JSDOM } = await import('jsdom');
+    const { Workbench } = await import('../../public/manager/src/components/Workbench');
+    const { WorkbenchSettingsToggle } = await import('../../public/manager/src/components/WorkbenchHeader');
+    const globals = globalThis as unknown as Record<string, unknown>, previous = globals['React']; globals['React'] = React;
+    try {
+        const actions = React.createElement(React.Fragment, null, React.createElement('button', { id: 'ceo-test' }, 'CEO'),
+            React.createElement(WorkbenchSettingsToggle, { open: false, onToggle() {} }));
+        const dom = new JSDOM(renderToStaticMarkup(React.createElement(Workbench, { mode: 'overview', active: true,
+            onModeChange() {}, header: null, modeActions: actions, overview: null, preview: null, logs: null,
+            settings: null, settingsOpen: false, onSettingsClose() {} })));
+        const tabs = dom.window.document.querySelector('.workbench-mode-tabs');
+        assert.equal(tabs?.nextElementSibling?.id, 'ceo-test');
+        assert.equal(tabs?.nextElementSibling?.nextElementSibling?.getAttribute('aria-label'), 'Instance settings');
+        dom.window.close();
+    } finally { globals['React'] = previous; }
     assert.equal(router.includes('jawCeoNavigatorContent'), false, 'CEO must not be injected into Navigator');
     assert.equal(list.includes('ceoPendingByPort'), false, 'instance list must not accept CEO pending counts by default');
     assert.equal(groups.includes('ceoWatchedPorts'), false, 'instance groups must not pass CEO watch state by default');

--- a/tests/unit/manager-frontend-contract.test.ts
+++ b/tests/unit/manager-frontend-contract.test.ts
@@ -366,7 +366,7 @@ test('manager instance rows support custom labels and latest activity titles', (
     assert.equal(latestRoute.includes('getMessages.all()'), false, 'latest endpoint must not fetch full message history');
 });
 
-test('manager workbench modes remain instance-only while Notes renders outside Workbench', () => {
+test('manager workbench modes remain instance-only while Notes renders outside Workbench', async () => {
     const app = read('public/manager/src/App.tsx');
     const router = read('public/manager/src/SidebarRailRouter.tsx');
     const workbench = read('public/manager/src/components/Workbench.tsx');
@@ -376,7 +376,21 @@ test('manager workbench modes remain instance-only while Notes renders outside W
     assert.ok(router.includes('DashboardSettingsWorkspace'), 'SidebarRailRouter must render Dashboard settings outside Workbench');
     assert.ok(router.includes("props.sidebarMode === 'notes'"), 'Notes must be selected by workspace mode, not a Workbench tab');
     assert.ok(router.includes("props.sidebarMode === 'settings'"), 'Dashboard settings must be selected by workspace mode, not a Workbench tab');
-    assert.ok(workbench.includes("const MODES: DashboardDetailTab[] = ['overview', 'preview', 'logs', 'settings']"), 'Workbench tabs must stay Overview/Preview/Logs/Settings only');
+    const React = await import('react');
+    const { renderToStaticMarkup } = await import('react-dom/server');
+    const { JSDOM } = await import('jsdom');
+    const { Workbench } = await import('../../public/manager/src/components/Workbench');
+    const globals = globalThis as unknown as Record<string, unknown>, previous = globals['React'];
+    globals['React'] = React;
+    try {
+        const dom = new JSDOM(renderToStaticMarkup(React.createElement(Workbench, { mode: 'preview', active: true,
+            onModeChange() {}, header: null, overview: null, logs: null, preview: React.createElement('iframe'),
+            settings: 'settings form', settingsOpen: true, onSettingsClose() {} })));
+        assert.deepEqual([...dom.window.document.querySelectorAll('[role="tab"]')].map(el => el.textContent), ['Overview', 'Preview', 'Logs']);
+        assert.equal(dom.window.document.querySelector('aside[aria-label="Instance settings"]')?.textContent?.includes('settings form'), true);
+        assert.equal(dom.window.document.querySelector('[data-preview-host]')?.hasAttribute('hidden'), false);
+        dom.window.close();
+    } finally { globals['React'] = previous; }
     assert.equal(workbench.includes("'notes'"), false, 'Workbench must not add Notes as a detail tab');
     assert.ok(app.includes('notesSelectedPath'), 'App must hydrate and persist selected note path');
     assert.ok(app.includes('notesViewMode'), 'App must hydrate and persist Notes view mode');
@@ -610,7 +624,6 @@ test('manager frontend routes layout through responsive shell components', () =>
     assert.ok(workbench.includes("'overview'"), 'workbench must expose Overview tab');
     assert.ok(workbench.includes("'preview'"), 'workbench must expose Preview tab');
     assert.ok(workbench.includes("'logs'"), 'workbench must expose Logs tab');
-    assert.ok(workbench.includes("'settings'"), 'workbench must expose Settings tab');
     assert.ok(detail.includes("props.activeTab === 'overview'"), 'detail panel must render Overview content');
     assert.ok(detail.includes("props.activeTab === 'logs'"), 'detail panel must render Logs content');
     assert.ok(detail.includes("props.activeTab === 'settings'"), 'detail panel must render Settings content');

--- a/tests/unit/manager-instance-settings.test.ts
+++ b/tests/unit/manager-instance-settings.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createInstanceSettingsNavigation, hydrateInstanceSettings, settingsDirtyAfter, useSettingsDirtyState } from '../../public/manager/src/hooks/useDashboardView';
+import { createManagerCaptureKeydownHandler, runManagerShortcut, type ManagerShortcutRunnerDeps } from '../../public/manager/src/manager-shortcut-runner';
+import { DEFAULT_MANAGER_SHORTCUT_KEYMAP } from '../../public/manager/src/manager-shortcuts';
+
+test('saved Settings becomes Overview plus panel, including missing and invalid flags', () => {
+    for (const flag of [undefined, false, true, 'true', 1, null]) {
+        assert.deepEqual(hydrateInstanceSettings({ selectedTab: 'settings', instanceSettingsOpen: flag }),
+            { selectedTab: 'overview', instanceSettingsOpen: true });
+        assert.deepEqual(hydrateInstanceSettings({ selectedTab: 'logs', instanceSettingsOpen: flag }),
+            { selectedTab: 'logs', instanceSettingsOpen: flag === true });
+    }
+});
+test('dirty cancellation has no writes; same-port open preserves draft; accepted close persists the mode', () => {
+    type Args = Parameters<typeof createInstanceSettingsNavigation>[0];
+    const writes: Parameters<Args['saveUi']>[0][] = [], dirtyChanges: boolean[] = [], ports: (number | null)[] = [];
+    let allowed = false, prompts = 0;
+    const view: Args['view'] = { activeDetailTab: 'preview', instanceSettingsOpen: true,
+        setInstanceSettingsOpen(next) { assert.equal(typeof next, 'boolean'); },
+        setSelectedPort(next) { if (typeof next !== 'function') ports.push(next); },
+        setSidebarMode() {}, setViewMode() {}, setDrawerOpen() {} };
+    const nav = createInstanceSettingsNavigation({ view, selectedPort: 3457, settingsDirty: true, panelSettingsDirty: true,
+        setSettingsDirty: dirty => dirtyChanges.push(dirty), clearPanelDirty: () => dirtyChanges.push(false), saveUi: async patch => { writes.push(patch); },
+        confirmDiscard: () => { prompts++; return allowed; } });
+    nav.setInstanceSettingsOpen(false); nav.setInstanceSettingsOpen(true, 3458);
+    assert.equal(prompts, 2); assert.deepEqual(writes, []); assert.deepEqual(ports, []); assert.deepEqual(dirtyChanges, []);
+    nav.setInstanceSettingsOpen(true, 3457);
+    assert.equal(prompts, 2); assert.deepEqual(dirtyChanges, []); assert.equal(writes.at(-1)?.selectedTab, 'preview');
+    allowed = true; nav.setInstanceSettingsOpen(true, 3458);
+    assert.deepEqual(ports, [3457, 3458]); assert.deepEqual(dirtyChanges, [false]);
+    nav.setInstanceSettingsOpen(false);
+    assert.equal(writes.at(-1)?.instanceSettingsOpen, false); assert.equal(writes.at(-1)?.selectedTab, 'preview');
+});
+test('closed panel still guards Dashboard dirty on port changes', () => {
+    type Args = Parameters<typeof createInstanceSettingsNavigation>[0];
+    const writes: unknown[] = [], ports: unknown[] = [];
+    let allow = false;
+    const view: Args['view'] = { activeDetailTab: 'preview', instanceSettingsOpen: false,
+        setInstanceSettingsOpen() {}, setSelectedPort: next => { ports.push(next); },
+        setSidebarMode() {}, setViewMode() {}, setDrawerOpen() {} };
+    const nav = createInstanceSettingsNavigation({ view, selectedPort: 3457, settingsDirty: true, panelSettingsDirty: false,
+        setSettingsDirty() {}, clearPanelDirty() {}, confirmDiscard: () => allow,
+        saveUi: async patch => { writes.push(patch); } });
+    assert.equal(nav.canLeaveDirtySettings(), false); // row / Preview / CEO guard uses this even when closed
+    nav.setInstanceSettingsOpen(true, 3458);
+    assert.deepEqual(ports, []); assert.deepEqual(writes, []);
+    allow = true; nav.setInstanceSettingsOpen(true, 3458);
+    assert.deepEqual(ports, [3458]); assert.equal(writes.length, 1);
+});
+test('clean or closed panel cannot mask Dashboard dirty', () => {
+    let entries = settingsDirtyAfter({ panel: false, dashboard: false }, 'dashboard', true);
+    entries = settingsDirtyAfter(entries, 'panel', false);
+    assert.equal(entries.panel || entries.dashboard, true);
+    entries = settingsDirtyAfter(entries, 'dashboard', false);
+    assert.equal(entries.panel || entries.dashboard, false);
+});
+test('shortcut toggle and tab cycling have separate owners', () => {
+    let toggles = 0;
+    const tabs: string[] = [];
+    const deps: ManagerShortcutRunnerDeps = { selectedInstance: null, filtered: [], activeDetailTab: 'logs',
+        toggleInstanceSettings() { toggles++; }, handleTabChange(tab) { tabs.push(tab); },
+        setDrawerOpen() {}, handleSidebarModeChange() {}, handlePreview() {}, selectRelativeInstance() {},
+        setPreviewRefreshKey() {}, handleSidebarToggle() {} };
+    runManagerShortcut('toggleInstanceSettings', deps); assert.equal(toggles, 1);
+    runManagerShortcut('nextTab', deps); assert.deepEqual(tabs, ['overview']);
+    runManagerShortcut('switchTab4', deps); assert.deepEqual(tabs, ['overview', 'settings']);
+    assert.equal(toggles, 1);
+});
+
+test('panel dirty callback stays stable through renders and cleanup preserves Dashboard dirty', async () => {
+    const React = await import('react');
+    const { JSDOM } = await import('jsdom');
+    const { createRoot } = await import('react-dom/client');
+    const dom = new JSDOM('<!doctype html><div id="root"></div>');
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const replacements = { window: dom.window, document: dom.window.document, IS_REACT_ACT_ENVIRONMENT: true };
+    const previous = new Map(Object.keys(replacements).map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+    for (const [key, value] of Object.entries(replacements)) globals[key] = value;
+    const root = createRoot(dom.window.document.getElementById('root')!);
+    let state: ReturnType<typeof useSettingsDirtyState> | undefined;
+    let notifications = 0, cleanups = 0;
+    function Panel(props: { onDirtyChange: (dirty: boolean) => void }) {
+        React.useEffect(() => {
+            notifications++;
+            assert.ok(notifications < 5, 'dirty notifications must settle, not loop');
+            props.onDirtyChange(true);
+        }, [props.onDirtyChange]);
+        React.useEffect(() => () => { cleanups++; props.onDirtyChange(false); }, [props.onDirtyChange]);
+        return null;
+    }
+    function Harness(props: { open: boolean }) {
+        state = useSettingsDirtyState();
+        return props.open ? React.createElement(Panel, { onDirtyChange: state.onPanelSettingsDirtyChange }) : null;
+    }
+    try {
+        await React.act(async () => { root.render(React.createElement(Harness, { open: true })); });
+        assert.equal(state?.panelSettingsDirty, true);
+        const callback = state?.onPanelSettingsDirtyChange;
+        await React.act(async () => { state?.onSettingsDirtyChange('dashboard', true); });
+        await React.act(async () => { root.render(React.createElement(Harness, { open: true })); });
+        assert.equal(state?.onPanelSettingsDirtyChange, callback);
+        assert.equal(notifications, 1); assert.equal(cleanups, 0);
+        await React.act(async () => { root.render(React.createElement(Harness, { open: false })); });
+        assert.equal(cleanups, 1); assert.equal(state?.panelSettingsDirty, false);
+        assert.equal(state?.settingsDirty, true);
+    } finally {
+        await React.act(async () => { root.unmount(); });
+        dom.window.close();
+        for (const [key, descriptor] of previous) {
+            if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+            else delete globals[key];
+        }
+    }
+});
+
+test('settings shortcut captures ordinary inputs once and yields to keybinding editors', async () => {
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<input id="field"><input id="binding" data-keybinding-capture>');
+    const previous = Object.getOwnPropertyDescriptor(globalThis, 'Element');
+    Object.defineProperty(globalThis, 'Element', { configurable: true, value: dom.window.Element });
+    const actions: string[] = [];
+    let bubbled = 0;
+    const handler = createManagerCaptureKeydownHandler(() => DEFAULT_MANAGER_SHORTCUT_KEYMAP, action => actions.push(action));
+    dom.window.addEventListener('keydown', handler, true);
+    dom.window.document.addEventListener('keydown', () => { bubbled++; });
+    const key = () => new dom.window.KeyboardEvent('keydown', { key: ',', metaKey: true, bubbles: true, cancelable: true });
+    try {
+        const captured = key(); dom.window.document.getElementById('field')!.dispatchEvent(captured);
+        assert.deepEqual(actions, ['toggleInstanceSettings']); assert.equal(captured.defaultPrevented, true);
+        assert.equal(bubbled, 0);
+        const editing = key(); dom.window.document.getElementById('binding')!.dispatchEvent(editing);
+        assert.equal(editing.defaultPrevented, false); assert.equal(actions.length, 1); assert.equal(bubbled, 1);
+        const prevented = key(); prevented.preventDefault();
+        dom.window.document.getElementById('field')!.dispatchEvent(prevented);
+        assert.equal(actions.length, 1);
+    } finally {
+        dom.window.removeEventListener('keydown', handler, true);
+        dom.window.close();
+        if (previous) Object.defineProperty(globalThis, 'Element', previous);
+        else Reflect.deleteProperty(globalThis, 'Element');
+    }
+});

--- a/tests/unit/manager-registry.test.ts
+++ b/tests/unit/manager-registry.test.ts
@@ -342,3 +342,20 @@ test('manager registry clears blank instance labels back to fallback', () => {
 
     assert.equal(saved.registry.instances['3462']?.label, null);
 });
+
+test('instance settings UI is a bounded boolean and its shortcut survives disk round-trip', () => {
+    const path = registryPath();
+    assert.equal(loadDashboardRegistry({ path }).registry.ui.instanceSettingsOpen, false);
+    for (const value of [true, false, 'true', 1, {}, null]) {
+        writeFileSync(path, JSON.stringify({ ui: { selectedTab: 'settings', instanceSettingsOpen: value } }));
+        const ui = loadDashboardRegistry({ path }).registry.ui;
+        assert.equal(ui.instanceSettingsOpen, value === true);
+        assert.equal(ui.selectedTab, 'settings');
+    }
+    patchDashboardRegistry({ ui: { selectedTab: 'overview', instanceSettingsOpen: true,
+        dashboardShortcutKeymap: { ...defaultDashboardRegistry().ui.dashboardShortcutKeymap, toggleInstanceSettings: 'Alt+S' } } }, { path });
+    assert.equal(loadDashboardRegistry({ path }).registry.ui.instanceSettingsOpen, true);
+    assert.equal(loadDashboardRegistry({ path }).registry.ui.dashboardShortcutKeymap.toggleInstanceSettings, 'Alt+S');
+    patchDashboardRegistry({ ui: { instanceSettingsOpen: false } }, { path });
+    assert.equal(loadDashboardRegistry({ path }).registry.ui.instanceSettingsOpen, false);
+});

--- a/tests/unit/manager-shortcuts.test.ts
+++ b/tests/unit/manager-shortcuts.test.ts
@@ -111,3 +111,43 @@ test('Alt+Digit recovers jumpInstance even when macOS rewrites the key character
         'jumpInstance3',
     );
 });
+
+test('instance settings shortcut defaults and overrides survive normalization', () => {
+    const defaults = normalizeManagerShortcutKeymap({});
+    assert.equal(defaults.toggleInstanceSettings, 'Meta+,');
+    assert.equal(actionForShortcutEvent(keyEvent(',', { metaKey: true }), defaults), 'toggleInstanceSettings');
+    assert.equal(actionForShortcutEvent(keyEvent(',', { ctrlKey: true }), defaults), null);
+    assert.equal(actionForShortcutEvent(keyEvent(',', { metaKey: true, shiftKey: true }), defaults), null);
+    const changed = normalizeManagerShortcutKeymap({ toggleInstanceSettings: 'Alt+S' });
+    assert.equal(actionForShortcutEvent(keyEvent('s', { altKey: true }), changed), 'toggleInstanceSettings');
+    assert.equal(actionForShortcutEvent(keyEvent(',', { metaKey: true }), changed), null);
+});
+
+test('settings toggle has its own localized label in all Manager locales', async () => {
+    const React = await import('react');
+    const { renderToStaticMarkup } = await import('react-dom/server');
+    const { JSDOM } = await import('jsdom');
+    const { DashboardSettingsWorkspace } = await import('../../public/manager/src/dashboard-settings/DashboardSettingsWorkspace');
+    const { defaultDashboardRegistry } = await import('../../src/manager/registry');
+    const globals = globalThis as unknown as Record<string, unknown>, previous = globals['React'];
+    globals['React'] = React;
+    try {
+        for (const [locale, expected] of [
+            ['ko', '인스턴스 설정'], ['en', 'Instance settings'],
+            ['ja', 'インスタンス設定'], ['zh', '实例设置'],
+        ] as const) {
+            const savedUi = defaultDashboardRegistry().ui;
+            const ui = { ...savedUi, locale,
+                dashboardShortcutKeymap: normalizeManagerShortcutKeymap(savedUi.dashboardShortcutKeymap) };
+            const dom = new JSDOM(renderToStaticMarkup(React.createElement(DashboardSettingsWorkspace, {
+                activeSection: 'display', ui, titleSupport: { ready: 0, legacy: 0, offline: 0, byPort: {} },
+                onUiPatch() {}, onOpenHelpTopic() {},
+            })));
+            const doc = dom.window.document;
+            assert.equal(doc.querySelector('label[for="dashboard-shortcut-toggleInstanceSettings"] > span')?.textContent, expected);
+            assert.equal(doc.querySelector<HTMLInputElement>('#dashboard-shortcut-toggleInstanceSettings')?.value, 'Meta+,');
+            assert.notEqual(doc.querySelector('label[for="dashboard-shortcut-nextInstance"] > span')?.textContent, expected);
+            dom.window.close();
+        }
+    } finally { globals['React'] = previous; }
+});


### PR DESCRIPTION
## Summary

Removes the `Settings` mode tab from the Manager Workbench (Overview / Preview / Logs remain) and moves instance settings into a side panel. A gear toggle at the right end of the mode bar (`aria-pressed`, `Meta+,` via the new `toggleInstanceSettings` shortcut) opens `aside.workbench-settings-panel` (420px, 480px at ≥1440px, overlay below 1024px) hosting the existing `SettingsShell` next to the persistent preview iframe. Escape / Close return focus to the toggle; the dirty-settings guard applies to closing and to port changes.

`ui.instanceSettingsOpen` is persisted through the registry whitelist (boolean only). A saved `selectedTab: 'settings'` from an older registry hydrates as overview + panel open, so nothing is lost on upgrade. Shortcut copy is added for the four locales; three duplicate mode-tab CSS skins are removed.

| tabs | panel |
|---|---|
| ![tabs](https://github.com/lidge-jun/cli-jaw-internal/blob/codex/workbench-modern-ui-devlog/_plan/260908_workbench_modern_ui/evidence/030_wp3_manager_tabs.png?raw=true) | ![panel](https://github.com/lidge-jun/cli-jaw-internal/blob/codex/workbench-modern-ui-devlog/_plan/260908_workbench_modern_ui/evidence/030_wp3_manager_settings_panel.png?raw=true) |

## Stack

1. #581 `codex/wbui-01-activity-header` → `dev`
2. #583 `codex/wbui-02-activity-expanded` → 01
3. **#this** `codex/wbui-03-settings-panel` → 02
4. `codex/wbui-04-unified-settings` → 03 — next
5. `codex/wbui-05-classic-shell` → 04
6. `codex/wbui-06-hardening` → 05

Plan: `devlog/_plan/260908_workbench_modern_ui/030_settings_panel.md`.

## Validation

- `npm run typecheck` (server) and `typecheck:frontend`, `build:frontend`, `check:frontend-build-output`: exit 0
- 10 focused test files incl. new `manager-instance-settings.test.ts`: 131/131; `App.tsx` stays at the 500-line cap
- `bash structure/verify-counts.sh`: ALL PASS (541)
- Rendered on a fresh `jaw dashboard serve` built from this branch (light + dark in devlog evidence)
- `test:manager:browser` (CDP) and full local suite NOT RUN; exact-head CI on this PR is the gate.

