### PR TITLE
feat(classic): t3-style token shell for localhost:3457 (wbui 5/6)

### DIFF
--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -2,8 +2,8 @@
 .chat-area {
     display: flex;
     flex-direction: column;
-    border-left: 1px solid var(--border);
-    border-right: 1px solid var(--border);
+    border-left: 1px solid var(--border-alpha);
+    border-right: 1px solid var(--border-alpha);
     overflow: hidden;
     min-height: 0;
     background: var(--bg);
@@ -12,7 +12,7 @@
 
 /* CRT noise grain texture — dark mode only, disabled in light mode to prevent gray cast */
 .chat-area::after {
-    content: '';
+    content: none;
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -32,8 +32,8 @@
     width: 44px;
     height: 24px;
     border-radius: 12px;
-    border: 1px solid var(--border);
-    background: var(--surface);
+    border: 1px solid var(--border-alpha);
+    background: var(--surface-1);
     cursor: pointer;
     padding: 0;
     flex-shrink: 0;
@@ -41,7 +41,7 @@
 }
 
 .theme-switch:hover {
-    border-color: var(--accent);
+    border-color: var(--border-strong);
 }
 
 .theme-switch-knob {
@@ -85,13 +85,14 @@
 }
 
 .chat-header {
-    padding: var(--space-3) var(--space-5);
-    border-bottom: 1px solid var(--border);
-    font-size: var(--text-md);
+    padding: 6px var(--space-5);
+    border-bottom: 1px solid var(--border-alpha);
+    background: var(--surface-1);
+    font-size: 14px;
     font-weight: 600;
-    font-family: var(--font-display);
-    letter-spacing: 0.5px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    font-family: var(--font-ui);
+    letter-spacing: 0;
+    box-shadow: none;
     position: relative;
     z-index: 2;
     display: flex;
@@ -136,10 +137,15 @@
     max-width: 100%;
 }
 
+@media (min-width: 901px) {
+    .chat-header, .chat-header-actions, .chat-header > span:first-child { flex-wrap: nowrap; }
+    .chat-header > span:first-child { overflow: hidden; }
+}
+
 .header-project {
     margin-left: 4px;
-    color: var(--text-muted, #888);
-    font-size: 0.8em;
+    color: var(--text-muted-60);
+    font-size: 12px;
     font-weight: 400;
     letter-spacing: 0.2px;
     max-width: 280px;
@@ -148,20 +154,20 @@
     white-space: nowrap;
     flex-shrink: 1;
     cursor: pointer;
-    border-radius: 6px;
+    border-radius: var(--radius-ctl);
     padding: 2px 8px;
     border: 1px solid transparent;
     transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
 }
 
 .header-project:hover {
-    color: var(--text, #ddd);
-    border-color: var(--border, #444);
-    background: rgba(128, 128, 128, 0.08);
+    color: var(--text);
+    border-color: var(--border-alpha);
+    background: var(--surface-2);
 }
 
 .header-project.is-empty {
-    border: 1px dashed var(--border, #555);
+    border: 1px dashed var(--border-strong);
     opacity: 0.8;
 }
 
@@ -179,15 +185,15 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     flex-shrink: 0;
-    color: var(--text-muted, #888);
-    font-family: var(--font-mono);
-    font-size: 0.78em;
+    color: var(--text-muted-60);
+    font-family: var(--font-mono-system);
+    font-size: 12px;
     font-weight: 500;
     letter-spacing: 0;
-    border-radius: 6px;
+    border-radius: var(--radius-ctl);
     padding: 2px 7px;
-    border: 1px solid var(--border, #444);
-    background: rgba(128, 128, 128, 0.06);
+    border: 1px solid var(--border-alpha);
+    background: var(--surface-3);
 }
 
 .header-git-status[hidden] {
@@ -2103,13 +2109,15 @@ div.math-placeholder {
 }
 
 .cmd-dropdown::-webkit-scrollbar {
-    width: 4px;
+    width: 6px;
 }
 
 .cmd-dropdown::-webkit-scrollbar-thumb {
-    background: var(--border);
-    border-radius: 2px;
+    background: var(--border-alpha);
+    border-radius: 3px;
 }
+
+.cmd-dropdown::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
 
 .cmd-recovery {
     margin-top: 8px;

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1,8 +1,8 @@
 /* ── Left Sidebar ── */
 .sidebar-left {
-    background: linear-gradient(180deg, var(--surface) 0%, color-mix(in oklch, var(--surface) 95%, #000) 100%);
-    border-right: 1px solid color-mix(in oklch, var(--border) 80%, var(--accent) 20%);
-    box-shadow: inset -1px 0 0 var(--border);
+    background: var(--surface-1);
+    border-right: 1px solid var(--border-alpha);
+    box-shadow: none;
     padding: 48px 16px 16px;
     display: flex;
     flex-direction: column;
@@ -14,7 +14,7 @@
 /* Sidebar ambient scanline + glow */
 .sidebar-left::before,
 .sidebar-right::before {
-    content: '';
+    content: none;
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -122,9 +122,9 @@
 
 /* ── Right Sidebar ── */
 .sidebar-right {
-    background: linear-gradient(180deg, var(--surface) 0%, color-mix(in oklch, var(--surface) 95%, #000) 100%);
-    border-left: 1px solid color-mix(in oklch, var(--border) 80%, var(--accent) 20%);
-    box-shadow: inset 1px 0 0 var(--border);
+    background: var(--surface-1);
+    border-left: 1px solid var(--border-alpha);
+    box-shadow: none;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
@@ -134,29 +134,34 @@
 
 .tab-bar {
     display: flex;
-    border-bottom: 1px solid var(--border);
+    margin: 0 8px 6px;
+    padding: 3px;
+    gap: 2px;
+    border: 1px solid var(--border-alpha);
+    border-radius: var(--radius-ctl);
+    background: var(--surface-1);
     flex-shrink: 0;
 }
 
 .tab-btn {
     flex: 1;
-    padding: 10px 8px;
+    padding: 4px 8px;
+    min-height: 28px;
+    border-radius: var(--radius-ctl);
     background: none;
     border: none;
-    border-bottom: 2px solid transparent;
-    color: var(--text-dim);
+    color: var(--text-muted-60);
     font-size: 11px;
-    font-family: var(--font-display);
+    font-family: var(--font-ui);
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 1px;
-    transition: color 0.15s, border-bottom-color 0.15s;
+    transition: color 0.15s, background-color 0.15s;
 }
 
-.tab-btn.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-}
+.tab-btn:hover { background: var(--surface-2); color: var(--text); }
+.tab-btn.active { color: var(--text); background: var(--surface-3); }
+.tab-btn:focus-visible { box-shadow: var(--focus-ring-shadow); }
 
 .tab-content {
     display: none;
@@ -531,4 +536,10 @@ body:has(#tabSettings.active):not(.right-collapsed) { --sidebar-right-w: min(56v
 .sidebar-right:has(#tabSettings.active) .sidebar-save-bar { display: none; }
 @media (max-width: 768px) {
     .sidebar-right:has(#tabSettings.active) { width: min(92vw, 760px); }
+}
+
+/* Classic header geometry; chat.css owns header typography and pills. */
+.chat-header { height: 44px; flex-shrink: 0; }
+@media (max-width: 900px) {
+    .chat-header { height: auto; min-height: 44px; }
 }

--- a/public/css/sidebar.css
+++ b/public/css/sidebar.css
@@ -5,6 +5,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    min-height: 28px;
+    border-radius: var(--radius-ctl);
 }
 .cli-status-header::after {
     content: '▸';
@@ -12,6 +14,8 @@
     color: var(--text-dim);
     margin-left: 8px;
 }
+.sidebar-left .cli-status-header:hover { background: var(--surface-2); }
+.sidebar-left .cli-status-header.expanded { background: var(--surface-3); }
 .cli-status-header.expanded::after {
     content: '▾';
 }
@@ -107,6 +111,7 @@
     align-items: center;
     gap: 8px;
     padding: 4px 0;
+    min-height: 28px;
     font-size: 12px;
 }
 
@@ -698,3 +703,21 @@ textarea.prompt-editor {
 /* Shared instance settings entry. */
 #tabSettings { flex: 1; min-height: 0; padding: 0; gap: 0; }
 .settings-frame { display: block; width: 100%; height: 100%; flex: 1; min-height: 0; border: 0; }
+
+/* Classic shell rows; preserve language select inline padding. */
+.sidebar-left .section-title { color: var(--text-muted-60); font-family: var(--font-ui); }
+.sidebar-left .sidebar-hb-btn {
+    min-height: 28px;
+    padding-block: 4px;
+    border-color: transparent;
+    border-radius: var(--radius-ctl);
+    background-color: var(--surface-1);
+    font-family: var(--font-ui);
+}
+.sidebar-left .sidebar-hb-btn:hover {
+    background-color: var(--surface-2);
+    border-color: transparent;
+    box-shadow: none;
+}
+.sidebar-left .sidebar-hb-btn:active { background-color: var(--surface-3); }
+.sidebar-left .sidebar-hb-btn:focus-visible { box-shadow: var(--focus-ring-shadow); }

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -1,5 +1,15 @@
 /* ── CSS Custom Properties ── */
 :root {
+    --surface-1: color-mix(in srgb, white 3%, transparent);
+    --surface-2: color-mix(in srgb, white 4%, transparent);
+    --surface-3: color-mix(in srgb, white 6%, transparent);
+    --border-alpha: color-mix(in srgb, white 8%, transparent);
+    --border-strong: color-mix(in srgb, white 12%, transparent);
+    --text-muted-60: color-mix(in oklab, var(--text) 60%, transparent);
+    --font-sans-system: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Apple SD Gothic Neo", "Pretendard", "Noto Sans KR", sans-serif;
+    --font-mono-system: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    --radius-ctl: 8px;
+    --focus-ring-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 70%, transparent);
     --bg: oklch(7% 0.01 280);
     --surface: oklch(11% 0.01 280);
     --border: oklch(17% 0.01 270);
@@ -26,7 +36,7 @@
     --code-label-color: oklch(66% 0.01 250);
     --modal-bg: oklch(0% 0 0 / 0.6);
     --font-display: 'Chakra Petch', 'Outfit', 'Pretendard', 'Noto Sans CJK SC', 'Noto Sans CJK JP', 'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', system-ui, sans-serif;
-    --font-ui: 'Outfit', 'Pretendard', 'Noto Sans CJK SC', 'Noto Sans CJK JP', 'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', -apple-system, system-ui, sans-serif;
+    --font-ui: var(--font-sans-system);
     --font-mono: 'SF Mono', 'JetBrains Mono', 'Fira Code', monospace;
     --sidebar-left-w: 220px;
     --sidebar-right-w: 260px;
@@ -151,9 +161,19 @@ body.right-collapsed {
 
 /* ── Light Theme ── */
 [data-theme="light"] {
-    --bg: oklch(97% 0 0);
+    --surface-1: color-mix(in srgb, black 3%, transparent);
+    --surface-2: color-mix(in srgb, black 4%, transparent);
+    --surface-3: color-mix(in srgb, black 6%, transparent);
+    --border-alpha: oklch(92% 0.004 286.32);
+    --border-strong: oklch(87.1% 0.006 286.286);
+    --text-muted-60: color-mix(in oklab, var(--text) 60%, transparent);
+    --font-sans-system: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Apple SD Gothic Neo", "Pretendard", "Noto Sans KR", sans-serif;
+    --font-mono-system: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    --radius-ctl: 8px;
+    --focus-ring-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 70%, transparent);
+    --bg: oklch(99.2% 0 0);
     --surface: oklch(100% 0 0);
-    --border: oklch(90% 0.01 270);
+    --border: var(--border-alpha);
     --text: oklch(15% 0.02 270);
     --text-dim: oklch(53% 0.02 270);
     --accent: oklch(62% 0.11 200);
@@ -230,18 +250,18 @@ input[type="text"] {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--border);
+    background: var(--border-alpha);
     border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in oklch, var(--accent) 30%, var(--text-dim));
+    background: var(--border-strong);
 }
 
 /* Firefox */
 * {
     scrollbar-width: thin;
-    scrollbar-color: var(--border) transparent;
+    scrollbar-color: var(--border-alpha) transparent;
 }
 
 /* ─── Focus visible ──────────────────────────────── */

--- a/public/js/features/theme.ts
+++ b/public/js/features/theme.ts
@@ -72,6 +72,7 @@ function toggleTheme(): void {
 
 function applyTheme(theme: string): void {
     const resolved = resolveTheme(theme);
+    // Shell tokens, including light overrides, live in public/css/variables.css.
     document.documentElement.setAttribute('data-theme', resolved);
 
     const btn = document.getElementById('toggleTheme');

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -506,18 +506,17 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 594 files source/assets, ~101419L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 594 files source/assets, ~101482L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)
 │   ├── manifest.json         ← PWA 매니페스트
 │   ├── sw.js                 ← Service Worker 오프라인 캐시
 │   ├── css/                  ← 12 files (variables/layout/markdown/chat/diagram/orc-state/sidebar/modals/tool-ui/trace-drawer/workflow-cockpit/chat-search)
-│   │   ├── chat.css          ← chat/message/virtual-scroll + inline image min-height/object-fit/error fallback (2525L)
+│   │   ├── chat.css          ← chat/message/virtual-scroll + inline image min-height/object-fit/error fallback (2533L)
 │   │   ├── native-requests.css ← live decision form, focus and bounded responsive scrolling (55L)
 │   │   └── activity.css      ← scoped live Activity disclosure and reversible Legacy visibility (261L)
 │   ├── manager/src/settings/ ← unified instance and Manager settings
 │   │   ├── settings-registry.ts ← scope-filtered page registry (35L)
-│   │   ├── pages/components/SlackSetup.tsx ← shared channel setup dialog + Slack manifest (126L)
-│   │   ├── pages/components/ChannelSetupEntry.tsx ← Telegram/Discord wizard entry and draft guard
+│   │   ├── pages/components/SlackSetup.tsx ← native Slack setup dialog (126L)
 │   │   ├── pages/manager/shared.tsx ← Manager locale copy and row controls (517L)
 │   │   ├── pages/manager/Display.tsx ← Manager display registry UI settings (92L)
 │   │   ├── pages/manager/Activity.tsx ← read-only title support (8L)

--- a/tests/unit/ui-quickfix-regression.test.ts
+++ b/tests/unit/ui-quickfix-regression.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { JSDOM } from 'jsdom';
 
 // ── Source files ──
 const statusSrc = [
@@ -215,4 +216,55 @@ test('UQ-013: .input-agent-name has flex:1 for space allocation', () => {
         ruleBody.includes('flex: 1') || ruleBody.includes('flex:1'),
         '.input-agent-name should have flex: 1',
     );
+});
+
+// CSSOM verifies declarations; browser QA verifies computed colors and geometry.
+// JSDOM CSSOM removes spaces after commas and percentage tokens in functions.
+test('WP5: classic tokens preserve legacy names and light/dark parity', () => {
+    const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+    try {
+        const style = dom.window.document.createElement('style');
+        style.textContent = fs.readFileSync(path.join(import.meta.dirname, '../../public/css/variables.css'), 'utf8');
+        dom.window.document.head.append(style);
+        assert.ok(style.sheet);
+        const rules = Array.from(style.sheet.cssRules);
+        const declaration = (selector: string): CSSStyleDeclaration => {
+            const rule = rules.find(r => 'selectorText' in r && r.selectorText === selector) as CSSStyleRule | undefined;
+            assert.ok(rule, selector); return rule.style;
+        };
+        const dark = declaration(':root'); const light = declaration('[data-theme="light"]');
+        const legacy = '--bg --surface --border --text --text-dim --accent --accent2 --green --user-bg --agent-bg --status-idle-bg --status-running-bg --status-running-color --status-steering-bg --status-steering-color --code-bg --link-color --table-border --stop-btn --stop-btn-hover --toggle-off --toggle-on --delete-color --code-label-color --modal-bg --font-display --font-ui --font-mono --sidebar-left-w --sidebar-right-w --sidebar-collapsed-w --space-1 --space-2 --space-3 --space-4 --space-5 --space-6 --space-8 --space-10 --space-12 --text-xs --text-sm --text-base --text-md --text-lg --text-xl --text-2xl --text-3xl --radius-sm --radius-md --radius-lg --radius-xl --radius-full --ease-out-expo --ease-spring --duration-fast --duration-base --duration-slow --error --error-dim --success --success-dim --warning --warning-dim --info --phase-1 --phase-2 --phase-3 --phase-4 --phase-5 --text-on-accent --noise-opacity --scanline-pct --glow-strength --toggle-w --toggle-h --toggle-knob --orc-glow --orc-glow-I --orc-glow-P --orc-glow-A --orc-glow-B --orc-glow-C --orc-glow-D'.split(' ');
+        for (const name of legacy) assert.ok(dark.getPropertyValue(name), name);
+        const names = '--surface-1 --surface-2 --surface-3 --border-alpha --border-strong --text-muted-60 --font-sans-system --font-mono-system --radius-ctl --focus-ring-shadow'.split(' ');
+        for (const name of names) for (const rule of [dark, light]) assert.ok(rule.getPropertyValue(name), name);
+        for (const [name, percent] of [['--surface-1', 3], ['--surface-2', 4], ['--surface-3', 6]] as const) {
+            assert.equal(dark.getPropertyValue(name).trim(), `color-mix(in srgb,white ${percent}%,transparent)`);
+            assert.equal(light.getPropertyValue(name).trim(), `color-mix(in srgb,black ${percent}%,transparent)`);
+        }
+        assert.equal(dark.getPropertyValue('--border-alpha').trim(), 'color-mix(in srgb,white 8%,transparent)');
+        assert.equal(dark.getPropertyValue('--border-strong').trim(), 'color-mix(in srgb,white 12%,transparent)');
+        assert.equal(light.getPropertyValue('--bg').trim(), 'oklch(99.2%0 0)');
+        assert.equal(light.getPropertyValue('--border-alpha').trim(), 'oklch(92%0.004 286.32)');
+        assert.equal(light.getPropertyValue('--border').trim(), 'var(--border-alpha)');
+        assert.equal(dark.getPropertyValue('--font-ui').trim(), 'var(--font-sans-system)');
+        for (const name of ['--font-sans-system', '--font-mono-system', '--radius-ctl', '--focus-ring-shadow', '--text-muted-60']) assert.equal(dark.getPropertyValue(name), light.getPropertyValue(name), name);
+        assert.equal(dark.getPropertyValue('--radius-ctl').trim(), '8px');
+        for (const rule of [dark, light]) {
+            assert.equal(rule.getPropertyValue('--focus-ring-shadow').trim(), '0 0 0 2px color-mix(in oklab,var(--accent) 70%,transparent)');
+        }
+        for (const [file, selector] of [
+            ['sidebar.css', '.sidebar-left .sidebar-hb-btn:focus-visible'],
+            ['layout.css', '.tab-btn:focus-visible'],
+        ] as const) {
+            const consumer = dom.window.document.createElement('style');
+            consumer.textContent = fs.readFileSync(path.join(import.meta.dirname, '../../public/css', file), 'utf8');
+            dom.window.document.head.append(consumer); assert.ok(consumer.sheet);
+            const rule = Array.from(consumer.sheet.cssRules).find(r => 'selectorText' in r && r.selectorText === selector) as CSSStyleRule | undefined;
+            assert.ok(rule, selector);
+            assert.equal(rule.style.getPropertyValue('box-shadow').trim(), 'var(--focus-ring-shadow)');
+        }
+        assert.equal(declaration('::-webkit-scrollbar').getPropertyValue('width').trim(), '6px');
+        assert.equal(declaration('::-webkit-scrollbar-thumb').getPropertyValue('background').trim(), 'var(--border-alpha)');
+        assert.equal(declaration('::-webkit-scrollbar-thumb:hover').getPropertyValue('background').trim(), 'var(--border-strong)');
+    } finally { dom.window.close(); }
 });


### PR DESCRIPTION
## Summary

Gives the classic chat UI at `localhost:3457` the t3code token shell without touching its grid, DOM or feature JS. `variables.css` adds `--surface-1/2/3`, `--border-alpha`, `--border-strong`, `--text-muted-60`, `--font-sans-system` (system stack with CJK fallback), `--font-mono-system`, `--radius-ctl` and `--focus-ring-shadow`, each with dark and light values, and points `--font-ui` at the system stack. The left sidebar gets 28px rows with alpha hover/active surfaces and uppercase muted section titles; the header becomes 44px with an alpha bottom border (min-height under 900px); the right-panel tabs become segmented pills; scrollbars are 6px. All 84 legacy token names stay defined in both themes, enforced by a new CSSOM regression test.

| dark | light |
|---|---|
| ![dark](https://github.com/lidge-jun/cli-jaw-internal/blob/codex/workbench-modern-ui-devlog/_plan/260908_workbench_modern_ui/evidence/050_wp5_classic_shell_dark.png?raw=true) | ![light](https://github.com/lidge-jun/cli-jaw-internal/blob/codex/workbench-modern-ui-devlog/_plan/260908_workbench_modern_ui/evidence/050_wp5_classic_shell_light.png?raw=true) |

## Stack

1. #581 `codex/wbui-01-activity-header` → `dev`
2. #583 `codex/wbui-02-activity-expanded` → 01
3. #585 `codex/wbui-03-settings-panel` → 02
4. #587 `codex/wbui-04-unified-settings` → 03
5. **#this** `codex/wbui-05-classic-shell` → 04
6. `codex/wbui-06-hardening` → 05 — next

Plan: `devlog/_plan/260908_workbench_modern_ui/050_classic_shell.md`.

## Validation

- `npm run typecheck:frontend`, `build:frontend`, `check:frontend-build-output`: exit 0
- 7 focused test files: 98/98; `bash structure/verify-counts.sh`: ALL PASS (549)
- Rendered at 1280×800 on a fresh instance built from this branch: header 44px, rows 28px, scrollbar 6px, 0/84 legacy tokens undefined, no horizontal overflow at 900/860/680px
- Full local suite NOT RUN; exact-head CI on this PR is the gate.

