### PR TITLE
test: align fixtures with native Code and runtime retirement

### DIFF
--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -207,7 +207,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 | Dashboard Schedule | `GET /api/dashboard/schedule/work` `POST /api/dashboard/schedule/work` `PATCH /api/dashboard/schedule/work/:id` `DELETE /api/dashboard/schedule/work/:id` `POST /api/dashboard/schedule/work/:id/dispatch` |
 | i18n | `GET /api/i18n/languages` `GET /api/i18n/:lang` |
 
-> 실제 코드(`server.ts` + `src/routes/*.ts` + mounted runtime/security/Jaw CEO/dashboard sub-router)에서 추출한 총 242개 route handler 기준이다. 이 중 API 엔드포인트는 241개이고, 나머지 1개는 `/` 엔트리이다. Browser API 43개는 `src/routes/browser.ts`에서 등록된다. Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 sub-router로 등록된다.
+> AST 추출기가 현재 인식하는 범위는 route handler 242개(API 241개와 `/` 엔트리 1개)다. 전체 API 총수는 아니다. `registerNativeCodeRoutes()` 내부의 `router.*`와 `app.use(prefix, router)` 연결은 아직 집계하지 못한다. 별도로 동작하는 native Code 핸들러 11개는 아래 [Native Code API](#native-code-api) 표에 명시하며, 이전 경로의 410 응답 핸들러도 추출 집계에서 빠져 있다. Browser API 43개는 `src/routes/browser.ts`, Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 등록된다.
 
 `PUT /api/heartbeat`의 job은 `mentionWatch: { channel: "slack", userId: "U...", channelIds: ["C..."], maxHits?, since? }`를 선택적으로 받는다. `channelIds`는 비어 있지 않아야 하고 저장 시 `slack.channelIds` allowlist의 부분집합이어야 하며, 실행 tick 직전 현재 allowlist와 다시 교집합한다. job id가 같은 기존 값에 대해 필드가 없으면 상속하고, `null`이면 삭제하며, 잘못된 값은 `400 invalid heartbeat mention watch`다. 파일 로드 정규화에서 잘못된 `mentionWatch`는 해당 job을 `enabled: false`로 내린다. 기본 운영값은 비활성이고, 설정된 watch는 별도 daemon이 아니라 기존 `runHeartbeatJob`에서 실행된다.
 

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -207,7 +207,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 | Dashboard Schedule | `GET /api/dashboard/schedule/work` `POST /api/dashboard/schedule/work` `PATCH /api/dashboard/schedule/work/:id` `DELETE /api/dashboard/schedule/work/:id` `POST /api/dashboard/schedule/work/:id/dispatch` |
 | i18n | `GET /api/i18n/languages` `GET /api/i18n/:lang` |
 
-> 실제 코드(`server.ts` + `src/routes/*.ts` + mounted runtime/security/Jaw CEO/dashboard sub-router)에서 추출한 총 261개 route handler 기준이다. 이 중 API 엔드포인트는 260개이고, 나머지 1개는 `/` 엔트리이다. Browser API 43개는 `src/routes/browser.ts`에서 등록된다. Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 sub-router로 등록된다.
+> 실제 코드(`server.ts` + `src/routes/*.ts` + mounted runtime/security/Jaw CEO/dashboard sub-router)에서 추출한 총 242개 route handler 기준이다. 이 중 API 엔드포인트는 241개이고, 나머지 1개는 `/` 엔트리이다. Browser API 43개는 `src/routes/browser.ts`에서 등록된다. Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 sub-router로 등록된다.
 
 `PUT /api/heartbeat`의 job은 `mentionWatch: { channel: "slack", userId: "U...", channelIds: ["C..."], maxHits?, since? }`를 선택적으로 받는다. `channelIds`는 비어 있지 않아야 하고 저장 시 `slack.channelIds` allowlist의 부분집합이어야 하며, 실행 tick 직전 현재 allowlist와 다시 교집합한다. job id가 같은 기존 값에 대해 필드가 없으면 상속하고, `null`이면 삭제하며, 잘못된 값은 `400 invalid heartbeat mention watch`다. 파일 로드 정규화에서 잘못된 `mentionWatch`는 해당 job을 `enabled: false`로 내린다. 기본 운영값은 비활성이고, 설정된 watch는 별도 daemon이 아니라 기존 `runHeartbeatJob`에서 실행된다.
 

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -207,7 +207,7 @@ All trace routes set `Cache-Control: no-store` before auth/parsing. Activity dis
 | Dashboard Schedule | `GET /api/dashboard/schedule/work` `POST /api/dashboard/schedule/work` `PATCH /api/dashboard/schedule/work/:id` `DELETE /api/dashboard/schedule/work/:id` `POST /api/dashboard/schedule/work/:id/dispatch` |
 | i18n | `GET /api/i18n/languages` `GET /api/i18n/:lang` |
 
-> AST 추출기가 현재 인식하는 범위는 route handler 242개(API 241개와 `/` 엔트리 1개)다. 전체 API 총수는 아니다. `registerNativeCodeRoutes()` 내부의 `router.*`와 `app.use(prefix, router)` 연결은 아직 집계하지 못한다. 별도로 동작하는 native Code 핸들러 11개는 아래 [Native Code API](#native-code-api) 표에 명시하며, 이전 경로의 410 응답 핸들러도 추출 집계에서 빠져 있다. Browser API 43개는 `src/routes/browser.ts`, Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 등록된다.
+> AST 추출기가 현재 인식하는 범위는 총 242개 route handler다. 이 추출 범위의 API 엔드포인트는 241개이고 `/` 엔트리는 1개다. 전체 API 총수는 아니다. `registerNativeCodeRoutes()` 내부의 `router.*`와 `app.use(prefix, router)` 연결은 아직 집계하지 못한다. 별도로 동작하는 native Code 핸들러 11개는 아래 [Native Code API](#native-code-api) 표에 명시하며, 이전 경로의 410 응답 핸들러도 추출 집계에서 빠져 있다. Browser API 43개는 `src/routes/browser.ts`, Jaw CEO 20개는 `src/routes/jaw-ceo.ts`에서 등록된다.
 
 `PUT /api/heartbeat`의 job은 `mentionWatch: { channel: "slack", userId: "U...", channelIds: ["C..."], maxHits?, since? }`를 선택적으로 받는다. `channelIds`는 비어 있지 않아야 하고 저장 시 `slack.channelIds` allowlist의 부분집합이어야 하며, 실행 tick 직전 현재 allowlist와 다시 교집합한다. job id가 같은 기존 값에 대해 필드가 없으면 상속하고, `null`이면 삭제하며, 잘못된 값은 `400 invalid heartbeat mention watch`다. 파일 로드 정규화에서 잘못된 `mentionWatch`는 해당 job을 `enabled: false`로 내린다. 기본 운영값은 비활성이고, 설정된 watch는 별도 daemon이 아니라 기존 `runHeartbeatJob`에서 실행된다.
 

--- a/tests/unit/dashboard-isolated-qa.test.ts
+++ b/tests/unit/dashboard-isolated-qa.test.ts
@@ -11,6 +11,7 @@ import express from 'express';
 import ts from 'typescript';
 import { readIsolatedQaPolicy, isolatedQaEnvironment } from '../../src/shared/isolated-qa.js';
 import type { DashboardLifecycleAction, DashboardLifecycleResult, DashboardScanResult } from '../../src/manager/types.js';
+import type { CodeHostOptions } from '../../src/code-mode/host.js';
 
 const repo = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const require = createRequire(import.meta.url);
@@ -163,6 +164,8 @@ async function managerFixture(t: TestContext, options: { normal?: boolean; corru
     const noop = () => undefined;
     const route = () => express.Router();
     const seen: string[] = [];
+    const nativeHostOptions: CodeHostOptions[] = [];
+    const nativeRegistrations: { app: express.Express; getHost: () => unknown; prefix: string }[] = [];
     let direct: (input: { action: string; port: number }) => Promise<{ ok: boolean; data: DashboardLifecycleResult }>;
     let server: http.Server | undefined;
     let listen: http.Server['listen'] | undefined;
@@ -180,7 +183,8 @@ async function managerFixture(t: TestContext, options: { normal?: boolean; corru
         server.listen = (() => { hit('listen'); return server; }) as http.Server['listen'];
         return server;
     } } });
-    stub('../core/config.js', { SETTINGS_PATH: join(f.root, 'manager/settings.json'), ensureDirs: () => hit('ensureDirs'), loadSettings: () => hit('loadSettings') });
+    stub('../core/config.js', { SETTINGS_PATH: join(f.root, 'manager/settings.json'), settings: { code: {} },
+        ensureDirs: () => hit('ensureDirs'), loadSettings: () => hit('loadSettings') });
     stub('./lifecycle.js', { DashboardLifecycleManager: class {
         constructor(readonly options: unknown) { hit('lifecycleConstructor'); }
         async hydrate() { hit('hydrate'); return { adopted: 0, pruned: 0 }; }
@@ -233,6 +237,19 @@ async function managerFixture(t: TestContext, options: { normal?: boolean; corru
     stub('./routes/runtime-monitor.js', { registerManagerRuntimeMonitorRoutes: noop });
     stub('./routes/embedded-browser.js', { registerEmbeddedBrowserRoutes: noop });
     stub('../routes/code.js', { registerCodeRoutes: noop });
+    stub('../routes/code-native.js', { registerNativeCodeRoutes: (app: express.Express,
+        _auth: express.RequestHandler, getHost: () => unknown, prefix: string) => {
+        hit('nativeRegistration');
+        nativeRegistrations.push({ app, getHost, prefix });
+    } });
+    stub('../code-mode/host.js', { createCodeHost: (options: CodeHostOptions) => {
+        hit('nativeHostConstructor');
+        nativeHostOptions.push(options);
+        return {
+            get: () => { hit('nativeHostGet'); throw new Error('FORBIDDEN NATIVE SESSION SENTINEL'); },
+            dispose: async () => { hit('nativeHostDispose'); },
+        };
+    } });
     stub('./memory/embedding/index.js', { VecStore: class {}, getVecDbPath: noop, createProvider: noop, syncAllInstances: noop });
     stub('../routes/jaw-ceo.js', { createJawCeoRouter: (deps: { runLifecycleAction: typeof direct }) => { direct = deps.runLifecycleAction; return route(); } });
 
@@ -280,8 +297,35 @@ async function managerFixture(t: TestContext, options: { normal?: boolean; corru
         }), signal: AbortSignal.timeout(2000) });
         return { status: response.status, body: await response.json() };
     };
-    return { ...f, registry, count, seen, error, request, direct: (action: string, port = 35482) => direct({ action, port }) };
+    return { ...f, registry, count, seen, error, request, nativeHostOptions, nativeRegistrations,
+        direct: (action: string, port = 35482) => direct({ action, port }) };
 }
+
+test('Manager registers the configured native Code host without acquiring a session', async t => {
+    for (const normal of [false, true]) {
+        await t.test(normal ? 'normal' : 'isolated QA', async child => {
+            const f = await managerFixture(child, { normal });
+            assert.equal(f.error, undefined);
+            assert.equal(f.count.ensureDirs, 1);
+            assert.equal(f.count.loadSettings, 1);
+            assert.equal(f.count.nativeHostConstructor, 1);
+            assert.equal(f.count.nativeRegistration, 1);
+            assert.equal(f.nativeHostOptions.length, 1);
+            const options = f.nativeHostOptions[0]!;
+            assert.equal(options.home, join(f.root, 'dashboard'));
+            assert.equal(options.role, 'manager');
+            assert.equal(typeof options.port, 'function');
+            assert.equal(options.maxConcurrentSessions, undefined);
+            assert.equal(options.idleReapMs, undefined);
+            assert.equal(f.nativeRegistrations.length, 1);
+            assert.equal(typeof f.nativeRegistrations[0]!.app, 'function');
+            assert.equal(typeof f.nativeRegistrations[0]!.getHost, 'function');
+            assert.equal(f.nativeRegistrations[0]!.prefix, '/api/code');
+            assert.equal(f.count.nativeHostGet, undefined);
+            assert.equal(f.count.nativeHostDispose, undefined);
+        });
+    }
+});
 
 test('Manager rejects malformed QA env and raw persisted ranges before body side effects', async t => {
     for (const options of [{ invalidEnv: true }, ...[0, 2, '1', null].map(count => ({ corrupt: { scan: { from: 35482, count } } })),

--- a/tests/unit/docs-extract-commands.test.ts
+++ b/tests/unit/docs-extract-commands.test.ts
@@ -115,6 +115,7 @@ test('docs commands extractor tracks hidden slash commands and runtime keys', as
 
     assert.ok(fileCommand, '/file should be present in command inventory');
     assert.equal(fileCommand.hidden, true, '/file should stay hidden');
-    assert.ok(inventory.runtimes.keys.includes('jwc'), 'runtime keys should include jwc');
+    assert.equal(inventory.runtimes.keys.includes('jwc'), false, 'retired jwc must not be an executable runtime key');
+    assert.ok(inventory.runtimes.keys.includes('codex-app'), 'runtime keys should include supported codex-app');
     assert.equal(inventory.runtimes.count, inventory.runtimes.keys.length, 'runtime count should match keys length');
 });

--- a/tests/unit/settings-runtime-gate-persistence.test.ts
+++ b/tests/unit/settings-runtime-gate-persistence.test.ts
@@ -52,8 +52,14 @@ function document(
     };
 }
 
-function withoutAbsentGate(value: Record<string, any>): Record<string, any> {
+function expectedPersisted(value: Record<string, any>): Record<string, any> {
     const expected = structuredClone(value);
+    delete expected.runtimeSelectionDiagnostic;
+    return expected;
+}
+
+function withoutAbsentGate(value: Record<string, any>): Record<string, any> {
+    const expected = expectedPersisted(value);
     if (expected.runtime?.codexApp?.multiplex === false) {
         delete expected.runtime.codexApp.multiplex;
         if (Object.keys(expected.runtime.codexApp).length === 0) delete expected.runtime.codexApp;
@@ -120,6 +126,21 @@ async function runChildScenario(name: string): Promise<void> {
         return;
     }
 
+    if (name === 'retired-diagnostic-save') {
+        write(document('jwc'));
+        config.loadSettings();
+        assert.equal(config.settings.cli, 'jwc');
+        assert.equal(config.settings.runtimeSelectionDiagnostic, 'retired_runtime:jwc');
+        config.settings.port = '4567';
+        config.saveSettings(config.settings);
+        assert.equal(config.getSettingsPersistenceShape(), 'absent');
+        assert.equal(disk(), expectedAbsentRaw(config.settings));
+        assert.equal(Object.hasOwn(JSON.parse(disk()), 'runtimeSelectionDiagnostic'), false);
+        assert.equal(config.settings.cli, 'jwc');
+        assert.equal(config.settings.runtimeSelectionDiagnostic, 'retired_runtime:jwc');
+        return;
+    }
+
     if (name === 'side-effect-rollback') {
         write(document());
         config.loadSettings();
@@ -144,7 +165,8 @@ async function runChildScenario(name: string): Promise<void> {
         });
         assert.equal(config.getSettingsPersistenceShape(), 'present');
         assert.equal(applied.runtime.codexApp.multiplex, multiplex);
-        assert.equal(disk(), JSON.stringify(applied, null, 2));
+        assert.equal(disk(), JSON.stringify(expectedPersisted(applied), null, 2));
+        assert.equal(Object.hasOwn(JSON.parse(disk()), 'runtimeSelectionDiagnostic'), false);
         return;
     }
 
@@ -222,7 +244,8 @@ async function runChildScenario(name: string): Promise<void> {
         assert.equal(config.settings.runtime.codexApp.multiplex, true);
         assert.equal(config.settings.runtimeDefaultMigration.state, 'accepted');
         assert.equal(config.getSettingsPersistenceShape(), 'present');
-        assert.equal(disk(), JSON.stringify(config.settings, null, 2));
+        assert.equal(disk(), JSON.stringify(expectedPersisted(config.settings), null, 2));
+        assert.equal(Object.hasOwn(JSON.parse(disk()), 'runtimeSelectionDiagnostic'), false);
         return;
     }
 
@@ -239,6 +262,7 @@ if (scenario) {
         'rollback',
         'side-effect-rollback',
         'port-save',
+        'retired-diagnostic-save',
         'explicit-false',
         'explicit-true',
         'sequential-malformed',

--- a/tests/unit/sidecar-smoke.test.ts
+++ b/tests/unit/sidecar-smoke.test.ts
@@ -164,8 +164,62 @@ for(const variant of ['nonce','pid','unknown','flood','oversized'] as const)test
         :variant==='unknown'?base.replace("kind:'imported'","kind:'unknown'")
         :variant==='oversized'?base.replace("kind:'imported'","kind:'error',error:'x'.repeat(40000)"):base;
     f.put('dist/src/telegram/bot.js',variant==='flood'?`for(let i=0;i<40;i++)process.send(${message});`:`process.send(${message});`);
-    const result=await f.run();assert.equal(result.ok,false);assert.ok(result.probes[0].issues.some(value=>/IPC|receipt/.test(value)));
-    if(variant==='flood'||variant==='oversized')assert.ok(result.probes[0].issues.includes('IPC bound/shape'));
+    const result=await f.run(),diagnostics=JSON.stringify({error:result.error,probes:result.probes});
+    assert.equal(result.ok,false,diagnostics);assert.ok(result.probes[0].issues.some(value=>/IPC|receipt/.test(value)),diagnostics);
+    if(variant==='flood'){
+        assert.ok(result.probes[0].issues.some(value=>value==='duplicate/invalid import receipt'||value==='IPC bound/shape'),diagnostics);
+        assert.equal(result.probes[0].closed,true,diagnostics);
+        assert.equal(result.probes[0].groupAbsent,process.platform==='win32'?null:true,diagnostics);
+    }
+    if(variant==='oversized')assert.ok(result.probes[0].issues.includes('IPC bound/shape'),diagnostics);
+});
+
+for(const packets of [32,33])test(`actual IPC handler rejects ${packets} synchronous receipts with exact count-bound behavior`,async t=>{
+    const f=fixture(t),spawn=childProcess.spawn;
+    // Keep the real import pending so its normal completion packet cannot
+    // contaminate this controlled batch. Production still owns child cleanup.
+    f.put('dist/src/telegram/bot.js','setInterval(()=>{},1000);await new Promise(()=>{});');
+    let spawns=0,targets=0,delivered=0,listeners=0,closed=false;
+    let target:ReturnType<typeof childProcess.spawn>|undefined;
+    try{
+        t.mock.method(childProcess,'spawn',(...args:Parameters<typeof childProcess.spawn>)=>{
+            const child=spawn(...args),[executable,argv]=args;
+            spawns++;
+            if(spawns===1&&Array.isArray(argv)&&argv.length===4
+                &&argv[0]===path.join(repo,'scripts/sidecar-smoke-probe.mjs')&&argv[2]==='telegram'
+                &&typeof argv[1]==='string'&&typeof argv[3]==='string'&&/^[a-f0-9]{48}$/.test(argv[3])
+                &&executable===path.join(argv[1],process.platform==='win32'?'node.exe':'node')){
+                targets++;target=child;
+                child.once('close',()=>{closed=true;});
+                const message={version:1,caseId:argv[2],nonce:argv[3],kind:'imported',
+                    pid:child.pid,node:process.version,executable};
+                queueMicrotask(()=>{
+                    listeners=child.listenerCount('message');
+                    if(listeners!==1||!child.pid)return;
+                    // One batch prevents cleanup from interleaving between
+                    // the duplicate receipt and the 33rd message.
+                    for(let i=0;i<packets;i++){child.emit('message',message);delivered++;}
+                });
+            }
+            return child;
+        });
+        syncBuiltinESMExports();
+        const result=await f.run(),row=result.probes[0];
+        const diagnostics=JSON.stringify({error:result.error,probes:result.probes,spawns,targets,delivered,listeners,closed});
+        assert.equal(targets,1,diagnostics);assert.equal(listeners,1,diagnostics);assert.equal(delivered,packets,diagnostics);
+        assert.equal(result.ok,false,diagnostics);assert.equal(result.code,1,diagnostics);
+        assert.ok(row,diagnostics);assert.equal(row.id,'telegram',diagnostics);assert.equal(row.pid,target?.pid,diagnostics);
+        assert.equal(row.imported,true,diagnostics);assert.equal(row.node,process.version,diagnostics);
+        assert.equal(row.executable,row.command[0],diagnostics);
+        assert.ok(row.issues.includes('duplicate/invalid import receipt'),diagnostics);
+        assert.equal(row.issues.includes('IPC bound/shape'),packets===33,diagnostics);
+        assert.equal(row.issues.includes('IPC identity'),false,diagnostics);
+        assert.equal(closed,true,diagnostics);assert.equal(row.closed,true,diagnostics);
+        assert.equal(row.groupAbsent,process.platform==='win32'?null:true,diagnostics);
+        assert.ok(row.portsAbsent.every(Boolean),diagnostics);
+    }finally{
+        t.mock.restoreAll();syncBuiltinESMExports();
+    }
 });
 
 test('outbound network, a non-loopback bind and wrong Manager health all fail before certification',async t=>{

--- a/tests/unit/skill-namespace-migration.test.ts
+++ b/tests/unit/skill-namespace-migration.test.ts
@@ -273,52 +273,23 @@ test('SNM-014: a correct compat link is stable across passes', () => {
     });
 });
 
-// The desktop app ships its own CommonJS copy of this migration. It cannot be
-// imported (it runs as a process and needs packaging assets absent from a
-// source checkout), and it has drifted before — its default set was 14 of 17
-// ids. These pin the invariants that actually bit us, the same way
-// desktop-control-skill-contract.test.ts pins the shipped skill.
-const CJS = fs.readFileSync(join(
-    import.meta.dirname, '..', '..',
-    'electron/sidecar/jawcode/packages/jwc/scripts/bootstrap-cli-jaw-home.cjs',
-), 'utf8');
-
-test('SNM-015: the Electron migrator does the reference tree, and does it first', () => {
-    assert.match(CJS, /function migrateRefNamespace\(\)/,
-        'a legacy reference tree re-creates legacy active dirs forever');
-    const call = CJS.indexOf('migrateRefNamespace();');
-    const activeLoop = CJS.indexOf('for (const [legacyId, canonicalId] of LEGACY_SKILL_ALIASES) {', call);
-    assert.ok(call > 0 && activeLoop > call,
-        'the reference tree must be migrated before the active tree');
+// The retired Electron CJS bootstrap is no longer a migration owner. The
+// surviving TS filesystem scenarios above and below retain that contract.
+test('SNM-015: the retired Electron migration bootstrap is absent', () => {
+    const bootstrap = join(import.meta.dirname, '..', '..',
+        'electron/sidecar/jawcode/packages/jwc/scripts/bootstrap-cli-jaw-home.cjs');
+    assert.throws(() => fs.lstatSync(bootstrap), { code: 'ENOENT' });
 });
 
-test('SNM-016: the Electron migrator refuses a borrowed reference tree', () => {
-    const body = CJS.slice(CJS.indexOf('function migrateRefNamespace()'));
-    assert.match(body.slice(0, 700), /isSymbolicLink\(\)\) return;/,
-        'migrating through a symlinked skills_ref writes into another home');
-});
-
-test('SNM-017: the Electron migrator renames rather than always backing up', () => {
-    assert.match(CJS, /legacy skill migrated: \$\{legacyId\} -> \$\{canonicalId\}/,
-        'always backing up empties the active tree and strands in-place edits');
-    assert.match(CJS, /function canonicalIsBlocked\(/);
-    assert.match(CJS, /function isOwnedCompatLink\(/,
-        'a link pointing outside the tree belongs to the user');
-});
-
-test('SNM-018: the Electron migrator resolves link targets instead of string-comparing', () => {
-    assert.match(CJS, /function linkPointsAt\(/);
-    assert.doesNotMatch(CJS, /current === canonicalId/,
-        'a Windows junction reads back absolute, so a literal compare churns every pass');
-});
-
-test('SNM-019: the Electron default set matches the runtime active set', () => {
-    // It shipped with 14 of 17, so the desktop app activated 27 skills where
-    // the CLI activated 30.
-    const base = CJS.slice(CJS.indexOf('const BASE_AUTO_ACTIVATE'), CJS.indexOf(']);', CJS.indexOf('const BASE_AUTO_ACTIVATE')));
-    const ids = [...base.matchAll(/"(jaw-[a-z-]+)"/g)].map(m => m[1]).sort();
-    const expected = [...CODEX_ACTIVE, ...OPENCLAW_ACTIVE].sort();
-    assert.deepEqual(ids, expected);
+test('SNM-019: the TS runtime owns the canonical default active sets', () => {
+    assert.deepEqual([...CODEX_ACTIVE].sort(), ['jaw-pdf']);
+    assert.deepEqual([...OPENCLAW_ACTIVE].sort(), [
+        'jaw-browser', 'jaw-memory', 'jaw-search',
+        'jaw-screen-capture', 'jaw-docx', 'jaw-xlsx', 'jaw-pptx', 'jaw-hwp',
+        'jaw-github', 'jaw-telegram-send', 'jaw-video', 'jaw-pdf-vision',
+        'jaw-diagram', 'jaw-structured-renderers', 'jaw-desktop-control',
+        'jaw-goal', 'jaw-calendar-reminders',
+    ].sort());
 });
 
 test('SNM-020: a user link aimed at another IN-TREE skill is still theirs', () => {
@@ -339,10 +310,20 @@ test('SNM-020: a user link aimed at another IN-TREE skill is still theirs', () =
     });
 });
 
-test('SNM-021: the Electron migrator clears a stray reference link', () => {
-    // TS removes it; CJS used to skip it, so the detector reported the same
-    // home pending forever.
-    assert.doesNotMatch(CJS, /if \(stat\.isSymbolicLink\(\) \|\| !stat\.isDirectory\(\)\) continue;/,
-        'a stray reference link must be removed, not skipped');
-});
+test('SNM-021: the TS migrator clears a stray reference link without touching its target', () => {
+    withBox(root => {
+        const home = makeHome(root, '.cli-jaw');
+        const owner = join(root, 'user-skills');
+        makeSkill(owner, 'browser', 'USER CONTENT\n');
+        const link = join(home, 'skills_ref', 'browser');
+        fs.symlinkSync(join(owner, 'browser'), link, 'junction');
 
+        assert.equal(hasPendingLegacySkillDirs(home), true);
+        const reports = migrateAllJawHomes(home);
+        assert.equal(reports.length, 1);
+        assert.deepEqual(reports[0]!.result.unlinked, ['skills_ref/browser']);
+        assert.throws(() => fs.lstatSync(link), { code: 'ENOENT' });
+        assert.equal(fs.readFileSync(join(owner, 'browser', 'SKILL.md'), 'utf8'), 'USER CONTENT\n');
+        assert.equal(hasPendingLegacySkillDirs(home), false);
+    });
+});


### PR DESCRIPTION
Current `dev` retained documentation and test assumptions from the retired runtime: route totals were stale, runtime inventory still required `jwc`, a migration test read the removed desktop bootstrap, persistence expectations included a memory-only diagnostic, and the isolated Manager fixture lacked native Code imports.

Align those docs and fixtures with current source contracts. Preserve the surviving migration/symlink scenarios, byte-exact persistence and rollback assertions, and real Manager isolation guards. Document the AST extractor's counted subset without claiming it covers all native Code routes or bypassing its drift patterns.

The IPC flood fixture also depended on scheduling: duplicate-receipt rejection could occur before the count bound. Retain exact end-to-end rejection and real cleanup assertions, and add deterministic 32/33-message tests through the actual handler with real child cleanup. Application code, limits, workflows, required checks and dependency versions are unchanged.

Validation: final head `20716b847` passed all nine required jobs in [Tests run 34169552944](https://github.com/lidge-jun/cli-jaw/actions/runs/34169552944). Both count-bound cases and the real-process flood case executed successfully. Independent documentation/security/test-isolation audits passed. Local product tests, typecheck, build and install were not run, as requested.

Stack, merge bottom-up:

| Layer | PR | Change |
| --- | --- | --- |
| 0 | This PR (merged) | Current-runtime documentation and fixture baseline |
| 1 | #599 | Sidebar selection and layout preference |
| 2 | #601 | Terminal navigation, theme and recovery |
