### PR TITLE
fix(boundary): skip history the destination already advertises on pre-push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ git fetch origin dev
 node scripts/check-private-boundary.mjs --range origin/dev HEAD
 ```
 
-Use the destination branch's current remote tip as the range base. The default check scans indexed paths; `--range` checks every outgoing commit, including private files added and later deleted. `.githooks/pre-push` passes Git's ref updates to `--pre-push` on stdin. Do not bypass this check with `--no-verify`.
+Use the destination branch's current remote tip as the range base. The default check scans indexed paths; `--range` checks every outgoing commit, including private files added and later deleted. `.githooks/pre-push` passes Git's ref updates to `--pre-push` on stdin, and in that mode commits any ref of the same destination already advertises are not re-scanned: a fast-forward of `preview`/`main` onto commits `dev` has already published introduces no new disclosure. Do not bypass this check with `--no-verify`.
 
 These checks reject private path names, not private content hidden under otherwise public names. Review the diff for private record links and content too. CI is a backstop after upload; it cannot prevent or retract disclosure from a push. Package exclusions also do not protect Git pushes: npm's `files` allowlist can override root `.npmignore`, so private paths need explicit exclusions there as well.
 

--- a/scripts/check-private-boundary.mjs
+++ b/scripts/check-private-boundary.mjs
@@ -30,26 +30,32 @@ export function checkRange(cwd, base, head, destination) {
     const oid = ref => git(cwd, ['rev-parse', '--verify', '--end-of-options', ref + '^{commit}']).trim();
     const headId = oid(head);
     const baseId = base ? oid(base) : null;
-    // A new ref has no old tip. Only exclude commits actually advertised by
-    // THIS destination; unrelated/private remote-tracking refs prove nothing.
-    let revArgs;
-    if (baseId) {
-        revArgs = [baseId + '..' + headId];
-    } else {
-        if (!destination) throw new Error('A destination is required to check a new remote ref');
-        const advertised = git(cwd, ['ls-remote', '--refs', '--', destination])
-            .split('\n').filter(Boolean).map(line => line.split(/\s+/)[0]);
-        if (advertised.some(sha => !/^[a-f0-9]{40,64}$/.test(sha))) throw new Error('Invalid destination refs');
-        const available = advertised.length ? execFileSync('git', ['cat-file', '--batch-check=%(objectname) %(objecttype)'], {
-            cwd, encoding: 'utf8', input: advertised.map(sha => sha + '^{commit}').join('\n') + '\n',
-            maxBuffer: 64 * 1024 * 1024,
-        }).split('\n').filter(line => /^[a-f0-9]{40,64} commit$/.test(line)).map(line => line.split(' ')[0]) : [];
-        revArgs = available.length ? [headId, '--not', ...available] : [headId];
-    }
+    // The guard is about NEW disclosure. A commit every ref of THIS destination
+    // already advertises is public there regardless of which branch receives it,
+    // so a fast-forward of preview/main onto commits that dev already published
+    // must not re-scan history that predates the private-record detachment.
+    // Only the destination's own refs count; unrelated/private remote-tracking
+    // refs prove nothing. A new ref has no old tip and needs the destination.
+    if (!baseId && !destination) throw new Error('A destination is required to check a new remote ref');
+    const available = destination ? advertisedCommits(cwd, destination) : [];
+    const exclude = [...(baseId ? [baseId] : []), ...available];
+    const revArgs = exclude.length ? [headId, '--not', ...exclude] : [headId];
     const commits = new Set([headId, ...git(cwd, ['rev-list', ...revArgs]).trim().split('\n').filter(Boolean)]);
     for (const commit of commits) {
         rejectPaths(git(cwd, ['ls-tree', '-r', '--name-only', '-z', commit]).split('\0').filter(Boolean), commit);
     }
+}
+
+/** Commits the destination remote currently advertises and this repository has. */
+function advertisedCommits(cwd, destination) {
+    const advertised = git(cwd, ['ls-remote', '--refs', '--', destination])
+        .split('\n').filter(Boolean).map(line => line.split(/\s+/)[0]);
+    if (advertised.some(sha => !/^[a-f0-9]{40,64}$/.test(sha))) throw new Error('Invalid destination refs');
+    if (!advertised.length) return [];
+    return execFileSync('git', ['cat-file', '--batch-check=%(objectname) %(objecttype)'], {
+        cwd, encoding: 'utf8', input: advertised.map(sha => sha + '^{commit}').join('\n') + '\n',
+        maxBuffer: 64 * 1024 * 1024,
+    }).split('\n').filter(line => /^[a-f0-9]{40,64} commit$/.test(line)).map(line => line.split(' ')[0]);
 }
 
 export function checkPush(cwd, input, destination) {

--- a/tests/unit/private-boundary.test.ts
+++ b/tests/unit/private-boundary.test.ts
@@ -96,6 +96,30 @@ test('a private remote-tracking ref cannot hide outgoing history from a new publ
     assert.throws(() => checkPush(root, input, remote), /devlog\/private/);
 });
 
+test('history the destination already advertises is not re-scanned when another branch fast-forwards onto it', t => {
+    // Mirrors the release train: dev detached private records and was pushed; preview and
+    // main are then fast-forwarded to commits dev already published at the same remote.
+    const root = fixture(t);
+    const remote = join(fixture(t), 'destination.git');
+    git(root, 'init', '--bare', '-q', remote);
+    put(root, 'README.md'); git(root, 'add', '.'); git(root, 'commit', '-qm', 'public base');
+    const base = git(root, 'rev-parse', 'HEAD');
+    git(root, 'push', '-q', remote, 'HEAD:refs/heads/main');
+    put(root, 'devlog/old.md'); git(root, 'add', '.'); git(root, 'commit', '-qm', 'legacy private record');
+    git(root, 'rm', '-q', 'devlog/old.md'); git(root, 'commit', '-qm', 'detach private records');
+    const dev = git(root, 'rev-parse', 'HEAD');
+    // Already published on dev at this destination; a preview fast-forward re-pushes the same commits.
+    git(root, 'push', '-q', remote, 'HEAD:refs/heads/dev');
+    assert.doesNotThrow(() => checkPush(root, 'refs/heads/preview ' + dev + ' refs/heads/preview ' + base, remote));
+    // Without the destination, the range still rejects the intermediate private commit.
+    assert.throws(() => checkRange(root, base, dev), /devlog\/old/);
+    // New private history above what the destination advertises is still rejected.
+    put(root, 'devlog/new.md'); git(root, 'add', '.'); git(root, 'commit', '-qm', 'new private');
+    git(root, 'rm', '-q', 'devlog/new.md'); git(root, 'commit', '-qm', 'clean tip');
+    const head = git(root, 'rev-parse', 'HEAD');
+    assert.throws(() => checkPush(root, 'refs/heads/dev ' + head + ' refs/heads/dev ' + dev, remote), /devlog\/new/);
+});
+
 test('prepublish lifecycle rejects private input before build and preserves build/check ordering', t => {
     const root = fixture(t);
     const lifecycle = JSON.parse(readFileSync(join(project, 'package.json'), 'utf8')).scripts.prepublishOnly;


### PR DESCRIPTION
## Problem

The pre-push private-boundary guard re-scans every commit between the target branch's old tip and the pushed tip. Since private records were detached from the tree (`3a3dfdc09`), fast-forwarding `preview` or `main` onto `dev` fails on legacy `.jwc/`/`devlog` history that `dev` itself already published at `origin`:

```
$ printf 'refs/heads/dev <dev> refs/heads/preview <preview>\n' | node scripts/check-private-boundary.mjs --pre-push origin
[private-boundary] 3091e8af...: private paths must live outside cli-jaw:
devlog
tests/unit/devlog-skill-contract.test.ts
```

This blocks `release-preview.sh` (`git push origin HEAD:preview`) and therefore the whole release train.

## Change

`checkRange` now excludes, in addition to the old tip, every commit that any ref of the same destination already advertises. A push that only fast-forwards onto commits the remote has is not a new disclosure. New private commits above the advertised set are still rejected, and `--range <base> <head>` without a destination is unchanged.

## Verification

- `npx tsx --experimental-test-module-mocks tests/run.mts tests/unit/private-boundary.test.ts`: 8 pass, 0 fail (one new test covering fast-forward onto advertised history, the same range without a destination, and a new private commit above it).
- Against the real remote: `dev -> preview` and `dev -> main` pre-push simulations now report OK; `--range origin/dev HEAD` OK.
- `bash structure/verify-counts.sh` 574 PASS; `git diff --check` clean.
