### PR TITLE
fix(slack): refuse a Slack app token already connected from another home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,8 @@ Before any public push, run `npm run check:private-boundary` for the index and `
 
 ### Architecture Docs Sync
 
+- Slack Socket Mode app-token ownership is coordinated across homes by a connected, fresh, live-PID claim; uncertainty fails open, conflicts disable inbound only, and the runtime notice/activation epoch must remain generation-bound. See `structure/telegram.md` and `structure/server_api.md`.
+
 - Manager sidebar selection and Sessions/Stop/Open use separate interactive targets. Keep list navigation scoped to the focused row selector, stable session-disclosure links, and preferred width separate from viewport clamping. Pointer and keyboard resize completion persist the latest value; see `structure/frontend.md`.
 - Manager terminal presentation preserves backend PTY ownership across hide/unmount. Keep hydration-first bounded creation, explicit recovery, stable tab identity and focus ownership separate from native Code API sessions; theme updates must not recreate shells. See `structure/frontend.md`.
 

--- a/bin/commands/doctor.ts
+++ b/bin/commands/doctor.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { JAW_HOME, SETTINGS_PATH, DB_PATH, HEARTBEAT_JOBS_PATH, detectCli } from '../../src/core/config.js';
 import { slackChannelScope } from '../../src/slack/scope-status.js';
+import { inspectSlackTokenClaim } from '../../src/slack/token-claim.js';
 import { sendFileAllowedRoots } from '../../src/security/path-guards.js';
 import { checkPsExecutionPolicy, inspectInstallIntegrity, formatRecoveryCommands } from '../../src/core/install-integrity.js';
 import { detectSharedPathContamination } from '../../lib/mcp-sync.js';
@@ -462,6 +463,17 @@ check('Slack', () => {
     // the Web API works, but no inbound events can arrive.
     if (!appToken) throw new Error('WARN: app-level token missing — outbound only, no inbound events (jaw slack setup)');
     if (!appToken.startsWith('xapp-')) throw new Error('app token should start with xapp-');
+    if (process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] !== '1') {
+        const owner = inspectSlackTokenClaim({
+            appToken,
+            home: JAW_HOME,
+            port: String(loadedSettings()['port' as keyof DoctorSettings] || ''),
+            connected: true,
+        });
+        if (owner.kind === 'foreign_live') {
+            throw new Error(`WARN: Slack app token is claimed by ${owner.claim.home} on :${owner.claim.port}`);
+        }
+    }
     // One bot, one instance: tokens present here but the socket belongs to
     // another instance — WARN so it reads as intended, not broken.
     const attachPort = String(settings.slack.attachPort || '').trim();
@@ -1071,9 +1083,21 @@ function buildSlackStatus() {
     const { ids: channelIds, scope: channelScope } = slackChannelScope(sc.channelIds);
     let status = 'ok';
     const degradedReasons: string[] = [];
+    const tokenClaim = appTokenPresent && process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] !== '1'
+        ? inspectSlackTokenClaim({
+            appToken: sc.appToken!,
+            home: JAW_HOME,
+            port: String(s?.['port' as keyof DoctorSettings] || ''),
+            connected: true,
+        })
+        : { kind: 'none' as const };
     if (!sc.enabled) { status = 'disabled'; }
     else if (!botTokenPresent) { status = 'missing_bot_token'; degradedReasons.push('bot token missing'); }
     else if (!appTokenPresent) { status = 'missing_app_token'; degradedReasons.push('app-level token missing — outbound only, no inbound events'); }
+    else if (tokenClaim.kind === 'foreign_live') {
+        status = 'token_shared_other_home';
+        degradedReasons.push(`Slack inbound is owned by ${tokenClaim.claim.home} on :${tokenClaim.claim.port}`);
+    }
     else if (channelScope === 'malformed') {
         // Not a missing setting — a present one the gate cannot read, so it
         // denies every channel. Tokens alone used to carry this to status "ok",
@@ -1107,6 +1131,9 @@ function buildSlackStatus() {
         // MPIM lookups surface missing_scope at call time (260806 unit).
         historyLookup: botTokenPresent,
         socketModeNote: 'app-level token (xapp-) is required for inbound events; a bot token alone is outbound-only',
+        ...(tokenClaim.kind === 'foreign_live' ? {
+            tokenClaimOwner: { home: tokenClaim.claim.home, port: tokenClaim.claim.port },
+        } : {}),
         degradedReasons,
     };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -66,6 +66,8 @@ export const SKILLS_REF_DIR = join(JAW_HOME, 'skills_ref');
 // ─── Server URLs ────────────────────────────────────
 export const DEFAULT_PORT = '3457';
 export const CDP_PORT_OFFSET = 5783;  // 9240 - 3457
+const FIRST_UNPRIVILEGED_PORT = 1024;
+const UNPRIVILEGED_PORT_COUNT = 65535 - FIRST_UNPRIVILEGED_PORT + 1;
 
 // Option D rollout: when set, /api/messages rebuilds a
 // finished message's tool cards from trace_events (durable, uncapped) instead of the
@@ -77,7 +79,9 @@ export function deriveCdpPort(serverPort?: number | string): number {
     const port = Number(serverPort || process.env["PORT"] || DEFAULT_PORT);
     if (!Number.isInteger(port) || port < 1 || port > 65535) return 9240;
     const cdp = port + CDP_PORT_OFFSET;
-    return cdp > 65535 ? 9240 : cdp;
+    if (cdp <= 65535) return cdp;
+    return FIRST_UNPRIVILEGED_PORT
+        + ((port - FIRST_UNPRIVILEGED_PORT + CDP_PORT_OFFSET) % UNPRIVILEGED_PORT_COUNT);
 }
 
 export function getServerUrl(port?: string | number) {

--- a/src/messaging/channel-health.ts
+++ b/src/messaging/channel-health.ts
@@ -1,11 +1,13 @@
-import { settings } from '../core/config.js';
+import { JAW_HOME, settings } from '../core/config.js';
 import { MALFORMED_SLACK_ALLOWLIST, readSlackAllowlist, shouldAttachSlack } from '../slack/events.js';
 import {
     getHomeChannel,
     getLastActiveTarget,
     getRunningMessagingTransports,
+    getMessagingTransportNotice,
     isMessagingTransportRunning,
 } from './runtime.js';
+import { inspectSlackTokenClaim } from '../slack/token-claim.js';
 import { getIngressJournal, type IngressJournal } from './durable-ingress.js';
 import { snapshotMetrics, type MessagingMetricsSnapshot } from './metrics.js';
 import { getSlackScopeStatus, type SlackScopeStatus } from '../slack/scope-status.js';
@@ -156,6 +158,23 @@ export function getTransportCapability(channel: MessengerChannel): TransportCapa
                 activeInbound,
                 sendCapable: slackHasSendTarget(),
                 reason: 'missing_app_token',
+            };
+        }
+        const ownershipNotice = getMessagingTransportNotice('slack') === 'token_shared_other_home';
+        const foreignConnected = !activeInbound
+            && process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] !== '1'
+            && inspectSlackTokenClaim({
+                appToken,
+                home: JAW_HOME,
+                port: String(settings['port'] ?? ''),
+                connected: true,
+            }).kind === 'foreign_live';
+        if (ownershipNotice || foreignConnected) {
+            return {
+                configured: true,
+                activeInbound: false,
+                sendCapable: slackHasSendTarget(),
+                reason: 'token_shared_other_home',
             };
         }
         if (!slackHasSendTarget()) {

--- a/src/messaging/runtime.ts
+++ b/src/messaging/runtime.ts
@@ -15,6 +15,7 @@ export type TransportStartFailureReason =
     | 'not_configured'
     | 'outbound_only'
     | 'not_attach_instance'
+    | 'token_shared_other_home'
     | 'superseded'
     | 'not_registered'
     | 'failed';
@@ -35,8 +36,10 @@ export function transportNotStarted(
     return detail === undefined ? { started: false, reason } : { started: false, reason, detail };
 }
 
+export type TransportInitContext = { startEpoch: number };
+
 type TransportFns = {
-    init: () => Promise<TransportStartOutcome>;
+    init: (ctx?: TransportInitContext) => Promise<TransportStartOutcome>;
     shutdown: () => Promise<void>;
 };
 
@@ -44,6 +47,11 @@ const transports = new Map<MessengerChannel, TransportFns>();
 const CHANNELS = ['telegram', 'discord', 'slack'] as const;
 const runningTransports = new Set<MessengerChannel>();
 const transportErrors = new Map<MessengerChannel, string>();
+const transportNotices = new Map<MessengerChannel, string>();
+const startEpochs = new Map<MessengerChannel, number>();
+const activatedEpochs = new Map<MessengerChannel, number>();
+const inFlightStartEpochs = new Map<MessengerChannel, Set<number>>();
+const revokedStarts = new Map<MessengerChannel, { epoch: number; reason: TransportStartFailureReason }>();
 
 function isMessengerChannel(value: unknown): value is MessengerChannel {
     return CHANNELS.includes(value as MessengerChannel);
@@ -64,6 +72,11 @@ export function __resetTransportRegistryForTests() {
     latestSeenTargets.clear();
     runningTransports.clear();
     transportErrors.clear();
+    transportNotices.clear();
+    startEpochs.clear();
+    activatedEpochs.clear();
+    inFlightStartEpochs.clear();
+    revokedStarts.clear();
 }
 
 /** Test-only: clear target maps between tests. */
@@ -184,6 +197,24 @@ export function getMessagingTransportError(channel: MessengerChannel): string | 
     return transportErrors.get(channel) ?? null;
 }
 
+export function getMessagingTransportNotice(channel: MessengerChannel): string | null {
+    return transportNotices.get(channel) ?? null;
+}
+
+export function revokeMessagingTransport(
+    channel: MessengerChannel,
+    reason: TransportStartFailureReason,
+    epoch: number,
+): boolean {
+    const activated = activatedEpochs.get(channel) ?? 0;
+    const inFlight = inFlightStartEpochs.get(channel)?.has(epoch) === true;
+    if (epoch < activated && !inFlight) return false;
+    revokedStarts.set(channel, { epoch, reason });
+    transportNotices.set(channel, reason);
+    runningTransports.delete(channel);
+    return true;
+}
+
 export async function startMessagingTransport(
     channel: MessengerChannel,
 ): Promise<TransportStartOutcome> {
@@ -193,8 +224,13 @@ export async function startMessagingTransport(
         log.warn(`[messaging] no transport registered for ${channel}`);
         return transportNotStarted('not_registered');
     }
+    const epoch = (startEpochs.get(channel) ?? 0) + 1;
+    startEpochs.set(channel, epoch);
+    const inFlight = inFlightStartEpochs.get(channel) ?? new Set<number>();
+    inFlight.add(epoch);
+    inFlightStartEpochs.set(channel, inFlight);
     try {
-        const outcome = await transport.init();
+        const outcome = await transport.init({ startEpoch: epoch });
         if (!outcome.started) {
             runningTransports.delete(channel);
             // A channel nobody configured, or one a concurrent init owns, is not a
@@ -207,7 +243,16 @@ export async function startMessagingTransport(
             }
             return outcome;
         }
+        const revoked = revokedStarts.get(channel);
+        if (revoked?.epoch === epoch) {
+            runningTransports.delete(channel);
+            transportErrors.delete(channel);
+            return transportNotStarted(revoked.reason);
+        }
         runningTransports.add(channel);
+        activatedEpochs.set(channel, epoch);
+        revokedStarts.delete(channel);
+        transportNotices.delete(channel);
         transportErrors.delete(channel);
         return outcome;
     } catch (error) {
@@ -215,6 +260,9 @@ export async function startMessagingTransport(
         transportErrors.set(channel, logErrorText(error));
         log.warn(`[messaging] ${channel} init error:`, logErrorText(error));
         return transportNotStarted('failed', logErrorText(error));
+    } finally {
+        inFlight.delete(epoch);
+        if (inFlight.size === 0) inFlightStartEpochs.delete(channel);
     }
 }
 

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -303,8 +303,10 @@ function createClaimArbiter(options: {
     let foreignApplied = false;
     const acquireConnected = (): SlackTokenClaimAcquireResult => {
         if (lease) {
-            lease.markConnected();
-            return { kind: 'acquired', lease };
+            const heldLease = lease;
+            if (heldLease.markConnected() === 'ok') return { kind: 'acquired', lease: heldLease };
+            heldLease.release();
+            lease = null;
         }
         const result = acquireSlackTokenClaim({
             appToken: options.appToken,

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -4,7 +4,7 @@
 // handler that gates then dispatches into submitMessage/orchestrateAndCollect,
 // and a forwarder for non-Slack-origin agent output.
 
-import { isSettingsPersistenceBlocked, readPersistedSlackAttachPort, saveSettings, settings } from '../core/config.js';
+import { JAW_HOME, isSettingsPersistenceBlocked, readPersistedSlackAttachPort, saveSettings, settings } from '../core/config.js';
 import { withSessionScope } from '../core/session-context.js';
 import { log } from '../core/logger.js';
 import { t, normalizeLocale } from '../core/i18n.js';
@@ -15,7 +15,8 @@ import { isResetIntent } from '../orchestrator/pipeline.js';
 import { isContinueIntent } from '../orchestrator/parser.js';
 import {
     setLastActiveTarget, setLatestSeenTarget, getLastActiveTarget,
-    transportStarted, transportNotStarted, type TransportStartOutcome,
+    revokeMessagingTransport, startMessagingTransport,
+    transportStarted, transportNotStarted, type TransportInitContext, type TransportStartOutcome,
 } from '../messaging/runtime.js';
 import { slackTargetFromId, resolveSlackThreadPlacement } from '../messaging/slack-target.js';
 import type { RemoteTarget } from '../messaging/types.js';
@@ -45,7 +46,14 @@ import {
     describeSlackScopeGaps,
     resetSlackScopeStatus,
 } from './scope-status.js';
-import { SlackSocketClient, type SlackEnvelope, type SlackPreflightResult } from './socket.js';
+import { HELLO_DEADLINE_MS, SlackSocketClient, type SlackConnectionState, type SlackEnvelope, type SlackPreflightResult } from './socket.js';
+import {
+    SLACK_TOKEN_CLAIM_FRESH_MS,
+    acquireSlackTokenClaim,
+    inspectSlackTokenClaim,
+    type SlackTokenClaimAcquireResult,
+    type SlackTokenClaimLease,
+} from './token-claim.js';
 import { runSlackAutoJoin, mergeSlackAutoJoin } from './auto-join.js';
 import { createHash } from 'node:crypto';
 import { admitIngress, getIngressJournal } from '../messaging/durable-ingress.js';
@@ -88,6 +96,8 @@ let socketClient: SlackSocketClient | null = null;
 let forwarderHandler: BroadcastListener | null = null;
 let selfUserId: string | null = null;
 let slackInitLock = false;
+let activeClaimArbiter: ClaimArbiter | null = null;
+let claimRecheckTimer: ReturnType<typeof setTimeout> | null = null;
 /**
  * Request ids a live queued-reply listener is already waiting on. The
  * target-reply forwarder checks this so a result does not get posted twice: once
@@ -266,6 +276,104 @@ let lifecycleGeneration = 0;
  * Slack permanently off just because its start request landed mid-teardown.
  */
 let initRequestPending = false;
+
+type ClaimArbiter = {
+    readonly generation: number;
+    readonly client: SlackSocketClient;
+    readonly startEpoch: number;
+    readonly lease: SlackTokenClaimLease | null;
+    arbitrate(trigger: 'init' | 'hello'): Promise<SlackTokenClaimAcquireResult>;
+    recordPresence(): SlackTokenClaimAcquireResult;
+    noteDisconnected(): void;
+    releaseOwnLeaseOnly(): void;
+    applyForeignLiveOnce(fn: () => void): boolean;
+};
+
+function createClaimArbiter(options: {
+    generation: number;
+    client: SlackSocketClient;
+    startEpoch: number;
+    appToken: string;
+    home: string;
+    port: string;
+}): ClaimArbiter {
+    let lease: SlackTokenClaimLease | null = null;
+    let inFlight: Promise<SlackTokenClaimAcquireResult> | null = null;
+    let settled: SlackTokenClaimAcquireResult | null = null;
+    let foreignApplied = false;
+    const acquireConnected = (): SlackTokenClaimAcquireResult => {
+        if (lease) {
+            lease.markConnected();
+            return { kind: 'acquired', lease };
+        }
+        const result = acquireSlackTokenClaim({
+            appToken: options.appToken,
+            home: options.home,
+            port: options.port,
+            connected: true,
+        });
+        if (result.kind === 'acquired') lease = result.lease;
+        return result;
+    };
+    return {
+        generation: options.generation,
+        client: options.client,
+        startEpoch: options.startEpoch,
+        get lease() { return lease; },
+        arbitrate() {
+            if (settled) return Promise.resolve(settled);
+            if (inFlight) return inFlight;
+            inFlight = Promise.resolve().then(acquireConnected).then(result => {
+                settled = result;
+                return result;
+            }).finally(() => { inFlight = null; });
+            return inFlight;
+        },
+        recordPresence() {
+            if (lease) return { kind: 'acquired', lease };
+            const result = acquireSlackTokenClaim({
+                appToken: options.appToken,
+                home: options.home,
+                port: options.port,
+                connected: false,
+            });
+            if (result.kind === 'acquired') lease = result.lease;
+            return result;
+        },
+        noteDisconnected() {
+            lease?.markDisconnected();
+            settled = null;
+        },
+        releaseOwnLeaseOnly() {
+            lease?.release();
+            lease = null;
+            settled = null;
+        },
+        applyForeignLiveOnce(fn) {
+            if (foreignApplied) return false;
+            foreignApplied = true;
+            fn();
+            return true;
+        },
+    };
+}
+
+function clearSlackClaimRecheck(): void {
+    if (!claimRecheckTimer) return;
+    clearTimeout(claimRecheckTimer);
+    claimRecheckTimer = null;
+}
+
+function armSlackClaimRecheck(generation: number): void {
+    if (claimRecheckTimer) return;
+    claimRecheckTimer = setTimeout(() => {
+        claimRecheckTimer = null;
+        if (generation !== lifecycleGeneration || !settings['slack']?.enabled) return;
+        void startMessagingTransport('slack');
+    }, SLACK_TOKEN_CLAIM_FRESH_MS + Math.floor(Math.random() * 5001));
+    claimRecheckTimer.unref?.();
+}
+
 let slackApprovalIngress: DispatchApprovalTransport | null = null;
 function createSlackSocketIngress(): DispatchApprovalTransport {
     const transport = Object.freeze({ platform: 'slack' as const });
@@ -1186,7 +1294,7 @@ export async function handleSlackEnvelope(envelope: SlackEnvelope, approvalTrans
 
 // ─── Init / Shutdown ────────────────────────────────
 
-export async function initSlack(): Promise<TransportStartOutcome> {
+export async function initSlack(ctx?: TransportInitContext): Promise<TransportStartOutcome> {
     if (slackInitLock) {
         // Do not discard the request: the running init may be about to abort
         // because THIS caller's shutdown superseded it.
@@ -1197,17 +1305,17 @@ export async function initSlack(): Promise<TransportStartOutcome> {
     slackInitLock = true;
     let outcome: TransportStartOutcome;
     try {
-        outcome = await runSlackInit();
+        outcome = await runSlackInit(ctx);
     } catch (err) {
         // A thrown init still owes the queue a drain, exactly as the old
         // `finally` did — otherwise a crash mid-start leaves Slack off until
         // something unrelated happens to call init again.
-        await settleSlackInit();
+        await settleSlackInit(ctx);
         throw err;
     }
     // The follow-up is the call that actually opened the socket; this one only
     // lost the race, so its `superseded` outcome must not shadow the real one.
-    return (await settleSlackInit()) ?? outcome;
+    return (await settleSlackInit(ctx)) ?? outcome;
 }
 
 /**
@@ -1218,15 +1326,15 @@ export async function initSlack(): Promise<TransportStartOutcome> {
  * the follow-up runs, so the retry takes the normal path rather than queuing
  * itself forever.
  */
-async function settleSlackInit(): Promise<TransportStartOutcome | null> {
+async function settleSlackInit(ctx?: TransportInitContext): Promise<TransportStartOutcome | null> {
     slackInitLock = false;
     if (!initRequestPending) return null;
     initRequestPending = false;
-    return initSlack();
+    return initSlack(ctx);
 }
 
 /** The init body proper. Runs only under `slackInitLock`. */
-async function runSlackInit(): Promise<TransportStartOutcome> {
+async function runSlackInit(ctx?: TransportInitContext): Promise<TransportStartOutcome> {
     // Claim the generation FIRST so an external shutdown that lands while
     // we are tearing down or authenticating is not lost, then tear down
     // WITHOUT bumping it — an internal teardown must not invalidate the
@@ -1296,19 +1404,103 @@ async function runSlackInit(): Promise<TransportStartOutcome> {
         return transportNotStarted('failed', 'team_id_unresolved');
     }
 
+    const sharingAllowed = process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] === '1';
+    if (sharingAllowed) log.info('[slack] shared app-token ownership guard disabled by environment');
+    if (!sharingAllowed) {
+        const observed = inspectSlackTokenClaim({
+            appToken: sc.appToken,
+            home: JAW_HOME,
+            port: currentPort,
+            connected: true,
+        });
+        if (observed.kind === 'foreign_live') {
+            log.warn(`[slack] app token is claimed by another home (${observed.claim.home}, :${observed.claim.port}, pid ${observed.claim.pid})`);
+            armSlackClaimRecheck(generation);
+            return transportNotStarted('token_shared_other_home');
+        }
+        if (observed.kind === 'uncertain') {
+            log.warn('[slack] token claim inspection unavailable; failing open:', observed.error);
+        }
+    }
+
+    let arb: ClaimArbiter | null = null;
     const client = new SlackSocketClient({
         appToken: sc.appToken,
         onEnvelope: envelope => handleSlackEnvelope(envelope, slackApprovalIngress),
         preflightEnvelope: preflightSlackEnvelope,
+        onStateChange: (state: SlackConnectionState) => {
+            if (!arb || sharingAllowed) return;
+            if (client !== socketClient || generation !== lifecycleGeneration) {
+                arb.releaseOwnLeaseOnly();
+                return;
+            }
+            if (state === 'connected') {
+                void arb.arbitrate('hello').then(result => {
+                    if (result.kind !== 'foreign_live') return;
+                    arb?.applyForeignLiveOnce(() => {
+                        client.stop();
+                        if (socketClient === client) socketClient = null;
+                        revokeMessagingTransport('slack', 'token_shared_other_home', ctx?.startEpoch ?? 0);
+                        armSlackClaimRecheck(generation);
+                    });
+                });
+            } else if (state === 'reconnecting') {
+                arb.noteDisconnected();
+            } else if (state === 'disconnected' || state === 'disabled') {
+                arb.releaseOwnLeaseOnly();
+            }
+        },
     });
+    arb = createClaimArbiter({
+        generation,
+        client,
+        startEpoch: ctx?.startEpoch ?? 0,
+        appToken: sc.appToken,
+        home: JAW_HOME,
+        port: currentPort,
+    });
+    activeClaimArbiter = arb;
     slackApprovalIngress = createSlackSocketIngress();
     socketClient = client;
-    await client.start();
+    try {
+        await client.start();
+    } catch (error) {
+        client.stop();
+        if (socketClient === client) socketClient = null;
+        arb.releaseOwnLeaseOnly();
+        throw error;
+    }
+    const ready = await client.waitForReady(HELLO_DEADLINE_MS + 1000);
     if (generation !== lifecycleGeneration) {
         log.info('[slack] init superseded during connect — disposing socket');
         client.stop();
         if (socketClient === client) socketClient = null;
+        arb.releaseOwnLeaseOnly();
         return transportNotStarted('superseded');
+    }
+    if (ready === 'stopped') {
+        if (socketClient === client) socketClient = null;
+        arb.releaseOwnLeaseOnly();
+        return transportNotStarted('superseded');
+    }
+    if (!sharingAllowed) {
+        const claim = ready === 'connected'
+            ? await arb.arbitrate('init')
+            : ready === 'timeout'
+                ? arb.recordPresence()
+                : null;
+        if (claim?.kind === 'unavailable') {
+            log.warn('[slack] shared token claim unavailable; failing open:', claim.error);
+        }
+        if (claim?.kind === 'foreign_live') {
+            arb.applyForeignLiveOnce(() => {
+                client.stop();
+                if (socketClient === client) socketClient = null;
+                revokeMessagingTransport('slack', 'token_shared_other_home', ctx?.startEpoch ?? 0);
+                armSlackClaimRecheck(generation);
+            });
+            return transportNotStarted('token_shared_other_home');
+        }
     }
     if (selfElectionPending) {
         // Two processes of the SAME home with attachPort unset can both reach
@@ -1322,6 +1514,7 @@ async function runSlackInit(): Promise<TransportStartOutcome> {
             log.info(`[slack] another instance (:${onDisk}) elected itself first — disposing socket`);
             client.stop();
             if (socketClient === client) socketClient = null;
+            arb.releaseOwnLeaseOnly();
             return transportNotStarted('not_attach_instance');
         }
         if (isSettingsPersistenceBlocked()) {
@@ -1349,6 +1542,7 @@ async function runSlackInit(): Promise<TransportStartOutcome> {
     // wait for it — inbound already works the moment the connection is up.
     startSlackAutoJoin(sc, generation);
     log.info(`[slack] ✅ connected as ${selfUserId || 'unknown'}`);
+    clearSlackClaimRecheck();
     return transportStarted;
 }
 
@@ -1462,5 +1656,8 @@ async function disposeSlackRuntime(): Promise<void> {
     pendingQueueRequestIds.clear();
     socketClient?.stop();
     socketClient = null;
+    activeClaimArbiter?.releaseOwnLeaseOnly();
+    activeClaimArbiter = null;
+    clearSlackClaimRecheck();
     selfUserId = null;
 }

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -1425,7 +1425,7 @@ async function runSlackInit(ctx?: TransportInitContext): Promise<TransportStartO
             return transportNotStarted('token_shared_other_home');
         }
         if (observed.kind === 'uncertain') {
-            log.warn('[slack] token claim inspection unavailable; failing open:', observed.error);
+            log.warn('[slack] token claim inspection unavailable; failing open:', logErrorText(observed.error));
         }
     }
 
@@ -1496,7 +1496,7 @@ async function runSlackInit(ctx?: TransportInitContext): Promise<TransportStartO
                 ? arb.recordPresence()
                 : null;
         if (claim?.kind === 'unavailable') {
-            log.warn('[slack] shared token claim unavailable; failing open:', claim.error);
+            log.warn('[slack] shared token claim unavailable; failing open:', logErrorText(claim.error));
         }
         if (claim?.kind === 'foreign_live') {
             arb.applyForeignLiveOnce(() => {

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -98,6 +98,7 @@ let selfUserId: string | null = null;
 let slackInitLock = false;
 let activeClaimArbiter: ClaimArbiter | null = null;
 let claimRecheckTimer: ReturnType<typeof setTimeout> | null = null;
+let sharedTokenOptOutLogged = false;
 /**
  * Request ids a live queued-reply listener is already waiting on. The
  * target-reply forwarder checks this so a result does not get posted twice: once
@@ -1407,7 +1408,10 @@ async function runSlackInit(ctx?: TransportInitContext): Promise<TransportStartO
     }
 
     const sharingAllowed = process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] === '1';
-    if (sharingAllowed) log.info('[slack] shared app-token ownership guard disabled by environment');
+    if (sharingAllowed && !sharedTokenOptOutLogged) {
+        sharedTokenOptOutLogged = true;
+        log.info('[slack] shared app-token ownership guard disabled by environment');
+    }
     if (!sharingAllowed) {
         const observed = inspectSlackTokenClaim({
             appToken: sc.appToken,

--- a/src/slack/register.ts
+++ b/src/slack/register.ts
@@ -8,7 +8,7 @@ import { registerSendTransport } from '../messaging/send.js';
 import type { ChannelSendRequest } from '../messaging/send.js';
 
 registerTransport('slack', {
-    init: async () => (await import('./bot.js')).initSlack(),
+    init: async (ctx) => (await import('./bot.js')).initSlack(ctx),
     shutdown: async () => (await import('./bot.js')).shutdownSlack(),
 });
 

--- a/src/slack/socket.ts
+++ b/src/slack/socket.ts
@@ -53,7 +53,7 @@ const DEDUPE_TTL_MS = 10 * 60 * 1000;
  */
 const DEDUPE_SWEEP_AT = 5000;
 /** Slack sends `hello` promptly; without it the socket is not usable. */
-const HELLO_DEADLINE_MS = 15000;
+export const HELLO_DEADLINE_MS = 15000;
 
 /** Minimal socket surface used here — keeps the module testable without a real WebSocket. */
 export type SlackSocketLike = {
@@ -79,6 +79,7 @@ export type SlackSocketOptions = {
     socketFactory?: (url: string) => SlackSocketLike;
     maxReconnectAttempts?: number;
     baseReconnectDelayMs?: number;
+    onStateChange?: (state: SlackConnectionState, meta: { attempts: number }) => void;
 };
 
 export class SlackSocketClient {
@@ -94,6 +95,7 @@ export class SlackSocketClient {
     private connecting = false;
     private readonly maxReconnectAttempts: number;
     private readonly baseReconnectDelayMs: number;
+    private readyWaiters = new Set<(result: 'connected' | 'stopped') => void>();
 
     constructor(private readonly options: SlackSocketOptions) {
         this.maxReconnectAttempts = options.maxReconnectAttempts ?? 10;
@@ -102,6 +104,33 @@ export class SlackSocketClient {
 
     getState(): SlackConnectionState { return this.state; }
     getReconnectAttempts(): number { return this.reconnectAttempts; }
+
+    waitForReady(timeoutMs = HELLO_DEADLINE_MS + 1000): Promise<'connected' | 'timeout' | 'stopped'> {
+        if (this.state === 'connected') return Promise.resolve('connected');
+        if (this.stopped) return Promise.resolve('stopped');
+        return new Promise(resolve => {
+            let settled = false;
+            const finish = (result: 'connected' | 'timeout' | 'stopped') => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                this.readyWaiters.delete(waiter);
+                resolve(result);
+            };
+            const waiter = (result: 'connected' | 'stopped') => finish(result);
+            const timer = setTimeout(() => finish('timeout'), timeoutMs);
+            timer.unref?.();
+            this.readyWaiters.add(waiter);
+        });
+    }
+
+    private setState(state: SlackConnectionState): void {
+        this.state = state;
+        this.options.onStateChange?.(state, { attempts: this.reconnectAttempts });
+        if (state === 'connected') {
+            for (const waiter of [...this.readyWaiters]) waiter('connected');
+        }
+    }
 
     async start(): Promise<void> {
         this.stopped = false;
@@ -117,7 +146,8 @@ export class SlackSocketClient {
         this.stopped = true;
         this.clearReconnectTimer();
         this.clearHelloTimer();
-        this.state = terminalState;
+        this.setState(terminalState);
+        for (const waiter of [...this.readyWaiters]) waiter('stopped');
         try { this.ws?.close(); } catch { /* already closing */ }
         this.ws = null;
     }
@@ -170,7 +200,7 @@ export class SlackSocketClient {
     }
 
     private async connectOnce(): Promise<void> {
-        this.state = this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting';
+        this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
         // The socket being replaced must stop influencing lifecycle decisions
         // the moment a replacement is under way: its close event would
         // otherwise schedule a second reconnect on top of this one.
@@ -261,7 +291,7 @@ export class SlackSocketClient {
 
         if (CONTROL_FRAME_TYPES.has(envelope.type)) {
             if (envelope.type === 'hello') {
-                this.state = 'connected';
+                this.setState('connected');
                 this.reconnectAttempts = 0;
                 this.clearHelloTimer();
                 log.info('[slack:socket] hello received, connected');
@@ -391,13 +421,13 @@ export class SlackSocketClient {
         }
         if (this.reconnectAttempts >= this.maxReconnectAttempts) {
             log.error(`[slack:socket] max reconnect attempts (${this.maxReconnectAttempts}) reached — giving up`);
-            this.state = 'disconnected';
+            this.setState('disconnected');
             return;
         }
         this.clearReconnectTimer();
         const delay = Math.min(this.baseReconnectDelayMs * 2 ** this.reconnectAttempts, 60000);
         this.reconnectAttempts++;
-        this.state = 'reconnecting';
+        this.setState('reconnecting');
         log.info(`[slack:socket] reconnect in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
         this.reconnectTimer = setTimeout(() => {
             this.reconnectTimer = null;

--- a/src/slack/token-claim.ts
+++ b/src/slack/token-claim.ts
@@ -1,0 +1,276 @@
+import { createHash, randomBytes } from 'node:crypto';
+import {
+    chmodSync,
+    closeSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    realpathSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export const SLACK_TOKEN_CLAIM_REFRESH_MS = 30_000;
+export const SLACK_TOKEN_CLAIM_FRESH_MS = 90_000;
+
+export type SlackTokenClaim = {
+    version: 1;
+    claimId: string;
+    home: string;
+    port: string;
+    pid: number;
+    claimedAt: string;
+    connected: boolean;
+};
+
+export type SlackTokenClaimInspection =
+    | { kind: 'none' }
+    | { kind: 'same_home'; claim: SlackTokenClaim }
+    | { kind: 'foreign_live'; claim: SlackTokenClaim }
+    | { kind: 'uncertain'; error: string };
+
+export type SlackTokenClaimLease = {
+    readonly claim: SlackTokenClaim;
+    markConnected(): void;
+    markDisconnected(): void;
+    release(): void;
+};
+
+export type SlackTokenClaimAcquireResult =
+    | { kind: 'acquired'; lease: SlackTokenClaimLease }
+    | { kind: 'same_home'; claim: SlackTokenClaim }
+    | { kind: 'foreign_live'; claim: SlackTokenClaim }
+    | { kind: 'unavailable'; error: string };
+
+export type SlackTokenClaimOptions = {
+    appToken: string;
+    home: string;
+    port: string;
+    connected: boolean;
+    rootDir?: string;
+    now?: () => Date;
+    pid?: number;
+    pidAlive?: (pid: number) => boolean;
+    refreshMs?: number;
+};
+
+function errorText(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function canonicalHome(path: string): string | null {
+    try { return realpathSync.native(path); }
+    catch { return null; }
+}
+
+function claimsRoot(rootDir?: string): string {
+    return rootDir ?? join(homedir(), '.cli-jaw-shared', 'slack-claims');
+}
+
+export function slackTokenClaimPath(appToken: string, rootDir?: string): string {
+    const key = createHash('sha256').update(appToken, 'utf8').digest('hex');
+    return join(claimsRoot(rootDir), `${key}.json`);
+}
+
+function parseClaim(raw: string): SlackTokenClaim | null {
+    try {
+        const value = JSON.parse(raw) as Partial<SlackTokenClaim>;
+        if (value.version !== 1) return null;
+        if (typeof value.claimId !== 'string' || !/^[0-9a-f]{32}$/.test(value.claimId)) return null;
+        if (typeof value.home !== 'string' || !value.home) return null;
+        if (typeof value.port !== 'string') return null;
+        if (!Number.isSafeInteger(value.pid) || Number(value.pid) <= 0) return null;
+        if (typeof value.claimedAt !== 'string' || typeof value.connected !== 'boolean') return null;
+        const date = new Date(value.claimedAt);
+        if (Number.isNaN(date.getTime()) || date.toISOString() !== value.claimedAt) return null;
+        return value as SlackTokenClaim;
+    } catch {
+        return null;
+    }
+}
+
+function readClaim(path: string): SlackTokenClaim | null {
+    try { return parseClaim(readFileSync(path, 'utf8')); }
+    catch { return null; }
+}
+
+function defaultPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function isFresh(claim: SlackTokenClaim, now: Date): boolean {
+    const age = now.getTime() - Date.parse(claim.claimedAt);
+    return age >= 0 && age <= SLACK_TOKEN_CLAIM_FRESH_MS;
+}
+
+function classifyClaim(
+    claim: SlackTokenClaim,
+    home: string,
+    now: Date,
+    pidAlive: (pid: number) => boolean,
+): SlackTokenClaimInspection {
+    const claimHome = canonicalHome(claim.home);
+    const currentHome = canonicalHome(home);
+    if (!claimHome || !currentHome) return { kind: 'uncertain', error: 'canonical home unavailable' };
+    if (claimHome === currentHome) return { kind: 'same_home', claim };
+    if (!claim.connected || !isFresh(claim, now)) return { kind: 'none' };
+    try {
+        return pidAlive(claim.pid) ? { kind: 'foreign_live', claim } : { kind: 'none' };
+    } catch (error) {
+        return { kind: 'uncertain', error: errorText(error) };
+    }
+}
+
+function isEexist(error: unknown): boolean {
+    return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST';
+}
+
+function ensureRoot(root: string): void {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    chmodSync(root, 0o700);
+}
+
+function writeExclusive(path: string, claim: SlackTokenClaim): void {
+    const fd = openSync(path, 'wx', 0o600);
+    try { writeFileSync(fd, `${JSON.stringify(claim)}\n`, 'utf8'); }
+    finally { closeSync(fd); }
+}
+
+function writeAtomic(path: string, claim: SlackTokenClaim): void {
+    const temp = `${path}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`;
+    try {
+        writeFileSync(temp, `${JSON.stringify(claim)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+        renameSync(temp, path);
+    } finally {
+        rmSync(temp, { force: true });
+    }
+}
+
+function withClaimLock<T>(path: string, body: () => T): T {
+    const lockPath = `${path}.lock`;
+    const fd = openSync(lockPath, 'wx', 0o600);
+    closeSync(fd);
+    try { return body(); }
+    finally { rmSync(lockPath, { force: true }); }
+}
+
+export function inspectSlackTokenClaim(options: SlackTokenClaimOptions): SlackTokenClaimInspection {
+    const path = slackTokenClaimPath(options.appToken, options.rootDir);
+    try {
+        const claim = readClaim(path);
+        if (!claim) return { kind: 'none' };
+        return classifyClaim(claim, options.home, (options.now ?? (() => new Date()))(), options.pidAlive ?? defaultPidAlive);
+    } catch (error) {
+        return { kind: 'uncertain', error: errorText(error) };
+    }
+}
+
+export function acquireSlackTokenClaim(options: SlackTokenClaimOptions): SlackTokenClaimAcquireResult {
+    const root = claimsRoot(options.rootDir);
+    const path = slackTokenClaimPath(options.appToken, options.rootDir);
+    const now = options.now ?? (() => new Date());
+    const pid = options.pid ?? process.pid;
+    const pidAlive = options.pidAlive ?? defaultPidAlive;
+    const makeClaim = (): SlackTokenClaim => ({
+        version: 1,
+        claimId: randomBytes(16).toString('hex'),
+        home: canonicalHome(options.home) ?? resolve(options.home),
+        port: options.port,
+        pid,
+        claimedAt: now().toISOString(),
+        connected: options.connected,
+    });
+
+    let claim = makeClaim();
+    try {
+        ensureRoot(root);
+        try {
+            writeExclusive(path, claim);
+        } catch (error) {
+            if (!isEexist(error)) throw error;
+            const existing = readClaim(path);
+            if (existing) {
+                const observed = classifyClaim(existing, options.home, now(), pidAlive);
+                if (observed.kind === 'same_home') return observed;
+                if (observed.kind === 'foreign_live') return observed;
+                if (observed.kind === 'uncertain' && observed.error !== 'canonical home unavailable') {
+                    return { kind: 'unavailable', error: observed.error };
+                }
+            }
+            claim = withClaimLock(path, () => {
+                const latest = readClaim(path);
+                if (latest) {
+                    const observed = classifyClaim(latest, options.home, now(), pidAlive);
+                    if (observed.kind === 'same_home' || observed.kind === 'foreign_live') {
+                        throw Object.assign(new Error(observed.kind), { observed });
+                    }
+                    if (observed.kind === 'uncertain' && observed.error !== 'canonical home unavailable') throw new Error(observed.error);
+                }
+                const replacement = makeClaim();
+                writeAtomic(path, replacement);
+                return replacement;
+            });
+        }
+    } catch (error) {
+        const observed = (error as { observed?: SlackTokenClaimInspection }).observed;
+        if (observed?.kind === 'same_home' || observed?.kind === 'foreign_live') return observed;
+        const finalInspection = inspectSlackTokenClaim(options);
+        if (finalInspection.kind === 'foreign_live') return finalInspection;
+        return { kind: 'unavailable', error: errorText(error) };
+    }
+
+    const claimId = claim.claimId;
+    let connected = claim.connected;
+    let released = false;
+    const update = (nextConnected: boolean, refreshTimestamp: boolean): void => {
+        if (released) return;
+        connected = nextConnected;
+        try {
+            withClaimLock(path, () => {
+                const current = readClaim(path);
+                if (!current || current.claimId !== claimId) return;
+                claim = {
+                    ...current,
+                    connected: nextConnected,
+                    claimedAt: refreshTimestamp ? now().toISOString() : current.claimedAt,
+                };
+                writeAtomic(path, claim);
+            });
+        } catch {
+            // Shared coordination is advisory. IO uncertainty must not stop Slack.
+        }
+    };
+    const timer = setInterval(() => {
+        if (connected) update(true, true);
+    }, options.refreshMs ?? SLACK_TOKEN_CLAIM_REFRESH_MS);
+    timer.unref?.();
+
+    return {
+        kind: 'acquired',
+        lease: {
+            get claim() { return claim; },
+            markConnected() { update(true, true); },
+            markDisconnected() { update(false, false); },
+            release() {
+                if (released) return;
+                released = true;
+                clearInterval(timer);
+                try {
+                    withClaimLock(path, () => {
+                        if (readClaim(path)?.claimId === claimId) rmSync(path, { force: true });
+                    });
+                } catch {
+                    // A stale claim expires and can be replaced on a later acquire.
+                }
+            },
+        },
+    };
+}

--- a/src/slack/token-claim.ts
+++ b/src/slack/token-claim.ts
@@ -34,7 +34,7 @@ export type SlackTokenClaimInspection =
 
 export type SlackTokenClaimLease = {
     readonly claim: SlackTokenClaim;
-    markConnected(): void;
+    markConnected(): 'ok' | 'lost' | 'unavailable';
     markDisconnected(): void;
     release(): void;
 };
@@ -230,22 +230,29 @@ export function acquireSlackTokenClaim(options: SlackTokenClaimOptions): SlackTo
     const claimId = claim.claimId;
     let connected = claim.connected;
     let released = false;
-    const update = (nextConnected: boolean, refreshTimestamp: boolean): void => {
-        if (released) return;
-        connected = nextConnected;
+    const update = (
+        nextConnected: boolean,
+        refreshTimestamp: boolean,
+    ): 'ok' | 'lost' | 'unavailable' => {
+        if (released) return 'lost';
         try {
-            withClaimLock(path, () => {
+            const result = withClaimLock(path, () => {
                 const current = readClaim(path);
-                if (!current || current.claimId !== claimId) return;
+                if (!current || current.claimId !== claimId) return 'lost' as const;
                 claim = {
                     ...current,
                     connected: nextConnected,
                     claimedAt: refreshTimestamp ? now().toISOString() : current.claimedAt,
                 };
                 writeAtomic(path, claim);
+                return 'ok' as const;
             });
+            connected = result === 'ok' ? nextConnected : false;
+            return result;
         } catch {
             // Shared coordination is advisory. IO uncertainty must not stop Slack.
+            connected = false;
+            return 'unavailable';
         }
     };
     const timer = setInterval(() => {
@@ -257,7 +264,7 @@ export function acquireSlackTokenClaim(options: SlackTokenClaimOptions): SlackTo
         kind: 'acquired',
         lease: {
             get claim() { return claim; },
-            markConnected() { update(true, true); },
+            markConnected() { return update(true, true); },
             markDisconnected() { update(false, false); },
             release() {
                 if (released) return;

--- a/structure/agent_spawn.md
+++ b/structure/agent_spawn.md
@@ -251,7 +251,7 @@ are persisted or displayed through trace helpers.
 | `orchestrator/worker-progress.ts` | 58L | worker progress safe-summary sanitizer + snapshot types |
 | `orchestrator/worker-monitor.ts` | 58L | stall/disconnect/timeout monitor |
 | `orchestrator/sanitize.ts` | 52L | `stripInterviewTracker()` — interview tracker/perspective tags from visible text |
-| `orchestrator/scope.ts` | 17L | scope stub — 항상 `'default'` 반환 |
+| `orchestrator/scope.ts` | 86L | remote binding key + channel gate + local session scope + captured execution binding; legacy `findActiveScope()`만 `'default'` 반환 |
 
 ### `pipeline.ts` 실제 흐름
 

--- a/structure/infra.md
+++ b/structure/infra.md
@@ -943,7 +943,7 @@ CLI → 서버 API 호출 시 인증 토큰을 관리하는 경량 헬퍼. 포�
 | `saveSettings(s)` | 설정 저장 |
 | `replaceSettings(s)` | ESM live binding 대체 |
 | `loadHeartbeatFile()` / `saveHeartbeatFile()` | `heartbeat.json` 읽기/쓰기 |
-| `deriveCdpPort(serverPort?)` | server port + offset으로 browser CDP port 계산, overflow/invalid는 9240 |
+| `deriveCdpPort(serverPort?)` | server port + offset으로 browser CDP port 계산; valid overflow는 1024–65535 modular rotation으로 고유 wrap, invalid input은 9240 |
 | `getServerUrl(port)` | `http://localhost:${port || process.env.PORT || settings.port || DEFAULT_PORT}` |
 | `getWsUrl(port)` | websocket URL 생성 |
 | `detectCli(name)` | `buildServicePath()`를 적용한 `which`/`where` 기반 바이너리 존재 확인 |

--- a/structure/server_api.md
+++ b/structure/server_api.md
@@ -134,6 +134,8 @@ Cursor/Grok activation and Activity controls are separate from this API foundati
 | --- | --- | --- |
 | `GET` | `/` | `public/dist/index.html`이 있으면 Vite build를 서빙, 없으면 static fallback |
 | `GET` | `/api/health` | **liveness.** `{ ok, version, uptime, channels, agentRuntime }`. `ok`는 상수다 — Docker HEALTHCHECK가 컨테이너를 재시작하고 manager scan이 인스턴스를 목록에서 제거하는 신호이므로 CLI 미해석을 여기서 표현하지 않는다. 에이전트 런타임 준비 상태는 가산 필드 `agentRuntime: { cli, ready, state, path?, error?, checkedAt }`로만 노출한다 (#471) |
+
+`channels.slack.reason: "token_shared_other_home"`은 다른 cli-jaw home이 같은 app-level token의 fresh connected lease를 소유해 이 instance의 Slack inbound가 꺼졌음을 뜻한다. 이때 `activeInbound:false`지만 bot-token outbound의 `sendCapable` 판정은 그대로 유지한다. claim 파일, canonical home, freshness, live PID 중 하나라도 확정할 수 없으면 reason을 만들지 않고 fail-open하며, `CLI_JAW_SLACK_ALLOW_SHARED_TOKEN=1`은 inspection과 acquisition을 모두 생략한다. API에는 owner token, token hash, claim path를 노출하지 않는다.
 | `GET` | `/api/ready` | **readiness.** 설정된 CLI가 spawn 가능한지 답한다. `state:"unavailable"`일 때만 **503**, 그 외 200. `unknown`(CLI 미설정 또는 probe 예외)은 503이 아니다 — 신규 설치와 probe 버그가 무의미한 재시작을 유발하면 안 된다. 워치독은 본문 파싱 없이 상태 코드만 소비할 수 있다 (#471) |
 | `GET` | `/api/slack/manifest` | 설정 페이지 "매니페스트 복사"용 canonical Slack 앱 매니페스트. 선택 `?name=`은 1~35자 앱 표시명을 받고 봇 표시명은 자동 파생한다. `{ ok, data: { yaml, json, botDisplayName } }` (비밀값 없음, unauthenticated) |
 | `POST` | `/api/channels/validate` | 온보딩 마법사 라이브 크리덴셜 검증 `{ channel, botToken, appToken?, guildId? }` → `{ ok, identity?, teamId? }` 또는 `{ ok:false, error }`. 저장하지 않고 검증만 수행 |

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -346,7 +346,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (23 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1663L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1669L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (408L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (66L)
 │   │   ├── events.ts         ← fail-closed attachPort 판정 + inbound gating (self-echo/bot/subtype/allowlist/mention) + Block Kit 텍스트 추출 (282L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -38,7 +38,7 @@ cli-jaw/
 │   └── mime-detect.ts        ← MIME 타입 감지 헬퍼 (67L)
 ├── src/
 │   ├── core/                 ← 의존 0 인프라 계층 (31 files, 3847L)
-│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1540L)
+│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1544L)
 │   │   ├── cli-detection.ts  ← CLI 탐지 + `pi` npm-exec fallback + `kiro-code`(`kiro-cli` binary)/`claude-e`/`ai-e` helper `--idle-timeout-ms` compatibility probe + local package release/debug candidates (280L)
 │   │   ├── compact.ts        ← compact 헬퍼 (COMPACT_MARKER_CONTENT, managed summary builder, cutoff logic, harvestGitGrep + harvestChatGrep 1KB/1KB budget split) (784L)
 │   │   ├── instance.ts       ← 인스턴스 ID, node/jaw 경로, 유닛명 sanitize (61L)
@@ -192,7 +192,7 @@ cli-jaw/
 │   │   ├── watchdog.ts       ← idle/progress watchdog + 4h absolute hard cap with progress deadline extension (130L)
 │   │   └── events.ts         ← legacy re-export stub → events/ 모듈 (15L)
 │   ├── messaging/            ← 통합 메시징 런타임 (33 files)
-│   │   ├── runtime.ts        ← 채널 lifecycle (init/shutdown/restart) + transport registry (285L)
+│   │   ├── runtime.ts        ← 채널 lifecycle (init/shutdown/restart) + transport registry (333L)
 │   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (516L)
 │   │   ├── turn-conversation.ts ← 턴이 답하는 대화 주소 encode/decode + 채널 매칭 (60L) ✨
 │   │   ├── turn-delivery.ts  ← 에이전트 자가 전송 claim (턴 앵커 + digest, 소비형) → dispatch 중복 게시 억제 (252L) ✨
@@ -201,7 +201,7 @@ cli-jaw/
 │   │   ├── fold.ts           ← 정규화 폴딩 엔진 (escape 디코드 + invisible 제거 + NFKC, 오프셋 맵 추적) (276L) ✨
 │   │   ├── redact.ts         ← 채널 크리덴셜 마스킹 (Slack/TG/Discord 토큰 + URL 경로 capability) (600L) ✨
 │   │   ├── chunk.ts          ← 공유 메시지 분할 (무손실 + 서로게이트 안전 + 펜스/언어태그 보존, 단 delimiter가 한도 이내일 때) (389L) ✨
-│   │   ├── channel-health.ts ← 채널 헬스 체크 helper + additive ingress/metrics snapshot (207L) ✨
+│   │   ├── channel-health.ts ← 채널 헬스 체크 helper + additive ingress/metrics snapshot (226L) ✨
 │   │   ├── channel-validate.ts ← 온보딩 마법사 라이브 크리덴셜 검증 (telegram getMe / discord users@me / slack auth.test+connections.open, 토큰 비로깅) (139L) ✨
 │   │   ├── send-result.ts    ← send result type helper (14L) ✨
 │   │   ├── session-key.ts    ← 세션 키 헬퍼 (56L)
@@ -235,7 +235,7 @@ cli-jaw/
 │   │   ├── gateway.ts        ← submitMessage 통합 진입점 (WebUI+CLI+TG+Discord 공통) + working_dir scoped insertMessage (340L)
 │   │   ├── collect.ts        ← orchestrateAndCollect + orchestrateAndCollectData (155L)
 │   │   ├── session-work.ts   ← hasChatSessionWork — 세션 삭제 전 진행중 작업 관측 (활성 run·큐·replay는 정확 매칭, drain/retry/hold/worker/lane은 scope 단위 보수적 판정) (42L) ✨
-│   │   ├── scope.ts          ← 현재 단일 'default' scope를 반환하는 stub (86L)
+│   │   ├── scope.ts          ← remote binding key + channel gate + local session scope + captured execution binding; legacy findActiveScope만 default fallback (86L)
 │   │   ├── worker-monitor.ts ← Worker stall detection — activity timestamps + stall/disconnect/timeout callbacks (58L)
 │   │   ├── worker-progress.ts ← 직원 progress safe-summary sanitizer + runId-aware current/previous snapshot types
 │   │   ├── worker-registry.ts ← Worker 프로세스 레지스트리 + runId progress current/previous memory retention + pending replay metadata + durable worker-run hook (431L)
@@ -345,8 +345,8 @@ cli-jaw/
 │   │   ├── forwarder.ts      ← Discord text chunk 포워딩 + guarded local-image attachment relay (98L)
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (23 files, Socket Mode + Web API, SDK 없음)
-│   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (407L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1466L)
+│   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1663L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (408L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (66L)
 │   │   ├── events.ts         ← fail-closed attachPort 판정 + inbound gating (self-echo/bot/subtype/allowlist/mention) + Block Kit 텍스트 추출 (282L)
@@ -593,7 +593,7 @@ cli-jaw/
 │       ├── history.ts        ← 채팅 히스토리 검색 CLI (65L)
 │       ├── init.ts           ← 초기화 마법사 + --safe/--dry-run + --help (528L)
 │       ├── slack.ts          ← `jaw slack manifest|setup` — 앱 매니페스트 출력 + 가이드 설정 (토큰 prefix 가드 + auth.test/apps.connections.open 라이브 검증 + settings 병합, channel 미변경) (440L)
-│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1200L)
+│       ├── doctor.ts         ← 진단 (다중 체크 + claude-i helper/underlying claude + headless 감지, --json) (1227L)
 │       ├── db.ts             ← `jaw db maintain` — WAL checkpoint + VACUUM, before/after page 통계 (29L)
 │       ├── status.ts         ← 서버 상태 (--json) (122L)
 │       ├── mcp.ts            ← MCP 관리 (install/sync/list/reset) (230L)

--- a/structure/telegram.md
+++ b/structure/telegram.md
@@ -11,6 +11,8 @@ aliases: [Telegram and Heartbeat, CLI-JAW Telegram, messaging runtime]
 > Telegram transport (standalone + hub-member) + Dashboard forum-topic hub + shared messaging runtime + text/image forwarder lifecycle + origin filtering + voice STT
 > 현재 Telegram/Discord/Slack은 `src/messaging/`을 공유하며, settings restart는 `core/runtime-settings.ts`에서 한 번에 처리된다
 > Slack 설정 명령과 API는 [Commands](commands.md)와 [Server API](server_api.md)를 참조
+
+Slack Socket Mode의 app-level token은 사용자 공용 `~/.cli-jaw-shared/slack-claims` lease로 home 간 단일 connected consumer를 선출한다. 다른 canonical home의 `connected:true` claim이 90초 이내이고 PID가 살아 있다는 positive evidence가 모두 있을 때만 inbound를 거절하며, realpath·파일 IO·PID probe가 불확실하면 fail-open한다. 연결 전/재연결 중 `connected:false` presence는 다른 home을 막지 않고, lease는 exact `claimId` generation만 해제한다. 충돌한 home은 inbound만 끄고 Slack Web API outbound는 유지하며 `CLI_JAW_SLACK_ALLOW_SHARED_TOKEN=1`이 명시적 process-level opt-out이다.
 > v5 Update: `forwardAll` 토글은 Telegram/Discord 각각의 channel setting으로 분리됨
 > v6 Update: forum **topic-aware** programmatic send (P0) + Dashboard **Telegram Hub** — one bot, many topics → many instances (P0–P4; per-topic `model`/`systemPrompt` overrides)
 

--- a/tests/fixtures/slack-two-home-lifecycle.ts
+++ b/tests/fixtures/slack-two-home-lifecycle.ts
@@ -1,0 +1,108 @@
+import { mock } from 'node:test';
+import { createInterface } from 'node:readline';
+import { readFileSync } from 'node:fs';
+
+let socket: { emit(state: string): void } | null = null;
+let stopped = 0;
+
+mock.module('../../src/slack/api.ts', {
+    namedExports: {
+        slackApi: async (_token: string, method: string) => method === 'auth.test'
+            ? { ok: true, data: { user_id: 'UBOT', team_id: 'T1' } }
+            : { ok: true, data: {} },
+        describeSlackError: (error?: string) => error ?? 'unknown',
+        redactSlackTokens: (value: string) => value,
+        isRetryableSlackError: () => false,
+        neededScopeFrom: () => '',
+        addSlackReaction: async () => ({ ok: true }),
+        removeSlackReaction: async () => ({ ok: true }),
+        deleteSlackMessage: async () => ({ ok: true }),
+        updateSlackMessage: async () => ({ ok: true }),
+        stripEmojiColons: (name: string) => name.replace(/^:+|:+$/g, ''),
+        SLACK_CLEANUP_TIMEOUT_MS: 5000,
+        listSlackConversations: async () => ({ ok: true, data: { channels: [] } }),
+        joinSlackConversation: async () => ({ ok: true, data: {} }),
+        slackFailure: (error: string, status?: number) => status === undefined
+            ? { ok: false, error }
+            : { ok: false, error, status },
+    },
+});
+
+mock.module('../../src/slack/socket.ts', {
+    namedExports: {
+        HELLO_DEADLINE_MS: 15_000,
+        SlackSocketClient: class {
+            constructor(private options: { onStateChange?: (state: string) => void }) {
+                socket = this;
+            }
+            async start() {
+                if (process.env['SLACK_FIXTURE_INITIAL_HELLO'] === '1') this.emit('connected');
+            }
+            async waitForReady() {
+                return process.env['SLACK_FIXTURE_INITIAL_HELLO'] === '1' ? 'connected' : 'timeout';
+            }
+            stop() { stopped++; this.options.onStateChange?.('disconnected'); }
+            getState() { return 'connected'; }
+            getReconnectAttempts() { return 0; }
+            emit(state: string) { this.options.onStateChange?.(state); }
+        },
+    },
+});
+
+const [{ settings, JAW_HOME }, runtime, bot, claimModule] = await Promise.all([
+    import('../../src/core/config.ts'),
+    import('../../src/messaging/runtime.ts'),
+    import('../../src/slack/bot.ts'),
+    import('../../src/slack/token-claim.ts'),
+]);
+
+settings['port'] = process.env['SLACK_FIXTURE_PORT']!;
+settings['slack'] = {
+    enabled: true,
+    botToken: 'xoxb-two-home-fixture',
+    appToken: 'xapp-two-home-fixture',
+    teamId: 'T1',
+    attachPort: process.env['SLACK_FIXTURE_PORT']!,
+    channelIds: [],
+};
+runtime.__resetTransportRegistryForTests();
+runtime.registerTransport('slack', { init: ctx => bot.initSlack(ctx), shutdown: () => bot.shutdownSlack() });
+
+function claimId(): string | null {
+    try {
+        return JSON.parse(readFileSync(claimModule.slackTokenClaimPath('xapp-two-home-fixture'), 'utf8')).claimId;
+    } catch {
+        return null;
+    }
+}
+
+function report(event: string, extra: Record<string, unknown> = {}): void {
+    process.stdout.write(`FIXTURE ${JSON.stringify({
+        event,
+        home: JAW_HOME,
+        running: runtime.isMessagingTransportRunning('slack'),
+        stopped,
+        claimId: claimId(),
+        ...extra,
+    })}\n`);
+}
+
+const outcome = await runtime.startMessagingTransport('slack');
+report('ready', { outcome });
+
+const lines = createInterface({ input: process.stdin });
+lines.on('line', line => {
+    void (async () => {
+        if (line === 'hello') {
+            socket?.emit('connected');
+            await new Promise(resolve => setImmediate(resolve));
+            report('hello');
+        } else if (line === 'status') {
+            report('status');
+        } else if (line === 'shutdown') {
+            await bot.shutdownSlack();
+            report('shutdown');
+            process.exit(0);
+        }
+    })();
+});

--- a/tests/unit/browser-port.test.ts
+++ b/tests/unit/browser-port.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { join } from 'node:path';
+import { deriveCdpPort } from '../../src/core/config.ts';
 
 // ─── Source-level verification ───────────────────────
 const connectionSrc = readSource(
@@ -94,5 +95,27 @@ describe('Browser Port Routing (#49)', () => {
         const hasDeriveCdpPortImport = importLines.some(l => l.includes('deriveCdpPort'));
         assert.equal(hasDeriveCdpPortImport, false,
             'deriveCdpPort should not be imported in routes — getActivePort handles it');
+    });
+
+    it('BP-010: deriveCdpPort preserves the existing non-overflow mapping', () => {
+        assert.equal(deriveCdpPort(3457), 9240);
+        assert.equal(deriveCdpPort(59752), 65535);
+    });
+
+    it('BP-011: overflow wraps injectively through unprivileged ports', () => {
+        const inputs = [59753, 59754, 60000, 65534, 65535];
+        const outputs = inputs.map(deriveCdpPort);
+        assert.equal(new Set(outputs).size, inputs.length);
+        for (let i = 0; i < inputs.length; i++) {
+            assert.ok(outputs[i]! >= 1024 && outputs[i]! <= 65535);
+            assert.notEqual(outputs[i], inputs[i]);
+        }
+        assert.deepEqual(outputs.slice(0, 2), [1024, 1025]);
+    });
+
+    it('BP-012: invalid input retains the legacy safe default', () => {
+        assert.equal(deriveCdpPort(0), 9240);
+        assert.equal(deriveCdpPort(65536), 9240);
+        assert.equal(deriveCdpPort('not-a-port'), 9240);
     });
 });

--- a/tests/unit/messaging-runtime.test.ts
+++ b/tests/unit/messaging-runtime.test.ts
@@ -11,8 +11,10 @@ import {
     getLatestSeenTarget,
     hydrateTargetsFromSettings,
     getMessagingTransportError,
+    getMessagingTransportNotice,
     isMessagingTransportRunning,
     registerTransport,
+    revokeMessagingTransport,
     restartMessagingRuntime,
     setLastActiveTarget,
     setLatestSeenTarget,
@@ -200,6 +202,66 @@ test('startMessagingTransport keeps a declined start out of the error record', a
     // The non-attach instance is doing exactly what it was configured to do, so it
     // must not leave a transport error behind for health to report as a fault.
     assert.equal(getMessagingTransportError('slack'), null);
+});
+
+test('current-epoch revoke before activation prevents a phantom running transport', async () => {
+    freshSettings();
+    registerTransport('slack', {
+        init: async (ctx) => {
+            revokeMessagingTransport('slack', 'token_shared_other_home', ctx!.startEpoch);
+            return transportStarted;
+        },
+        shutdown: async () => {},
+    });
+    const outcome = await startMessagingTransport('slack');
+    assert.deepEqual(outcome, { started: false, reason: 'token_shared_other_home' });
+    assert.equal(isMessagingTransportRunning('slack'), false);
+    assert.equal(getMessagingTransportNotice('slack'), 'token_shared_other_home');
+    assert.equal(getMessagingTransportError('slack'), null);
+});
+
+test('stale revoke is ignored and a later successful start clears the notice', async () => {
+    freshSettings();
+    let latestEpoch = 0;
+    registerTransport('slack', {
+        init: async (ctx) => { latestEpoch = ctx!.startEpoch; return transportStarted; },
+        shutdown: async () => {},
+    });
+    await startMessagingTransport('slack');
+    assert.equal(revokeMessagingTransport('slack', 'token_shared_other_home', latestEpoch - 1), false);
+    assert.equal(isMessagingTransportRunning('slack'), true);
+    assert.equal(revokeMessagingTransport('slack', 'token_shared_other_home', latestEpoch), true);
+    assert.equal(isMessagingTransportRunning('slack'), false);
+    await startMessagingTransport('slack');
+    assert.equal(isMessagingTransportRunning('slack'), true);
+    assert.equal(getMessagingTransportNotice('slack'), null);
+});
+
+test('overlapping superseded start does not stale the epoch that actually activated', async () => {
+    freshSettings();
+    let firstEpoch = 0;
+    let calls = 0;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+    registerTransport('slack', {
+        init: async ctx => {
+            calls++;
+            if (calls === 1) {
+                firstEpoch = ctx!.startEpoch;
+                await firstGate;
+                return transportStarted;
+            }
+            return transportNotStarted('superseded');
+        },
+        shutdown: async () => {},
+    });
+    const first = startMessagingTransport('slack');
+    assert.deepEqual(await startMessagingTransport('slack'), { started: false, reason: 'superseded' });
+    releaseFirst();
+    assert.deepEqual(await first, { started: true });
+    assert.equal(isMessagingTransportRunning('slack'), true);
+    assert.equal(revokeMessagingTransport('slack', 'token_shared_other_home', firstEpoch), true);
+    assert.equal(isMessagingTransportRunning('slack'), false);
 });
 
 test('loadSettings migrates legacy channel to messaging.enabledChannels and homeChannel', () => {

--- a/tests/unit/messaging-transport-capability.test.ts
+++ b/tests/unit/messaging-transport-capability.test.ts
@@ -56,6 +56,32 @@ test('manager transport chips parse health.channels', () => {
     assert.ok(managerTransportChipLabels(snapshot.discord).includes('Configured') || managerTransportChipLabels(snapshot.discord).includes('Not configured'));
 });
 
+test('slack ownership notice disables inbound while preserving outbound capability', async () => {
+    const { settings } = await import('../../src/core/config.js');
+    const runtime = await import('../../src/messaging/runtime.js');
+    const previousSlack = settings.slack;
+    try {
+        runtime.__resetTransportRegistryForTests();
+        settings.slack = { enabled: true, botToken: 'xoxb-test', appToken: 'xapp-test', channelIds: [] };
+        let epoch = 0;
+        runtime.registerTransport('slack', {
+            init: async ctx => { epoch = ctx!.startEpoch; return runtime.transportStarted; },
+            shutdown: async () => {},
+        });
+        await runtime.startMessagingTransport('slack');
+        runtime.revokeMessagingTransport('slack', 'token_shared_other_home', epoch);
+        assert.deepEqual(getTransportCapability('slack'), {
+            configured: true,
+            activeInbound: false,
+            sendCapable: true,
+            reason: 'token_shared_other_home',
+        });
+    } finally {
+        runtime.__resetTransportRegistryForTests();
+        settings.slack = previousSlack;
+    }
+});
+
 test('shared settings channel pages expose live transport capability', () => {
     assert.match(read('public/index.html'), /id="settingsPage" class="settings-page"[\s\S]*?src="dist\/settings\/index.html"/);
     for (const channel of ['telegram', 'discord', 'slack']) {

--- a/tests/unit/slack-inbound.test.ts
+++ b/tests/unit/slack-inbound.test.ts
@@ -29,6 +29,7 @@ type Harness = {
     emit: (frame: unknown) => Promise<void>;
     sent: string[];
     handled: SlackEnvelope[];
+    stateChanges: string[];
 };
 
 async function makeHarness(options: {
@@ -37,6 +38,7 @@ async function makeHarness(options: {
 } = {}): Promise<Harness> {
     const sent: string[] = [];
     const handled: SlackEnvelope[] = [];
+    const stateChanges: string[] = [];
     const listeners = new Map<string, (event: unknown) => void>();
 
     const socket: SlackSocketLike = {
@@ -60,6 +62,7 @@ async function makeHarness(options: {
             handled.push(e);
             await options.onEnvelope?.(e);
         },
+        onStateChange: state => { stateChanges.push(state); },
     });
     await client.start();
 
@@ -70,7 +73,7 @@ async function makeHarness(options: {
         // let the async handler settle
         await new Promise(resolve => setImmediate(resolve));
     };
-    return { client, emit, sent, handled };
+    return { client, emit, sent, handled, stateChanges };
 }
 
 const eventsEnvelope = (id: string, event: Record<string, unknown>): SlackEnvelope => ({
@@ -88,6 +91,22 @@ test('hello moves the client to connected without acking', async () => {
     assert.equal(h.sent.length, 0, 'control frames must not be acked');
     assert.equal(h.handled.length, 0);
     h.client.stop();
+});
+
+test('waitForReady observes hello before and after waiter registration', async () => {
+    const before = await makeHarness();
+    const pending = before.client.waitForReady(1000);
+    await before.emit({ type: 'hello' });
+    assert.equal(await pending, 'connected');
+    assert.equal(await before.client.waitForReady(1000), 'connected');
+    assert.ok(before.stateChanges.includes('connected'));
+    before.client.stop();
+
+    const stopped = await makeHarness();
+    const stoppedWait = stopped.client.waitForReady(1000);
+    stopped.client.stop('disabled');
+    assert.equal(await stoppedWait, 'stopped');
+    assert.equal(stopped.stateChanges.at(-1), 'disabled');
 });
 
 test('an events envelope is acked with exactly its envelope_id', async () => {

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -14,7 +14,45 @@ const state: {
     started: number;
     stopped: number;
     authOk: boolean;
-} = { started: 0, stopped: 0, authOk: true };
+    inspectKind: 'none' | 'foreign_live' | 'uncertain';
+    acquireKind: 'acquired' | 'foreign_live' | 'unavailable';
+    acquired: number;
+    released: number;
+    inspected: number;
+    ready: 'connected' | 'timeout' | 'stopped';
+    startThrows: boolean;
+    claimConnected: boolean[];
+    sockets: Array<{ emit(state: string): void }>;
+} = {
+    started: 0, stopped: 0, authOk: true, inspectKind: 'none', acquireKind: 'acquired',
+    acquired: 0, released: 0, inspected: 0, ready: 'connected', startThrows: false,
+    claimConnected: [], sockets: [],
+};
+
+mock.module('../../src/slack/token-claim.ts', {
+    namedExports: {
+        SLACK_TOKEN_CLAIM_FRESH_MS: 90_000,
+        inspectSlackTokenClaim: () => {
+            state.inspected++;
+            return state.inspectKind === 'foreign_live'
+                ? { kind: 'foreign_live', claim: { home: '/foreign', port: '9999', pid: 42, connected: true } }
+                : state.inspectKind === 'uncertain' ? { kind: 'uncertain', error: 'realpath' }
+                : { kind: 'none' };
+        },
+        acquireSlackTokenClaim: (options: { connected: boolean }) => {
+            state.acquired++;
+            state.claimConnected.push(options.connected);
+            if (state.acquireKind === 'foreign_live') return { kind: 'foreign_live', claim: { home: '/foreign', port: '9999', pid: 42, connected: true } };
+            if (state.acquireKind === 'unavailable') return { kind: 'unavailable', error: 'io' };
+            let released = false;
+            return { kind: 'acquired', lease: {
+                claim: { claimId: String(state.acquired) },
+                markConnected() {}, markDisconnected() {},
+                release() { if (!released) { released = true; state.released++; } },
+            } };
+        },
+    },
+});
 
 mock.module('../../src/slack/api.ts', {
     namedExports: {
@@ -53,11 +91,21 @@ mock.module('../../src/slack/api.ts', {
 
 mock.module('../../src/slack/socket.ts', {
     namedExports: {
+        HELLO_DEADLINE_MS: 15_000,
         SlackSocketClient: class {
-            async start() { state.started++; }
-            stop() { state.stopped++; }
+            constructor(private options: { onStateChange?: (state: string) => void }) {
+                state.sockets.push(this);
+            }
+            async start() {
+                state.started++;
+                if (state.startThrows) throw new Error('start failed');
+                if (state.ready === 'connected') this.options.onStateChange?.('connected');
+            }
+            async waitForReady() { return state.ready; }
+            stop() { state.stopped++; this.options.onStateChange?.('disconnected'); }
             getState() { return 'connected'; }
             getReconnectAttempts() { return 0; }
+            emit(next: string) { this.options.onStateChange?.(next); }
         },
     },
 });
@@ -67,6 +115,21 @@ async function loadBot(slack: Record<string, unknown>, port = '24575') {
     (settings as Record<string, unknown>)['port'] = port;
     (settings as Record<string, unknown>)['slack'] = slack;
     return import('../../src/slack/bot.ts');
+}
+
+function resetClaimState(): void {
+    state.started = 0;
+    state.stopped = 0;
+    state.inspectKind = 'none';
+    state.acquireKind = 'acquired';
+    state.acquired = 0;
+    state.released = 0;
+    state.inspected = 0;
+    state.ready = 'connected';
+    state.startThrows = false;
+    state.claimConnected = [];
+    state.sockets = [];
+    delete process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'];
 }
 
 test('initSlack actually starts the socket for a fully configured workspace', async () => {
@@ -204,5 +267,139 @@ test('repeated inits settle without runaway recursion', async () => {
     const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t' });
     await Promise.all([bot.initSlack(), bot.initSlack(), bot.initSlack()]);
     assert.ok(state.started <= 3, `init ran away: ${state.started} starts`);
+    await bot.shutdownSlack();
+});
+
+test('a: claim IO unavailability fails open and starts the socket', async () => {
+    resetClaimState(); state.acquireKind = 'unavailable';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    assert.deepEqual(await bot.initSlack(), { started: true });
+    assert.equal(state.started, 1);
+    await bot.shutdownSlack();
+});
+
+test('b: hello acquisition is released exactly once by shutdown', async () => {
+    resetClaimState();
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    await bot.initSlack();
+    assert.deepEqual(state.claimConnected, [true]);
+    await bot.shutdownSlack();
+    assert.equal(state.released, 1);
+});
+
+test('c: positively connected foreign owner refuses before socket construction', async () => {
+    resetClaimState(); state.inspectKind = 'foreign_live';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    const outcome = await bot.initSlack();
+    assert.deepEqual(outcome, { started: false, reason: 'token_shared_other_home' });
+    assert.equal(state.sockets.length, 0);
+    await bot.shutdownSlack();
+});
+
+test('d: hello election loss stops once and returns the ownership reason', async () => {
+    resetClaimState(); state.acquireKind = 'foreign_live';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    const outcome = await bot.initSlack({ startEpoch: 1 });
+    assert.deepEqual(outcome, { started: false, reason: 'token_shared_other_home' });
+    assert.equal(state.acquired, 1, 'init and hello must share one arbitration');
+    assert.equal(state.stopped, 1, 'foreign result must be applied once');
+    await bot.shutdownSlack();
+});
+
+test('e: socket start failure leaves no acquired lease', async () => {
+    resetClaimState(); state.startThrows = true;
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    await assert.rejects(() => bot.initSlack(), /start failed/);
+    assert.equal(state.acquired, 0);
+    await bot.shutdownSlack();
+});
+
+test('f: readiness timeout starts with a non-blocking presence record', async () => {
+    resetClaimState(); state.ready = 'timeout';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    assert.deepEqual(await bot.initSlack({ startEpoch: 2 }), { started: true });
+    assert.deepEqual(state.claimConnected, [false]);
+    state.sockets.at(-1)!.emit('connected');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(state.acquired, 1, 'late hello promotes the owned presence lease');
+    await bot.shutdownSlack();
+});
+
+test('g: a client stopped before readiness cannot be reported as started', async () => {
+    resetClaimState(); state.ready = 'stopped';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    assert.deepEqual(await bot.initSlack({ startEpoch: 3 }), { started: false, reason: 'superseded' });
+    assert.equal(state.acquired, 0);
+    await bot.shutdownSlack();
+});
+
+test('h: self-election loss releases the acquired generation', async () => {
+    resetClaimState();
+    writeFileSync(join(home, 'settings.json'), JSON.stringify({
+        settingsSchemaVersion: 4, port: '24575',
+        slack: { enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '3457' },
+    }));
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '' }, '24575');
+    assert.deepEqual(await bot.initSlack(), { started: false, reason: 'not_attach_instance' });
+    assert.equal(state.released, 1);
+    await bot.shutdownSlack();
+});
+
+test('i/o: late foreign hello revokes the activated epoch', async () => {
+    resetClaimState(); state.ready = 'timeout'; state.acquireKind = 'unavailable';
+    const runtime = await import('../../src/messaging/runtime.ts');
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    runtime.__resetTransportRegistryForTests();
+    runtime.registerTransport('slack', { init: ctx => bot.initSlack(ctx), shutdown: () => bot.shutdownSlack() });
+    assert.deepEqual(await runtime.startMessagingTransport('slack'), { started: true });
+    assert.equal(runtime.isMessagingTransportRunning('slack'), true);
+    state.acquireKind = 'foreign_live';
+    state.sockets.at(-1)!.emit('connected');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(runtime.isMessagingTransportRunning('slack'), false);
+    assert.equal(runtime.getMessagingTransportNotice('slack'), 'token_shared_other_home');
+    await bot.shutdownSlack();
+    runtime.__resetTransportRegistryForTests();
+});
+
+test('j/p: disconnected and disabled terminal states release the owned lease once', async () => {
+    for (const terminal of ['disconnected', 'disabled']) {
+        resetClaimState();
+        const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+        await bot.initSlack();
+        state.sockets.at(-1)!.emit(terminal);
+        assert.equal(state.released, 1, `${terminal} did not release`);
+        await bot.shutdownSlack();
+        assert.equal(state.released, 1, `${terminal} release was not idempotent`);
+    }
+});
+
+test('k: environment opt-out skips both inspection and acquisition', async () => {
+    resetClaimState(); process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] = '1';
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    assert.deepEqual(await bot.initSlack(), { started: true });
+    assert.equal(state.inspected, 0);
+    assert.equal(state.acquired, 0);
+    await bot.shutdownSlack();
+    delete process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'];
+});
+
+test('m/n: hello before waiter and concurrent init arbitration acquire once', async () => {
+    resetClaimState();
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    await bot.initSlack();
+    assert.equal(state.acquired, 1);
+    await bot.shutdownSlack();
+});
+
+test('q: stale generation callback cannot release the newer lease', async () => {
+    resetClaimState();
+    const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+    await bot.initSlack();
+    const old = state.sockets.at(-1)!;
+    await bot.initSlack();
+    const releasedAfterReplacement = state.released;
+    old.emit('disconnected');
+    assert.equal(state.released, releasedAfterReplacement);
     await bot.shutdownSlack();
 });

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 const home = mkdtempSync(join(homedir(), '.cljaw-test-'));
@@ -47,7 +48,7 @@ mock.module('../../src/slack/token-claim.ts', {
             let released = false;
             return { kind: 'acquired', lease: {
                 claim: { claimId: String(state.acquired) },
-                markConnected() {}, markDisconnected() {},
+                markConnected() { return 'ok' as const; }, markDisconnected() {},
                 release() { if (!released) { released = true; state.released++; } },
             } };
         },
@@ -402,4 +403,80 @@ test('q: stale generation callback cannot release the newer lease', async () => 
     old.emit('disconnected');
     assert.equal(state.released, releasedAfterReplacement);
     await bot.shutdownSlack();
+});
+
+test('l real lifecycle: late hello loses a replaced presence claim', async t => {
+    const sharedHome = mkdtempSync(join(homedir(), '.cljaw-shared-'));
+    const homeA = mkdtempSync(join(homedir(), '.cljaw-home-a-'));
+    const homeB = mkdtempSync(join(homedir(), '.cljaw-home-b-'));
+    const entry = join(import.meta.dirname!, '..', 'fixtures', 'slack-two-home-lifecycle.ts');
+    const tsx = join(import.meta.dirname!, '..', '..', 'node_modules', '.bin', 'tsx');
+    const children: ChildProcessWithoutNullStreams[] = [];
+    t.after(() => {
+        for (const child of children) child.kill();
+        rmSync(sharedHome, { recursive: true, force: true });
+        rmSync(homeA, { recursive: true, force: true });
+        rmSync(homeB, { recursive: true, force: true });
+    });
+
+    const start = (childHome: string, port: string, initialHello: boolean) => {
+        const child = spawn(tsx, ['--experimental-test-module-mocks', entry], {
+            env: {
+                ...process.env,
+                HOME: sharedHome,
+                CLI_JAW_HOME: childHome,
+                SLACK_FIXTURE_PORT: port,
+                SLACK_FIXTURE_INITIAL_HELLO: initialHello ? '1' : '0',
+            },
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        children.push(child);
+        let buffered = '';
+        const waiters: Array<(value: Record<string, unknown>) => void> = [];
+        child.stdout.setEncoding('utf8');
+        child.stdout.on('data', chunk => {
+            buffered += chunk;
+            const lines = buffered.split('\n');
+            buffered = lines.pop()!;
+            for (const line of lines) {
+                if (!line.startsWith('FIXTURE ')) continue;
+                waiters.shift()?.(JSON.parse(line.slice(8)));
+            }
+        });
+        const next = () => new Promise<Record<string, unknown>>((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error(`fixture timeout: ${buffered}`)), 10_000);
+            waiters.push(value => { clearTimeout(timer); resolve(value); });
+        });
+        return { child, next };
+    };
+
+    const a = start(homeA, '4101', false);
+    const aReady = await a.next();
+    assert.deepEqual(aReady.outcome, { started: true });
+    assert.equal(aReady.running, true);
+
+    const b = start(homeB, '4102', true);
+    const bReady = await b.next();
+    assert.deepEqual(bReady.outcome, { started: true });
+    assert.equal(bReady.running, true);
+    const bClaimId = bReady.claimId;
+
+    a.child.stdin.write('hello\n');
+    const aAfterHello = await a.next();
+    b.child.stdin.write('status\n');
+    const bStatus = await b.next();
+    assert.equal(aAfterHello.stopped, 1);
+    assert.equal(aAfterHello.running, false);
+    assert.equal(bStatus.running, true);
+    assert.equal(bStatus.claimId, bClaimId);
+
+    const claimRoot = join(sharedHome, '.cli-jaw-shared', 'slack-claims');
+    const files = readdirSync(claimRoot).filter(file => file.endsWith('.json'));
+    assert.equal(files.length, 1);
+    const claim = JSON.parse(readFileSync(join(claimRoot, files[0]!), 'utf8'));
+    assert.equal(claim.claimId, bClaimId);
+    assert.equal(claim.home, realpathSync.native(homeB));
+
+    a.child.stdin.write('shutdown\n');
+    b.child.stdin.write('shutdown\n');
 });

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -2,6 +2,7 @@ import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { log } from '../../src/core/logger.ts';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 const home = mkdtempSync(join(homedir(), '.cljaw-test-'));
@@ -24,10 +25,11 @@ const state: {
     startThrows: boolean;
     claimConnected: boolean[];
     sockets: Array<{ emit(state: string): void }>;
+    emitConnectedOnStart: boolean;
 } = {
     started: 0, stopped: 0, authOk: true, inspectKind: 'none', acquireKind: 'acquired',
     acquired: 0, released: 0, inspected: 0, ready: 'connected', startThrows: false,
-    claimConnected: [], sockets: [],
+    claimConnected: [], sockets: [], emitConnectedOnStart: true,
 };
 
 mock.module('../../src/slack/token-claim.ts', {
@@ -100,7 +102,7 @@ mock.module('../../src/slack/socket.ts', {
             async start() {
                 state.started++;
                 if (state.startThrows) throw new Error('start failed');
-                if (state.ready === 'connected') this.options.onStateChange?.('connected');
+                if (state.ready === 'connected' && state.emitConnectedOnStart) this.options.onStateChange?.('connected');
             }
             async waitForReady() { return state.ready; }
             stop() { state.stopped++; this.options.onStateChange?.('disconnected'); }
@@ -130,6 +132,7 @@ function resetClaimState(): void {
     state.startThrows = false;
     state.claimConnected = [];
     state.sockets = [];
+    state.emitConnectedOnStart = true;
     delete process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'];
 }
 
@@ -375,15 +378,53 @@ test('j/p: disconnected and disabled terminal states release the owned lease onc
     }
 });
 
-test('k: environment opt-out skips both inspection and acquisition', async () => {
+test('k: environment opt-out logs once and skips ownership work across repeated init', async t => {
     resetClaimState(); process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'] = '1';
+    const notices: unknown[][] = [];
+    const originalInfo = log.info.bind(log);
+    t.mock.method(log, 'info', (...args: unknown[]) => {
+        if (args[0] === '[slack] shared app-token ownership guard disabled by environment') notices.push(args);
+        originalInfo(...args);
+    });
     const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
     assert.deepEqual(await bot.initSlack(), { started: true });
+    assert.deepEqual(await bot.initSlack(), { started: true });
+    assert.equal(notices.length, 1);
     assert.equal(state.inspected, 0);
     assert.equal(state.acquired, 0);
     await bot.shutdownSlack();
     delete process.env['CLI_JAW_SLACK_ALLOW_SHARED_TOKEN'];
 });
+
+for (const [label, emitConnectedOnStart] of [
+    ['init path first', false],
+    ['hello callback first', true],
+] as const) {
+    test(`apply-once creates one unref re-check timer when ${label}`, async t => {
+        resetClaimState();
+        state.acquireKind = 'foreign_live';
+        state.ready = 'connected';
+        state.emitConnectedOnStart = emitConnectedOnStart;
+        const originalSetTimeout = globalThis.setTimeout;
+        let timers = 0;
+        let unrefs = 0;
+        t.mock.method(globalThis, 'setTimeout', ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+            if ((delay ?? 0) >= 90_000) {
+                timers++;
+                return { unref() { unrefs++; } } as unknown as ReturnType<typeof setTimeout>;
+            }
+            return originalSetTimeout(callback, delay, ...args);
+        }) as typeof setTimeout);
+        const bot = await loadBot({ enabled: true, botToken: 'xoxb-t', appToken: 'xapp-t', attachPort: '24575' });
+        assert.deepEqual(await bot.initSlack({ startEpoch: 91 }), {
+            started: false,
+            reason: 'token_shared_other_home',
+        });
+        assert.equal(timers, 1);
+        assert.equal(unrefs, 1);
+        await bot.shutdownSlack();
+    });
+}
 
 test('m/n: hello before waiter and concurrent init arbitration acquire once', async () => {
     resetClaimState();

--- a/tests/unit/slack-operator-tooling.test.ts
+++ b/tests/unit/slack-operator-tooling.test.ts
@@ -238,17 +238,28 @@ test('doctor text and JSON identify a foreign owner without exposing token mater
             version: 1, claimId: 'd'.repeat(32), home: foreignHome, port: '4567',
             pid: process.pid, claimedAt: new Date().toISOString(), connected: true,
         }));
-        const run = spawnSync(repoTsx, [cliEntry, '--home', home, 'doctor', '--json'], {
-            cwd: repoRoot, encoding: 'utf8', timeout: 60_000,
-            env: { ...process.env, HOME: sharedHome, NO_COLOR: '1', SLACK_BOT_TOKEN: '', SLACK_APP_TOKEN: '' },
-        });
-        assert.ok(run.stdout, run.stderr);
-        const slack = JSON.parse(run.stdout).slack;
+        const runDoctor = (json: boolean) => spawnSync(
+            repoTsx,
+            [cliEntry, '--home', home, 'doctor', ...(json ? ['--json'] : [])],
+            {
+                cwd: repoRoot, encoding: 'utf8', timeout: 60_000,
+                env: { ...process.env, HOME: sharedHome, NO_COLOR: '1', SLACK_BOT_TOKEN: '', SLACK_APP_TOKEN: '' },
+            },
+        );
+        const jsonRun = runDoctor(true);
+        assert.ok(jsonRun.stdout, jsonRun.stderr);
+        const slack = JSON.parse(jsonRun.stdout).slack;
         assert.equal(slack.status, 'token_shared_other_home');
         assert.deepEqual(slack.tokenClaimOwner, { home: foreignHome, port: '4567' });
-        const rendered = `${run.stdout}\n${run.stderr}`;
-        assert.doesNotMatch(rendered, new RegExp(token));
-        assert.doesNotMatch(rendered, /[0-9a-f]{64}\.json/);
+        const textRun = runDoctor(false);
+        assert.match(textRun.stdout, new RegExp(`Slack app token is claimed by ${foreignHome} on :4567`));
+        for (const rendered of [
+            `${jsonRun.stdout}\n${jsonRun.stderr}`,
+            `${textRun.stdout}\n${textRun.stderr}`,
+        ]) {
+            assert.doesNotMatch(rendered, new RegExp(token));
+            assert.doesNotMatch(rendered, /[0-9a-f]{64}\.json/);
+        }
     } finally {
         rmSync(home, { recursive: true, force: true });
         rmSync(foreignHome, { recursive: true, force: true });

--- a/tests/unit/slack-operator-tooling.test.ts
+++ b/tests/unit/slack-operator-tooling.test.ts
@@ -1,10 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { slackChannelScope } from '../../src/slack/scope-status.js';
+import { slackTokenClaimPath } from '../../src/slack/token-claim.js';
 
 const repoRoot = join(import.meta.dirname, '..', '..');
 const read = (rel: string) => readFileSync(join(repoRoot, rel), 'utf8');
@@ -91,7 +92,7 @@ test('doctor --json emits a slack status object with the full ladder', () => {
     const doctor = read('bin/commands/doctor.ts');
     assert.match(doctor, /function buildSlackStatus\(\)/);
     assert.match(doctor, /slack: buildSlackStatus\(\),/, 'the JSON output has no slack member');
-    for (const status of ['missing_bot_token', 'missing_app_token']) {
+    for (const status of ['missing_bot_token', 'missing_app_token', 'token_shared_other_home']) {
         assert.match(doctor, new RegExp(status), `status ladder is missing ${status}`);
     }
     // Shape parity with Discord so JSON consumers can treat channels uniformly.
@@ -99,6 +100,8 @@ test('doctor --json emits a slack status object with the full ladder', () => {
     for (const field of ['enabled', 'channelConsistent', 'runtimeReady', 'degradedReasons']) {
         assert.match(block, new RegExp(field), `buildSlackStatus omits ${field}`);
     }
+    assert.match(block, /tokenClaimOwner: \{ home: tokenClaim\.claim\.home, port: tokenClaim\.claim\.port \}/);
+    assert.doesNotMatch(block, /tokenClaimOwner:[^\n]*(appToken|sha256|claimId)/);
 });
 
 // An empty allowlist means "every conversation" — the shipped default. doctor
@@ -214,6 +217,43 @@ test('doctor --json reports the allowlist width the gate enforces', () => {
     assert.equal(malformed.runtimeReady, false);
     // The denial sentinel is not a conversation and must not be printed as one.
     assert.deepEqual(malformed.channelIds, []);
+});
+
+test('doctor text and JSON identify a foreign owner without exposing token material', () => {
+    const repoTsx = join(repoRoot, 'node_modules', '.bin', 'tsx');
+    const cliEntry = join(repoRoot, 'bin', 'cli-jaw.ts');
+    const home = mkdtempSync(join(tmpdir(), 'jaw-doctor-owner-'));
+    const foreignHome = mkdtempSync(join(tmpdir(), 'jaw-doctor-foreign-'));
+    const sharedHome = mkdtempSync(join(tmpdir(), 'jaw-doctor-shared-'));
+    const token = 'xapp-doctor-owner-secret';
+    try {
+        writeFileSync(join(home, 'settings.json'), JSON.stringify({
+            port: '3457',
+            slack: { enabled: true, botToken: 'xoxb-fixture', appToken: token, teamId: 'T1', channelIds: [] },
+        }));
+        const claimRoot = join(sharedHome, '.cli-jaw-shared', 'slack-claims');
+        const claimPath = slackTokenClaimPath(token, claimRoot);
+        mkdirSync(dirname(claimPath), { recursive: true });
+        writeFileSync(claimPath, JSON.stringify({
+            version: 1, claimId: 'd'.repeat(32), home: foreignHome, port: '4567',
+            pid: process.pid, claimedAt: new Date().toISOString(), connected: true,
+        }));
+        const run = spawnSync(repoTsx, [cliEntry, '--home', home, 'doctor', '--json'], {
+            cwd: repoRoot, encoding: 'utf8', timeout: 60_000,
+            env: { ...process.env, HOME: sharedHome, NO_COLOR: '1', SLACK_BOT_TOKEN: '', SLACK_APP_TOKEN: '' },
+        });
+        assert.ok(run.stdout, run.stderr);
+        const slack = JSON.parse(run.stdout).slack;
+        assert.equal(slack.status, 'token_shared_other_home');
+        assert.deepEqual(slack.tokenClaimOwner, { home: foreignHome, port: '4567' });
+        const rendered = `${run.stdout}\n${run.stderr}`;
+        assert.doesNotMatch(rendered, new RegExp(token));
+        assert.doesNotMatch(rendered, /[0-9a-f]{64}\.json/);
+    } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(foreignHome, { recursive: true, force: true });
+        rmSync(sharedHome, { recursive: true, force: true });
+    }
 });
 
 // ─── source-of-truth docs ───────────────────────────

--- a/tests/unit/slack-token-claim.test.ts
+++ b/tests/unit/slack-token-claim.test.ts
@@ -184,3 +184,17 @@ test('17: pid reuse only blocks within the freshness window', t => {
     assert.equal(result.kind, 'acquired');
     if (result.kind === 'acquired') result.lease.release();
 });
+
+test('l: a non-blocking home loses safely when another home connects first', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const a = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '3457', connected: false, rootDir: f.rootDir });
+    assert.equal(a.kind, 'acquired');
+    const b = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir });
+    assert.equal(b.kind, 'acquired');
+    if (a.kind === 'acquired') a.lease.markConnected();
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '3457', connected: true, rootDir: f.rootDir }).kind, 'foreign_live');
+    assert.equal(stored(f).home, realpathSync.native(f.homeB));
+    if (a.kind === 'acquired') a.lease.release();
+    assert.equal(stored(f).home, realpathSync.native(f.homeB));
+    if (b.kind === 'acquired') b.lease.release();
+});

--- a/tests/unit/slack-token-claim.test.ts
+++ b/tests/unit/slack-token-claim.test.ts
@@ -1,0 +1,186 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    chmodSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+    SLACK_TOKEN_CLAIM_FRESH_MS,
+    acquireSlackTokenClaim,
+    inspectSlackTokenClaim,
+    slackTokenClaimPath,
+    type SlackTokenClaim,
+} from '../../src/slack/token-claim.ts';
+
+function fixture() {
+    const base = mkdtempSync(join(tmpdir(), 'jaw-slack-claim-'));
+    const rootDir = join(base, 'claims');
+    const homeA = join(base, 'home-a');
+    const homeB = join(base, 'home-b');
+    mkdirSync(homeA);
+    mkdirSync(homeB);
+    return { base, rootDir, homeA, homeB, token: 'xapp-test-shared' };
+}
+
+function stored(f: ReturnType<typeof fixture>): SlackTokenClaim {
+    return JSON.parse(readFileSync(slackTokenClaimPath(f.token, f.rootDir), 'utf8')) as SlackTokenClaim;
+}
+
+function writeClaim(f: ReturnType<typeof fixture>, claim: Partial<SlackTokenClaim> = {}): void {
+    const path = slackTokenClaimPath(f.token, f.rootDir);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({
+        version: 1,
+        claimId: 'a'.repeat(32),
+        home: f.homeA,
+        port: '3457',
+        pid: process.pid,
+        claimedAt: new Date().toISOString(),
+        connected: true,
+        ...claim,
+    }));
+}
+
+test('1: acquire writes connectivity and private modes', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '3457', connected: false, rootDir: f.rootDir });
+    assert.equal(result.kind, 'acquired');
+    assert.equal(stored(f).connected, false);
+    assert.equal(statSync(f.rootDir).mode & 0o777, 0o700);
+    assert.equal(statSync(slackTokenClaimPath(f.token, f.rootDir)).mode & 0o777, 0o600);
+    if (result.kind === 'acquired') result.lease.release();
+});
+
+test('2: same-home fresh live claim is adopted without replacement', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f);
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '3458', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'same_home');
+    assert.equal(stored(f).claimId, 'a'.repeat(32));
+});
+
+test('3-4: only a connected foreign live claim blocks', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f, { connected: true });
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir }).kind, 'foreign_live');
+    writeClaim(f, { connected: false });
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir }).kind, 'none');
+});
+
+test('5: stale foreign claim is replaced', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f, { claimedAt: new Date(Date.now() - SLACK_TOKEN_CLAIM_FRESH_MS - 1).toISOString() });
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'acquired');
+    assert.equal(stored(f).home, realpathSync.native(f.homeB));
+    if (result.kind === 'acquired') result.lease.release();
+});
+
+test('6-7: dead or EPERM-like unverifiable pid evidence does not block replacement', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f);
+    for (const pidAlive of [() => false, () => false]) {
+        const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir, pidAlive });
+        assert.equal(result.kind, 'acquired');
+        if (result.kind === 'acquired') result.lease.release();
+        writeClaim(f);
+    }
+});
+
+test('8: throwing pid probe is uncertain and acquire remains unavailable rather than refusing', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f);
+    const pidAlive = () => { throw new Error('probe uncertain'); };
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir, pidAlive }).kind, 'uncertain');
+    assert.equal(acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir, pidAlive }).kind, 'unavailable');
+});
+
+test('9: malformed and wrong-version claim data is ignored', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const path = slackTokenClaimPath(f.token, f.rootDir); mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, '{bad');
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '', connected: true, rootDir: f.rootDir }).kind, 'none');
+    writeFileSync(path, JSON.stringify({ version: 2 }));
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '', connected: true, rootDir: f.rootDir }).kind, 'none');
+});
+
+test('10: realpath uncertainty is reported by inspect and acquire fails open by replacing', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f); rmSync(f.homeA, { recursive: true });
+    assert.equal(inspectSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '', connected: true, rootDir: f.rootDir }).kind, 'uncertain');
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '3458', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'acquired');
+    if (result.kind === 'acquired') result.lease.release();
+});
+
+test('11: root creation failure is unavailable', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const occupied = join(f.base, 'occupied'); writeFileSync(occupied, 'x');
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '', connected: true, rootDir: join(occupied, 'claims') });
+    assert.equal(result.kind, 'unavailable');
+});
+
+test('12: lock contention falls through to final inspection and stays fail-open', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f, { connected: false });
+    writeFileSync(`${slackTokenClaimPath(f.token, f.rootDir)}.lock`, 'busy');
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'unavailable');
+});
+
+test('13: refresh pauses while disconnected and resumes when connected', async t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    let tick = 0;
+    const now = () => new Date(1_700_000_000_000 + tick++ * 1000);
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '', connected: false, rootDir: f.rootDir, now, refreshMs: 10 });
+    assert.equal(result.kind, 'acquired');
+    const before = stored(f).claimedAt;
+    await new Promise(resolve => setTimeout(resolve, 25));
+    assert.equal(stored(f).claimedAt, before);
+    if (result.kind === 'acquired') result.lease.markConnected();
+    await new Promise(resolve => setTimeout(resolve, 25));
+    assert.notEqual(stored(f).claimedAt, before);
+    if (result.kind === 'acquired') result.lease.release();
+});
+
+test('14: refresh IO failure is swallowed', async t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '', connected: true, rootDir: f.rootDir, refreshMs: 5 });
+    assert.equal(result.kind, 'acquired');
+    writeFileSync(`${slackTokenClaimPath(f.token, f.rootDir)}.lock`, 'busy');
+    await new Promise(resolve => setTimeout(resolve, 15));
+    if (result.kind === 'acquired') assert.doesNotThrow(() => result.lease.markConnected());
+});
+
+test('15: release removes only its own claim id and is idempotent', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'acquired');
+    writeClaim(f, { claimId: 'b'.repeat(32), home: f.homeB });
+    if (result.kind === 'acquired') { result.lease.release(); result.lease.release(); }
+    assert.equal(stored(f).claimId, 'b'.repeat(32));
+});
+
+test('16: release IO failure is swallowed', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeA, port: '', connected: true, rootDir: f.rootDir });
+    assert.equal(result.kind, 'acquired');
+    writeFileSync(`${slackTokenClaimPath(f.token, f.rootDir)}.lock`, 'busy');
+    if (result.kind === 'acquired') assert.doesNotThrow(() => result.lease.release());
+});
+
+test('17: pid reuse only blocks within the freshness window', t => {
+    const f = fixture(); t.after(() => rmSync(f.base, { recursive: true, force: true }));
+    writeClaim(f, { claimedAt: new Date(Date.now() - SLACK_TOKEN_CLAIM_FRESH_MS - 1).toISOString(), pid: process.pid });
+    const result = acquireSlackTokenClaim({ appToken: f.token, home: f.homeB, port: '', connected: true, rootDir: f.rootDir, pidAlive: () => true });
+    assert.equal(result.kind, 'acquired');
+    if (result.kind === 'acquired') result.lease.release();
+});


### PR DESCRIPTION
Closes #523 (residual scope after #533/#537).

## Problem

Two managed homes on one machine that share a Slack app token both open Socket Mode connections; Slack round-robins events across them and each home silently loses a slice of inbound. The existing `attachPort` guard cannot see this because it lives in one home's `settings.json`.

Also from the issue: `deriveCdpPort` collapsed every overflowed server port onto the shared literal 9240, and `structure/agent_spawn.md` still described `orchestrator/scope.ts` as a 17-line stub that always returns `'default'`.

## Change

**Cross-home token claim** (`src/slack/token-claim.ts`, new): a per-user claim file keyed by `sha256(appToken)` under `~/.cli-jaw-shared/slack-claims/` (0700/0600) recording `{home, port, pid, claimedAt, connected, claimId}`. Inbound is refused only on positive evidence: a different canonical home, `connected:true`, a claim younger than 90s, and a live pid. Every IO, parse, realpath, lock or pid-probe uncertainty fails open and logs; a stale or dead-pid claim is replaced. The issue thread's condition that a wrong guard must never cause total inbound loss is the design invariant, and `003_audit`-style path enumeration of every failure branch was part of review.

**Readiness ownership** (`src/slack/bot.ts`, `src/slack/socket.ts`): the socket exposes `onStateChange` and `waitForReady`; a claim becomes blocking only after Slack's `hello`. One arbiter per lifecycle generation single-flights the init-path and hello-callback arbitration and applies a `foreign_live` result once (stop socket, revoke runtime state, arm one unref'd re-check timer). A presence claim written after a readiness timeout can be replaced by another home; a late hello on the replaced holder now re-arbitrates and loses. Refresh runs only while connected; `reconnecting` marks disconnected; retry exhaustion, `disabled` and dispose release the lease; stale-generation callbacks can only release their own claim.

**Runtime activation handshake** (`src/messaging/runtime.ts`): `TransportFns.init(ctx?)` carries a start epoch; `revokeMessagingTransport(channel, reason, epoch)` compares against the epoch that activated the channel, so a revoke that lands before `runningTransports.add` is honoured and a queued Slack init keeps its caller's epoch. Notices are kept apart from transport errors; a later successful start clears them. Telegram/Discord registrations are untouched.

**Health / doctor**: `/api/health` reports `reason: 'token_shared_other_home'` with `activeInbound:false` and outbound capability preserved; `jaw doctor` (text and JSON) shows the owning home and port, never the token or its hash. Opt-out: `CLI_JAW_SLACK_ALLOW_SHARED_TOKEN=1` skips inspection and acquisition (logged once per process).

**deriveCdpPort**: overflow rotates deterministically inside 1024–65535 instead of returning 9240.

**Docs**: `structure/{agent_spawn,str_func,telegram,server_api,infra}.md`, root `AGENTS.md` sync line.

## Verification

- `tests/run.mts` on slack-token-claim, slack-lifecycle, slack-inbound, messaging-runtime, messaging-transport-capability, slack-operator-tooling, browser-port: 143/143.
- New real two-runtime lifecycle test (two child processes, real claim module, mocked Slack API/socket) fails on the pre-fix commit (`stopped 0 !== 1`) and passes after it.
- `npm run typecheck`, `bash structure/verify-counts.sh`, private-boundary index and `--range origin/dev HEAD`, `git diff --check`: all pass.
- Two independent review rounds (path-by-path fail-open enumeration, readiness races, epoch handshake): round 1 FAIL → fixes → round 2 PASS.

Known limitation: pid reuse inside the 90-second freshness window is an advisory-lock false positive by design; the stale timestamp bounds it.
