### PR TITLE
fix(docs-check): match wrapped broadcast() calls in the websocket drift scan

### DIFF
--- a/structure/check-doc-drift.sh
+++ b/structure/check-doc-drift.sh
@@ -484,7 +484,9 @@ function collectTsFiles(dir) {
 const actual = new Set();
 for (const file of ['server.ts', ...collectTsFiles('src')]) {
   const text = fs.readFileSync(file, 'utf8');
-  for (const match of text.matchAll(/broadcast\('([^']+)'/g)) {
+  // The first argument may sit on its own line when the call is wrapped
+  // (src/agent/events/helpers.ts), so allow whitespace after the paren.
+  for (const match of text.matchAll(/broadcast\(\s*'([^']+)'/g)) {
     actual.add(match[1]);
   }
 }


### PR DESCRIPTION
## Problem

`bash structure/check-doc-drift.sh` (part of `gate:all`, local-only since `gate:doc-drift` is skipped on CI) reports on current `dev`:

```
❌ server_api.md — websocket event list drifted
  counts: doc 55 vs actual 54
  extra events:
    - agent_tool
```

`agent_tool` is still live: the only remaining publisher after #598 is the wrapped call in `src/agent/events/helpers.ts:78-82` (`broadcast(\n    'agent_tool',`), and the scan's regex `/broadcast\('([^']+)'/` only matched a single-line form. `origin/main` (v2.17.40) passes because it still had single-line `broadcast('agent_tool', ...)` calls in the retired Jawcode adapter.

## Change

Allow whitespace between the paren and the quoted event name. All four drift checks pass on `dev`; no doc rows change.

## Verification

- `bash structure/check-doc-drift.sh`: 4/4 pass.
- `npm run gate:all` on this branch: 23/23 (run locally; the doc-drift gate is CI-skipped).
