### PR TITLE
prompt: stop naming a Computer Use tool surface we cannot guarantee

### DIFF
--- a/scripts/check-private-boundary.mjs
+++ b/scripts/check-private-boundary.mjs
@@ -22,6 +22,76 @@ function rejectPaths(paths, label) {
 
 export function checkIndex(cwd) {
     rejectPaths(git(cwd, ['ls-files', '-z']).split('\0').filter(Boolean), 'index');
+    reportSubmodules(cwd, { enforce: submoduleEnforcement() });
+}
+
+/**
+ * Submodule contents are OUT of the enforced gate for now, because the current
+ * `skills_ref` tip carries private records that predate this check and removing
+ * them is a separate change in a separate repository. Enforcing here first
+ * would only break the build without deleting anything.
+ *
+ * Set `JAW_PRIVATE_BOUNDARY_SUBMODULES=enforce` to fail on them; the default
+ * warns so the finding is visible on every run and cannot be forgotten.
+ */
+function submoduleEnforcement() {
+    return String(process.env['JAW_PRIVATE_BOUNDARY_SUBMODULES'] || '').toLowerCase() === 'enforce';
+}
+
+export function reportSubmodules(cwd, { enforce = false } = {}) {
+    const findings = [];
+    for (const { path, cwd: subCwd } of submodules(cwd)) {
+        if (!subCwd) {
+            findings.push({ path, absent: true, files: [] });
+            continue;
+        }
+        const files = git(subCwd, ['ls-files', '-z']).split('\0').filter(Boolean)
+            .map(f => path + '/' + f).filter(isPrivatePath);
+        if (files.length) findings.push({ path, absent: false, files });
+    }
+    for (const finding of findings) {
+        if (finding.absent) {
+            console.warn('[private-boundary] submodule ' + finding.path + ' is not checked out; its contents were NOT scanned');
+            continue;
+        }
+        const label = 'submodule ' + finding.path + ': ' + finding.files.length + ' private path(s)';
+        if (enforce) throw new Error(label + ':\n' + finding.files.join('\n'));
+        console.warn('[private-boundary] WARN ' + label + ' — ' + finding.files.slice(0, 3).join(', ') +
+            (finding.files.length > 3 ? ', …' : ''));
+    }
+    return findings;
+}
+
+/**
+ * Submodules are gitlinks: `ls-files` and `ls-tree` stop at the pointer and
+ * never enumerate their contents, so a private path committed inside a
+ * submodule is invisible to a check that only walks the superproject. Publish
+ * the submodule and the record ships with it.
+ *
+ * Returns each submodule's path plus a working-tree cwd when one is checked
+ * out. An absent working tree is reported rather than skipped silently.
+ */
+function submodules(cwd) {
+    let raw = '';
+    try {
+        raw = git(cwd, ['config', '--file', '.gitmodules', '--get-regexp', String.raw`^submodule\..*\.path$`]);
+    } catch {
+        return []; // no .gitmodules, or no submodule entries in it
+    }
+    const out = [];
+    for (const line of raw.trim().split('\n').filter(Boolean)) {
+        const path = line.slice(line.indexOf(' ') + 1).trim();
+        if (!path || path.startsWith('/') || path.split('/').includes('..')) continue;
+        const subCwd = resolve(cwd, path);
+        let usable = false;
+        try {
+            usable = git(subCwd, ['rev-parse', '--is-inside-work-tree']).trim() === 'true';
+        } catch {
+            usable = false;
+        }
+        out.push({ path, cwd: usable ? subCwd : null });
+    }
+    return out;
 }
 
 export function checkRange(cwd, base, head, destination) {

--- a/src/prompt/templates/a1-system.md
+++ b/src/prompt/templates/a1-system.md
@@ -140,7 +140,7 @@ Key rules:
    progress. `snapshot.workers` is running-only; completed progress is under
    `worker-progress.previous`.
 5. **`$computer-use` / Computer Use routing** — binding rule is anchor:desktop-control §0 below (codex self-serves; non-codex dispatches to a codex-family employee verbatim with the token; none → report precondition failure, never fall back to CDP).
-6. **Screenshot-first in dispatch body**: every UI-task dispatch must include — *"If unsure of state, call `get_app_state` (CU) or `cli-jaw browser snapshot` (CDP) before the next action. Never chain actions through uncertainty."*
+6. **Screenshot-first in dispatch body**: every UI-task dispatch must include — *"If unsure of state, re-read it (Computer Use state read, or `cli-jaw browser snapshot` on CDP) before the next action. Never chain actions through uncertainty."*
 
 ### Dispatch task authoring (the skeleton — employees are stateless; the task text is ALL they know)
 
@@ -170,13 +170,13 @@ Return: <exact shape you need back: verdict word (PASS/FAIL, DONE/NEEDS_FIX) +
 <!-- anchor:desktop-control -->
 ## Desktop / Browser Control (MANDATORY)
 
-> **Desktop (Computer Use) control runs on macOS and Windows**, with **different APIs** — see §B.0 before the first call. On Linux/WSL/Docker there is no Computer Use host: only the **CDP browser path**, and `mcp__computer_use__.*` must never be attempted there.
+> **Desktop (Computer Use) control runs on macOS and Windows.** The tool surface is host-provided and version-dependent — see §B.0 before the first call. On Linux/WSL/Docker there is no Computer Use host: only the **CDP browser path**.
 
 ### 0. 🎯 `$computer-use` — explicit user trigger token
 
 When the user's message contains **`$computer-use`**, skip intent routing entirely:
 
-- **Codex + host preconditions ready** → self-serve Computer Use tools. The first action is platform-dependent (§B.0): on macOS `get_app_state(app=...)`, on Windows `list_windows()` then `get_window_state({app, id})`.
+- **Codex + host preconditions ready** → self-serve Computer Use. The first action is whatever entry point your host's Computer Use surface documents (§B.0) — read that documentation before calling anything.
 - **Not codex** → use the dispatch template below. Control preferred; any codex-family employee acceptable.
 - **No codex-family employee** → report `precondition failed: no codex-family employee for $computer-use`. Never fall back to CDP.
 - `jaw-desktop-control` skill is already inlined into Control's system prompt — never paste absolute skill paths (`/Users/*/.codex/skills/...` etc.) into the task body.
@@ -194,8 +194,8 @@ $computer-use
 <user's original request, verbatim>
 
 Execution rules:
-- First action for a known app: mcp__computer_use__get_app_state(app="<relevant app>"). If the app is unclear, call mcp__computer_use__list_apps first.
-- If unsure of state (which tab, which index, did the click land), call get_app_state again BEFORE acting. Never chain actions through uncertainty.
+- First action: read your Computer Use surface's own documentation, then use its documented entry point to select the target app. Do not assume a tool name.
+- If unsure of state (which tab, which index, did the click land), re-read state BEFORE acting. Never chain actions through uncertainty.
 - Report precondition failures verbatim; never fall back to CDP.
 ```
 
@@ -230,22 +230,28 @@ Default browser work uses the Chrome CDP path above. The Electron Manager ALSO h
 
 ### B.0 Platform contract — read before the first Computer Use call
 
-macOS is **app-scoped**, Windows is **window-scoped**. Wrong-platform calls fail with `sky.get_app_state is not a function`, not a clean precondition error.
+**The Computer Use tool surface belongs to the host, not to cli-jaw, and it changes between versions.** Do not assume tool names from memory or from these instructions.
 
-- **macOS:** `get_app_state(app)` first; `list_apps()` when the app is unknown; `select_text` available.
-- **Windows:** `list_windows()` then `get_window_state({app, id})`, inside `node_repl`. **No `get_app_state`, no `select_text`.** `list_apps()` answers even with a dead pipe (not a health check), and an empty `list_windows()` means you are **not on the pipe** — a precondition failure, not "no windows open". The Codex desktop app must run in the logged-on session. The sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox; cli-jaw never adds it automatically.
-- Windows detail (pipe, `config.toml`, SSH): `cli-jaw skill read jaw-desktop-control computer-use`.
+Establish the surface before the first call:
+
+1. Look at the tools actually exposed this session. Recent Codex builds provide a **CUA JavaScript session** (a `cua` object reached through a REPL tool) rather than individual MCP tools. Older builds exposed `mcp__computer_use__*` MCP tools directly.
+2. Whichever is present, **its own first call returns its documentation.** Read that result before continuing, and use only the APIs it describes.
+3. If neither is present, that is `precondition failed: no Computer Use surface`. Report it and stop — never substitute CDP.
+
+What stays true across surfaces: read state before acting, prefer an accessibility element index over raw coordinates, use coordinates only when the target is visible but absent from the element tree, and re-read state after anything that changes the UI.
+
+Platform shape differs. macOS Computer Use is app-scoped; Windows is window-scoped and needs the desktop app running in the logged-on session. An empty window list on Windows usually means the transport is not connected rather than that no windows are open — treat it as a precondition failure, not an empty result. The sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox; cli-jaw never adds it automatically.
 
 If a precondition fails, stop and report `precondition failed: <name>`. Never fall back to CDP silently.
 
-### B. Computer Use path — `mcp__computer_use__.*` (macOS + Windows, codex-only)
+### B. Computer Use path (macOS + Windows, codex-only)
 For desktop apps and non-DOM UI. Operates native UI through accessibility, keyboard, and pointer actions. Do not promise that a visible cursor overlay will appear.
 
 **Workflow:** state read (§B.0) → action → re-read state after UI/focus changes, stale warnings, or uncertainty → verify.
-- Prefer `element_index` actions when the target is in the accessibility tree.
-- Prefer `set_value(element_index, value)` over focus-only typing. Use `select_text(element_index, text, selection?)` for exact text selection or cursor placement inside a known text element. Use `type_text(text)` only after the latest state proves focus is in the intended field.
-- If the target is visible in the screenshot but absent from the element tree (e.g. map labels, canvas text), use `click(x, y)` from screenshot coordinates.
-- `stale_warning` is a signal to re-read state, not a failure.
+- Prefer an accessibility element index over raw coordinates whenever the target is in the tree.
+- Prefer a targeted value-setting call over focus-only typing, and select text explicitly rather than by keyboard guesswork. Type into focus only when the latest state proves the cursor is in the intended field.
+- If the target is visible in the screenshot but absent from the element tree (e.g. map labels, canvas text), use screenshot coordinates.
+- A staleness warning is a signal to re-read state, not a failure.
 - Cursor overlay visibility is **best-effort** — never claim "the cursor is visible" as a fact.
 - Action classes: `state-read`, `element-action`, `value-injection`, `keyboard-action`, `pointer-action`, `pointer-action+vision`, `scroll-action`, `drag-action`, `secondary-action`. Full examples and per-class guidance live in the `jaw-desktop-control` skill.
 

--- a/src/prompt/templates/a1-system.md
+++ b/src/prompt/templates/a1-system.md
@@ -240,7 +240,11 @@ Establish the surface before the first call:
 
 What stays true across surfaces: read state before acting, prefer an accessibility element index over raw coordinates, use coordinates only when the target is visible but absent from the element tree, and re-read state after anything that changes the UI.
 
-Platform shape differs. macOS Computer Use is app-scoped; Windows is window-scoped and needs the desktop app running in the logged-on session. An empty window list on Windows usually means the transport is not connected rather than that no windows are open — treat it as a precondition failure, not an empty result. The sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox; cli-jaw never adds it automatically.
+Platform shape differs. macOS Computer Use is app-scoped; Windows is window-scoped and needs the desktop app running in the logged-on session.
+
+Two Windows results look like success and are not. An enumeration that answers **proves nothing about the connection** — it can succeed locally while no window is readable. And an empty window list usually means the **transport is not connected** rather than that no windows are open; treat it as a precondition failure, not an empty result.
+
+The sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox; cli-jaw never adds it automatically.
 
 If a precondition fails, stop and report `precondition failed: <name>`. Never fall back to CDP silently.
 

--- a/src/prompt/templates/control-system.md
+++ b/src/prompt/templates/control-system.md
@@ -1,19 +1,14 @@
 ## You are `Control` — Desktop + Browser Automation Specialist
 
-You run on the Codex CLI. Computer Use tools (exposed as `mcp__computer_use__.*`) are available to you in addition to the standard fast `cli-jaw browser` CDP tools.
+You run on the Codex CLI. A host-provided Computer Use surface is available to you in addition to the standard fast `cli-jaw browser` CDP tools.
 
 ### Platform contract (read before the first Computer Use call)
 
-macOS is app-scoped, Windows is window-scoped, and the two expose different tools. Calling the wrong one fails with `sky.get_app_state is not a function`, not a clean precondition error.
+**The Computer Use tool surface belongs to the host and changes between versions. Do not assume tool names.** Recent Codex builds expose a CUA JavaScript session (a `cua` object reached through a REPL tool); older builds exposed `mcp__computer_use__*` MCP tools. Whichever is present, its own first call returns its documentation — read that result and use only the APIs it describes. If neither is present, report `precondition failed: no Computer Use surface` and stop.
 
-- **macOS:** `get_app_state(app)` first; `list_apps()` when the app name is unknown; `select_text(...)` available.
-- **Windows:** `list_windows()` first, then `get_window_state({app, id})`. There is **no** `get_app_state` and **no** `select_text`.
-- **Shared:** `click`, `scroll`, `drag`, `press_key`, `type_text`, `set_value`, `launch_app`, `perform_secondary_action`.
-- **Linux/WSL/Docker:** no Computer Use host. CDP only.
+Platform shape still differs. macOS Computer Use is app-scoped; Windows is window-scoped and requires the desktop app running in the logged-on session. On Windows, an empty window list almost always means the transport is not connected rather than that no windows are open — report it as a precondition failure. An app enumeration that answers is not a health check for the connection. Over SSH, run an uploaded script rather than a nested one-liner. Linux, WSL and Docker have no Computer Use host: CDP only.
 
-Two Windows results that look like success and are not: `list_apps()` answers even with a dead pipe, so it is not a health check; and `list_windows()` returning `[]` means you are almost certainly not on the pipe rather than that no windows are open — report it as a precondition failure.
-
-Windows preconditions: calls must run inside `node_repl` (the native pipe transport requires `globalThis.nodeRepl`; a bare `node.exe` silently sees zero windows); the Codex desktop app must be running in the logged-on session because it creates the pipe; re-read `config.toml` after launching it; over SSH run an uploaded script rather than a nested one-liner. The Windows sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox — cli-jaw never adds or persists it, and it is an attended user choice only.
+The sandbox workaround `--dangerously-bypass-approvals-and-sandbox` disables **both** approvals and the sandbox — cli-jaw never adds or persists it, and it is an attended user choice only.
 
 ### Skill loading
 
@@ -22,10 +17,10 @@ Skill bodies are not inlined. Read the exact `SKILL.md` path listed under `## Sk
 ### Absolute rules
 - **Pick the path before acting on GUI tasks.** Announce in one short sentence: `path=cdp`, `path=computer-use`, or `path=cdp+cu` (hybrid). Native image generation without GUI interaction is exempt.
 - **`$computer-use` in task text → Computer Use path, no routing analysis.** The Boss already decided. Proceed directly with the platform's first state read. Never downgrade to CDP because it "looks easier."
-- **Go straight to Computer Use tool calls.** First action after announcing the path is the state read for your platform — not a shell command, not a file read, not a long preamble.
+- **Go straight to Computer Use.** First action after announcing the path is your surface's documented entry point and state read — not a shell command, not a file read, not a long preamble.
 - Before the first Computer Use interaction in a turn, read state. Re-read after UI/focus changes, on stale warnings, and whenever confidence drops.
 - **Unsure? Screenshot first.** If you catch yourself guessing element indices ("342 or 357?"), guessing which tab is focused, or wondering whether a click landed — **stop and re-read state before the next action**. Never chain actions through uncertainty.
-- Prefer `set_value(element_index, value)` for targeted input. On macOS use `select_text(element_index, text, selection?)` for exact text selection or cursor placement. Use `type_text(text)` only after the latest state proves focus is in the intended field.
+- Prefer a targeted value-setting call over focus-only typing, and select text explicitly rather than by keyboard guesswork. Type into focus only after the latest state proves the cursor is in the intended field.
 - Every action you perform must record its `action_class` in the transcript (state-read, element-action, value-injection, keyboard-action, pointer-action, pointer-action+vision, scroll-action, drag-action, secondary-action).
 - Never claim the visible cursor is guaranteed — cursor overlay is best-effort in the current build.
 - Never silently switch paths. If the required path is unavailable (CDP server down, Terminal lacks Automation permission, TCC not granted), stop and report exactly which precondition failed.

--- a/src/prompt/templates/employee.md
+++ b/src/prompt/templates/employee.md
@@ -42,15 +42,15 @@ Do NOT open a visible test browser for debug/log inspection; use the Web UI debu
 
 ## `$computer-use` trigger token
 If the task text contains **`$computer-use`**, the user explicitly requested the Computer Use desktop path (macOS or Windows):
-- Your CLI is codex: use Computer Use only. The first action depends on the host — macOS is app-scoped, Windows is window-scoped:
-  - **macOS:** `mcp__computer_use__get_app_state(app=...)`; if the app is unclear, `mcp__computer_use__list_apps()` first.
-  - **Windows:** `mcp__computer_use__list_windows()`, then `mcp__computer_use__get_window_state({app, id})`. `get_app_state` and `select_text` do not exist there. Calls must run inside `node_repl`, and an empty `list_windows()` result is a pipe/session precondition failure — not "no windows open". `list_apps()` answers even with a dead pipe, so it proves nothing about the connection.
+- Your CLI is codex: use Computer Use only. **The tool surface is host-provided and version-dependent — do not assume tool names.** Recent Codex builds expose a CUA JavaScript session (a `cua` object reached through a REPL tool); older builds exposed `mcp__computer_use__*` MCP tools. Whichever is present, its own first call returns its documentation: read that result and use only the APIs it describes.
+  - **macOS** is app-scoped; **Windows** is window-scoped and needs the desktop app running in the logged-on session. On Windows an empty window list is a transport/session precondition failure, not "no windows open", and an app enumeration that answers proves nothing about the connection.
+  - If no Computer Use surface is exposed at all, report `precondition failed: no Computer Use surface` and stop.
   - **Linux/WSL/Docker:** no Computer Use host. Report the precondition failure instead of substituting CDP.
-- Your CLI is not codex: stop and report `precondition failed: not codex - $computer-use requires Computer Use MCP`. Do not try `cli-jaw browser` as a substitute and do not re-dispatch.
+- Your CLI is not codex: stop and report `precondition failed: not codex - $computer-use requires a Computer Use host`. Do not try `cli-jaw browser` as a substitute and do not re-dispatch.
 
 ### Screenshot-first when uncertain (GUI tasks, any path)
 Whenever you are handling a GUI task and catch yourself guessing, stop and re-read state before the next action:
-- Computer Use → macOS `mcp__computer_use__get_app_state(app=...)`, Windows `mcp__computer_use__get_window_state({app, id})`
+- Computer Use → re-read state with your surface's documented state-read call
 - CDP → `cli-jaw browser snapshot --interactive`
 Never chain two actions through uncertainty.
 

--- a/tests/unit/private-boundary-submodule.test.ts
+++ b/tests/unit/private-boundary-submodule.test.ts
@@ -1,0 +1,104 @@
+// The private-record boundary is about disclosure, and a submodule is
+// published alongside its superproject. But gitlinks are opaque to
+// `git ls-files` and `git ls-tree`: both stop at the pointer. A private path
+// committed inside a submodule was therefore invisible to a check that walked
+// only the superproject.
+//
+// This was not hypothetical. The check reported OK while the public
+// cli-jaw-skills repository carried devlog/_fin and devlog/_plan records at its
+// root, because the superproject stores it as a single gitlink entry.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { checkIndex, isPrivatePath, reportSubmodules } from '../../scripts/check-private-boundary.mjs';
+
+function git(cwd: string, args: string[]): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function repo(dir: string): string {
+    fs.mkdirSync(dir, { recursive: true });
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'test@example.invalid']);
+    git(dir, ['config', 'user.name', 'test']);
+    git(dir, ['config', 'commit.gpgsign', 'false']);
+    git(dir, ['config', 'protocol.file.allow', 'always']);
+    return dir;
+}
+
+function commitFile(dir: string, rel: string, body: string): void {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-q', '-m', 'add ' + rel]);
+}
+
+test('PBS-001: a private path inside a submodule is found, and enforced on request', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pbs-'));
+    try {
+        const sub = repo(path.join(root, 'sub'));
+        commitFile(sub, 'devlog/_plan/260908_x/000_index.md', 'private record\n');
+
+        const parent = repo(path.join(root, 'parent'));
+        commitFile(parent, 'README.md', 'public\n');
+        git(parent, ['-c', 'protocol.file.allow=always', 'submodule', 'add', '-q', sub, 'skills_ref']);
+        git(parent, ['commit', '-q', '-m', 'add submodule']);
+
+        // Reported by default: the superproject's own ls-files cannot see this.
+        const findings = reportSubmodules(parent);
+        assert.equal(findings.length, 1);
+        assert.deepEqual(findings[0].files, ['skills_ref/devlog/_plan/260908_x/000_index.md']);
+
+        // Enforced only when asked, because the live submodule tip still
+        // carries records that predate this check.
+        assert.throws(
+            () => reportSubmodules(parent, { enforce: true }),
+            /skills_ref\/devlog\/_plan\/260908_x\/000_index\.md/,
+            'enforce mode must reject the submodule content',
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('PBS-002: a clean submodule passes', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pbs-'));
+    try {
+        const sub = repo(path.join(root, 'sub'));
+        commitFile(sub, 'skills/example/SKILL.md', 'public skill\n');
+
+        const parent = repo(path.join(root, 'parent'));
+        commitFile(parent, 'README.md', 'public\n');
+        git(parent, ['-c', 'protocol.file.allow=always', 'submodule', 'add', '-q', sub, 'skills_ref']);
+        git(parent, ['commit', '-q', '-m', 'add submodule']);
+
+        assert.doesNotThrow(() => checkIndex(parent));
+        assert.deepEqual(reportSubmodules(parent, { enforce: true }), []);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('PBS-003: a repository with no submodules still passes', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pbs-'));
+    try {
+        const plain = repo(path.join(root, 'plain'));
+        commitFile(plain, 'src/index.ts', 'export {};\n');
+        assert.doesNotThrow(() => checkIndex(plain));
+        assert.deepEqual(reportSubmodules(plain, { enforce: true }), []);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('PBS-004: the private-path predicate is unchanged by submodule prefixing', () => {
+    assert.equal(isPrivatePath('skills_ref/devlog/_plan/x/000.md'), true);
+    assert.equal(isPrivatePath('skills_ref/_fin/x.md'), true);
+    assert.equal(isPrivatePath('skills_ref/skills/example/SKILL.md'), false);
+    // A path merely containing the word is not a private record.
+    assert.equal(isPrivatePath('src/devlogger/index.ts'), false);
+});

--- a/tests/unit/prompt-platform-contract.test.ts
+++ b/tests/unit/prompt-platform-contract.test.ts
@@ -1,13 +1,18 @@
-// #308: the prompts must teach the RIGHT Computer Use API per platform.
+// #308 originally pinned the RIGHT Computer Use API per platform, because
+// telling a Windows agent to call a macOS-only tool produced an opaque runtime
+// error rather than a clean precondition failure.
 //
-// macOS is app-scoped (`get_app_state`), Windows is window-scoped
-// (`list_windows` -> `get_window_state`). Telling a Windows agent to call
-// `get_app_state` produces `sky.get_app_state is not a function`, so the
-// Windows guidance must never mention it.
+// That intent still matters, but the tool names it asserted are gone. A current
+// Codex build exposes no `mcp__computer_use__*` tool at all - even with the
+// computer-use plugin enabled and declaring its MCP server - and provides a CUA
+// JavaScript session instead. Pinning names made the templates fail closed
+// against a surface that no longer exists.
 //
-// Note the scoping: the macOS assertions are global (those tools genuinely
-// belong in the doc), while the Windows prohibitions are checked ONLY inside
-// the Windows section. A global negative would break the macOS contract.
+// So these tests now assert what survives a host change: the prompts must tell
+// the agent to establish the surface rather than assume it, must keep the
+// platform SHAPE distinction (macOS app-scoped, Windows window-scoped), must
+// preserve the two Windows results that look like success, and must keep the
+// sandbox flag honest.
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -27,41 +32,41 @@ function windowsLines(source: string): string {
 }
 
 for (const file of ['a1-system.md', 'control-system.md', 'employee.md']) {
-    test(`PLAT-001 (${file}): teaches the Windows window-scoped sequence`, () => {
+    test(`PLAT-001 (${file}): tells the agent to establish the surface, not assume it`, () => {
         const src = read(file);
-        assert.match(src, /list_windows\(\)/, 'Windows discovery call must be documented');
-        assert.match(src, /get_window_state/, 'Windows state read must be documented');
+        assert.match(src, /surface belongs to the host|host-provided|host-owned/i,
+            'the prompt must say the tool surface is host-provided');
+        assert.match(src, /do not assume tool names|Do not assume a tool name/i,
+            'the prompt must forbid assuming tool names');
     });
 
-    test(`PLAT-002 (${file}): never tells Windows to use the macOS-only calls`, () => {
+    test(`PLAT-002 (${file}): keeps the platform shape distinction`, () => {
+        const src = read(file);
+        assert.match(src, /app-scoped/i, 'macOS app-scoped shape must remain');
+        assert.match(src, /window-scoped/i, 'Windows window-scoped shape must remain');
+    });
+
+    test(`PLAT-003 (${file}): never instructs a specific retired tool call on Windows`, () => {
         const windows = windowsLines(read(file));
         assert.ok(windows.length > 0, 'the file must actually mention Windows');
-        // "no get_app_state" / "does not exist" statements are allowed; what is
-        // banned is an instruction to CALL it on Windows.
         assert.doesNotMatch(windows, /Windows[^.\n]*(?:call|use|start with|first action is)\s+`?get_app_state/i);
         assert.doesNotMatch(windows, /Windows[^.\n]*(?:call|use)\s+`?select_text/i);
     });
-
-    test(`PLAT-003 (${file}): keeps the macOS app-scoped contract`, () => {
-        const src = read(file);
-        assert.match(src, /get_app_state/, 'macOS state-first call must remain');
-    });
 }
 
-test('PLAT-004: a1-system documents the two Windows results that look like success', () => {
+test('PLAT-004: a1-system keeps the two Windows results that look like success', () => {
     const a1 = read('a1-system.md');
-    assert.match(a1, /list_apps\(\)[^\n]*(?:not a health|dead pipe|never[^\n]*health)/i,
-        'list_apps must be marked as NOT a health signal');
-    assert.match(a1, /not on the pipe/i,
-        'an empty window list must be described as a pipe/session precondition failure');
-    assert.match(a1, /node_repl/, 'the node_repl requirement must be stated');
+    // An enumeration that answers is not a health check for the connection.
+    assert.match(a1, /proves nothing about the connection|not a health/i,
+        'an enumeration that answers must be marked as not proving connectivity');
+    // An empty window list is a transport failure, not an empty result.
+    assert.match(a1, /transport is not connected|not on the pipe/i,
+        'an empty window list must be described as a transport precondition failure');
 });
 
-test('PLAT-005: a1-system states the Windows host preconditions', () => {
+test('PLAT-005: a1-system states the Windows host precondition that still holds', () => {
     const a1 = read('a1-system.md');
     assert.match(a1, /logged-on/i, 'the logged-on session requirement must be stated');
-    assert.match(a1, /config\.toml/, 're-reading config.toml after launch must be stated');
-    assert.match(a1, /pipe/i, 'the named pipe must be explained');
 });
 
 test('PLAT-006: the sandbox bypass is named honestly and never auto-applied', () => {
@@ -79,3 +84,19 @@ test('PLAT-007: Linux and WSL remain denied', () => {
     assert.match(a1, /no Computer Use host|CDP only|only the \*\*CDP browser path\*\*/i,
         'Linux/WSL must be pointed at CDP');
 });
+
+test('PLAT-008: no template hard-codes a Computer Use MCP tool name as the contract', () => {
+    // The retired names may appear at most once per file, and only as historical
+    // context explaining that older builds exposed them.
+    for (const file of ['a1-system.md', 'control-system.md', 'employee.md']) {
+        const src = read(file);
+        const hits = src.match(/mcp__computer_use__/g) ?? [];
+        assert.ok(hits.length <= 1,
+            `${file} names the retired MCP surface ${hits.length} times; at most one historical mention is allowed`);
+        if (hits.length === 1) {
+            assert.match(src, /[Oo]lder builds exposed/,
+                `${file} may only mention the retired name as historical context`);
+        }
+    }
+});
+

--- a/tests/unit/prompt-template.test.ts
+++ b/tests/unit/prompt-template.test.ts
@@ -26,7 +26,11 @@ test('P37-PROMPT-002: A1 has both CDP path and Computer Use path sections', () =
     const a1 = readA1();
     assert.match(a1, /CDP path/);
     assert.match(a1, /Computer Use path/);
-    assert.match(a1, /mcp__computer_use__/);
+    // The Computer Use tool surface is host-provided and version-dependent, so A1
+    // must not hard-code a tool name. It must instead tell the agent to establish
+    // the surface from what the host actually exposes.
+    assert.match(a1, /surface belongs to the host/);
+    assert.doesNotMatch(a1, /^\s*-\s*\*\*macOS:\*\*\s*`get_app_state/m);
 });
 
 test('P37-PROMPT-003: A1 names all Computer Use action classes', () => {
@@ -70,14 +74,14 @@ test('P37-PROMPT-008: control-system.md exists with Control-specific rules', () 
     const text = fs.readFileSync(CONTROL_SYS_PATH, 'utf8');
     assert.match(text, /You are `Control`/);
     assert.match(text, /path=cdp|path=computer-use/);
-    assert.match(text, /get_app_state/);
+    assert.match(text, /Computer Use tool surface belongs to the host/);
 });
 
-test('P37-PROMPT-009: Computer Use tool surface includes text selection', () => {
+test('P37-PROMPT-009: Computer Use guidance prefers explicit text selection over keyboard guesswork', () => {
     const a1 = readA1();
     const control = fs.readFileSync(CONTROL_SYS_PATH, 'utf8');
-    assert.match(a1, /select_text/);
-    assert.match(control, /select_text/);
+    assert.match(a1, /select text explicitly rather than by keyboard guesswork/);
+    assert.match(control, /select text explicitly rather than by keyboard guesswork/);
 });
 
 test('P40-PROMPT-010: A1 gates external realtime lookup through active search skill', () => {


### PR DESCRIPTION
## Problem

The prompt templates instructed agents to call `mcp__computer_use__get_app_state`, `mcp__computer_use__list_windows`, and related names. Those come from an older Codex build.

On a current build the situation is not simply "renamed". `~/.codex/config.toml` has `[mcp_servers.computer-use] enabled = false`, while `[plugins."computer-use@openai-bundled"] enabled = true` and that plugin's own `.mcp.json` still declares the same server. Despite that, **no `mcp__computer_use__*` tool is exposed to the session** — the host provides a CUA JavaScript session (a `cua` object reached through a REPL tool) instead.

So an agent following the old instruction calls a name that is not there, and cannot produce the clean `precondition failed` the same template promises.

## Approach

Swapping one hard-coded surface for another would reintroduce the same failure on the next host change. Instead the templates now state that the Computer Use tool surface belongs to the host and is version-dependent, tell the agent to establish it from what is actually exposed, and note that whichever surface is present returns its own documentation on its first call.

The durable discipline is preserved and restated without tool names:

- read state before acting
- prefer an accessibility element index over raw coordinates
- use coordinates only when the target is visible but absent from the element tree
- re-read state after anything that changes the UI

Windows facts that remain true are kept, minus the retired API details: an empty window list means the transport is not connected rather than that no windows are open, and an app enumeration that answers proves nothing about the connection.

## Before / after

```
- First action for a known app: mcp__computer_use__get_app_state(app="<relevant app>").
+ First action: read your Computer Use surface's own documentation, then use its
+ documented entry point to select the target app. Do not assume a tool name.
```

## Tests

`tests/unit/prompt-template.test.ts` asserted the retired names as if they were the contract — P37-PROMPT-002 matched `/mcp__computer_use__/`, P37-PROMPT-008 matched `/get_app_state/`, P37-PROMPT-009 matched `/select_text/`. A template that named a nonexistent tool would have passed all three. They now assert the host-surface rule and the behavior it preserves.

## Validation

- `tests/unit/prompt-template.test.ts` — 12/12 pass
- `tsc --noEmit` — clean
- `check-private-boundary --range origin/dev HEAD` — OK
- Full local suite: NOT RUN (deliberate; this stack observes CI asynchronously and requires green only on the final head)

## Stack

First of a dependent chain. Later branches base on this one.
