### PR TITLE
test(slack): wait for two-home fixtures to exit before cleanup

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.41-preview.20260908151812",
+  "version": "2.17.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.41-preview.20260908151812",
+      "version": "2.17.41",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.41-preview.20260908151812",
+  "version": "2.17.41",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.41-preview.20260908151812",
+  "version": "2.17.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.41-preview.20260908151812",
+      "version": "2.17.41",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.41-preview.20260908151812",
+  "version": "2.17.41",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Slack, Telegram, and Discord interfaces with 33 skills active by default from a 230-skill reference library",
   "type": "module",
   "keywords": [

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -453,11 +453,20 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
     const entry = join(import.meta.dirname!, '..', 'fixtures', 'slack-two-home-lifecycle.ts');
     const tsx = join(import.meta.dirname!, '..', '..', 'node_modules', '.bin', 'tsx');
     const children: ChildProcessWithoutNullStreams[] = [];
+    const exited = new Map<ChildProcessWithoutNullStreams, Promise<void>>();
+    const rmQuiet = (path: string) => {
+        // A child still winding down can recreate a lock file between the
+        // recursive listing and the rmdir (ENOTEMPTY on CI). Retry once after
+        // the children are gone; a leftover temp dir is not a test failure.
+        for (let attempt = 0; attempt < 3; attempt++) {
+            try { rmSync(path, { recursive: true, force: true }); return; } catch { /* retry */ }
+        }
+    };
     t.after(() => {
-        for (const child of children) child.kill();
-        rmSync(sharedHome, { recursive: true, force: true });
-        rmSync(homeA, { recursive: true, force: true });
-        rmSync(homeB, { recursive: true, force: true });
+        for (const child of children) if (child.exitCode === null) child.kill();
+        rmQuiet(sharedHome);
+        rmQuiet(homeA);
+        rmQuiet(homeB);
     });
 
     const start = (childHome: string, port: string, initialHello: boolean) => {
@@ -472,6 +481,7 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
             stdio: ['pipe', 'pipe', 'pipe'],
         });
         children.push(child);
+        exited.set(child, new Promise<void>(resolve => child.once('exit', () => resolve())));
         let buffered = '';
         const waiters: Array<(value: Record<string, unknown>) => void> = [];
         child.stdout.setEncoding('utf8');
@@ -520,4 +530,11 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
 
     a.child.stdin.write('shutdown\n');
     b.child.stdin.write('shutdown\n');
+    // Both fixtures release their leases and exit on shutdown; wait for the
+    // reports and the process exits so cleanup never races a live child.
+    await a.next();
+    await b.next();
+    a.child.stdin.end();
+    b.child.stdin.end();
+    await Promise.all([exited.get(a.child), exited.get(b.child)]);
 });


### PR DESCRIPTION
## Problem

The promotion of v2.17.41 stopped at the preview CI gate: `test 3/4` on `47d1ffb5` failed in `l real lifecycle: late hello loses a replaced presence claim` with `ENOTEMPTY: directory not empty, rmdir .../slack-claims` ([run 34195260622](https://github.com/lidge-jun/cli-jaw/actions/runs/34195260622)). The after-hook killed the two child fixtures and removed the shared claims root in the same tick; on the runner the children were still releasing their leases, so the recursive delete raced a lock file. The product path under test passed (the assertions before cleanup all held).

## Change

Wait for both fixtures' `shutdown` reports and process exits before cleanup, and tolerate a transient cleanup failure (a leftover temp dir is not a product signal). This branch is based on `origin/preview` (`47d1ffb5`, the stable bump commit) so `dev` catches up to the preview head as the release procedure requires.

## Verification

- `tests/unit/slack-lifecycle.test.ts` 26/26, three consecutive local runs, no leftover `~/.cljaw-*` dirs.
