### PR TITLE
vision: replace the regex extractor with a brace scanner

### DIFF
--- a/src/browser/actions.ts
+++ b/src/browser/actions.ts
@@ -2,6 +2,7 @@ import { getActivePage, getCdpSession, getBrowserStateVersion, markBrowserStateC
 import { JAW_HOME } from '../core/config.js';
 import { join } from 'path';
 import fs from 'fs';
+import { imageSize } from './image-size.js';
 import type { ConsoleMessage, Locator, Page, Request } from 'playwright-core';
 
 const SCREENSHOTS_DIR = join(JAW_HOME, 'screenshots');
@@ -255,9 +256,18 @@ export async function screenshot(port: number, opts: BrowserActionOptions = {}) 
         await page.screenshot({ path: filepath, fullPage: optionBoolean(opts, 'fullPage'), type, ...(clip ? { clip } : {}) });
     }
     const dpr = await page.evaluate('window.devicePixelRatio');
-    const viewport = page.viewportSize();
-    return { path: filepath, dpr, viewport, ...(clip ? { clip } : {}) };
+    // `viewportSize()` is null under connectOverCDP, which Playwright attaches
+    // with noDefaultViewport. Fall back to the page's own measurement so
+    // callers that need a frame get one.
+    const viewport = page.viewportSize()
+        ?? await page.evaluate('({ width: window.innerWidth, height: window.innerHeight })') as { width: number; height: number };
+    // The size of the file that was actually written, which is what a model
+    // sees. A clip is trimmed to the viewport before capture, so the requested
+    // rectangle is not a reliable stand-in.
+    const image = imageSize(filepath);
+    return { path: filepath, dpr, viewport, ...(image ? { image } : {}), ...(clip ? { clip } : {}) };
 }
+
 
 function normalizeClip(value: unknown): ClipRect | undefined {
     if (!value) return undefined;

--- a/src/browser/grounding-candidate.ts
+++ b/src/browser/grounding-candidate.ts
@@ -1,0 +1,218 @@
+/**
+ * src/browser/grounding-candidate.ts — the shape a grounding answer takes, and
+ * how it is recovered from model output.
+ *
+ * Two things were wrong with the previous extractor, and both are structural
+ * rather than cosmetic.
+ *
+ * It matched with `/\{[^{}]*"found"...\}/`. The `[^{}]*` class cannot cross a
+ * nested object, so a well-formed `{"found":true,"bbox":{...},"point":{...}}`
+ * could never match at all — the richer schema was unreachable no matter what
+ * the model returned. It also required canonical key order and rejected
+ * negative numbers.
+ *
+ * And nothing bounded the coordinate. A hallucinated `{"x":99999}` was
+ * converted and clicked.
+ *
+ * On bbox: it is carried for verification, cropping, and size sanity — NOT as
+ * an accuracy mechanism. A controlled comparison (GUI-Actor, same training
+ * recipe) scores bbox output below point output, so asking a model for a box
+ * does not make its answer better. The box earns its place by letting us
+ * reconcile against element geometry and re-crop for a second look.
+ */
+
+export type Point = { x: number; y: number };
+export type BBox = { x: number; y: number; width: number; height: number };
+export type Viewport = { width: number; height: number };
+
+export type CandidateKind = 'grounding_bbox' | 'coordinate' | 'not_found';
+
+export type GroundingCandidate = {
+    schemaVersion: 'grounding-candidate-v1';
+    found: boolean;
+    kind: CandidateKind;
+    bbox: BBox | null;
+    point: Point;
+    /** 0..1. Not comparable across providers; use it for gating, not for ranking. */
+    confidence: number;
+    description?: string;
+    reason?: string;
+    /** Machine-readable caveats, e.g. `point_only`, `out_of_bounds`. */
+    riskFlags: string[];
+};
+
+/** Below this, a candidate must be verified before it is acted on. */
+export const LOW_CONFIDENCE_THRESHOLD = 0.75;
+
+/** A point-only answer carries no extent, so it starts as a coin flip. */
+const POINT_ONLY_CONFIDENCE = 0.5;
+const BBOX_CONFIDENCE = 0.8;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function finiteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizePoint(value: unknown): Point | null {
+    if (!isRecord(value)) return null;
+    const x = finiteNumber(value['x']);
+    const y = finiteNumber(value['y']);
+    return x === null || y === null ? null : { x, y };
+}
+
+function normalizeBBox(value: unknown): BBox | null {
+    if (!isRecord(value)) return null;
+    const x = finiteNumber(value['x']);
+    const y = finiteNumber(value['y']);
+    const width = finiteNumber(value['width']);
+    const height = finiteNumber(value['height']);
+    if (x === null || y === null || width === null || height === null) return null;
+    // A zero-area box carries no extent, which is the only thing a box is for.
+    if (width <= 0 || height <= 0) return null;
+    return { x, y, width, height };
+}
+
+function centerOfBBox(bbox: BBox): Point {
+    return { x: Math.round(bbox.x + bbox.width / 2), y: Math.round(bbox.y + bbox.height / 2) };
+}
+
+function clampConfidence(value: unknown, fallback: number): number {
+    const n = finiteNumber(value);
+    return n === null ? fallback : Math.max(0, Math.min(1, n));
+}
+
+/**
+ * Accepts the current shape and the legacy `{found,x,y}` one.
+ *
+ * A legacy answer is normalized rather than rejected, but it is marked:
+ * `kind: 'coordinate'`, `point_only` in riskFlags, and a confidence that fails
+ * the gate. It says where to click without saying how big the thing is, and
+ * that difference should survive into the decision.
+ */
+export function normalizeCandidate(raw: unknown): GroundingCandidate | null {
+    if (!isRecord(raw)) return null;
+    if (typeof raw['found'] !== 'boolean') return null;
+
+    if (!raw['found']) {
+        return {
+            schemaVersion: 'grounding-candidate-v1',
+            found: false,
+            kind: 'not_found',
+            bbox: null,
+            point: { x: 0, y: 0 },
+            confidence: 0,
+            description: typeof raw['description'] === 'string' ? raw['description'] : 'not found',
+            reason: typeof raw['reason'] === 'string' ? raw['reason'] : 'target_not_found',
+            riskFlags: [],
+        };
+    }
+
+    const bbox = normalizeBBox(raw['bbox']);
+    const explicitPoint = normalizePoint(raw['point']);
+    const legacyPoint = normalizePoint(raw); // top-level {x, y}
+    const point = explicitPoint ?? legacyPoint ?? (bbox ? centerOfBBox(bbox) : null);
+    if (!point) return null;
+
+    const pointOnly = !bbox;
+    const candidate: GroundingCandidate = {
+        schemaVersion: 'grounding-candidate-v1',
+        found: true,
+        kind: bbox ? 'grounding_bbox' : 'coordinate',
+        bbox,
+        point,
+        confidence: clampConfidence(raw['confidence'], pointOnly ? POINT_ONLY_CONFIDENCE : BBOX_CONFIDENCE),
+        riskFlags: pointOnly ? ['point_only'] : [],
+    };
+    if (typeof raw['description'] === 'string') candidate.description = raw['description'];
+    if (typeof raw['reason'] === 'string') candidate.reason = raw['reason'];
+    return candidate;
+}
+
+/**
+ * Scan out balanced top-level JSON objects, tracking string state and escapes
+ * so a brace inside a string literal does not open or close a span.
+ *
+ * This replaces a regex that could not represent nesting at all.
+ */
+export function extractJsonObjects(text: string): string[] {
+    const objects: string[] = [];
+    let start = -1;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (escaped) { escaped = false; continue; }
+        if (inString && ch === '\\') { escaped = true; continue; }
+        if (ch === '"') { inString = !inString; continue; }
+        if (inString) continue;
+        if (ch === '{') {
+            if (depth === 0) start = i;
+            depth += 1;
+        } else if (ch === '}') {
+            if (depth === 0) continue; // stray closer
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+                objects.push(text.slice(start, i + 1));
+                start = -1;
+            }
+        }
+    }
+    return objects;
+}
+
+/**
+ * Recover a candidate from arbitrary model text.
+ *
+ * Scans from the end: the answer is the last thing said, and earlier objects
+ * are usually reasoning or echoed input.
+ */
+export function parseCandidate(text: string): GroundingCandidate | null {
+    const objects = extractJsonObjects(text);
+    for (let i = objects.length - 1; i >= 0; i--) {
+        let parsed: unknown;
+        try { parsed = JSON.parse(objects[i] as string); } catch { continue; }
+        const candidate = normalizeCandidate(parsed);
+        if (candidate) return candidate;
+    }
+    return null;
+}
+
+/**
+ * Reject a point that cannot be on screen.
+ *
+ * The old path converted and clicked whatever came back, so a hallucinated
+ * coordinate produced a click at an arbitrary place. Bounds are checked in the
+ * candidate's own frame — image pixels when a clip was captured, otherwise the
+ * viewport scaled by device pixel ratio.
+ */
+export function validateCandidate(
+    candidate: GroundingCandidate,
+    frame: { width: number; height: number },
+): GroundingCandidate {
+    if (!candidate.found) return candidate;
+    const { x, y } = candidate.point;
+    const inside = x >= 0 && y >= 0 && x <= frame.width && y <= frame.height;
+    if (inside) return candidate;
+    return {
+        ...candidate,
+        found: false,
+        kind: 'not_found',
+        confidence: 0,
+        reason: `point (${x}, ${y}) is outside the ${frame.width}x${frame.height} capture`,
+        riskFlags: [...candidate.riskFlags, 'out_of_bounds'],
+    };
+}
+
+/** A candidate that must be verified before it is acted on. */
+export function isLowConfidence(
+    candidate: GroundingCandidate,
+    threshold = LOW_CONFIDENCE_THRESHOLD,
+): boolean {
+    return candidate.confidence < threshold || candidate.riskFlags.includes('point_only');
+}
+

--- a/src/browser/grounding-candidate.ts
+++ b/src/browser/grounding-candidate.ts
@@ -48,6 +48,17 @@ export const LOW_CONFIDENCE_THRESHOLD = 0.75;
 const POINT_ONLY_CONFIDENCE = 0.5;
 const BBOX_CONFIDENCE = 0.8;
 
+/**
+ * Beyond this, a coordinate is not a plausible screen position. Finiteness is
+ * too weak a gate: `1e308` is finite, and a bbox that size yields a center of
+ * `5e307` which then flows into a click.
+ */
+export const MAX_PLAUSIBLE_COORDINATE = 100_000;
+
+function plausible(n: number): boolean {
+    return Math.abs(n) <= MAX_PLAUSIBLE_COORDINATE;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
@@ -60,7 +71,8 @@ function normalizePoint(value: unknown): Point | null {
     if (!isRecord(value)) return null;
     const x = finiteNumber(value['x']);
     const y = finiteNumber(value['y']);
-    return x === null || y === null ? null : { x, y };
+    if (x === null || y === null) return null;
+    return plausible(x) && plausible(y) ? { x, y } : null;
 }
 
 function normalizeBBox(value: unknown): BBox | null {
@@ -72,6 +84,8 @@ function normalizeBBox(value: unknown): BBox | null {
     if (x === null || y === null || width === null || height === null) return null;
     // A zero-area box carries no extent, which is the only thing a box is for.
     if (width <= 0 || height <= 0) return null;
+    // A box larger than any screen is a confused answer, not a big target.
+    if (![x, y, width, height].every(plausible)) return null;
     return { x, y, width, height };
 }
 
@@ -116,6 +130,13 @@ export function normalizeCandidate(raw: unknown): GroundingCandidate | null {
     const point = explicitPoint ?? legacyPoint ?? (bbox ? centerOfBBox(bbox) : null);
     if (!point) return null;
 
+    // Two stated locations that disagree is evidence of a confused answer.
+    // Prefer the richer field, but say so rather than resolving it silently.
+    const disagrees = Boolean(
+        explicitPoint && legacyPoint &&
+        (explicitPoint.x !== legacyPoint.x || explicitPoint.y !== legacyPoint.y),
+    );
+
     const pointOnly = !bbox;
     const candidate: GroundingCandidate = {
         schemaVersion: 'grounding-candidate-v1',
@@ -124,7 +145,10 @@ export function normalizeCandidate(raw: unknown): GroundingCandidate | null {
         bbox,
         point,
         confidence: clampConfidence(raw['confidence'], pointOnly ? POINT_ONLY_CONFIDENCE : BBOX_CONFIDENCE),
-        riskFlags: pointOnly ? ['point_only'] : [],
+        riskFlags: [
+            ...(pointOnly ? ['point_only'] : []),
+            ...(disagrees ? ['conflicting_point'] : []),
+        ],
     };
     if (typeof raw['description'] === 'string') candidate.description = raw['description'];
     if (typeof raw['reason'] === 'string') candidate.reason = raw['reason'];
@@ -132,34 +156,62 @@ export function normalizeCandidate(raw: unknown): GroundingCandidate | null {
 }
 
 /**
- * Scan out balanced top-level JSON objects, tracking string state and escapes
- * so a brace inside a string literal does not open or close a span.
+ * Scan out balanced JSON objects, tracking string state and escapes so a brace
+ * inside a string literal does not open or close a span.
  *
- * This replaces a regex that could not represent nesting at all.
+ * Emits nested objects as well as depth-0 ones, innermost first within a span.
+ * Models routinely wrap the answer — `{"result":{...}}`, `{"candidates":[...]}`
+ * — and a depth-0-only scan silently loses those, which the regex it replaced
+ * happened to handle.
+ *
+ * A stray quote is the hard case. Model text quotes page content ("the 15\"
+ * monitor"), and stdout truncation can cut inside a string literal, either of
+ * which leaves an odd quote count that inverts string tracking for everything
+ * after it. Tracking from the start of the text would then hide the real
+ * answer entirely, so the scan is also run from each subsequent `{` as a
+ * fresh origin, and any span that parses is kept.
  */
 export function extractJsonObjects(text: string): string[] {
+    const found = new Set<string>();
+    const out: string[] = [];
+    for (const span of scanFrom(text, 0)) {
+        if (!found.has(span)) { found.add(span); out.push(span); }
+    }
+    // Re-scan from each opening brace. A prior stray quote can only desync the
+    // tracker to the LEFT of a given origin, so restarting recovers the spans
+    // it swallowed. Bounded to keep a pathological input from going quadratic.
+    let origins = 0;
+    for (let i = 0; i < text.length && origins < MAX_RESCAN_ORIGINS; i++) {
+        if (text[i] !== '{') continue;
+        origins += 1;
+        for (const span of scanFrom(text, i)) {
+            if (!found.has(span)) { found.add(span); out.push(span); }
+        }
+    }
+    return out;
+}
+
+/** Restart budget for the stray-quote recovery above. */
+const MAX_RESCAN_ORIGINS = 64;
+
+function scanFrom(text: string, from: number): string[] {
     const objects: string[] = [];
-    let start = -1;
-    let depth = 0;
+    const starts: number[] = [];
     let inString = false;
     let escaped = false;
 
-    for (let i = 0; i < text.length; i++) {
+    for (let i = from; i < text.length; i++) {
         const ch = text[i];
         if (escaped) { escaped = false; continue; }
         if (inString && ch === '\\') { escaped = true; continue; }
         if (ch === '"') { inString = !inString; continue; }
         if (inString) continue;
         if (ch === '{') {
-            if (depth === 0) start = i;
-            depth += 1;
+            starts.push(i);
         } else if (ch === '}') {
-            if (depth === 0) continue; // stray closer
-            depth -= 1;
-            if (depth === 0 && start !== -1) {
-                objects.push(text.slice(start, i + 1));
-                start = -1;
-            }
+            const start = starts.pop();
+            if (start === undefined) continue; // stray closer
+            objects.push(text.slice(start, i + 1));
         }
     }
     return objects;
@@ -168,18 +220,31 @@ export function extractJsonObjects(text: string): string[] {
 /**
  * Recover a candidate from arbitrary model text.
  *
- * Scans from the end: the answer is the last thing said, and earlier objects
- * are usually reasoning or echoed input.
+ * Prefers a located answer over a not-found one, and only then prefers the
+ * later of two equally useful candidates.
+ *
+ * Ordering alone is not enough here. The prompt itself contains a literal
+ * `{"found":false,...}` template, so any echo of the instructions parses as a
+ * perfectly valid not-found answer — and taking simply the last one turns a
+ * successful lookup into "target not found". Preferring `found: true` is what
+ * actually resolves that, not the scan direction.
+ *
+ * A malformed span is skipped rather than aborting the scan: a stray quote in
+ * quoted page text can desynchronize string tracking for the rest of the
+ * input, so a later object may be the only parseable one.
  */
 export function parseCandidate(text: string): GroundingCandidate | null {
     const objects = extractJsonObjects(text);
+    let fallback: GroundingCandidate | null = null;
     for (let i = objects.length - 1; i >= 0; i--) {
         let parsed: unknown;
         try { parsed = JSON.parse(objects[i] as string); } catch { continue; }
         const candidate = normalizeCandidate(parsed);
-        if (candidate) return candidate;
+        if (!candidate) continue;
+        if (candidate.found) return candidate;
+        fallback ??= candidate;
     }
-    return null;
+    return fallback;
 }
 
 /**
@@ -215,4 +280,3 @@ export function isLowConfidence(
 ): boolean {
     return candidate.confidence < threshold || candidate.riskFlags.includes('point_only');
 }
-

--- a/src/browser/image-size.ts
+++ b/src/browser/image-size.ts
@@ -1,0 +1,55 @@
+/**
+ * src/browser/image-size.ts — read pixel dimensions from a capture file.
+ *
+ * Kept out of actions.ts so it can be tested without the CDP layer.
+ *
+ * This exists because the bounds check needs the frame the model actually saw.
+ * The requested clip is not that frame: Playwright trims a clip to the viewport
+ * before capture, and the route accepts an array clip whose `.width` is
+ * undefined — and comparing a number against `undefined` is always false, so
+ * such a bound looks present while checking nothing.
+ */
+import fs from 'fs';
+
+/**
+ * Returns null when the size cannot be read. Callers must fail closed on null:
+ * a plausible-looking default would be worse than admitting it is unknown.
+ */
+export function imageSize(filepath: string): { width: number; height: number } | null {
+    let head: Buffer;
+    try {
+        const fd = fs.openSync(filepath, 'r');
+        try {
+            const buffer = Buffer.alloc(65536);
+            const read = fs.readSync(fd, buffer, 0, buffer.length, 0);
+            head = buffer.subarray(0, read);
+        } finally {
+            fs.closeSync(fd);
+        }
+    } catch { return null; }
+
+    // PNG: 8-byte signature, then an IHDR chunk whose data begins at byte 16.
+    if (head.length >= 24 && head.readUInt32BE(0) === 0x89504e47) {
+        return { width: head.readUInt32BE(16), height: head.readUInt32BE(20) };
+    }
+
+    // JPEG: walk the segment chain to a start-of-frame marker.
+    if (head.length >= 4 && head[0] === 0xff && head[1] === 0xd8) {
+        let i = 2;
+        while (i + 9 < head.length) {
+            if (head[i] !== 0xff) { i += 1; continue; }
+            const marker = head[i + 1] as number;
+            // Standalone markers carry no length field.
+            if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) { i += 2; continue; }
+            const length = head.readUInt16BE(i + 2);
+            if (length < 2) return null; // malformed chain
+            // SOF0..SOF15, excluding DHT (c4), JPG (c8) and DAC (cc).
+            if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+                return { height: head.readUInt16BE(i + 5), width: head.readUInt16BE(i + 7) };
+            }
+            i += 2 + length;
+        }
+    }
+    return null;
+}
+

--- a/src/browser/vision.ts
+++ b/src/browser/vision.ts
@@ -6,7 +6,7 @@ import { spawn } from 'child_process';
 import { StringDecoder } from 'string_decoder';
 import { screenshot, mouseClick, snapshot } from './actions.js';
 import { sanitizeTarget, appendBounded } from './vision-input.js';
-import { parseCandidate, type GroundingCandidate } from './grounding-candidate.js';
+import { parseCandidate, validateCandidate, type GroundingCandidate } from './grounding-candidate.js';
 
 export { sanitizeTarget, appendBounded, MAX_TARGET_LENGTH, MAX_CODEX_STDOUT_BYTES } from './vision-input.js';
 export * from './grounding-candidate.js';
@@ -196,21 +196,29 @@ export async function visionClick(port: number, target: string, opts: VisionClic
         return { success: false, reason: 'target not found', provider: result.provider };
     }
 
-    // 2b. Bound the answer in its own frame before converting it. The frame is
-    // the captured image: a clip's own size, otherwise the viewport scaled by
-    // device pixel ratio. Without this a hallucinated coordinate was converted
-    // and clicked at an arbitrary place on the page.
-    const frame = clip
-        ? { width: clip.width * dpr, height: clip.height * dpr }
-        : viewportProbe.viewport
-            ? { width: viewportProbe.viewport.width * dpr, height: viewportProbe.viewport.height * dpr }
-            : null;
-    if (frame && (result.x < 0 || result.y < 0 || result.x > frame.width || result.y > frame.height)) {
+    // 2b. Bound the answer in the frame it was actually given: the pixel size
+    // of the file the model saw. The requested clip is not a stand-in — it is
+    // trimmed to the viewport before capture, and it can arrive as an array
+    // whose `.width` is undefined. Comparing against `undefined` is always
+    // false, which is how a bound can look present and check nothing.
+    //
+    // This fails CLOSED. If the capture size cannot be read, the coordinate is
+    // unverifiable and the click does not happen.
+    const frame = ss.image ?? null;
+    if (!frame) {
         return {
             success: false,
-            reason: `point (${result.x}, ${result.y}) is outside the ${frame.width}x${frame.height} capture`,
+            reason: 'capture size unavailable, so the coordinate could not be bounds-checked',
             provider: result.provider,
         };
+    }
+    const checked = validateCandidate(
+        { schemaVersion: 'grounding-candidate-v1', found: true, kind: 'coordinate', bbox: null,
+          point: { x: result.x, y: result.y }, confidence: 1, riskFlags: [] },
+        frame,
+    );
+    if (!checked.found) {
+        return { success: false, reason: checked.reason ?? 'out of bounds', provider: result.provider };
     }
 
     // 3. DPR correction: image pixels → CSS pixels

--- a/src/browser/vision.ts
+++ b/src/browser/vision.ts
@@ -6,8 +6,10 @@ import { spawn } from 'child_process';
 import { StringDecoder } from 'string_decoder';
 import { screenshot, mouseClick, snapshot } from './actions.js';
 import { sanitizeTarget, appendBounded } from './vision-input.js';
+import { parseCandidate, type GroundingCandidate } from './grounding-candidate.js';
 
 export { sanitizeTarget, appendBounded, MAX_TARGET_LENGTH, MAX_CODEX_STDOUT_BYTES } from './vision-input.js';
+export * from './grounding-candidate.js';
 
 export interface VisionClickOptions {
     provider?: 'codex';
@@ -38,16 +40,14 @@ function recordText(record: JsonRecord, key: string): string | null {
     return typeof value === 'string' ? value : null;
 }
 
-function parseVisionCoordinates(value: unknown): VisionCoordinates | null {
-    if (!isRecord(value)) return null;
-    if (typeof value["found"] !== 'boolean') return null;
-    if (typeof value["x"] !== 'number' || typeof value["y"] !== 'number') return null;
+/** Project the candidate onto the legacy coordinate shape this module returns. */
+function toVisionCoordinates(candidate: GroundingCandidate): VisionCoordinates {
     return {
-        found: value["found"],
-        x: value["x"],
-        y: value["y"],
+        found: candidate.found,
+        x: candidate.point.x,
+        y: candidate.point.y,
         provider: 'codex',
-        ...(typeof value["description"] === 'string' ? { description: value["description"] } : {}),
+        ...(candidate.description ? { description: candidate.description } : {}),
     };
 }
 
@@ -131,20 +131,19 @@ function codexVision(screenshotPath: string, target: string): Promise<VisionCoor
             try {
                 const lines = stdout.split('\n').filter(l => l.trim());
 
-                // Scan ALL events for coordinate JSON (agent_message, command output, etc.)
-                // Codex is agentic — JSON may appear in any event type
-                for (const line of lines.reverse()) { // Reverse: last message most likely has the answer
+                // Scan events newest-first: the answer is the last thing said.
+                // codex is agentic, so the JSON can land in any event type.
+                for (const line of lines.reverse()) {
                     try {
                         const event: unknown = JSON.parse(line);
                         const textsToSearch = collectEventTexts(event);
 
                         for (const text of textsToSearch) {
-                            // Try to extract {"found":...,"x":...,"y":...} from text
-                            const jsonMatch = text.match(/\{[^{}]*"found"\s*:\s*(true|false)[^{}]*"x"\s*:\s*\d+[^{}]*"y"\s*:\s*\d+[^{}]*\}/);
-                            if (jsonMatch) {
-                                const coords = parseVisionCoordinates(JSON.parse(jsonMatch[0]));
-                                if (coords) return resolve(coords);
-                            }
+                            // A brace scanner rather than a regex: the previous
+                            // pattern's [^{}]* class could not cross a nested
+                            // object, so a bbox-carrying answer never matched.
+                            const candidate = parseCandidate(text);
+                            if (candidate) return resolve(toVisionCoordinates(candidate));
                         }
                     } catch { /* skip non-JSON lines */ }
                 }
@@ -195,6 +194,23 @@ export async function visionClick(port: number, target: string, opts: VisionClic
 
     if (!result.found) {
         return { success: false, reason: 'target not found', provider: result.provider };
+    }
+
+    // 2b. Bound the answer in its own frame before converting it. The frame is
+    // the captured image: a clip's own size, otherwise the viewport scaled by
+    // device pixel ratio. Without this a hallucinated coordinate was converted
+    // and clicked at an arbitrary place on the page.
+    const frame = clip
+        ? { width: clip.width * dpr, height: clip.height * dpr }
+        : viewportProbe.viewport
+            ? { width: viewportProbe.viewport.width * dpr, height: viewportProbe.viewport.height * dpr }
+            : null;
+    if (frame && (result.x < 0 || result.y < 0 || result.x > frame.width || result.y > frame.height)) {
+        return {
+            success: false,
+            reason: `point (${result.x}, ${result.y}) is outside the ${frame.width}x${frame.height} capture`,
+            provider: result.provider,
+        };
     }
 
     // 3. DPR correction: image pixels → CSS pixels

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -379,6 +379,8 @@ cli-jaw/
 │   │   ├── primitives.ts     ← low-level CDP primitives (294L)
 │   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore) + guardrail options (251L)
 │   │   ├── vision-input.ts   ← 미신뢰 target 정화(quote-run 붕괴, 제로폭/bidi 제거, surrogate-safe 절단) + stdout 상한 (80L)
+│   │   ├── grounding-candidate.ts ← grounding-candidate-v1 스키마 + brace 스캐너(중첩/stray-quote 복구) + 좌표 타당성/경계 검증 (282L)
+│   │   ├── image-size.ts     ← PNG/JPEG 헤더에서 캡처 픽셀 크기 판독(실패 시 null → fail-closed) (55L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)
 │   │   ├── runtime-owner-store.ts ← runtime owner store (55L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -375,9 +375,9 @@ cli-jaw/
 │   ├── browser/              ← Chrome CDP 제어 + web-ai 자동화 + adaptive-fetch
 │   │   ├── connection.ts     ← Chrome 탐지/launch/CDP 연결 + readiness polling + retry + headless + runtime diagnostics/orphan cleanup + activePort/active-tab 상태 관리 (820L)
 │   │   ├── launch-policy.ts  ← browser start mode 정규화 + agent/debug/manual launch policy (51L)
-│   │   ├── actions.ts        ← snapshot/click/type/navigate/screenshot + browser primitive actions (516L)
+│   │   ├── actions.ts        ← snapshot/click/type/navigate/screenshot + browser primitive actions (526L)
 │   │   ├── primitives.ts     ← low-level CDP primitives (294L)
-│   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore) + guardrail options (243L)
+│   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore) + guardrail options (251L)
 │   │   ├── vision-input.ts   ← 미신뢰 target 정화(quote-run 붕괴, 제로폭/bidi 제거, surrogate-safe 절단) + stdout 상한 (80L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -377,7 +377,7 @@ cli-jaw/
 │   │   ├── launch-policy.ts  ← browser start mode 정규화 + agent/debug/manual launch policy (51L)
 │   │   ├── actions.ts        ← snapshot/click/type/navigate/screenshot + browser primitive actions (516L)
 │   │   ├── primitives.ts     ← low-level CDP primitives (294L)
-│   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore) + guardrail options (227L)
+│   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore) + guardrail options (243L)
 │   │   ├── vision-input.ts   ← 미신뢰 target 정화(quote-run 붕괴, 제로폭/bidi 제거, surrogate-safe 절단) + stdout 상한 (80L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)

--- a/tests/unit/grounding-candidate.test.ts
+++ b/tests/unit/grounding-candidate.test.ts
@@ -1,0 +1,193 @@
+// The old extractor used /\{[^{}]*"found"...\}/. That class cannot cross a
+// nested object, so a well-formed {found, bbox:{...}, point:{...}} response was
+// unmatchable no matter what the model returned - the richer schema was
+// unreachable by construction, not by choice.
+//
+// These tests attack the scanner rather than confirm it: braces inside strings,
+// escaped quotes, unbalanced input, and the ordering that decides which object
+// wins when a model emits several.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    extractJsonObjects,
+    normalizeCandidate,
+    parseCandidate,
+    validateCandidate,
+    isLowConfidence,
+    LOW_CONFIDENCE_THRESHOLD,
+} from '../../src/browser/grounding-candidate.ts';
+
+test('GC-001: the nested shape the old regex could never match', () => {
+    const text = '{"found":true,"bbox":{"x":10,"y":20,"width":30,"height":40},"point":{"x":25,"y":40},"confidence":0.9}';
+    const c = parseCandidate(text);
+    assert.ok(c, 'a nested object must parse');
+    assert.equal(c.kind, 'grounding_bbox');
+    assert.deepEqual(c.bbox, { x: 10, y: 20, width: 30, height: 40 });
+    assert.deepEqual(c.point, { x: 25, y: 40 });
+    assert.equal(c.confidence, 0.9);
+    assert.deepEqual(c.riskFlags, []);
+});
+
+test('GC-002: braces inside strings do not open or close a span', () => {
+    const text = '{"found":true,"x":5,"y":6,"description":"the { button } widget"}';
+    const c = parseCandidate(text);
+    assert.ok(c);
+    assert.equal(c.description, 'the { button } widget');
+    assert.deepEqual(c.point, { x: 5, y: 6 });
+});
+
+test('GC-003: escaped quotes do not end the string', () => {
+    const text = String.raw`{"found":true,"x":1,"y":2,"description":"a \"quoted\" label"}`;
+    const c = parseCandidate(text);
+    assert.ok(c);
+    assert.equal(c.description, 'a "quoted" label');
+});
+
+test('GC-004: an escaped backslash before a quote still terminates the string', () => {
+    // "path\\" ends the string; a naive escape tracker reads it as an escaped
+    // quote and swallows the rest of the object.
+    const text = String.raw`{"found":true,"x":3,"y":4,"description":"path\\"}`;
+    const c = parseCandidate(text);
+    assert.ok(c, 'the object must still close');
+    assert.deepEqual(c.point, { x: 3, y: 4 });
+});
+
+test('GC-005: prose and markdown fences around the answer are ignored', () => {
+    const text = 'Let me look at the screenshot.\n\n\u0060\u0060\u0060json\n{"found":true,"x":7,"y":8}\n\u0060\u0060\u0060\nThat is the button.';
+    const c = parseCandidate(text);
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 7, y: 8 });
+});
+
+test('GC-006: the LAST valid object wins', () => {
+    // Models restate. The answer is what they said last, not first.
+    const text = '{"found":false,"x":0,"y":0} then reconsidered {"found":true,"x":9,"y":9}';
+    const c = parseCandidate(text);
+    assert.ok(c);
+    assert.equal(c.found, true);
+    assert.deepEqual(c.point, { x: 9, y: 9 });
+});
+
+test('GC-007: key order does not matter', () => {
+    const c = parseCandidate('{"y":2,"description":"d","x":1,"found":true}');
+    assert.ok(c, 'the old regex required found -> x -> y in that order');
+    assert.deepEqual(c.point, { x: 1, y: 2 });
+});
+
+test('GC-008: negative and fractional coordinates parse', () => {
+    const c = parseCandidate('{"found":true,"x":-5,"y":12.5}');
+    assert.ok(c, 'the old regex required \\d+ and rejected these');
+    assert.deepEqual(c.point, { x: -5, y: 12.5 });
+});
+
+test('GC-009: unbalanced or truncated input yields nothing rather than throwing', () => {
+    assert.equal(parseCandidate('{"found":true,"x":1'), null);
+    assert.equal(parseCandidate('}}}{{{'), null);
+    assert.equal(parseCandidate(''), null);
+    assert.equal(parseCandidate('no json at all'), null);
+    assert.deepEqual(extractJsonObjects('{"a":1'), []);
+    assert.deepEqual(extractJsonObjects('}{'), []);
+});
+
+test('GC-010: a point-only answer is accepted but marked', () => {
+    const c = parseCandidate('{"found":true,"x":4,"y":5}');
+    assert.ok(c);
+    assert.equal(c.kind, 'coordinate');
+    assert.equal(c.bbox, null);
+    assert.ok(c.riskFlags.includes('point_only'));
+    assert.ok(isLowConfidence(c), 'a point-only answer must fail the gate');
+});
+
+test('GC-011: a bbox without a point derives its center', () => {
+    const c = parseCandidate('{"found":true,"bbox":{"x":10,"y":10,"width":20,"height":40}}');
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 20, y: 30 });
+    assert.equal(c.kind, 'grounding_bbox');
+});
+
+test('GC-012: a zero-area bbox is not a bbox', () => {
+    // A box with no extent carries no information a point does not.
+    const c = parseCandidate('{"found":true,"bbox":{"x":1,"y":1,"width":0,"height":5},"x":3,"y":4}');
+    assert.ok(c);
+    assert.equal(c.bbox, null);
+    assert.equal(c.kind, 'coordinate');
+    assert.ok(c.riskFlags.includes('point_only'));
+});
+
+test('GC-013: not-found carries a reason and never a coordinate', () => {
+    const c = parseCandidate('{"found":false,"description":"no such control"}');
+    assert.ok(c);
+    assert.equal(c.kind, 'not_found');
+    assert.equal(c.confidence, 0);
+    assert.equal(c.reason, 'target_not_found');
+});
+
+test('GC-014: confidence is clamped, not trusted', () => {
+    assert.equal(normalizeCandidate({ found: true, x: 1, y: 1, confidence: 5 })?.confidence, 1);
+    assert.equal(normalizeCandidate({ found: true, x: 1, y: 1, confidence: -2 })?.confidence, 0);
+    assert.equal(normalizeCandidate({ found: true, x: 1, y: 1, confidence: 'high' })?.confidence, 0.5);
+    assert.equal(normalizeCandidate({ found: true, x: 1, y: 1, confidence: NaN })?.confidence, 0.5);
+});
+
+test('GC-015: malformed candidates are rejected', () => {
+    assert.equal(normalizeCandidate(null), null);
+    assert.equal(normalizeCandidate([]), null);
+    assert.equal(normalizeCandidate({ x: 1, y: 1 }), null, 'found is required');
+    assert.equal(normalizeCandidate({ found: 'yes', x: 1, y: 1 }), null, 'found must be boolean');
+    assert.equal(normalizeCandidate({ found: true }), null, 'a found candidate needs a location');
+    assert.equal(normalizeCandidate({ found: true, x: Infinity, y: 1 }), null);
+});
+
+test('GC-016: an out-of-bounds point is rejected before it can be clicked', () => {
+    // The old path converted and clicked whatever came back.
+    const c = parseCandidate('{"found":true,"x":99999,"y":99999}');
+    assert.ok(c);
+    const checked = validateCandidate(c, { width: 1280, height: 800 });
+    assert.equal(checked.found, false);
+    assert.equal(checked.kind, 'not_found');
+    assert.ok(checked.riskFlags.includes('out_of_bounds'));
+    assert.match(checked.reason ?? '', /outside the 1280x800 capture/);
+});
+
+test('GC-017: an in-bounds point passes through untouched', () => {
+    const c = parseCandidate('{"found":true,"bbox":{"x":0,"y":0,"width":10,"height":10},"point":{"x":5,"y":5},"confidence":0.95}');
+    assert.ok(c);
+    assert.deepEqual(validateCandidate(c, { width: 1280, height: 800 }), c);
+});
+
+test('GC-018: the frame edges are inclusive', () => {
+    const c = parseCandidate('{"found":true,"x":1280,"y":800}');
+    assert.ok(c);
+    assert.equal(validateCandidate(c, { width: 1280, height: 800 }).found, true);
+
+    const over = parseCandidate('{"found":true,"x":1281,"y":800}');
+    assert.ok(over);
+    assert.equal(validateCandidate(over, { width: 1280, height: 800 }).found, false);
+});
+
+test('GC-019: a negative coordinate is out of bounds', () => {
+    const c = parseCandidate('{"found":true,"x":-1,"y":10}');
+    assert.ok(c);
+    assert.equal(validateCandidate(c, { width: 1280, height: 800 }).found, false);
+});
+
+test('GC-020: validating a not-found candidate is a no-op', () => {
+    const c = parseCandidate('{"found":false}');
+    assert.ok(c);
+    assert.deepEqual(validateCandidate(c, { width: 100, height: 100 }), c);
+});
+
+test('GC-021: the confidence gate is explicit about what it gates', () => {
+    const strong = normalizeCandidate({ found: true, bbox: { x: 0, y: 0, width: 10, height: 10 }, confidence: 0.9 });
+    assert.ok(strong && !isLowConfidence(strong));
+
+    const weak = normalizeCandidate({ found: true, bbox: { x: 0, y: 0, width: 10, height: 10 }, confidence: 0.5 });
+    assert.ok(weak && isLowConfidence(weak));
+
+    // A confident point-only answer is still point-only.
+    const confidentButBlind = normalizeCandidate({ found: true, x: 1, y: 1, confidence: 1 });
+    assert.ok(confidentButBlind && isLowConfidence(confidentButBlind));
+
+    assert.equal(LOW_CONFIDENCE_THRESHOLD, 0.75);
+});
+

--- a/tests/unit/grounding-candidate.test.ts
+++ b/tests/unit/grounding-candidate.test.ts
@@ -15,6 +15,7 @@ import {
     validateCandidate,
     isLowConfidence,
     LOW_CONFIDENCE_THRESHOLD,
+    MAX_PLAUSIBLE_COORDINATE,
 } from '../../src/browser/grounding-candidate.ts';
 
 test('GC-001: the nested shape the old regex could never match', () => {
@@ -66,6 +67,70 @@ test('GC-006: the LAST valid object wins', () => {
     assert.ok(c);
     assert.equal(c.found, true);
     assert.deepEqual(c.point, { x: 9, y: 9 });
+});
+
+test('GC-006b: a located answer beats a later not-found one', () => {
+    // The prompt itself contains a literal {"found":false,...} template, so any
+    // echo of the instructions parses as a valid not-found answer. Taking
+    // simply the last object turned a successful lookup into "target not
+    // found" - scan direction alone does not resolve this.
+    const echo = '{"found":true,"x":40,"y":50} ... If not found: {"found":false,"x":0,"y":0,"description":"not found"}';
+    const c = parseCandidate(echo);
+    assert.ok(c);
+    assert.equal(c.found, true, 'the located answer must win over a trailing template');
+    assert.deepEqual(c.point, { x: 40, y: 50 });
+});
+
+test('GC-006c: a genuine not-found is still reported', () => {
+    const c = parseCandidate('I looked carefully. {"found":false,"description":"no such control"}');
+    assert.ok(c);
+    assert.equal(c.found, false);
+});
+
+test('GC-022: an answer wrapped in another object is still found', () => {
+    // Models routinely wrap. A depth-0-only scan loses these, which the regex
+    // this replaced happened to handle.
+    const wrapped = parseCandidate('{"result":{"found":true,"x":10,"y":20}}');
+    assert.ok(wrapped, 'a wrapper object must not hide the answer');
+    assert.deepEqual(wrapped.point, { x: 10, y: 20 });
+
+    const inArray = parseCandidate('{"candidates":[{"found":true,"x":1,"y":2}]}');
+    assert.ok(inArray, 'an answer inside an array must be found');
+    assert.deepEqual(inArray.point, { x: 1, y: 2 });
+
+    const deep = parseCandidate('{"a":{"b":{"c":{"found":true,"x":3,"y":4}}}}');
+    assert.ok(deep);
+    assert.deepEqual(deep.point, { x: 3, y: 4 });
+});
+
+test('GC-023: a stray quote earlier in the text does not hide the answer', () => {
+    // An unbalanced quote inverts string tracking for the remainder. Quoted
+    // page text ('the 15" monitor') does this by accident, and stdout
+    // truncation can cut inside a string literal to the same effect.
+    const c = parseCandidate('the bezel is 15" wide. {"found":true,"x":5,"y":6}');
+    assert.ok(c, 'a stray quote must not swallow the rest of the input');
+    assert.deepEqual(c.point, { x: 5, y: 6 });
+});
+
+test('GC-024: implausible coordinates are rejected at normalization', () => {
+    // Finiteness is too weak a gate: 1e308 is finite, and a bbox that size
+    // yields a center of 5e307 that would flow into a click.
+    assert.equal(normalizeCandidate({ found: true, bbox: { x: 0, y: 0, width: 1e308, height: 1e308 } }), null);
+    assert.equal(normalizeCandidate({ found: true, x: 1e12, y: 1 }), null);
+    assert.equal(normalizeCandidate({ found: true, x: -1e12, y: 1 }), null);
+    // The bound is generous enough for any real display.
+    assert.ok(normalizeCandidate({ found: true, x: MAX_PLAUSIBLE_COORDINATE, y: 1 }));
+    assert.ok(normalizeCandidate({ found: true, x: 7680, y: 4320 }), '8K must still be accepted');
+});
+
+test('GC-025: two locations that disagree are flagged, not silently resolved', () => {
+    const c = normalizeCandidate({ found: true, x: 1, y: 1, point: { x: 900, y: 900 } });
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 900, y: 900 }, 'the richer field wins');
+    assert.ok(c.riskFlags.includes('conflicting_point'), 'but the disagreement must be visible');
+
+    const agreeing = normalizeCandidate({ found: true, x: 5, y: 5, point: { x: 5, y: 5 } });
+    assert.ok(agreeing && !agreeing.riskFlags.includes('conflicting_point'));
 });
 
 test('GC-007: key order does not matter', () => {
@@ -190,4 +255,3 @@ test('GC-021: the confidence gate is explicit about what it gates', () => {
 
     assert.equal(LOW_CONFIDENCE_THRESHOLD, 0.75);
 });
-

--- a/tests/unit/image-size.test.ts
+++ b/tests/unit/image-size.test.ts
@@ -1,0 +1,69 @@
+// The bounds check is only as good as the frame it compares against. The
+// first attempt used the REQUESTED clip, which is wrong twice over: Playwright
+// trims a clip to the viewport before capture, and the route accepts an array
+// clip whose .width is undefined - and comparing a number against undefined is
+// always false, so the bound looked present and checked nothing.
+//
+// Reading the written file's own header removes both problems.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { imageSize } from '../../src/browser/image-size.ts';
+
+function tmp(name: string, bytes: Buffer): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'imgsize-'));
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, bytes);
+    return file;
+}
+
+function pngHeader(width: number, height: number): Buffer {
+    const b = Buffer.alloc(24);
+    b.writeUInt32BE(0x89504e47, 0);
+    b.writeUInt32BE(0x0d0a1a0a, 4);
+    b.writeUInt32BE(13, 8);
+    b.write('IHDR', 12, 'ascii');
+    b.writeUInt32BE(width, 16);
+    b.writeUInt32BE(height, 20);
+    return b;
+}
+
+test('IMG-001: PNG dimensions are read from the IHDR chunk', () => {
+    const file = tmp('a.png', pngHeader(1280, 800));
+    assert.deepEqual(imageSize(file), { width: 1280, height: 800 });
+});
+
+test('IMG-002: a retina capture reports device pixels, not CSS pixels', () => {
+    // This is the whole point: the model sees the file, so the file is the frame.
+    const file = tmp('r.png', pngHeader(2560, 1600));
+    assert.deepEqual(imageSize(file), { width: 2560, height: 1600 });
+});
+
+test('IMG-003: JPEG dimensions are read from the start-of-frame marker', () => {
+    const b = Buffer.from([
+        0xff, 0xd8,             // SOI
+        0xff, 0xe0, 0x00, 0x04, 0x00, 0x00,   // APP0, length 4
+        0xff, 0xc0, 0x00, 0x11, 0x08,         // SOF0, length 17, precision 8
+        0x02, 0x58,             // height 600
+        0x03, 0x20,             // width 800
+        0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    assert.deepEqual(imageSize(tmp('a.jpg', b)), { width: 800, height: 600 });
+});
+
+test('IMG-004: an unreadable or unknown file yields null rather than a guess', () => {
+    assert.equal(imageSize('/nonexistent/path/to/nothing.png'), null);
+    assert.equal(imageSize(tmp('a.txt', Buffer.from('not an image'))), null);
+    assert.equal(imageSize(tmp('t.png', Buffer.from([0x89, 0x50]))), null, 'a truncated header is not a size');
+    assert.equal(imageSize(tmp('e.png', Buffer.alloc(0))), null);
+});
+
+test('IMG-005: a JPEG with no start-of-frame yields null', () => {
+    // Callers must fail closed on null; returning a plausible-looking default
+    // would be worse than admitting the size is unknown.
+    const b = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xd9]);
+    assert.equal(imageSize(tmp('n.jpg', b)), null);
+});
+

--- a/tests/unit/vision-ndjson-stream.test.ts
+++ b/tests/unit/vision-ndjson-stream.test.ts
@@ -1,0 +1,130 @@
+// The audit that reshaped this work made one point that outlived every
+// individual fix: the tests exercised the pure modules while all three bounds
+// bypasses lived in the seam between them - codexVision's NDJSON loop and
+// visionClick's frame derivation.
+//
+// This file covers that seam's parsing half directly, using the real event
+// shapes codex emits, so a regression there fails here rather than in
+// production. The dispatch half needs a live browser and belongs with the
+// verification work later in this stack.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCandidate } from '../../src/browser/grounding-candidate.ts';
+
+/** The prompt codexVision sends carries a literal not-found template. */
+const PROMPT_ECHO = 'If not found: {"found":false,"x":0,"y":0,"description":"not found"}';
+
+/** Mirror of collectEventTexts: item.text, then item.aggregated_output. */
+function collectEventTexts(event: unknown): string[] {
+    const e = event as { item?: { text?: unknown; aggregated_output?: unknown } };
+    if (!e || typeof e !== 'object' || !e.item) return [];
+    return [e.item.text, e.item.aggregated_output].filter((t): t is string => typeof t === 'string');
+}
+
+/** Mirror of the scan in codexVision: newest event first. */
+function resolveFromStream(ndjson: string) {
+    const lines = ndjson.split('\n').filter(l => l.trim());
+    for (const line of [...lines].reverse()) {
+        let event: unknown;
+        try { event = JSON.parse(line); } catch { continue; }
+        for (const text of collectEventTexts(event)) {
+            const candidate = parseCandidate(text);
+            if (candidate) return candidate;
+        }
+    }
+    return null;
+}
+
+function agentMessage(text: string): string {
+    return JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text } });
+}
+
+test('VNS-001: a plain coordinate answer resolves from the stream', () => {
+    const stream = [
+        JSON.stringify({ type: 'thread.started', thread_id: 'x' }),
+        JSON.stringify({ type: 'turn.started' }),
+        agentMessage('{"found":true,"x":120,"y":340,"description":"submit button"}'),
+        JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 120, y: 340 });
+});
+
+test('VNS-002: an echo of the prompt template does not erase the answer', () => {
+    // This is the regression that motivated preferring a located answer: the
+    // model restates its instructions after answering.
+    const stream = [
+        agentMessage(`Found it. {"found":true,"x":40,"y":50} (${PROMPT_ECHO})`),
+        JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.equal(c.found, true, 'a trailing template must not win');
+    assert.deepEqual(c.point, { x: 40, y: 50 });
+});
+
+test('VNS-003: a later real answer supersedes an earlier one', () => {
+    const stream = [
+        agentMessage('{"found":true,"x":1,"y":1}'),
+        agentMessage('On closer look: {"found":true,"x":700,"y":220}'),
+    ].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 700, y: 220 }, 'the newest event wins');
+});
+
+test('VNS-004: a genuine not-found survives the stream', () => {
+    const stream = [agentMessage('I searched. {"found":false,"description":"no such control"}')].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.equal(c.found, false);
+});
+
+test('VNS-005: command output quoting page text does not hide the answer', () => {
+    // aggregated_output carries arbitrary text, including unbalanced quotes.
+    const stream = [
+        JSON.stringify({
+            type: 'item.completed',
+            item: { type: 'command_execution', aggregated_output: 'label: the 15" monitor' },
+        }),
+        agentMessage('{"found":true,"x":88,"y":99}'),
+    ].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 88, y: 99 });
+});
+
+test('VNS-006: an answer wrapped by the model is still recovered', () => {
+    const stream = [agentMessage('{"result":{"found":true,"x":11,"y":22}}')].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c, 'a wrapper object must not hide the answer');
+    assert.deepEqual(c.point, { x: 11, y: 22 });
+});
+
+test('VNS-007: non-JSON lines and empty events are skipped, not fatal', () => {
+    const stream = [
+        'not json at all',
+        '',
+        JSON.stringify({ type: 'turn.started' }),
+        JSON.stringify({ type: 'item.completed', item: { type: 'reasoning' } }),
+        agentMessage('{"found":true,"x":3,"y":4}'),
+    ].join('\n');
+    const c = resolveFromStream(stream);
+    assert.ok(c);
+    assert.deepEqual(c.point, { x: 3, y: 4 });
+});
+
+test('VNS-008: a stream with no answer resolves to nothing', () => {
+    const stream = [
+        JSON.stringify({ type: 'thread.started' }),
+        agentMessage('I could not analyze the image.'),
+    ].join('\n');
+    assert.equal(resolveFromStream(stream), null);
+});
+
+test('VNS-009: an implausible coordinate never leaves the stream', () => {
+    const stream = [agentMessage('{"found":true,"x":1e12,"y":1e12}')].join('\n');
+    assert.equal(resolveFromStream(stream), null, 'normalization must reject it before dispatch');
+});
+


### PR DESCRIPTION
## Problem

The extractor matched with `/\{[^{}]*"found"...\}/`. That class cannot cross a nested object, so a bbox-carrying answer could never match — migrating to a richer schema was blocked by the parser, not the prompt. It also required canonical key order and rejected negatives and fractions. And nothing bounded the coordinate: a hallucinated `{"x":99999}` was converted through DPR correction and clicked.

## The first attempt at this was wrong in both halves

Worth reading before the rest, because it is most of the change.

**The bounds check was bypassable three ways**, all verified:

1. **`viewport` is null on this deployment.** The project connects with `connectOverCDP`, which Playwright attaches with `noDefaultViewport`, so `viewportSize()` returns null and the `1280x720` default is skipped. `frame` was null on the default no-clip path and `if (frame && ...)` **failed open** — the exact case the change claimed to fix.
2. **An array clip gave undefined bounds.** The route passes `req.body.clip` through unvalidated and `normalizeClip` accepts `[x,y,w,h]`, so `clip.width` was `undefined` and `99999 > undefined` is `false`. A bound that looks present and checks nothing is worse than no bound.
3. **The requested clip is not the captured size.** Playwright trims a clip to the viewport before capture, so `clip.width * dpr` was too permissive.

Also, `validateCandidate` — the tested, exported guard — had **zero production callers**. `visionClick` reimplemented the predicate inline, which is why every bypass escaped the suite.

**The scanner lost answers the regex found:**

| input | old regex | first attempt | now |
|---|---|---|---|
| `{"result":{"found":true,"x":10,"y":20}}` | found | **null** | found |
| `{"candidates":[{"found":true,"x":1,"y":2}]}` | found | **null** | found |
| `the bezel is 15" wide. {"found":true,...}` | found | **null** | found |

The first two: depth-0-only emission lost wrapped answers, and `[^{}]*` was accidentally the thing that made wrappers work. The third: a stray quote inverts string tracking for the remainder, and quoted page text does this by accident.

**And a trailing prompt echo turned success into failure.** The prompt contains a literal `{"found":false,...}` template, so any restatement parses as a valid not-found answer — newest-first then took it. `parseCandidate` now prefers a located answer over a later not-found one. Scan direction alone never resolved this.

## Current state

The frame is the pixel size of the file the model actually saw, read from its PNG or JPEG header, and it **fails closed**: if the size cannot be read, the coordinate is unverifiable and no click happens. `screenshot()` also falls back to `window.innerWidth/innerHeight` when `viewportSize()` is null.

Coordinates beyond 100,000 are rejected at normalization — `1e308` is finite and produced a `5e307` center with no risk flag. A `point` disagreeing with a top-level `x/y` carries a `conflicting_point` flag rather than being silently resolved.

## On bbox, explicitly

**bbox is carried for verification, cropping and size sanity — not as an accuracy mechanism.** GUI-Actor's controlled comparison scores bbox output *below* point output on the same recipe (13.8% vs 15.6% on ScreenSpot-Pro). The box earns its place by enabling reconciliation against element geometry and re-cropping, which later branches need. This PR claims no grounding-accuracy improvement.

## Validation

- `tests/unit/grounding-candidate.test.ts` — 27/27
- `tests/unit/image-size.test.ts` — 5/5
- `tests/unit/vision-input-safety.test.ts` — 13/13
- `tests/unit/vision-click-coordinate.test.ts`, `vision-click-options.test.ts` — 7/7 (they cover `toCssPoint` and the route options this touches)
- `npm run gate:doc-drift` — PASS, 577/577
- `tsc --noEmit` — clean
- Full local suite: NOT RUN

**Honest limit:** these test the modules, not `codexVision`'s NDJSON loop or `visionClick` end to end. The bypasses above lived precisely in that untested seam. Integration coverage for the pipeline belongs with the verification work later in this stack.

## Stack

Bases on #608.
