### PR TITLE
test(slack): give the two-home fixtures CI boot headroom

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.41",
+  "version": "2.17.41-preview.20260908155225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw-electron",
-      "version": "2.17.41",
+      "version": "2.17.41-preview.20260908155225",
       "dependencies": {
         "fix-path": "^4.0.0",
         "node-pty": "^1.1.0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw-electron",
-  "version": "2.17.41",
+  "version": "2.17.41-preview.20260908155225",
   "description": "Electron desktop shell for cli-jaw manager dashboard",
   "private": true,
   "main": "out/main/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.41",
+  "version": "2.17.41-preview.20260908155225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-jaw",
-      "version": "2.17.41",
+      "version": "2.17.41-preview.20260908155225",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-jaw",
-  "version": "2.17.41",
+  "version": "2.17.41-preview.20260908155225",
   "description": "Personal AI assistant powered by Pi, Antigravity, AI-E, Claude, Claude E, Codex, Codex App, Cursor, Grok, Kiro, OpenCode, and Copilot — Web, Terminal, Slack, Telegram, and Discord interfaces with 33 skills active by default from a 230-skill reference library",
   "type": "module",
   "keywords": [

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -483,6 +483,9 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
         children.push(child);
         exited.set(child, new Promise<void>(resolve => child.once('exit', () => resolve())));
         let buffered = '';
+        let stderrTail = '';
+        child.stderr.setEncoding('utf8');
+        child.stderr.on('data', chunk => { stderrTail = (stderrTail + chunk).slice(-2000); });
         const waiters: Array<(value: Record<string, unknown>) => void> = [];
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', chunk => {
@@ -495,7 +498,12 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
             }
         });
         const next = () => new Promise<Record<string, unknown>>((resolve, reject) => {
-            const timer = setTimeout(() => reject(new Error(`fixture timeout: ${buffered}`)), 10_000);
+            // A cold tsx boot of the whole server graph under module mocks takes
+            // several seconds on a loaded CI runner (preview run 34196670148 hit
+            // the 10s bound with nothing printed yet). The bound is a hang guard,
+            // not a performance assertion, so give CI the headroom it needs and
+            // include stderr so a real crash is readable.
+            const timer = setTimeout(() => reject(new Error(`fixture timeout: stdout=${JSON.stringify(buffered)} stderr=${JSON.stringify(stderrTail)}`)), process.env['CI'] ? 60_000 : 20_000);
             waiters.push(value => { clearTimeout(timer); resolve(value); });
         });
         return { child, next };


### PR DESCRIPTION
## Problem

Second preview certification of v2.17.41 ([run 34196670148](https://github.com/lidge-jun/cli-jaw/actions/runs/34196670148), `test 3/4`) failed in `l real lifecycle: late hello loses a replaced presence claim` with `fixture timeout:` and an **empty** stdout buffer: the first child fixture had not finished booting tsx + the server module graph under `mock.module` within the test's 10s per-report bound. The same test passes locally in ~0.5s (26/26, repeated), and passed on the PR CI for #605 and #609; the bound is a hang guard, not a performance assertion.

## Change

Raise the per-report bound to 60s when `CI` is set (20s locally) and include the child's stderr tail in the timeout error so a real crash is readable next time. No product change. Based on `origin/preview` (`b2f1e2d34`) so `dev` stays a descendant of the preview head.

## Verification

`CI=true npx tsx --experimental-test-module-mocks tests/run.mts tests/unit/slack-lifecycle.test.ts`: 26/26 twice.
