### PR TITLE
eval: measure grounding instead of asserting it works

### DIFF
--- a/scripts/grounding-eval.mjs
+++ b/scripts/grounding-eval.mjs
@@ -29,7 +29,7 @@ const root = path.resolve(here, '..');
 const fixtureDir = path.join(root, 'tests/fixtures/grounding');
 
 function parseArgs(argv) {
-    const opts = { port: 9222, json: false, only: null, base: 'http://127.0.0.1:3457' };
+    const opts = { port: null, json: false, only: null, base: 'http://127.0.0.1:3457' };
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         if (a === '--json') opts.json = true;
@@ -49,8 +49,12 @@ const usage = `grounding-eval — measure grounding on fixed local fixtures
 Requires a running cli-jaw server and a browser session. This is an
 operator-run tool; its output is recorded evidence, not a gate.`;
 
-async function api(base, method, route, body) {
-    const res = await fetch(base + route, {
+async function api(base, method, route, body, port) {
+    // The route resolves the CDP port from the query string, so an operator
+    // targeting a specific Chrome needs it forwarded. It used to be parsed and
+    // then ignored, which silently ran against whatever port was active.
+    const url = base + route + (port ? `?port=${port}` : '');
+    const res = await fetch(url, {
         method,
         headers: { 'content-type': 'application/json' },
         ...(body ? { body: JSON.stringify(body) } : {}),
@@ -99,23 +103,54 @@ async function main() {
     for (const c of cases) {
         const started = Date.now();
         try {
-            await api(opts.base, 'POST', '/api/browser/navigate', { url: fixtureUrl });
+            const nav = await api(opts.base, 'POST', '/api/browser/navigate', { url: fixtureUrl }, opts.port);
+            // A failed navigation would score the whole case against whatever
+            // page happened to be loaded, which is worse than not scoring it.
+            if (nav.status >= 400) throw new Error(`navigate failed (${nav.status}): ${nav.body?.error ?? ''}`);
+
             // Record what actually receives the click, since "success" alone
             // cannot distinguish a correct click from a wrong one.
-            await api(opts.base, 'POST', '/api/browser/evaluate', { expression: INSTALL_WITNESS });
+            const install = await api(opts.base, 'POST', '/api/browser/evaluate', { expression: INSTALL_WITNESS }, opts.port);
+            if (install.status >= 400) throw new Error(`witness install failed (${install.status})`);
 
-            const res = await api(opts.base, 'POST', '/api/browser/vision-click', { target: c.target });
-            const witness = await api(opts.base, 'POST', '/api/browser/evaluate', { expression: CLICK_WITNESS });
+            const res = await api(opts.base, 'POST', '/api/browser/vision-click', { target: c.target }, opts.port);
+            const witness = await api(opts.base, 'POST', '/api/browser/evaluate', { expression: CLICK_WITNESS }, opts.port);
             const clicked = witness.body?.result ?? null;
             const ms = Date.now() - started;
 
             // A case that declares abstention correct is scored inverted: an
             // abstention is the right answer, and a confident click is not.
+            //
+            // But a REFUSAL and a FAILURE are not the same thing. Scoring an
+            // HTTP error or a crashed call as "correctly declined" would turn
+            // harness breakage into a good result — the one direction an
+            // evaluation must never fail. Only a real refusal counts.
             if (c.expectAbstention) {
+                if (res.status >= 400) {
+                    results.push({ id: c.id, expected: 'abstain', outcome: { kind: 'errored', ms, error: `HTTP ${res.status}` } });
+                    continue;
+                }
+                const refused = res.body?.success === false && Boolean(res.body?.code || res.body?.reason);
                 const outcome = res.body?.success === true
                     ? { kind: 'misclick', ms, got: clicked ?? 'unknown' }
-                    : { kind: 'verified', ms };
+                    : refused
+                        ? { kind: 'verified', ms }
+                        : { kind: 'errored', ms, error: 'declined without a reason' };
                 results.push({ id: c.id, expected: 'abstain', outcome });
+                continue;
+            }
+
+            // A case with no DOM target expects a coordinate click. It cannot
+            // be scored by element identity — the witness reports whatever the
+            // coordinate landed on — so it is scored by landing INSIDE the
+            // named region instead.
+            if (c.expectRegion) {
+                const outcome = res.body?.success !== true
+                    ? { kind: 'abstained', ms, reason: res.body?.code ?? res.body?.reason ?? 'declined' }
+                    : clicked === c.expectRegion
+                        ? { kind: 'verified', ms }
+                        : { kind: 'misclick', ms, got: clicked ?? 'unknown' };
+                results.push({ id: c.id, expected: c.expectRegion, outcome });
                 continue;
             }
 
@@ -155,4 +190,3 @@ main().then(code => process.exit(code)).catch(err => {
     console.error('grounding-eval failed:', err?.message ?? err);
     process.exit(1);
 });
-

--- a/scripts/grounding-eval.mjs
+++ b/scripts/grounding-eval.mjs
@@ -60,17 +60,31 @@ async function api(base, method, route, body) {
     catch { return { status: res.status, body: { raw: text } }; }
 }
 
-/** Which element ended up focused or activated, so a click can be scored. */
-const CLICK_WITNESS = `(() => {
-    const el = window.__lastClickTarget;
-    return el && el.id ? el.id : null;
-})()`;
-
+/**
+ * Record what the page actually received, so a click can be scored against
+ * reality rather than against the response's own claim.
+ *
+ * The listener walks UP from the event target to the nearest element with an
+ * id. A click on a button's inner span reports the span otherwise, and the
+ * harness would score a correct click as a misclick - measuring its own
+ * instrumentation rather than the pipeline.
+ *
+ * Reinstalled per case, since navigation discards it.
+ */
 const INSTALL_WITNESS = `(() => {
-    window.__lastClickTarget = null;
-    document.addEventListener('click', (e) => { window.__lastClickTarget = e.target; }, true);
+    window.__jawClickedId = null;
+    document.addEventListener('click', (e) => {
+        let node = e.target;
+        for (let i = 0; node && i < 24; i++) {
+            if (node.id) { window.__jawClickedId = node.id; return; }
+            node = node.parentElement;
+        }
+        window.__jawClickedId = null;
+    }, true);
     return true;
 })()`;
+
+const CLICK_WITNESS = 'window.__jawClickedId';
 
 async function main() {
     const opts = parseArgs(process.argv.slice(2));
@@ -88,10 +102,10 @@ async function main() {
             await api(opts.base, 'POST', '/api/browser/navigate', { url: fixtureUrl });
             // Record what actually receives the click, since "success" alone
             // cannot distinguish a correct click from a wrong one.
-            await api(opts.base, 'POST', '/api/browser/evaluate', { script: INSTALL_WITNESS });
+            await api(opts.base, 'POST', '/api/browser/evaluate', { expression: INSTALL_WITNESS });
 
             const res = await api(opts.base, 'POST', '/api/browser/vision-click', { target: c.target });
-            const witness = await api(opts.base, 'POST', '/api/browser/evaluate', { script: CLICK_WITNESS });
+            const witness = await api(opts.base, 'POST', '/api/browser/evaluate', { expression: CLICK_WITNESS });
             const clicked = witness.body?.result ?? null;
             const ms = Date.now() - started;
 

--- a/scripts/grounding-eval.mjs
+++ b/scripts/grounding-eval.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * scripts/grounding-eval.mjs — run the grounding cases and report the rates.
+ *
+ * EXECUTION HOME, stated rather than assumed.
+ *
+ * This is an OPERATOR-RUN tool, not a CI check. It needs a live Chrome and a
+ * codex spawn, and `test.yml` has no fixture that provides either. Adding one
+ * would mean a model round-trip per case inside CI, which is slow, costs
+ * money, and is non-deterministic in a place that must be neither.
+ *
+ * So the contract is: an operator runs it, and its output is recorded
+ * evidence. That is a weaker guarantee than a gate, and saying so is the
+ * point — the alternative was a harness that quietly ran nowhere.
+ *
+ *   cli-jaw serve                       # in another terminal
+ *   node scripts/grounding-eval.mjs     # add --json to capture the report
+ *
+ * Exit status reflects the run, not a threshold: 0 when every case was
+ * scored, 1 when any case errored. There is deliberately no pass/fail bar,
+ * because a number invented before the first measurement is not a standard.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+const fixtureDir = path.join(root, 'tests/fixtures/grounding');
+
+function parseArgs(argv) {
+    const opts = { port: 9222, json: false, only: null, base: 'http://127.0.0.1:3457' };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--json') opts.json = true;
+        else if (a === '--port') opts.port = Number(argv[++i]);
+        else if (a === '--only') opts.only = String(argv[++i]);
+        else if (a === '--base') opts.base = String(argv[++i]);
+        else if (a === '--help' || a === '-h') opts.help = true;
+    }
+    return opts;
+}
+
+const usage = `grounding-eval — measure grounding on fixed local fixtures
+
+  node scripts/grounding-eval.mjs [--port 9222] [--base http://127.0.0.1:3457]
+                                  [--only <case-id>] [--json]
+
+Requires a running cli-jaw server and a browser session. This is an
+operator-run tool; its output is recorded evidence, not a gate.`;
+
+async function api(base, method, route, body) {
+    const res = await fetch(base + route, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    const text = await res.text();
+    try { return { status: res.status, body: JSON.parse(text) }; }
+    catch { return { status: res.status, body: { raw: text } }; }
+}
+
+/** Which element ended up focused or activated, so a click can be scored. */
+const CLICK_WITNESS = `(() => {
+    const el = window.__lastClickTarget;
+    return el && el.id ? el.id : null;
+})()`;
+
+const INSTALL_WITNESS = `(() => {
+    window.__lastClickTarget = null;
+    document.addEventListener('click', (e) => { window.__lastClickTarget = e.target; }, true);
+    return true;
+})()`;
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    if (opts.help) { console.log(usage); return 0; }
+
+    const { scoreRun, classify, formatReport } = await import('../src/browser/grounding-eval.ts');
+    const spec = JSON.parse(fs.readFileSync(path.join(fixtureDir, 'cases.json'), 'utf8'));
+    const fixtureUrl = 'file://' + path.join(fixtureDir, spec.fixture);
+    const cases = opts.only ? spec.cases.filter(c => c.id === opts.only) : spec.cases;
+
+    const results = [];
+    for (const c of cases) {
+        const started = Date.now();
+        try {
+            await api(opts.base, 'POST', '/api/browser/navigate', { url: fixtureUrl });
+            // Record what actually receives the click, since "success" alone
+            // cannot distinguish a correct click from a wrong one.
+            await api(opts.base, 'POST', '/api/browser/evaluate', { script: INSTALL_WITNESS });
+
+            const res = await api(opts.base, 'POST', '/api/browser/vision-click', { target: c.target });
+            const witness = await api(opts.base, 'POST', '/api/browser/evaluate', { script: CLICK_WITNESS });
+            const clicked = witness.body?.result ?? null;
+            const ms = Date.now() - started;
+
+            // A case that declares abstention correct is scored inverted: an
+            // abstention is the right answer, and a confident click is not.
+            if (c.expectAbstention) {
+                const outcome = res.body?.success === true
+                    ? { kind: 'misclick', ms, got: clicked ?? 'unknown' }
+                    : { kind: 'verified', ms };
+                results.push({ id: c.id, expected: 'abstain', outcome });
+                continue;
+            }
+
+            results.push({
+                id: c.id,
+                expected: c.expected ?? 'coordinate',
+                outcome: classify(res.body ?? {}, c.expected ?? 'coordinate', ms, clicked ?? undefined),
+            });
+        } catch (err) {
+            results.push({
+                id: c.id,
+                expected: c.expected ?? 'coordinate',
+                outcome: { kind: 'errored', ms: Date.now() - started, error: String(err?.message ?? err) },
+            });
+        }
+    }
+
+    const report = scoreRun(results);
+    if (opts.json) {
+        console.log(JSON.stringify({ report, results }, null, 2));
+    } else {
+        for (const r of results) {
+            const o = r.outcome;
+            const detail = o.kind === 'misclick' ? ` (got ${o.got}, wanted ${r.expected})`
+                : o.kind === 'abstained' ? ` (${o.reason})`
+                : o.kind === 'errored' ? ` (${o.error})`
+                : '';
+            console.log(`${o.kind.padEnd(10)} ${r.id}${detail}`);
+        }
+        console.log('');
+        console.log(formatReport(report));
+    }
+    return report.errored > 0 ? 1 : 0;
+}
+
+main().then(code => process.exit(code)).catch(err => {
+    console.error('grounding-eval failed:', err?.message ?? err);
+    process.exit(1);
+});
+

--- a/src/browser/grounding-eval.ts
+++ b/src/browser/grounding-eval.ts
@@ -60,6 +60,15 @@ export type EvalReport = {
     verifiedRate: number;
     /** The number to watch: a wrong click is worse than no click. */
     misclickRate: number;
+    /**
+     * Refusals on cases where CLICKING was the correct answer.
+     *
+     * Deliberately not "all abstentions": on a refusal-expected case a decline
+     * is the right answer and is counted as verified, so blending the two
+     * would mix "the pipeline declined when it should have acted" with "the
+     * pipeline declined when it should have declined". Those are opposite
+     * signals wearing the same name.
+     */
     abstentionRate: number;
     latency: { p50: number; p95: number; max: number } | null;
     /** Cases where clicking the named element is correct. */
@@ -120,7 +129,8 @@ export function scoreRun(results: CaseResult[]): EvalReport {
         ...counts,
         verifiedRate: rate(counts.verified),
         misclickRate: rate(counts.misclicked),
-        abstentionRate: rate(counts.abstained),
+        // Scoped to click cases, per the field's own contract above.
+        abstentionRate: click.scored === 0 ? 0 : click.abstained / click.scored,
         latency: durations.length
             ? { p50: percentile(durations, 50), p95: percentile(durations, 95), max: durations[durations.length - 1] as number }
             : null,
@@ -173,7 +183,7 @@ export function formatReport(report: EvalReport): string {
         `cases           ${report.total} (${report.scored} scored, ${report.errored} errored)`,
         `verified        ${report.verified} (${pct(report.verifiedRate)})`,
         `misclicked      ${report.misclicked} (${pct(report.misclickRate)})`,
-        `abstained       ${report.abstained} (${pct(report.abstentionRate)})`,
+        `abstained       ${report.abstained} (${pct(report.abstentionRate)} of cases that should have clicked)`,
     ];
     if (report.latency) {
         lines.push(`latency         p50 ${report.latency.p50}ms  p95 ${report.latency.p95}ms  max ${report.latency.max}ms`);

--- a/src/browser/grounding-eval.ts
+++ b/src/browser/grounding-eval.ts
@@ -30,6 +30,24 @@ export type CaseOutcome =
 
 export type CaseResult = { id: string; expected: string; outcome: CaseOutcome };
 
+/**
+ * Some cases expect the pipeline to DECLINE — an occluded target, an ambiguous
+ * one, a target that is not on the page. Those are scored inverted: an
+ * abstention is correct and a confident click is the misclick.
+ *
+ * They are counted separately as well as together, because a single blended
+ * rate is ambiguous: 80% could mean the pipeline clicks accurately, or that it
+ * refuses reliably, or any mixture. Those are different claims.
+ */
+export type ScoredGroup = {
+    scored: number;
+    verified: number;
+    misclicked: number;
+    abstained: number;
+    verifiedRate: number;
+    misclickRate: number;
+};
+
 export type EvalReport = {
     total: number;
     /** Cases the harness could actually score. */
@@ -44,6 +62,10 @@ export type EvalReport = {
     misclickRate: number;
     abstentionRate: number;
     latency: { p50: number; p95: number; max: number } | null;
+    /** Cases where clicking the named element is correct. */
+    click: ScoredGroup;
+    /** Cases where declining is correct. */
+    refusal: ScoredGroup;
 };
 
 /**
@@ -63,12 +85,17 @@ export function percentile(sortedMs: number[], p: number): number {
 export function scoreRun(results: CaseResult[]): EvalReport {
     const counts = { verified: 0, misclicked: 0, abstained: 0, errored: 0 };
     const durations: number[] = [];
+    const group = (): ScoredGroup => ({ scored: 0, verified: 0, misclicked: 0, abstained: 0, verifiedRate: 0, misclickRate: 0 });
+    const click = group();
+    const refusal = group();
 
     for (const r of results) {
+        // `expected: 'abstain'` marks a case whose correct answer is a refusal.
+        const bucket = r.expected === 'abstain' ? refusal : click;
         switch (r.outcome.kind) {
-            case 'verified': counts.verified += 1; break;
-            case 'misclick': counts.misclicked += 1; break;
-            case 'abstained': counts.abstained += 1; break;
+            case 'verified': counts.verified += 1; bucket.verified += 1; bucket.scored += 1; break;
+            case 'misclick': counts.misclicked += 1; bucket.misclicked += 1; bucket.scored += 1; break;
+            case 'abstained': counts.abstained += 1; bucket.abstained += 1; bucket.scored += 1; break;
             case 'errored': counts.errored += 1; break;
         }
         // An errored case measures the harness, not the pipeline, so its
@@ -82,6 +109,10 @@ export function scoreRun(results: CaseResult[]): EvalReport {
     const scored = counts.verified + counts.misclicked + counts.abstained;
     const rate = (n: number) => (scored === 0 ? 0 : n / scored);
     durations.sort((a, b) => a - b);
+    for (const g of [click, refusal]) {
+        g.verifiedRate = g.scored === 0 ? 0 : g.verified / g.scored;
+        g.misclickRate = g.scored === 0 ? 0 : g.misclicked / g.scored;
+    }
 
     return {
         total: results.length,
@@ -93,6 +124,8 @@ export function scoreRun(results: CaseResult[]): EvalReport {
         latency: durations.length
             ? { p50: percentile(durations, 50), p95: percentile(durations, 95), max: durations[durations.length - 1] as number }
             : null,
+        click,
+        refusal,
     };
 }
 
@@ -145,7 +178,11 @@ export function formatReport(report: EvalReport): string {
     if (report.latency) {
         lines.push(`latency         p50 ${report.latency.p50}ms  p95 ${report.latency.p95}ms  max ${report.latency.max}ms`);
     }
+    lines.push(
+        '',
+        `when clicking   ${report.click.verified}/${report.click.scored} right, ${report.click.misclicked} wrong`,
+        `when refusing   ${report.refusal.verified}/${report.refusal.scored} correctly declined`,
+    );
     lines.push('', 'An abstention is the pipeline declining, not failing. Read the misclick', 'rate first: a wrong click is worse than no click.');
     return lines.join('\n');
 }
-

--- a/src/browser/grounding-eval.ts
+++ b/src/browser/grounding-eval.ts
@@ -1,0 +1,151 @@
+/**
+ * src/browser/grounding-eval.ts — scoring for the grounding harness.
+ *
+ * Every phase in this work shipped on unit evidence with the same admitted
+ * gap: the pipeline seam needs a live browser and a model spawn, so nothing
+ * measured whether grounding actually works. This is the scoring half of the
+ * thing that measures it. The runner is separate and lives in scripts/, so the
+ * arithmetic here stays testable without Chrome.
+ *
+ * The measurement that matters is NOT "did the call return success". A click
+ * that lands on the wrong element also returns success, which is the failure
+ * this whole stack was opened to address. So a case declares the element it
+ * expects, and a run is scored against what was actually clicked.
+ *
+ * Abstention is a first-class outcome, not a failure. Refusing an ambiguous
+ * target, an occluded one, or a stale observation is the pipeline working.
+ * Folding those into "failed" would make every guard look like a regression
+ * and reward a system that clicks confidently regardless.
+ */
+
+export type CaseOutcome =
+    /** Clicked, and it was the expected element. */
+    | { kind: 'verified'; ms: number }
+    /** Clicked, but not the expected element. The outcome worth minimising. */
+    | { kind: 'misclick'; ms: number; got: string }
+    /** Declined to click, with a reason. Correct behaviour when unsure. */
+    | { kind: 'abstained'; ms: number; reason: string }
+    /** The harness could not run the case. Not evidence either way. */
+    | { kind: 'errored'; ms: number; error: string };
+
+export type CaseResult = { id: string; expected: string; outcome: CaseOutcome };
+
+export type EvalReport = {
+    total: number;
+    /** Cases the harness could actually score. */
+    scored: number;
+    verified: number;
+    misclicked: number;
+    abstained: number;
+    errored: number;
+    /** Of scored cases. A misclick costs the same as an abstention here. */
+    verifiedRate: number;
+    /** The number to watch: a wrong click is worse than no click. */
+    misclickRate: number;
+    abstentionRate: number;
+    latency: { p50: number; p95: number; max: number } | null;
+};
+
+/**
+ * Percentile by nearest-rank on a sorted sample.
+ *
+ * Deliberately not interpolating: with a handful of cases an interpolated p95
+ * reports a duration that never happened, which reads as precision the sample
+ * does not have.
+ */
+export function percentile(sortedMs: number[], p: number): number {
+    if (sortedMs.length === 0) return 0;
+    const rank = Math.ceil((p / 100) * sortedMs.length);
+    const index = Math.min(Math.max(rank, 1), sortedMs.length) - 1;
+    return sortedMs[index] as number;
+}
+
+export function scoreRun(results: CaseResult[]): EvalReport {
+    const counts = { verified: 0, misclicked: 0, abstained: 0, errored: 0 };
+    const durations: number[] = [];
+
+    for (const r of results) {
+        switch (r.outcome.kind) {
+            case 'verified': counts.verified += 1; break;
+            case 'misclick': counts.misclicked += 1; break;
+            case 'abstained': counts.abstained += 1; break;
+            case 'errored': counts.errored += 1; break;
+        }
+        // An errored case measures the harness, not the pipeline, so its
+        // duration would skew the latency picture.
+        if (r.outcome.kind !== 'errored') durations.push(r.outcome.ms);
+    }
+
+    // Errors are excluded from the denominator. A case the harness could not
+    // run is not evidence that grounding failed, and counting it as one would
+    // let a broken fixture look like a regression.
+    const scored = counts.verified + counts.misclicked + counts.abstained;
+    const rate = (n: number) => (scored === 0 ? 0 : n / scored);
+    durations.sort((a, b) => a - b);
+
+    return {
+        total: results.length,
+        scored,
+        ...counts,
+        verifiedRate: rate(counts.verified),
+        misclickRate: rate(counts.misclicked),
+        abstentionRate: rate(counts.abstained),
+        latency: durations.length
+            ? { p50: percentile(durations, 50), p95: percentile(durations, 95), max: durations[durations.length - 1] as number }
+            : null,
+    };
+}
+
+/**
+ * Decide a case outcome from what the pipeline returned.
+ *
+ * The refusal codes are named rather than pattern-matched on prose, so a
+ * reworded message cannot silently reclassify a refusal as a failure.
+ */
+export const ABSTENTION_CODES = new Set([
+    'COMPUTER_TARGET_AMBIGUOUS',
+    'COMPUTER_TARGET_COVERED',
+    'COMPUTER_VERIFY_DISAGREED',
+    'COMPUTER_OBSERVATION_EXPIRED',
+    'COMPUTER_OBSERVATION_STALE',
+]);
+
+export function classify(
+    response: { success?: boolean; code?: string; reason?: string; ref?: string },
+    expected: string,
+    ms: number,
+    clickedRef?: string,
+): CaseOutcome {
+    if (response.success !== true) {
+        if (response.code && ABSTENTION_CODES.has(response.code)) {
+            return { kind: 'abstained', ms, reason: response.code };
+        }
+        // "Target not found" is also an abstention: the pipeline declined
+        // rather than clicked, which is the behaviour being measured.
+        if (response.reason) return { kind: 'abstained', ms, reason: response.reason };
+        return { kind: 'errored', ms, error: 'no reason given' };
+    }
+
+    const got = clickedRef ?? response.ref;
+    // Success without an identifiable target cannot be scored. Calling it
+    // verified would be the exact assumption this harness exists to test.
+    if (!got) return { kind: 'errored', ms, error: 'clicked but no element identity was reported' };
+    return got === expected ? { kind: 'verified', ms } : { kind: 'misclick', ms, got };
+}
+
+/** One line per rate, plus the caveat the numbers need to be read with. */
+export function formatReport(report: EvalReport): string {
+    const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+    const lines = [
+        `cases           ${report.total} (${report.scored} scored, ${report.errored} errored)`,
+        `verified        ${report.verified} (${pct(report.verifiedRate)})`,
+        `misclicked      ${report.misclicked} (${pct(report.misclickRate)})`,
+        `abstained       ${report.abstained} (${pct(report.abstentionRate)})`,
+    ];
+    if (report.latency) {
+        lines.push(`latency         p50 ${report.latency.p50}ms  p95 ${report.latency.p95}ms  max ${report.latency.max}ms`);
+    }
+    lines.push('', 'An abstention is the pipeline declining, not failing. Read the misclick', 'rate first: a wrong click is worse than no click.');
+    return lines.join('\n');
+}
+

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -384,7 +384,7 @@ cli-jaw/
 │   │   ├── occlusion.ts      ← 클릭 지점 페이지 hit-test 함수 + 가림 판정(자손/label/presentational은 통과, 미확인은 fail-open) (179L)
 │   │   ├── verify-candidate.ts ← 후보 주변 확대 크롭 기하 + 2차 응답 드리프트 판정(합의 시 좌표 교체) (143L)
 │   │   ├── vision-provider.ts ← codex 호출 인자 구성(샌드박스 우회는 명시적 opt-in, 기본 off) + Windows 종료코드 해석 (101L)
-│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) (188L)
+│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) (198L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)
 │   │   ├── runtime-owner-store.ts ← runtime owner store (55L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -384,7 +384,7 @@ cli-jaw/
 │   │   ├── occlusion.ts      ← 클릭 지점 페이지 hit-test 함수 + 가림 판정(자손/label/presentational은 통과, 미확인은 fail-open) (179L)
 │   │   ├── verify-candidate.ts ← 후보 주변 확대 크롭 기하 + 2차 응답 드리프트 판정(합의 시 좌표 교체) (143L)
 │   │   ├── vision-provider.ts ← codex 호출 인자 구성(샌드박스 우회는 명시적 opt-in, 기본 off) + Windows 종료코드 해석 (101L)
-│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) (151L)
+│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) (188L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)
 │   │   ├── runtime-owner-store.ts ← runtime owner store (55L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -384,6 +384,7 @@ cli-jaw/
 │   │   ├── occlusion.ts      ← 클릭 지점 페이지 hit-test 함수 + 가림 판정(자손/label/presentational은 통과, 미확인은 fail-open) (179L)
 │   │   ├── verify-candidate.ts ← 후보 주변 확대 크롭 기하 + 2차 응답 드리프트 판정(합의 시 좌표 교체) (143L)
 │   │   ├── vision-provider.ts ← codex 호출 인자 구성(샌드박스 우회는 명시적 opt-in, 기본 off) + Windows 종료코드 해석 (101L)
+│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) (151L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)
 │   │   ├── runtime-owner-store.ts ← runtime owner store (55L)

--- a/tests/fixtures/grounding/cases.json
+++ b/tests/fixtures/grounding/cases.json
@@ -39,8 +39,8 @@
     {
       "id": "canvas",
       "target": "the middle of the drawing board",
-      "expected": null,
-      "why": "no DOM ref exists; a coordinate click is correct here"
+      "expectRegion": "board",
+      "why": "no DOM ref exists; a coordinate click landing inside the canvas is correct. Scored by region rather than by ref identity, because expected:null compared the witness id against the literal string 'coordinate' and could only ever score a misclick."
     },
     {
       "id": "banner-accept",

--- a/tests/fixtures/grounding/cases.json
+++ b/tests/fixtures/grounding/cases.json
@@ -1,0 +1,57 @@
+{
+  "fixture": "grounding-basic.html",
+  "note": "Each case names the element a correct pipeline should click, or declares that abstaining is the right answer. Expectations are element ids, resolved by the runner from what was actually clicked.",
+  "cases": [
+    {
+      "id": "plain-button",
+      "target": "the Save button",
+      "expected": "save"
+    },
+    {
+      "id": "similar-name",
+      "target": "the Save as button",
+      "expected": "save-as",
+      "why": "substring name matching can confuse this with Save"
+    },
+    {
+      "id": "small-icon",
+      "target": "the Bold icon button",
+      "expected": "icon-bold",
+      "why": "a 20px target beside a wide one"
+    },
+    {
+      "id": "wide-control",
+      "target": "the Publish this document now button",
+      "expected": "wide"
+    },
+    {
+      "id": "covered",
+      "target": "the Covered button",
+      "expectAbstention": true,
+      "why": "an overlay would receive the click"
+    },
+    {
+      "id": "ambiguous",
+      "target": "the Open button",
+      "expectAbstention": true,
+      "why": "two elements share the name"
+    },
+    {
+      "id": "canvas",
+      "target": "the middle of the drawing board",
+      "expected": null,
+      "why": "no DOM ref exists; a coordinate click is correct here"
+    },
+    {
+      "id": "banner-accept",
+      "target": "the Accept button in the cookie banner",
+      "expected": "accept"
+    },
+    {
+      "id": "absent",
+      "target": "the Delete account button",
+      "expectAbstention": true,
+      "why": "the target is not on the page"
+    }
+  ]
+}

--- a/tests/fixtures/grounding/grounding-basic.html
+++ b/tests/fixtures/grounding/grounding-basic.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>grounding fixture</title>
+<style>
+  body { font: 14px system-ui; margin: 0; padding: 24px; }
+  .bar { display: flex; gap: 8px; align-items: center; padding: 8px; background: #eee; }
+  .bar button { padding: 6px 10px; }
+  .icon { width: 20px; height: 20px; padding: 0; }
+  .banner { position: fixed; inset: auto 0 0 0; background: #222; color: #fff; padding: 20px; }
+  .stack { position: relative; margin-top: 40px; height: 120px; }
+  .under { position: absolute; inset: 0; }
+  .over { position: absolute; inset: 0; background: rgba(0,0,0,.03); }
+  canvas { border: 1px solid #999; margin-top: 24px; }
+  .twin { margin-top: 24px; display: flex; gap: 12px; }
+</style>
+
+<!-- A crowded toolbar: small icons beside a wide control. -->
+<div class="bar">
+  <button id="save">Save</button>
+  <button id="save-as">Save as…</button>
+  <button id="icon-bold" class="icon" aria-label="Bold">B</button>
+  <button id="icon-italic" class="icon" aria-label="Italic">I</button>
+  <button id="wide" style="flex:1">Publish this document now</button>
+</div>
+
+<!-- An element genuinely covered by an overlay. -->
+<div class="stack">
+  <button id="covered" class="under">Covered button</button>
+  <div id="overlay" class="over"></div>
+</div>
+
+<!-- Duplicate accessible names: ambiguous by construction. -->
+<div class="twin">
+  <button id="twin-a">Open</button>
+  <button id="twin-b">Open</button>
+</div>
+
+<!-- No DOM target at all. -->
+<canvas id="board" width="240" height="120"></canvas>
+
+<!-- A fixed banner over the bottom of the page. -->
+<div id="consent-banner" class="banner">We use cookies. <button id="accept">Accept</button></div>
+

--- a/tests/unit/grounding-eval.test.ts
+++ b/tests/unit/grounding-eval.test.ts
@@ -136,15 +136,19 @@ test('EV-014: the fixture cases are well formed and name their expectations', ()
         assert.ok(c.id && !ids.has(c.id), `duplicate or missing id: ${c.id}`);
         ids.add(c.id);
         assert.ok(c.target, `${c.id} must describe a target`);
-        const declares = c.expectAbstention === true || 'expected' in c;
-        assert.ok(declares, `${c.id} must declare an expected element or expect an abstention`);
+        const declares = c.expectAbstention === true || typeof c.expectRegion === 'string' || 'expected' in c;
+        assert.ok(declares, `${c.id} must declare an expected element, a region, or an abstention`);
     }
 
     // The suite must include cases where refusing is the correct answer, or it
     // would only reward clicking.
     assert.ok(spec.cases.some((c: { expectAbstention?: boolean }) => c.expectAbstention === true));
-    // And at least one with no DOM target at all.
-    assert.ok(spec.cases.some((c: { expected?: unknown }) => c.expected === null));
+    // And at least one with no DOM target at all, scored by region rather than
+    // by ref identity — comparing a witness id against a stand-in string could
+    // only ever produce a misclick, so the case was unscoreable by design.
+    assert.ok(spec.cases.some((c: { expectRegion?: string }) => typeof c.expectRegion === 'string'));
+    // Nothing may claim an expectation of null: that was the unscoreable shape.
+    assert.ok(!spec.cases.some((c: { expected?: unknown }) => c.expected === null));
 });
 
 test('EV-015: the runner declares where it runs', () => {
@@ -219,4 +223,41 @@ test('EV-019: the witness attributes a click to the element that owns it', () =>
     assert.match(runner, /if \(node\.id\)/);
     // And the walk is bounded.
     assert.match(runner, /i < 24/);
+});
+
+test('EV-020: a broken abstention case is not scored as correct behaviour', () => {
+    // The most dangerous scoring bug available: an HTTP error and a genuine
+    // refusal both mean "did not click", so an inverted case scored both as
+    // verified. That converts harness breakage into a good result, which is
+    // the one direction an evaluation must never fail.
+    const root4 = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const runner = fs.readFileSync(join(root4, 'scripts/grounding-eval.mjs'), 'utf8');
+
+    // An HTTP failure on an abstention case must error, not verify.
+    assert.match(runner, /res\.status >= 400[\s\S]{0,220}kind: 'errored'/);
+    // And a refusal must carry a reason to count as one.
+    assert.match(runner, /declined without a reason/);
+});
+
+test('EV-021: navigation and witness installation are checked before scoring', () => {
+    // A failed navigate would score the case against whatever page happened to
+    // be loaded, which is worse than not scoring it at all.
+    const root5 = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const runner = fs.readFileSync(join(root5, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.match(runner, /navigate failed/);
+    assert.match(runner, /witness install failed/);
+});
+
+test('EV-022: --port reaches the server instead of being parsed and dropped', () => {
+    // It was advertised in the usage text and then never referenced, so an
+    // operator targeting a specific Chrome silently ran against another.
+    const root6 = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const runner = fs.readFileSync(join(root6, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.match(runner, /\?port=/, 'the port must be forwarded on the query string');
+    // Every call site passes it, so one forgotten argument cannot half-apply it.
+    const calls = runner.match(/await api\(opts\.base[^;]*/g) ?? [];
+    assert.ok(calls.length >= 4);
+    for (const call of calls) {
+        assert.match(call, /opts\.port/, `call site does not forward the port: ${call.slice(0, 70)}`);
+    }
 });

--- a/tests/unit/grounding-eval.test.ts
+++ b/tests/unit/grounding-eval.test.ts
@@ -261,3 +261,31 @@ test('EV-022: --port reaches the server instead of being parsed and dropped', ()
         assert.match(call, /opts\.port/, `call site does not forward the port: ${call.slice(0, 70)}`);
     }
 });
+
+test('EV-023: abstentionRate counts declining when it should have clicked', () => {
+    // On a refusal-expected case a decline is the RIGHT answer and is counted
+    // as verified. Blending it into one abstention rate would mix "declined
+    // when it should have acted" with "declined when it should have declined"
+    // - opposite signals wearing the same name.
+    const results: CaseResult[] = [
+        { id: 'clicked', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'gave-up', expected: 'e1', outcome: { kind: 'abstained', ms: 10, reason: 'COMPUTER_TARGET_AMBIGUOUS' } },
+        // Correctly declined: recorded as verified, not as an abstention.
+        { id: 'refused-a', expected: 'abstain', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'refused-b', expected: 'abstain', outcome: { kind: 'verified', ms: 10 } },
+    ];
+    const report = scoreRun(results);
+
+    // One of the two click cases gave up.
+    assert.equal(report.abstentionRate, 0.5);
+    // Not 1/4, which is what a blended denominator would have reported.
+    assert.notEqual(report.abstentionRate, 0.25);
+    assert.equal(report.refusal.verified, 2, 'the correct declines are elsewhere');
+});
+
+test('EV-024: the report says which denominator the abstention rate uses', () => {
+    const text = formatReport(scoreRun([
+        { id: 'a', expected: 'e1', outcome: { kind: 'abstained', ms: 10, reason: 'x' } },
+    ]));
+    assert.match(text, /of cases that should have clicked/);
+});

--- a/tests/unit/grounding-eval.test.ts
+++ b/tests/unit/grounding-eval.test.ts
@@ -158,3 +158,65 @@ test('EV-015: the runner declares where it runs', () => {
     assert.match(src, /no pass\/fail bar/);
 });
 
+test('EV-016: click cases and refusal cases are reported separately', () => {
+    // A single blended rate is ambiguous: 80% could mean the pipeline clicks
+    // accurately, or that it refuses reliably, or any mixture. Those are
+    // different claims about different behaviour.
+    const results: CaseResult[] = [
+        { id: 'a', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'b', expected: 'e1', outcome: { kind: 'misclick', ms: 10, got: 'e9' } },
+        { id: 'c', expected: 'abstain', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'd', expected: 'abstain', outcome: { kind: 'misclick', ms: 10, got: 'e9' } },
+    ];
+    const report = scoreRun(results);
+
+    assert.equal(report.click.scored, 2);
+    assert.equal(report.click.verified, 1);
+    assert.equal(report.click.misclicked, 1);
+    assert.equal(report.refusal.scored, 2);
+    assert.equal(report.refusal.verified, 1, 'a correct decline');
+    assert.equal(report.refusal.misclicked, 1, 'a confident click where refusing was right');
+
+    // The blended figure still exists, but it cannot be read as either claim.
+    assert.equal(report.verifiedRate, 0.5);
+});
+
+test('EV-017: the report states both behaviours', () => {
+    const text = formatReport(scoreRun([
+        { id: 'a', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'b', expected: 'abstain', outcome: { kind: 'verified', ms: 10 } },
+    ]));
+    assert.match(text, /when clicking\s+1\/1 right/);
+    assert.match(text, /when refusing\s+1\/1 correctly declined/);
+});
+
+test('EV-018: the runner calls the routes that actually exist', () => {
+    // The first version sent {script} to /api/browser/evaluate, which takes
+    // {expression}. A harness that cannot run is worse than none, and nothing
+    // in a unit test would have caught it.
+    const root2 = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const runner = fs.readFileSync(join(root2, 'scripts/grounding-eval.mjs'), 'utf8');
+    const routes = fs.readFileSync(join(root2, 'src/routes/browser.ts'), 'utf8');
+
+    for (const route of ['/api/browser/navigate', '/api/browser/evaluate', '/api/browser/vision-click']) {
+        assert.ok(runner.includes(route), `runner must call ${route}`);
+        assert.ok(routes.includes(`'${route}'`), `${route} must exist`);
+    }
+
+    // evaluate takes req.body.expression, not req.body.script.
+    assert.match(routes, /browser\.evaluate\(cdpPort\(req\), req\.body\.expression\)/);
+    assert.match(runner, /'\/api\/browser\/evaluate', \{ expression:/);
+    assert.doesNotMatch(runner, /'\/api\/browser\/evaluate', \{ script:/);
+});
+
+test('EV-019: the witness attributes a click to the element that owns it', () => {
+    // A click on a button's inner span reports the span as e.target. Without
+    // walking up to the nearest id, the harness would score a correct click as
+    // a misclick - measuring its own instrumentation rather than the pipeline.
+    const root3 = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const runner = fs.readFileSync(join(root3, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.match(runner, /node\.parentElement/);
+    assert.match(runner, /if \(node\.id\)/);
+    // And the walk is bounded.
+    assert.match(runner, /i < 24/);
+});

--- a/tests/unit/grounding-eval.test.ts
+++ b/tests/unit/grounding-eval.test.ts
@@ -1,0 +1,160 @@
+// Every phase in this work shipped on unit evidence with the same admitted
+// gap: nothing measured whether grounding actually works. This is the scoring
+// half of the thing that measures it.
+//
+// The measurement that matters is NOT "did the call return success". A click
+// landing on the wrong element also returns success - that is the failure this
+// whole stack exists to address - so a case declares what it expects and a run
+// is scored against what was actually clicked.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    scoreRun,
+    classify,
+    percentile,
+    formatReport,
+    ABSTENTION_CODES,
+    type CaseResult,
+} from '../../src/browser/grounding-eval.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ok = (id: string, ms = 100): CaseResult => ({ id, expected: 'e1', outcome: { kind: 'verified', ms } });
+const bad = (id: string, got = 'e9', ms = 100): CaseResult => ({ id, expected: 'e1', outcome: { kind: 'misclick', ms, got } });
+const abst = (id: string, reason = 'COMPUTER_TARGET_AMBIGUOUS', ms = 100): CaseResult => ({ id, expected: 'e1', outcome: { kind: 'abstained', ms, reason } });
+const err = (id: string, ms = 100): CaseResult => ({ id, expected: 'e1', outcome: { kind: 'errored', ms, error: 'boom' } });
+
+test('EV-001: a click on the wrong element is a misclick, not a success', () => {
+    // The entire point. Scoring on the response's own success flag would score
+    // the defect this work exists to remove as a pass.
+    const o = classify({ success: true, ref: 'e9' }, 'e1', 120);
+    assert.equal(o.kind, 'misclick');
+    assert.equal(o.kind === 'misclick' && o.got, 'e9');
+});
+
+test('EV-002: a click on the expected element is verified', () => {
+    assert.equal(classify({ success: true, ref: 'e1' }, 'e1', 120).kind, 'verified');
+});
+
+test('EV-003: an observed click beats the response’s own claim', () => {
+    // The witness is what the page saw. If the response says one thing and the
+    // DOM another, the DOM is the evidence.
+    const o = classify({ success: true, ref: 'e1' }, 'e1', 120, 'e9');
+    assert.equal(o.kind, 'misclick', 'the observed target wins');
+});
+
+test('EV-004: every refusal code counts as an abstention', () => {
+    for (const code of ABSTENTION_CODES) {
+        const o = classify({ success: false, code }, 'e1', 50);
+        assert.equal(o.kind, 'abstained', `${code} must be an abstention`);
+        assert.equal(o.kind === 'abstained' && o.reason, code);
+    }
+});
+
+test('EV-005: a refusal with only prose is still an abstention', () => {
+    // "Target not found" is the pipeline declining rather than clicking, which
+    // is the behaviour being measured.
+    const o = classify({ success: false, reason: 'target not found' }, 'e1', 50);
+    assert.equal(o.kind, 'abstained');
+});
+
+test('EV-006: a success with no identifiable target cannot be scored', () => {
+    // Calling this verified would be exactly the assumption the harness exists
+    // to test.
+    const o = classify({ success: true }, 'e1', 50);
+    assert.equal(o.kind, 'errored');
+    assert.match(o.kind === 'errored' ? o.error : '', /no element identity/);
+});
+
+test('EV-007: abstentions do not count against the verified rate as failures', () => {
+    // Folding refusals into "failed" would make every guard added in this
+    // stack look like a regression, and reward a system that clicks anyway.
+    const report = scoreRun([ok('a'), ok('b'), abst('c'), abst('d')]);
+    assert.equal(report.verified, 2);
+    assert.equal(report.abstained, 2);
+    assert.equal(report.misclickRate, 0, 'no wrong clicks happened');
+    assert.equal(report.verifiedRate, 0.5);
+    assert.equal(report.abstentionRate, 0.5);
+});
+
+test('EV-008: errored cases leave the denominator', () => {
+    // A case the harness could not run is not evidence that grounding failed.
+    const report = scoreRun([ok('a'), bad('b'), err('c')]);
+    assert.equal(report.total, 3);
+    assert.equal(report.scored, 2);
+    assert.equal(report.verifiedRate, 0.5);
+    assert.equal(report.misclickRate, 0.5);
+});
+
+test('EV-009: an all-errored run reports zero rather than dividing by zero', () => {
+    const report = scoreRun([err('a'), err('b')]);
+    assert.equal(report.scored, 0);
+    assert.equal(report.verifiedRate, 0);
+    assert.equal(report.misclickRate, 0);
+    assert.equal(report.latency, null, 'errored durations measure the harness, not the pipeline');
+});
+
+test('EV-010: an empty run is not a perfect run', () => {
+    const report = scoreRun([]);
+    assert.equal(report.verifiedRate, 0);
+    assert.equal(report.latency, null);
+});
+
+test('EV-011: percentiles use nearest-rank, not interpolation', () => {
+    // With a handful of cases an interpolated p95 reports a duration that
+    // never happened, which reads as precision the sample does not have.
+    const s = [10, 20, 30, 40];
+    assert.equal(percentile(s, 50), 20);
+    assert.equal(percentile(s, 95), 40);
+    assert.equal(percentile(s, 100), 40);
+    assert.equal(percentile([], 50), 0);
+    assert.equal(percentile([7], 95), 7);
+});
+
+test('EV-012: latency excludes errored cases', () => {
+    const report = scoreRun([ok('a', 100), ok('b', 200), err('c', 60_000)]);
+    assert.ok(report.latency);
+    assert.equal(report.latency.max, 200, 'a harness failure must not dominate the latency picture');
+});
+
+test('EV-013: the report reads the misclick rate first', () => {
+    const text = formatReport(scoreRun([ok('a'), bad('b'), abst('c')]));
+    assert.match(text, /misclicked/);
+    assert.match(text, /abstention is the pipeline declining, not failing/);
+    assert.match(text, /wrong click is worse than no click/);
+});
+
+test('EV-014: the fixture cases are well formed and name their expectations', () => {
+    const spec = JSON.parse(fs.readFileSync(join(root, 'tests/fixtures/grounding/cases.json'), 'utf8'));
+    assert.ok(fs.existsSync(join(root, 'tests/fixtures/grounding', spec.fixture)));
+    assert.ok(spec.cases.length >= 8, 'a handful of cases is not a measurement');
+
+    const ids = new Set<string>();
+    for (const c of spec.cases) {
+        assert.ok(c.id && !ids.has(c.id), `duplicate or missing id: ${c.id}`);
+        ids.add(c.id);
+        assert.ok(c.target, `${c.id} must describe a target`);
+        const declares = c.expectAbstention === true || 'expected' in c;
+        assert.ok(declares, `${c.id} must declare an expected element or expect an abstention`);
+    }
+
+    // The suite must include cases where refusing is the correct answer, or it
+    // would only reward clicking.
+    assert.ok(spec.cases.some((c: { expectAbstention?: boolean }) => c.expectAbstention === true));
+    // And at least one with no DOM target at all.
+    assert.ok(spec.cases.some((c: { expected?: unknown }) => c.expected === null));
+});
+
+test('EV-015: the runner declares where it runs', () => {
+    // Criterion c-11: a harness that never states its execution home is a
+    // harness that runs nowhere.
+    const src = fs.readFileSync(join(root, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.match(src, /EXECUTION HOME/);
+    assert.match(src, /OPERATOR-RUN tool, not a CI check/);
+    assert.match(src, /recorded\s+\*?\s*evidence/);
+    // And it must not invent a pass mark before the first measurement.
+    assert.match(src, /no pass\/fail bar/);
+});
+


### PR DESCRIPTION
## Problem

Every phase in this stack shipped on unit evidence with the same admitted gap: the pipeline seam needs a live browser and a model spawn, so **nothing measured whether grounding actually works.**

## What is measured

Not whether the call returned success. **A click landing on the wrong element also returns success** — that is the failure this whole stack was opened to address.

So each case names the element a correct pipeline should click, the runner records what the page actually received through a capture-phase listener, and the score compares those. `EV-003` pins that the observed target beats the response's own claim when they disagree.

| outcome | meaning |
|---|---|
| verified | clicked, and it was the expected element |
| **misclick** | clicked something else — the number to watch |
| abstained | declined to click, with a reason |
| errored | the harness could not run the case |

## Abstention is not failure

Refusing an ambiguous target, an occluded one, or a stale observation is the pipeline working. Folding those into "failed" would make every guard added in this stack look like a regression and reward a system that clicks regardless.

Three of the nine cases expect an abstention and are scored **inverted** — a confident click there is the misclick.

## Two arithmetic choices worth stating

**Errored cases leave the denominator.** A case the harness could not run is not evidence that grounding failed, and counting it as one would let a broken fixture look like a regression. Their durations are also excluded, so a 60s harness failure cannot dominate the latency picture.

**Percentiles are nearest-rank, not interpolated.** With nine cases an interpolated p95 reports a duration that never happened, which reads as precision the sample does not have.

## Execution home, declared

Criterion c-11 asked for this to be stated rather than assumed.

`test.yml` has no Chrome-plus-codex fixture, and adding one would mean a model round-trip per case inside CI — slow, costly, and non-deterministic where it must be neither. **This is an operator-run tool whose output is recorded evidence.**

That is a weaker guarantee than a gate, and saying so is the point: the alternative was a harness that quietly ran nowhere. `EV-015` asserts the runner declares this, so the claim cannot be dropped later.

There is deliberately **no pass/fail threshold**. A number invented before the first measurement is not a standard.

## Fixture

Covers what actually breaks grounding: a 20px icon beside a wide control, two buttons sharing an accessible name, an element under an overlay, a similar-but-different label (`Save` vs `Save as…`), a canvas with no ref, and a target that is not on the page.

## Validation

- `tests/unit/grounding-eval.test.ts` — 15/15
- `npm run gate:doc-drift` — PASS
- `tsc --noEmit` — clean
- Full local suite: NOT RUN

**Honest limit: the harness has not been run against a live browser in this cycle.** The scoring, the classification and the fixture shape are tested; the end-to-end run is the operator step this PR creates rather than performs.

## Stack

Bases on #615.
