### PR TITLE
eval: the harness scored its own breakage as good behaviour

### DIFF
--- a/bin/commands/browser.ts
+++ b/bin/commands/browser.ts
@@ -468,6 +468,9 @@ try {
                 } else if (kind === 'infrastructure') {
                     console.log(`${c.red}❌ could not complete the lookup for "${target}": ${r["reason"]}${c.reset}`);
                     console.log(`${c.dim}   ${code} — this is a capture or environment failure, not a missing element${c.reset}`);
+                } else if (kind === 'grounding-failure') {
+                    console.log(`${c.red}❌ could not ground "${target}": ${r["reason"]}${c.reset}`);
+                    console.log(`${c.dim}   ${code} — the answer was outside the image it came from${c.reset}`);
                 } else {
                     console.log(`${c.red}❌ "${target}" not found: ${r["reason"]}${c.reset}`);
                 }

--- a/scripts/grounding-eval.mjs
+++ b/scripts/grounding-eval.mjs
@@ -94,7 +94,7 @@ async function main() {
     const opts = parseArgs(process.argv.slice(2));
     if (opts.help) { console.log(usage); return 0; }
 
-    const { scoreRun, classify, formatReport } = await import('../src/browser/grounding-eval.ts');
+    const { scoreRun, classify, classifyFailure, formatReport } = await import('../src/browser/grounding-eval.ts');
     const spec = JSON.parse(fs.readFileSync(path.join(fixtureDir, 'cases.json'), 'utf8'));
     const fixtureUrl = 'file://' + path.join(fixtureDir, spec.fixture);
     const cases = opts.only ? spec.cases.filter(c => c.id === opts.only) : spec.cases;
@@ -125,17 +125,34 @@ async function main() {
             // HTTP error or a crashed call as "correctly declined" would turn
             // harness breakage into a good result — the one direction an
             // evaluation must never fail. Only a real refusal counts.
+            //
+            // That was the intent; the predicate below did not honour it. It
+            // asked whether a code or a reason was PRESENT, so a capture that
+            // could not be measured scored as the occlusion guard firing
+            // correctly — on the very cases that exist as evidence for those
+            // guards. It now asks what the code MEANS, through the same
+            // classifier the CLI and the scorer use.
+            //
+            // `classifyFailure`, not `classify`: this site needs a predicate.
+            // `classify` would return `abstained` for a correct refusal, which
+            // `scoreRun` files as `refusal.abstained` with `refusal.verified`
+            // at zero — reporting "0/3 correctly declined" for perfect work.
             if (c.expectAbstention) {
                 if (res.status >= 400) {
                     results.push({ id: c.id, expected: 'abstain', outcome: { kind: 'errored', ms, error: `HTTP ${res.status}` } });
                     continue;
                 }
-                const refused = res.body?.success === false && Boolean(res.body?.code || res.body?.reason);
+                const kind = res.body?.success === false ? classifyFailure(res.body?.code) : null;
                 const outcome = res.body?.success === true
                     ? { kind: 'misclick', ms, got: clicked ?? 'unknown' }
-                    : refused
+                    : kind === 'abstention' || kind === 'not-found'
+                        // Declining because the target was ambiguous, covered,
+                        // stale, or simply absent are all correct answers on a
+                        // case whose right answer is to decline.
                         ? { kind: 'verified', ms }
-                        : { kind: 'errored', ms, error: 'declined without a reason' };
+                        : kind === 'grounding-failure'
+                            ? { kind: 'grounding-failure', ms, reason: res.body?.code }
+                            : { kind: 'errored', ms, error: res.body?.code ?? res.body?.reason ?? 'declined without a reason' };
                 results.push({ id: c.id, expected: 'abstain', outcome });
                 continue;
             }
@@ -145,8 +162,18 @@ async function main() {
             // coordinate landed on — so it is scored by landing INSIDE the
             // named region instead.
             if (c.expectRegion) {
+                // This branch had no status check at all, so a 500 from the
+                // route's catch — `{error}`, no `success` field — scored as a
+                // decline and exited 0. And its `?? 'declined'` fallback
+                // manufactured a reason where `classify` would have said none
+                // was given, making it strictly more permissive than the
+                // function it stood beside.
+                if (res.status >= 400) {
+                    results.push({ id: c.id, expected: c.expectRegion, outcome: { kind: 'errored', ms, error: `HTTP ${res.status}` } });
+                    continue;
+                }
                 const outcome = res.body?.success !== true
-                    ? { kind: 'abstained', ms, reason: res.body?.code ?? res.body?.reason ?? 'declined' }
+                    ? classify(res.body ?? {}, c.expectRegion, ms)
                     : clicked === c.expectRegion
                         ? { kind: 'verified', ms }
                         : { kind: 'misclick', ms, got: clicked ?? 'unknown' };
@@ -162,7 +189,11 @@ async function main() {
         } catch (err) {
             results.push({
                 id: c.id,
-                expected: c.expected ?? 'coordinate',
+                // A thrown refusal-expected case belongs in the refusal
+                // bucket. It files as an error either way today, but the
+                // bucket is read from `expected`, so getting it wrong here
+                // would put it in the wrong group the moment that changes.
+                expected: c.expectAbstention ? 'abstain' : (c.expectRegion ?? c.expected ?? 'coordinate'),
                 outcome: { kind: 'errored', ms: Date.now() - started, error: String(err?.message ?? err) },
             });
         }

--- a/src/browser/grounding-eval.ts
+++ b/src/browser/grounding-eval.ts
@@ -25,6 +25,17 @@ export type CaseOutcome =
     | { kind: 'misclick'; ms: number; got: string }
     /** Declined to click, with a reason. Correct behaviour when unsure. */
     | { kind: 'abstained'; ms: number; reason: string }
+    /**
+     * Did not click, and declining was not the right answer either.
+     *
+     * The element was there, it was described, and the pipeline could not
+     * ground it — or it returned a point outside the frame it was shown. That
+     * is a failure of the thing being measured, and it is neither of the two
+     * outcomes it used to be filed under. Calling it an abstention credits the
+     * pipeline with restraint it did not exercise; calling it an error blames
+     * the harness for a defect in the pipeline. It stays in the denominator.
+     */
+    | { kind: 'grounding-failure'; ms: number; reason: string }
     /** The harness could not run the case. Not evidence either way. */
     | { kind: 'errored'; ms: number; error: string };
 
@@ -44,6 +55,7 @@ export type ScoredGroup = {
     verified: number;
     misclicked: number;
     abstained: number;
+    groundingFailed: number;
     verifiedRate: number;
     misclickRate: number;
 };
@@ -56,7 +68,17 @@ export type EvalReport = {
     misclicked: number;
     abstained: number;
     errored: number;
-    /** Of scored cases. A misclick costs the same as an abstention here. */
+    /** Cases the pipeline failed to ground when grounding was the answer. */
+    groundingFailed: number;
+    /**
+     * Scoped to click cases, like every other rate here.
+     *
+     * A blended rate cannot be read: a refusal-case misclick means "clicked
+     * when it should have declined" and a click-case misclick means "clicked
+     * the wrong element". Summing them produced one number meaning two
+     * different failures with different remedies — the same defect that was
+     * already found and fixed for `abstentionRate` alone, one field away.
+     */
     verifiedRate: number;
     /** The number to watch: a wrong click is worse than no click. */
     misclickRate: number;
@@ -75,6 +97,14 @@ export type EvalReport = {
     click: ScoredGroup;
     /** Cases where declining is correct. */
     refusal: ScoredGroup;
+    /**
+     * What actually went wrong on the cases the harness could not run.
+     *
+     * A bare count leaves the operator correlating a number against the
+     * per-case lines above it. Distinct strings, because ten cases failing for
+     * one reason is a different situation from ten failing for ten.
+     */
+    errors: string[];
 };
 
 /**
@@ -92,11 +122,12 @@ export function percentile(sortedMs: number[], p: number): number {
 }
 
 export function scoreRun(results: CaseResult[]): EvalReport {
-    const counts = { verified: 0, misclicked: 0, abstained: 0, errored: 0 };
+    const counts = { verified: 0, misclicked: 0, abstained: 0, groundingFailed: 0, errored: 0 };
     const durations: number[] = [];
-    const group = (): ScoredGroup => ({ scored: 0, verified: 0, misclicked: 0, abstained: 0, verifiedRate: 0, misclickRate: 0 });
+    const group = (): ScoredGroup => ({ scored: 0, verified: 0, misclicked: 0, abstained: 0, groundingFailed: 0, verifiedRate: 0, misclickRate: 0 });
     const click = group();
     const refusal = group();
+    const errors = new Set<string>();
 
     for (const r of results) {
         // `expected: 'abstain'` marks a case whose correct answer is a refusal.
@@ -105,7 +136,11 @@ export function scoreRun(results: CaseResult[]): EvalReport {
             case 'verified': counts.verified += 1; bucket.verified += 1; bucket.scored += 1; break;
             case 'misclick': counts.misclicked += 1; bucket.misclicked += 1; bucket.scored += 1; break;
             case 'abstained': counts.abstained += 1; bucket.abstained += 1; bucket.scored += 1; break;
-            case 'errored': counts.errored += 1; break;
+            // A grounding failure stays in the denominator. It is a defect in
+            // the thing being measured, so excluding it would let a pipeline
+            // that grounds nothing report a clean sheet.
+            case 'grounding-failure': counts.groundingFailed += 1; bucket.groundingFailed += 1; bucket.scored += 1; break;
+            case 'errored': counts.errored += 1; errors.add(r.outcome.error); break;
         }
         // An errored case measures the harness, not the pipeline, so its
         // duration would skew the latency picture.
@@ -115,8 +150,7 @@ export function scoreRun(results: CaseResult[]): EvalReport {
     // Errors are excluded from the denominator. A case the harness could not
     // run is not evidence that grounding failed, and counting it as one would
     // let a broken fixture look like a regression.
-    const scored = counts.verified + counts.misclicked + counts.abstained;
-    const rate = (n: number) => (scored === 0 ? 0 : n / scored);
+    const scored = counts.verified + counts.misclicked + counts.abstained + counts.groundingFailed;
     durations.sort((a, b) => a - b);
     for (const g of [click, refusal]) {
         g.verifiedRate = g.scored === 0 ? 0 : g.verified / g.scored;
@@ -127,15 +161,17 @@ export function scoreRun(results: CaseResult[]): EvalReport {
         total: results.length,
         scored,
         ...counts,
-        verifiedRate: rate(counts.verified),
-        misclickRate: rate(counts.misclicked),
-        // Scoped to click cases, per the field's own contract above.
+        // All three headline rates are scoped to click cases. Blending them
+        // with refusal cases produced numbers that could not be read.
+        verifiedRate: click.verifiedRate,
+        misclickRate: click.misclickRate,
         abstentionRate: click.scored === 0 ? 0 : click.abstained / click.scored,
         latency: durations.length
             ? { p50: percentile(durations, 50), p95: percentile(durations, 95), max: durations[durations.length - 1] as number }
             : null,
         click,
         refusal,
+        errors: [...errors],
     };
 }
 
@@ -173,18 +209,44 @@ export const NOT_FOUND_CODE = 'COMPUTER_TARGET_NOT_FOUND';
  */
 export const INFRASTRUCTURE_CODES = new Set([
     'COMPUTER_CAPTURE_UNMEASURABLE',
-    'COMPUTER_CANDIDATE_OUT_OF_BOUNDS',
     'COMPUTER_VIEWPORT_UNAVAILABLE',
     'COMPUTER_CAPTURE_NO_DPR',
 ]);
 
+/**
+ * The pipeline produced an answer that was wrong on its face.
+ *
+ * `COMPUTER_CANDIDATE_OUT_OF_BOUNDS` fires when the model returns a point
+ * outside the frame it was shown. That is a defect in the thing being
+ * measured, not in the environment measuring it — grouping it with the
+ * capture failures would take a real grounding defect out of the denominator
+ * and blame the harness for it.
+ */
+export const GROUNDING_FAILURE_CODES = new Set([
+    'COMPUTER_CANDIDATE_OUT_OF_BOUNDS',
+]);
+
 /** What a failed vision-click actually was, for callers that must say so. */
-export type FailureKind = 'abstention' | 'not-found' | 'infrastructure' | 'unknown';
+export type FailureKind =
+    | 'abstention'
+    | 'not-found'
+    | 'grounding-failure'
+    | 'infrastructure'
+    /** A `success:false` body with no code at all — a protocol violation. */
+    | 'uncoded'
+    /** A code this build does not recognise. Forward compatibility, not breakage. */
+    | 'unknown';
 
 export function classifyFailure(code: string | null | undefined): FailureKind {
-    if (!code) return 'unknown';
+    // An absent code and an unrecognised one are different situations. The
+    // first says the responder does not speak this protocol — an older server,
+    // most likely, since this runner talks to a separately built one over
+    // HTTP. The second says it speaks a newer dialect. Collapsing them would
+    // let a version skew silently reinstate the mis-scoring this fixes.
+    if (!code) return 'uncoded';
     if (ABSTENTION_CODES.has(code)) return 'abstention';
     if (code === NOT_FOUND_CODE) return 'not-found';
+    if (GROUNDING_FAILURE_CODES.has(code)) return 'grounding-failure';
     if (INFRASTRUCTURE_CODES.has(code)) return 'infrastructure';
     return 'unknown';
 }
@@ -196,11 +258,43 @@ export function classify(
     clickedRef?: string,
 ): CaseOutcome {
     if (response.success !== true) {
-        if (response.code && ABSTENTION_CODES.has(response.code)) {
-            return { kind: 'abstained', ms, reason: response.code };
+        const kind = classifyFailure(response.code);
+        if (kind === 'abstention') {
+            return { kind: 'abstained', ms, reason: response.code as string };
         }
-        // "Target not found" is also an abstention: the pipeline declined
-        // rather than clicked, which is the behaviour being measured.
+        if (kind === 'infrastructure') {
+            // The harness could not ask the question. That is not evidence
+            // about grounding in either direction, and scoring it as
+            // restraint made a broken capture look like good judgement.
+            return { kind: 'errored', ms, error: response.code as string };
+        }
+        if (kind === 'grounding-failure') {
+            return { kind: 'grounding-failure', ms, reason: response.code as string };
+        }
+        if (kind === 'not-found') {
+            // Expected-aware, because the same code means opposite things.
+            // On a case that should have declined, not finding the target IS
+            // the right answer. On a case where the element is present and
+            // described, failing to find it is a grounding failure — filing it
+            // as an abstention credits restraint that was never exercised and
+            // keeps it out of the misclick denominator, so a pipeline that
+            // grounds nothing reports a clean sheet.
+            return expected === 'abstain'
+                ? { kind: 'abstained', ms, reason: response.code as string }
+                : { kind: 'grounding-failure', ms, reason: response.code as string };
+        }
+        if (kind === 'uncoded' && response.reason) {
+            // A `success:false` body carrying prose and no code. Every current
+            // source path names its failures, so this means the responder is
+            // older than the naming — which is exactly the case where the
+            // prose could be describing a capture failure. Scoring it as an
+            // abstention is the mistake this function was rewritten to stop,
+            // so it is surfaced as unscoreable rather than credited.
+            return { kind: 'errored', ms, error: `uncoded failure: ${response.reason}` };
+        }
+        // An unrecognised code is forward compatibility, not breakage: this
+        // build cannot judge a dialect it does not know, and hard-failing
+        // would make the harness brittle against its own future.
         if (response.reason) return { kind: 'abstained', ms, reason: response.reason };
         return { kind: 'errored', ms, error: 'no reason given' };
     }
@@ -221,14 +315,21 @@ export function formatReport(report: EvalReport): string {
         `misclicked      ${report.misclicked} (${pct(report.misclickRate)})`,
         `abstained       ${report.abstained} (${pct(report.abstentionRate)} of cases that should have clicked)`,
     ];
+    if (report.groundingFailed > 0) {
+        lines.push(`not grounded    ${report.groundingFailed} (the target was there and the pipeline could not find it)`);
+    }
     if (report.latency) {
         lines.push(`latency         p50 ${report.latency.p50}ms  p95 ${report.latency.p95}ms  max ${report.latency.max}ms`);
     }
     lines.push(
         '',
         `when clicking   ${report.click.verified}/${report.click.scored} right, ${report.click.misclicked} wrong`,
-        `when refusing   ${report.refusal.verified}/${report.refusal.scored} correctly declined`,
+        `when refusing   ${report.refusal.verified}/${report.refusal.scored} correctly declined, ${report.refusal.misclicked} clicked anyway`,
     );
+    if (report.errors.length > 0) {
+        lines.push('', 'could not be scored:');
+        for (const e of report.errors) lines.push(`  ${e}`);
+    }
     lines.push('', 'An abstention is the pipeline declining, not failing. Read the misclick', 'rate first: a wrong click is worse than no click.');
     return lines.join('\n');
 }

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -384,7 +384,7 @@ cli-jaw/
 │   │   ├── occlusion.ts      ← 클릭 지점 페이지 hit-test 함수 + 가림 판정(자손/label/presentational은 통과, 미확인은 fail-open) (179L)
 │   │   ├── verify-candidate.ts ← 후보 주변 확대 크롭 기하 + 2차 응답 드리프트 판정(합의 시 좌표 교체) + remainingObservationBudget (200L)
 │   │   ├── vision-provider.ts ← codex 호출 인자 구성(샌드박스 우회는 명시적 opt-in, 기본 off) + Windows 종료코드 해석 (101L)
-│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/오류 분리, nearest-rank 백분위) + classifyFailure(기권/미발견/인프라 3분류) (234L)
+│   │   ├── grounding-eval.ts ← 평가 하니스 채점(오클릭/기권/그라운딩실패/오류 분리, click 버킷 기준 rate, nearest-rank 백분위) + classifyFailure 5분류 (335L)
 │   │   ├── runtime-diagnostics.ts ← runtime diagnostics helper (121L)
 │   │   ├── runtime-owner.ts  ← browser runtime owner management (135L)
 │   │   ├── runtime-owner-store.ts ← runtime owner store (55L)

--- a/tests/unit/grounding-eval-scoring.test.ts
+++ b/tests/unit/grounding-eval-scoring.test.ts
@@ -1,0 +1,173 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    classify,
+    classifyFailure,
+    scoreRun,
+    formatReport,
+    ABSTENTION_CODES,
+    INFRASTRUCTURE_CODES,
+    GROUNDING_FAILURE_CODES,
+    NOT_FOUND_CODE,
+    type CaseResult,
+} from '../../src/browser/grounding-eval.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// The harness measures whether the pipeline behaves well. Every case below is
+// about the one direction it must never fail: breakage reading as good
+// behaviour.
+
+test('ES-001: an infrastructure failure is unscoreable, not restraint', () => {
+    for (const code of INFRASTRUCTURE_CODES) {
+        const o = classify({ success: false, code }, 'e1', 50);
+        assert.equal(o.kind, 'errored', `${code} is the harness failing to ask, not the pipeline declining`);
+    }
+});
+
+test('ES-002: an out-of-frame answer is a grounding failure, not infrastructure', () => {
+    // validateCandidate rejects a point the MODEL returned as outside the image
+    // it was shown. Filing that under "the environment broke" would take a real
+    // defect out of the denominator and blame the harness through the exit code.
+    assert.ok(!INFRASTRUCTURE_CODES.has('COMPUTER_CANDIDATE_OUT_OF_BOUNDS'));
+    assert.ok(GROUNDING_FAILURE_CODES.has('COMPUTER_CANDIDATE_OUT_OF_BOUNDS'));
+    const o = classify({ success: false, code: 'COMPUTER_CANDIDATE_OUT_OF_BOUNDS' }, 'e1', 50);
+    assert.equal(o.kind, 'grounding-failure');
+});
+
+test('ES-003: not-found means opposite things and is scored accordingly', () => {
+    // On a case that should decline, not finding the target is correct.
+    const declining = classify({ success: false, code: NOT_FOUND_CODE }, 'abstain', 50);
+    assert.equal(declining.kind, 'abstained');
+    // On a case where the element is present and described, it is a failure to
+    // ground it. Calling that restraint credits judgement never exercised.
+    const clicking = classify({ success: false, code: NOT_FOUND_CODE }, 'e1', 50);
+    assert.equal(clicking.kind, 'grounding-failure');
+});
+
+test('ES-004: an absent code and an unrecognised one are different situations', () => {
+    // The runner talks to a separately built server over HTTP. Prose with no
+    // code means an older responder, whose prose could be describing a capture
+    // failure — the exact case this stops crediting.
+    assert.equal(classifyFailure(undefined), 'uncoded');
+    assert.equal(classifyFailure('COMPUTER_SOMETHING_FUTURE'), 'unknown');
+    const old = classify({ success: false, reason: 'capture size unavailable' }, 'e1', 50);
+    assert.equal(old.kind, 'errored');
+    // A dialect this build does not know is forward compatibility, not
+    // breakage; hard-failing would make the harness brittle against its future.
+    const future = classify({ success: false, code: 'COMPUTER_SOMETHING_FUTURE', reason: 'declined' }, 'e1', 50);
+    assert.equal(future.kind, 'abstained');
+});
+
+test('ES-005: the four code sets are disjoint', () => {
+    const all = [...ABSTENTION_CODES, ...INFRASTRUCTURE_CODES, ...GROUNDING_FAILURE_CODES, NOT_FOUND_CODE];
+    assert.equal(new Set(all).size, all.length, 'a code cannot mean two things');
+});
+
+test('ES-006: a grounding failure stays in the denominator', () => {
+    // Excluding it would let a pipeline that grounds nothing report a clean
+    // sheet: no wrong clicks, because no clicks.
+    const results: CaseResult[] = [
+        { id: 'a', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'b', expected: 'e2', outcome: { kind: 'grounding-failure', ms: 10, reason: NOT_FOUND_CODE } },
+    ];
+    const report = scoreRun(results);
+    assert.equal(report.scored, 2, 'both cases were evidence about grounding');
+    assert.equal(report.groundingFailed, 1);
+    assert.equal(report.verifiedRate, 0.5, 'not 1.0');
+});
+
+test('ES-007: an errored case still leaves the denominator', () => {
+    const results: CaseResult[] = [
+        { id: 'a', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'b', expected: 'e2', outcome: { kind: 'errored', ms: 10, error: 'COMPUTER_CAPTURE_NO_DPR' } },
+    ];
+    const report = scoreRun(results);
+    assert.equal(report.scored, 1, 'a case the harness could not run is not evidence');
+    assert.equal(report.verifiedRate, 1);
+});
+
+test('ES-008: the headline rates no longer blend click and refusal cases', () => {
+    // A refusal-case misclick means "clicked when it should have declined"; a
+    // click-case misclick means "clicked the wrong element". Summing them gave
+    // one number meaning two different failures.
+    const results: CaseResult[] = [
+        { id: 'click-ok', expected: 'e1', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'click-ok2', expected: 'e2', outcome: { kind: 'verified', ms: 10 } },
+        { id: 'refuse-bad', expected: 'abstain', outcome: { kind: 'misclick', ms: 10, got: 'e9' } },
+    ];
+    const report = scoreRun(results);
+    assert.equal(report.verifiedRate, 1, 'every click case was right');
+    assert.equal(report.misclickRate, 0, 'no click case clicked the wrong element');
+    assert.equal(report.refusal.misclicked, 1, 'and the refusal failure is still visible');
+    assert.equal(report.misclicked, 1, 'the raw count keeps the total');
+});
+
+test('ES-009: the report names what could not be scored', () => {
+    const report = scoreRun([
+        { id: 'a', expected: 'e1', outcome: { kind: 'errored', ms: 5, error: 'COMPUTER_CAPTURE_NO_DPR' } },
+        { id: 'b', expected: 'e2', outcome: { kind: 'errored', ms: 5, error: 'COMPUTER_CAPTURE_NO_DPR' } },
+        { id: 'c', expected: 'e3', outcome: { kind: 'errored', ms: 5, error: 'HTTP 500' } },
+    ]);
+    assert.deepEqual(report.errors.sort(), ['COMPUTER_CAPTURE_NO_DPR', 'HTTP 500'], 'distinct, because ten failures for one reason is not ten reasons');
+    const text = formatReport(report);
+    assert.match(text, /could not be scored/);
+    assert.match(text, /HTTP 500/);
+});
+
+test('ES-010: the refusal line shows what went wrong, like the click line does', () => {
+    const report = scoreRun([
+        { id: 'a', expected: 'abstain', outcome: { kind: 'verified', ms: 5 } },
+        { id: 'b', expected: 'abstain', outcome: { kind: 'misclick', ms: 5, got: 'e9' } },
+    ]);
+    assert.match(formatReport(report), /clicked anyway/);
+});
+
+test('ES-011: a grounding failure is reported in words, not just counted', () => {
+    const report = scoreRun([
+        { id: 'a', expected: 'e1', outcome: { kind: 'grounding-failure', ms: 5, reason: NOT_FOUND_CODE } },
+    ]);
+    assert.match(formatReport(report), /not grounded/);
+});
+
+// ─── the runner ─────────────────────────────────────────────────────────
+
+test('ES-012: the refusal site asks what a code means, not whether one exists', () => {
+    const runner = fs.readFileSync(join(root, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.doesNotMatch(
+        runner,
+        /Boolean\(res\.body\?\.code \|\| res\.body\?\.reason\)/,
+        'presence was never the right signal',
+    );
+    assert.match(runner, /classifyFailure\(res\.body\?\.code\)/);
+});
+
+test('ES-013: the refusal site uses the predicate, not the outcome function', () => {
+    // classify() would return 'abstained' for a correct refusal, which scoreRun
+    // files as refusal.abstained with refusal.verified at zero — reporting
+    // "0/3 correctly declined" for perfect behaviour.
+    const runner = fs.readFileSync(join(root, 'scripts/grounding-eval.mjs'), 'utf8');
+    const block = runner.slice(runner.indexOf('if (c.expectAbstention)'), runner.indexOf('if (c.expectRegion)'));
+    assert.match(block, /classifyFailure/);
+    assert.doesNotMatch(block, /classify\(res\.body/);
+});
+
+test('ES-014: the region path checks the HTTP status it never checked', () => {
+    const runner = fs.readFileSync(join(root, 'scripts/grounding-eval.mjs'), 'utf8');
+    const block = runner.slice(runner.indexOf('if (c.expectRegion)'), runner.indexOf('results.push({\n                id: c.id,'));
+    assert.match(block, /res\.status >= 400/, 'a crashed server scored as a decline and exited 0');
+    // Read the executable lines only. The comment above them quotes the
+    // fallback by name to explain why it is gone, and a scan that cannot tell
+    // an explanation from the thing it explains would fail on its own footnote.
+    const code = block.split('\n').filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n');
+    assert.doesNotMatch(code, /\?\? 'declined'/, 'and it manufactured a reason where none was given');
+    assert.match(code, /classify\(res\.body \?\? \{\}, c\.expectRegion, ms\)/, 'the shared function decides instead');
+});
+
+test('ES-015: a thrown refusal case is filed in the refusal bucket', () => {
+    const runner = fs.readFileSync(join(root, 'scripts/grounding-eval.mjs'), 'utf8');
+    assert.match(runner, /c\.expectAbstention \? 'abstain'/);
+});

--- a/tests/unit/grounding-eval.test.ts
+++ b/tests/unit/grounding-eval.test.ts
@@ -53,10 +53,22 @@ test('EV-004: every refusal code counts as an abstention', () => {
     }
 });
 
-test('EV-005: a refusal with only prose is still an abstention', () => {
-    // "Target not found" is the pipeline declining rather than clicking, which
-    // is the behaviour being measured.
+test('EV-005: a refusal with prose and no code cannot be scored', () => {
+    // This used to assert 'abstained', which is what let an unmeasurable
+    // capture score as restraint. Every current source path names its
+    // failures, so prose without a code means the responder predates the
+    // naming — and the prose could be describing anything, including the
+    // infrastructure failures this now separates. Unscoreable is the honest
+    // answer; crediting it was the defect.
     const o = classify({ success: false, reason: 'target not found' }, 'e1', 50);
+    assert.equal(o.kind, 'errored');
+    assert.match(o.kind === 'errored' ? o.error : '', /uncoded failure/);
+});
+
+test('EV-005b: the pipeline declining by name is still an abstention', () => {
+    // The behaviour EV-005 meant to protect, expressed through the code the
+    // pipeline now actually sends, on a case where declining is correct.
+    const o = classify({ success: false, code: 'COMPUTER_TARGET_NOT_FOUND' }, 'abstain', 50);
     assert.equal(o.kind, 'abstained');
 });
 

--- a/tests/unit/observation-freshness.test.ts
+++ b/tests/unit/observation-freshness.test.ts
@@ -129,12 +129,15 @@ test('OF-012: every failure return carries a code', () => {
     }
 });
 
-test('OF-013: the three failure meanings are distinguishable', () => {
+test('OF-013: the failure meanings are distinguishable', () => {
     assert.equal(classifyFailure('COMPUTER_TARGET_COVERED'), 'abstention');
     assert.equal(classifyFailure('COMPUTER_OBSERVATION_STALE'), 'abstention');
     assert.equal(classifyFailure(NOT_FOUND_CODE), 'not-found');
     assert.equal(classifyFailure('COMPUTER_CAPTURE_NO_DPR'), 'infrastructure');
-    assert.equal(classifyFailure(null), 'unknown');
+    // An absent code and an unrecognised one were the same answer when this
+    // test was written; the scoring phase separated them, because one means
+    // the responder predates the naming and the other means it postdates it.
+    assert.equal(classifyFailure(null), 'uncoded');
     assert.equal(classifyFailure('COMPUTER_SOMETHING_NEW'), 'unknown');
 });
 
@@ -166,4 +169,3 @@ test('OF-016: the verification capture fails closed on an unmeasurable image, li
 test('OF-017: verification judges against the captured crop, not the requested one', () => {
     assert.match(visionSrc, /judgeVerification\(local, cropShot\.clip \?\? crop, css\)/);
 });
-


### PR DESCRIPTION
The evaluation harness scored its own breakage as good behaviour, in three places.

`classify()` checked `ABSTENTION_CODES` and then bucketed any remaining `reason` as an abstention, so a screenshot whose size could not be read scored identically to a deliberate refusal on an ambiguous target. The runner was worse: its `expectAbstention` branch asked `Boolean(code || reason)`, which on `covered`, `ambiguous` and `absent` — the three cases that exist as evidence for the occlusion and ambiguity guards — turned a capture failure into the guard firing correctly. The comment directly above that predicate says a refusal and a failure are not the same thing.

The region branch had no HTTP status check at all, unlike the abstention branch beside it, so a 500 from the route's catch returned `{error}`, `success` was `undefined`, and a crashed server scored as a decline and exited 0.

## What the plan audit corrected

Two of my own classifications were wrong, and the audit found a defect larger than the one I set out to fix.

`COMPUTER_CANDIDATE_OUT_OF_BOUNDS` is not infrastructure. It fires when the model returns a point outside the image it was shown, which is a defect in the thing being measured. Routing it to `errored` would have taken a real grounding failure out of the denominator and blamed the harness for it through the exit code.

`COMPUTER_TARGET_NOT_FOUND` means opposite things depending on the case: correct restraint where declining is the answer, a failure to ground where the element is present and described. Filing the second as an abstention credits judgement never exercised and keeps it out of the misclick denominator, so a pipeline that grounds nothing reports 0% misclick and reads as admirably cautious. Both now land in a `grounding-failure` outcome that **stays in the denominator**.

And `verifiedRate` / `misclickRate` still blended the click and refusal buckets — exactly the defect #616 found for `abstentionRate` and fixed one field away. A refusal-case misclick means "clicked when it should have declined"; a click-case misclick means "clicked the wrong element". All three rates are now scoped to click cases; the raw counts keep the totals.

## Also

An absent code and an unrecognised one were the same answer while meaning opposite things. This runner talks to a separately built server over HTTP, so prose-without-a-code means an older responder whose prose could be describing a capture failure — crediting it would reinstate the mis-scoring through the fix's own escape hatch. An unrecognised code stays an abstention, because a build cannot judge a dialect it does not know.

The report names the distinct errors and shows what went wrong on refusal cases, which required carrying them on `EvalReport` rather than discarding them in `scoreRun`.

`EV-005` asserted the behaviour being fixed here, so it now asserts the opposite; `EV-005b` covers what it was protecting, expressed through the code the pipeline actually sends.

## Deliberately deferred

Exit-code semantics (a run where every click lands wrong still exits 0; an empty `--only` run exits 0) is a contract change to the operator interface. Latency blending early refusals with full clicks is a reporting refinement. Both are recorded rather than folded in silently.

## Validation

`tests/unit/grounding-eval-scoring.test.ts`, 15 cases: infrastructure codes are unscoreable, an out-of-frame answer is a grounding failure, not-found is expected-aware, the code sets are disjoint, a grounding failure stays in the denominator while an error leaves it, the headline rates no longer blend, and the runner's three sites ask what a code means.

82 pass across the grounding and vision suites under tsx. Typecheck clean, `gate:doc-drift` and `verify-counts` pass. Full local suite **NOT RUN**; CI on this head is the evidence.
