### PR TITLE
browser: a ref is a position in a parse, and nothing checked it still meant the same element

### DIFF
--- a/src/browser/actions.ts
+++ b/src/browser/actions.ts
@@ -2,6 +2,7 @@ import { getActivePage, getCdpSession, getBrowserStateVersion, markBrowserStateC
 import { JAW_HOME } from '../core/config.js';
 import { join } from 'path';
 import fs from 'fs';
+import { createHash } from 'crypto';
 import { imageSize } from './image-size.js';
 import { hitTestInPage } from './occlusion.js';
 import { clampClipToViewport } from './verify-candidate.js';
@@ -27,10 +28,29 @@ type SnapshotNode = {
 
 type SnapshotState = {
     snapshotId: string;
+    /**
+     * Bumped by navigation-ish actions, never by the page changing itself.
+     *
+     * Read by nothing since the ref cache was removed — its four conditions
+     * could not see a DOM mutation, which is why that branch is gone. Kept
+     * because the snapshotId round-trip will need to say which browser epoch a
+     * caller's snapshot belongs to, and recomputing it later is not free.
+     */
     stateVersion: number;
     targetId: string | null;
     url: string;
     nodes: SnapshotNode[];
+    /**
+     * A digest of the node list, so a shift can be detected at all.
+     *
+     * A ref is a position in a parse, not a handle on an element. Comparing
+     * one node's role, name and occurrence therefore asks whether the LOCATOR
+     * would be spelled the same, which is a different question from whether
+     * the ELEMENT is the same: delete one row from ten identical ones and
+     * every surviving index still carries a byte-identical tuple while naming
+     * its neighbour. Only the whole list can say the positions moved.
+     */
+    digest: string;
 };
 
 type ClipRect = { x: number; y: number; width: number; height: number };
@@ -187,6 +207,11 @@ export async function snapshot(port: number, opts: BrowserActionOptions = {}) {
         }
     }
 
+    // The whole parse, held before any filtering. It is what the refs were
+    // numbered against and the only view of the page that does not depend on
+    // how this particular call was asked.
+    const unfiltered = nodes;
+
     if (opts["interactive"]) {
         nodes = nodes.filter(n => INTERACTIVE_ROLES.includes(n.role));
     }
@@ -201,8 +226,28 @@ export async function snapshot(port: number, opts: BrowserActionOptions = {}) {
         targetId: normalizeActiveTargetId(activeTab),
         url: page.url(),
         nodes,
+        // Digest the UNFILTERED parse, not the list being returned.
+        //
+        // `interactive` and `maxNodes` shape what a caller is shown; they say
+        // nothing about the page. Fingerprinting the shown list would make the
+        // digest depend on the request, so a later lookup that re-snapshots
+        // with different options would compare 40 interactive nodes against
+        // 400 unfiltered ones and conclude the page moved every single time —
+        // on a page that had not changed by one byte.
+        digest: snapshotDigest(unfiltered),
     };
-    if (opts["json"]) return { nodes, meta: { total, shown: nodes.length, snapshotId: latestSnapshot.snapshotId } };
+    // `digest` is DIAGNOSTIC. A caller can hold it to see whether the page
+    // changed between two snapshots it took itself, but it is not a token: ref
+    // lookups compare against the most recent internal parse, which rotates
+    // whenever anything re-snapshots, so a held digest does not mean "my refs
+    // were validated against what I saw". Binding the check to the caller's
+    // own observation needs the snapshotId round-trip, which is its own unit.
+    if (opts["json"]) {
+        return {
+            nodes,
+            meta: { total, shown: nodes.length, snapshotId: latestSnapshot.snapshotId, digest: latestSnapshot.digest, digestIsDiagnostic: true },
+        };
+    }
     return nodes;
 }
 
@@ -214,6 +259,32 @@ function annotateOccurrences(nodes: Omit<SnapshotNode, 'occurrence'>[]): Snapsho
         counts.set(key, occurrence + 1);
         return { ...node, occurrence };
     });
+}
+
+/**
+ * A fingerprint of the parse a set of refs came from.
+ *
+ * Includes `depth` because a node moving between parents changes what a ref
+ * means without changing its role or name, and the node count because an
+ * insertion and a deletion elsewhere can otherwise cancel out.
+ *
+ * This is deliberately coarse. It answers "is this the same list of nodes in
+ * the same order", which is the only question positional refs can be honest
+ * about — not "is this the same page", which is a claim the accessibility
+ * tree cannot make.
+ */
+export function snapshotDigest(nodes: Array<Pick<SnapshotNode, 'role' | 'name' | 'depth'>>): string {
+    const h = createHash('sha1');
+    h.update(String(nodes.length));
+    for (const n of nodes) {
+        h.update('\u0000');
+        h.update(n.role);
+        h.update('\u0000');
+        h.update(n.name);
+        h.update('\u0000');
+        h.update(String(n.depth));
+    }
+    return h.digest('hex').slice(0, 16);
 }
 
 /**
@@ -265,25 +336,126 @@ export function locatorForNode(page: Page, node: Pick<SnapshotNode, 'role' | 'na
 
 // ─── ref → locator ─────────────────────────────
 
+/**
+ * Re-find a node the caller saw, after the list it came from moved.
+ *
+ * A shifted list makes the REF meaningless without making the INTENT
+ * meaningless: if what the caller pointed at is still there and still
+ * unambiguous, that is the element they meant.
+ *
+ * Uniqueness in the fresh list is not enough to say so, which is the trap this
+ * function exists inside. Two rows each carrying `button "Delete"`, the caller
+ * points at the first, the page removes that row — now exactly one Delete
+ * remains, and resolving to it deletes the OTHER row. Removal is what
+ * manufactured the uniqueness, so the rule is at its weakest precisely when
+ * the caller's element is the thing that went away. That is the original
+ * defect reproduced inside its own fix, on an operation nobody can undo.
+ *
+ * So uniqueness must hold on BOTH sides. A name that was unique before and is
+ * unique now is the same element by any reading available here. A set that
+ * shrank to one is ambiguous, not recovered.
+ *
+ * `depth` participates because the digest uses it: the key that decides which
+ * element to click should not be weaker than the key that decides whether to
+ * be suspicious. An empty name is not identifying at all — `parseAriaYaml`
+ * folds a name its regex failed to capture into the same bucket as a genuinely
+ * unnamed node, so recovering `button ""` to some other `button ""` would be a
+ * wrong click justified by a parser artifact.
+ */
+export function recoverNode(
+    previous: SnapshotNode,
+    previousAll: SnapshotNode[],
+    fresh: SnapshotNode[],
+): SnapshotNode | 'ambiguous' | 'absent' | 'moved' {
+    if (!previous.name) return 'ambiguous';
+    const same = (n: SnapshotNode) =>
+        n.role === previous.role && n.name === previous.name && n.depth === previous.depth;
+    if (previousAll.filter(same).length !== 1) return 'ambiguous';
+    const matches = fresh.filter(same);
+    if (matches.length === 1) return matches[0] as SnapshotNode;
+    if (matches.length > 1) return 'ambiguous';
+    // Nothing at that role, name AND depth. The element may still be on the
+    // page one level in or out — a modal wrapped it, a section above it
+    // expanded — so "absent" would be a claim this cannot support. Only when
+    // the role and name are gone entirely is it really gone.
+    return fresh.some(n => n.role === previous.role && n.name === previous.name)
+        ? 'moved'
+        : 'absent';
+}
+
 async function refToLocator(page: Page, port: number, ref: string): Promise<Locator> {
-    let nodes: SnapshotNode[];
-    const activeTab = await getActiveTab(port).catch(() => ({ ok: false as const }));
-    const activeTargetId = normalizeActiveTargetId(activeTab);
-    if (
-        latestSnapshot
-        && latestSnapshot.targetId
-        && activeTargetId === latestSnapshot.targetId
-        && latestSnapshot.stateVersion === getBrowserStateVersion()
-        && latestSnapshot.url === page.url()
-    ) {
-        nodes = latestSnapshot.nodes;
-    } else {
-        const fresh = await snapshot(port) as SnapshotNode[];
-        nodes = fresh;
+    // Capture the basis BEFORE anything can replace it. `snapshot()` assigns
+    // `latestSnapshot` before it returns, so reading the module state after
+    // the call would compare the fresh parse against itself — a check that
+    // passes unconditionally and looks like it is working.
+    const previousState = latestSnapshot;
+    // There is no cache branch any more, and its absence is the point.
+    //
+    // It used to resolve a ref straight out of the stored parse when the tab,
+    // URL and state version all matched. None of those can see a DOM
+    // mutation — `click` and `type` do not bump the state version — and
+    // `occurrence` is not a handle: it becomes `.nth(occurrence)` against the
+    // LIVE DOM at click time, so a feed prepending one same-named element
+    // silently shifted every index. That was the one remaining route to a
+    // locator with no freshness check at all.
+    //
+    // It also almost never ran. `resolveActiveTargetId` returns null unless
+    // `verifiedActiveTargetId` was set, which only `switchTab` and one branch
+    // of `createTab` do, so `previousState.targetId` was falsy and the guard
+    // failed on every ordinary navigate-snapshot-click flow. Keeping it would
+    // have preserved an unguarded path for the benefit of two callers, and a
+    // cache that cannot be validated without re-snapshotting is not a cache.
+    const fresh = await snapshot(port) as SnapshotNode[];
+    const node = fresh.find(n => n.ref === ref);
+
+    // No previous parse at all: there is no claim to contradict, so the lookup
+    // proceeds. That is the fail-open posture `assertFreshObservationBundle`
+    // takes for a MISSING value.
+    if (!previousState) {
+        if (!node) throw new Error(`ref ${ref} not found — re-run snapshot`);
+        return locatorForNode(page, node);
     }
-    const node = nodes.find(n => n.ref === ref);
-    if (!node) throw new Error(`ref ${ref} not found — re-run snapshot`);
-    return locatorForNode(page, node);
+
+    // A basis taken of a DIFFERENT page is the opposite case, and folding the
+    // two together was a mistake: an absent basis says nothing, while a basis
+    // from another URL is affirmative evidence that every positional ref is
+    // meaningless. The precedent says so too —
+    // `assertFreshObservationBundle` throws on a known URL mismatch and fails
+    // open only when a side is absent.
+    if (previousState.url !== page.url()) {
+        throw new Error(
+            `ref ${ref} was taken on ${previousState.url} and the page is now ${page.url()} — re-run snapshot`,
+        );
+    }
+
+    const moved = previousState.digest !== snapshotDigest(fresh);
+    if (!moved) {
+        if (!node) throw new Error(`ref ${ref} not found — re-run snapshot`);
+        return locatorForNode(page, node);
+    }
+
+    // The list moved, so this ref is a position that no longer means what it
+    // meant. Recover by intent rather than by index.
+    const was = previousState.nodes.find(n => n.ref === ref);
+    if (!was) throw new Error(`ref ${ref} not found — re-run snapshot`);
+
+    const recovered = recoverNode(was, previousState.nodes, fresh);
+    if (recovered === 'absent') {
+        throw new Error(
+            `ref ${ref} named ${was.role} "${was.name}", which is no longer on the page — re-run snapshot`,
+        );
+    }
+    if (recovered === 'moved') {
+        throw new Error(
+            `ref ${ref} named ${was.role} "${was.name}", which is still on the page but somewhere else in the tree — re-run snapshot`,
+        );
+    }
+    if (recovered === 'ambiguous') {
+        throw new Error(
+            `the page changed and ref ${ref} (${was.role} "${was.name}") is now one of several — re-run snapshot`,
+        );
+    }
+    return locatorForNode(page, recovered);
 }
 
 /**

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -375,7 +375,7 @@ cli-jaw/
 │   ├── browser/              ← Chrome CDP 제어 + web-ai 자동화 + adaptive-fetch
 │   │   ├── connection.ts     ← Chrome 탐지/launch/CDP 연결 + readiness polling + retry + headless + runtime diagnostics/orphan cleanup + activePort/active-tab 상태 관리 (820L)
 │   │   ├── launch-policy.ts  ← browser start mode 정규화 + agent/debug/manual launch policy (51L)
-│   │   ├── actions.ts        ← snapshot/click/type/navigate/screenshot + observePageIdentity(신선도 전용 저비용 프로브) + browser primitive actions (748L)
+│   │   ├── actions.ts        ← snapshot/click/type/navigate/screenshot + observePageIdentity(신선도 전용 저비용 프로브) + browser primitive actions (920L)
 │   │   ├── primitives.ts     ← low-level CDP primitives (294L)
 │   │   ├── vision.ts         ← vision-click 파이프라인 + Codex provider(--ephemeral, stdin ignore, 남은 예산 기반 timeout) + reconcile와 무관한 신선도 거부 + 실패 코드 명명 (566L)
 │   │   ├── vision-input.ts   ← 미신뢰 target 정화(quote-run 붕괴, 제로폭/bidi 제거, surrogate-safe 절단) + stdout 상한 (80L)

--- a/tests/unit/browser-observation-primitives.test.ts
+++ b/tests/unit/browser-observation-primitives.test.ts
@@ -16,7 +16,14 @@ test('BOP-001: snapshot supports maxNodes/json and occurrence-safe refs', () => 
     assert.match(actionsSrc, /occurrence/);
     assert.match(actionsSrc, /latestSnapshot/);
     assert.match(actionsSrc, /targetId: normalizeActiveTargetId\(activeTab\)/);
-    assert.match(actionsSrc, /activeTargetId === latestSnapshot\.targetId/);
+    // This used to assert the ref lookup's cache guard, which compared the
+    // active target against the stored snapshot's. That branch is gone: none
+    // of its conditions could see a DOM mutation, while `.nth(occurrence)`
+    // indexes the live DOM at click time, so it was the one remaining route to
+    // a locator with no freshness check. Refs are now always resolved against
+    // a fresh parse, with the previous one held as the comparison basis.
+    assert.match(actionsSrc, /const previousState = latestSnapshot;/);
+    assert.doesNotMatch(actionsSrc, /cacheUsable/);
 });
 
 test('BOP-002: screenshot supports json and validated clip metadata', () => {

--- a/tests/unit/ref-identity.test.ts
+++ b/tests/unit/ref-identity.test.ts
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { snapshotDigest, recoverNode } from '../../src/browser/actions.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const actionsSrc = fs.readFileSync(join(root, 'src/browser/actions.ts'), 'utf8');
+
+type N = { ref: string; role: string; name: string; depth: number; occurrence: number };
+let counter = 0;
+const node = (role: string, name: string, depth = 1): N =>
+    ({ ref: `e${++counter}`, role, name, depth, occurrence: 0 });
+
+// A ref is a position in a parse, not a handle on an element. Everything here
+// is about what that costs and what can honestly be claimed instead.
+
+test('RI-001: an insertion above a ref changes the digest', () => {
+    const before = [node('button', 'A'), node('button', 'B'), node('button', 'C')];
+    const after = [node('status', 'Loading'), ...before];
+    assert.notEqual(snapshotDigest(before), snapshotDigest(after));
+});
+
+test('RI-002: a deletion inside a uniform run changes the digest', () => {
+    // The case a per-node tuple cannot see. Ten identical rows, delete one, and
+    // every surviving index still carries a byte-identical role+name+occurrence
+    // while naming its neighbour. Only the list can tell.
+    const rows = (n: number) => Array.from({ length: n }, () => node('link', 'Open'));
+    assert.notEqual(snapshotDigest(rows(10)), snapshotDigest(rows(9)));
+});
+
+test('RI-003: reordering changes the digest even with the same members', () => {
+    const a = [node('button', 'Save'), node('button', 'Cancel')];
+    assert.notEqual(snapshotDigest(a), snapshotDigest([...a].reverse()));
+});
+
+test('RI-004: depth is part of the fingerprint', () => {
+    // A node moving between parents changes what a ref means without changing
+    // its role or name.
+    assert.notEqual(snapshotDigest([node('button', 'Save', 1)]), snapshotDigest([node('button', 'Save', 3)]));
+});
+
+test('RI-005: an unchanged list keeps its digest', () => {
+    const list = [node('button', 'Save'), node('link', 'Open'), node('textbox', '')];
+    assert.equal(snapshotDigest(list), snapshotDigest(list.map(n => ({ ...n }))));
+    assert.equal(snapshotDigest([]), snapshotDigest([]));
+});
+
+test('RI-006: the digest does not depend on how the snapshot was requested', () => {
+    // `interactive` and `maxNodes` shape what a caller is shown and say nothing
+    // about the page. Digesting the shown list made the fingerprint a function
+    // of the REQUEST, so a lookup that re-snapshotted with different options
+    // compared 40 interactive nodes against 400 unfiltered ones and concluded
+    // the page had moved — every time, on a page that had not changed.
+    assert.match(actionsSrc, /const unfiltered = nodes;/);
+    assert.match(actionsSrc, /digest: snapshotDigest\(unfiltered\)/);
+    const capture = actionsSrc.indexOf('const unfiltered = nodes;');
+    const filter = actionsSrc.indexOf("if (opts[\"interactive\"])");
+    assert.ok(capture < filter, 'the whole parse must be captured before it is filtered');
+});
+
+// ─── recovery, which is where a wrong click would come from ─────────────
+
+test('RI-007: a uniquely named node that survived is recovered', () => {
+    const was = node('button', 'Publish');
+    const before = [node('status', 'Idle'), was];
+    const after = [node('status', 'Saving'), node('status', 'Idle'), { ...was, ref: 'e99' }];
+    const got = recoverNode(was, before, after);
+    assert.notEqual(got, 'absent');
+    assert.notEqual(got, 'ambiguous');
+    assert.equal((got as N).ref, 'e99');
+});
+
+test('RI-008: a node whose twin was removed is NOT recovered', () => {
+    // The trap. Two rows each carrying `button "Delete"`; the caller points at
+    // the first; the page removes that row. Exactly one Delete now remains, so
+    // a uniqueness-in-the-fresh-list rule resolves to it and deletes the OTHER
+    // row — the original defect, reproduced inside its own fix, on an operation
+    // nobody can undo. Removal is what manufactured the uniqueness.
+    const rowA = node('button', 'Delete');
+    const rowB = node('button', 'Delete');
+    const before = [rowA, rowB];
+    const after = [{ ...rowB, ref: 'e77' }];
+    assert.equal(recoverNode(rowA, before, after), 'ambiguous');
+});
+
+test('RI-009: a node that was never unique is not recovered either', () => {
+    const a = node('link', 'Open');
+    const before = [a, node('link', 'Open'), node('link', 'Open')];
+    const after = [node('link', 'Open'), node('link', 'Open'), node('link', 'Open')];
+    assert.equal(recoverNode(a, before, after), 'ambiguous');
+});
+
+test('RI-010: a genuinely absent node reports absence, not ambiguity', () => {
+    const was = node('button', 'Publish');
+    assert.equal(recoverNode(was, [was], [node('button', 'Save')]), 'absent');
+});
+
+test('RI-011: an empty name is not identifying', () => {
+    // parseAriaYaml folds a name its regex failed to capture into the same
+    // bucket as a genuinely unnamed node, so recovering `button ""` to some
+    // other `button ""` would be a wrong click justified by a parser artifact.
+    const was = node('button', '');
+    assert.equal(recoverNode(was, [was], [{ ...node('button', ''), ref: 'e88' }]), 'ambiguous');
+});
+
+test('RI-012: depth participates in recovery, as it does in the digest', () => {
+    // The key that decides which element to CLICK should not be weaker than
+    // the key that decides whether to be suspicious. But a depth change is not
+    // absence: a modal wrapping the target, or a section above it expanding,
+    // moves it without removing it, and saying "no longer on the page" about
+    // an element plainly still there sends the reader somewhere useless.
+    const was = node('button', 'Edit', 2);
+    const elsewhere = { ...node('button', 'Edit', 5), ref: 'e55' };
+    assert.equal(recoverNode(was, [was], [elsewhere]), 'moved');
+});
+
+test('RI-012b: a genuinely gone element is still absent, not moved', () => {
+    const was = node('button', 'Publish', 2);
+    assert.equal(recoverNode(was, [was], [node('button', 'Save', 2)]), 'absent');
+});
+
+test('RI-012c: the three failures say different things', () => {
+    // "gone", "still here but somewhere else", and "now one of several" send a
+    // reader to three different places.
+    assert.match(actionsSrc, /which is no longer on the page — re-run snapshot/);
+    assert.match(actionsSrc, /still on the page but somewhere else in the tree — re-run snapshot/);
+    assert.match(actionsSrc, /is now one of several — re-run snapshot/);
+});
+
+test('RI-017: the exported digest does not pretend to be a token', () => {
+    // A caller holding a digest would reasonably assume its refs were checked
+    // against the snapshot it saw. They were not: the internal basis rotates
+    // whenever anything re-snapshots, including a ref lookup itself. Binding
+    // the check to the caller's own observation needs the snapshotId
+    // round-trip, which is its own unit.
+    assert.match(actionsSrc, /digestIsDiagnostic: true/);
+    assert.match(actionsSrc, /it is not a token/);
+});
+
+// ─── the lookup path ────────────────────────────────────────────────────
+
+test('RI-013: the comparison basis is captured before the re-snapshot', () => {
+    // `snapshot()` assigns `latestSnapshot` before it returns, so reading the
+    // module state after the call compares the fresh parse against itself — a
+    // check that passes unconditionally and looks like it is working. No test
+    // over a pure function can see this, which is why it is asserted here.
+    const fn = actionsSrc.slice(
+        actionsSrc.indexOf('async function refToLocator'),
+        actionsSrc.indexOf('What would receive a click at a viewport point'),
+    );
+    const captureAt = fn.indexOf('const previousState = latestSnapshot;');
+    const snapshotAt = fn.indexOf('await snapshot(port)');
+    assert.ok(captureAt > 0 && snapshotAt > 0);
+    assert.ok(captureAt < snapshotAt, 'the capture must come first');
+});
+
+test('RI-014: a basis from another page is a refusal, not a fail-open', () => {
+    // An absent basis says nothing about the page; a basis from a different URL
+    // is affirmative evidence that every positional ref is meaningless. The
+    // precedent agrees — assertFreshObservationBundle throws on a known URL
+    // mismatch and fails open only when a side is absent.
+    const fn = actionsSrc.slice(
+        actionsSrc.indexOf('async function refToLocator'),
+        actionsSrc.indexOf('What would receive a click at a viewport point'),
+    );
+    assert.match(fn, /if \(!previousState\) \{/);
+    assert.match(fn, /and the page is now .* — re-run snapshot/);
+    assert.doesNotMatch(fn, /!previousState \|\| previousState\.url !== page\.url\(\)/);
+});
+
+test('RI-015: there is no longer a path to a locator with no freshness check', () => {
+    // The cache branch resolved straight out of the stored parse when tab, URL
+    // and state version matched — none of which can see a DOM mutation, while
+    // `.nth(occurrence)` indexes the live DOM at click time.
+    const fn = actionsSrc.slice(
+        actionsSrc.indexOf('async function refToLocator'),
+        actionsSrc.indexOf('What would receive a click at a viewport point'),
+    );
+    assert.doesNotMatch(fn, /cacheUsable/);
+    assert.equal((fn.match(/await snapshot\(port\)/g) || []).length, 1, 'exactly one parse is read');
+});
+
+test('RI-016: the snapshot carries its digest to callers', () => {
+    assert.match(actionsSrc, /snapshotId: latestSnapshot\.snapshotId, digest: latestSnapshot\.digest/);
+});


### PR DESCRIPTION
`parseAriaYaml` numbers refs positionally, so `e17` is an index into a parse rather than a handle on anything. `refToLocator` re-snapshots on a cache miss and looks the ref up in the fresh parse, where position 17 may now be a different element — resolved through a locator built from the **new** node's role and name, clicked, and reported as the ref the caller asked for.

**Trigger.** Snapshot a page, let a live region insert one node above the target, click the ref you were given. Before: the click lands on the neighbour and returns `{ok: true}`. After: either it resolves to the element you meant, or it refuses and says which of three things went wrong.

The cache branch that was supposed to prevent this could not. Its four conditions — same tab, same URL, same `stateVersion`, cache present — cannot see a DOM mutation, since `click` and `type` do not bump the version, while `.nth(occurrence)` indexes the **live** DOM at click time. It also almost never ran: `resolveActiveTargetId` returns `null` unless `verifiedActiveTargetId` was set by `switchTab` or one branch of `createTab`, so `targetId` was falsy on every ordinary navigate-snapshot-click flow. It is deleted — keeping it would have preserved the last route to a locator with no freshness check at all, for the benefit of two callers.

## Three designs; the audit killed the first two

**A per-node tuple cannot prove identity.** Comparing `role + name + occurrence` asks whether the *locator* would be spelled the same, which is a different question from whether the *element* is the same. Ten identical rows, delete one, and every surviving index carries a byte-identical tuple while naming its neighbour — blind exactly on delete-a-row and feed-append pages, which is where positional drift happens. A digest over the whole list is the honest instrument.

**Digesting the returned list made the fingerprint a function of the request.** `snapshot --interactive` stores 40 nodes; `refToLocator` re-snapshots unfiltered and gets 400; the digests differ every time on a page that changed by nothing. Every such click fell to recovery and hard-errored on any page with duplicate accessible names — a functional regression to the documented flow. The digest is now over the whole parse, captured before the filter.

**Recovering by uniqueness in the fresh list reproduced the original defect inside its own fix.** Two rows each with a Delete button; the caller points at the first; the page removes that row. Exactly one Delete remains, so a fresh-list uniqueness rule resolves to it and **deletes the other row**. Removal is what manufactured the uniqueness, so the rule was weakest precisely when the caller's element was the thing that went away — on an operation nobody can undo. Uniqueness must hold on both sides: a set that shrank to one is ambiguous, not recovered.

## Also

A URL mismatch now refuses. It had been folded together with "no previous parse" and failed open on both, citing `assertFreshObservationBundle` as precedent — which throws on a known mismatch and fails open only when a side is *absent*. An absent basis says nothing; a basis from another page is affirmative evidence that every positional ref is meaningless.

Three failures that used to be one message: **gone**, **still here but somewhere else in the tree**, and **now one of several**. A depth change is not absence.

`meta.digest` is labelled `digestIsDiagnostic`. A caller holding one would reasonably assume its refs were checked against the snapshot it saw; they were not, because the internal basis rotates whenever anything re-snapshots — including a ref lookup itself.

## Recorded, not fixed

The basis rotation above, the unscoped `latestSnapshot` singleton, `elementBoxes` restoring a basis *older* than the boxes it measured, a mid-session parser fallback producing a spurious "moved", and `drag` now taking two parses. These belong to the `snapshotId` round-trip unit, which is the only mechanism that binds the check to the caller's own observation.

Playwright's `aria-ref` would delete the positional counter outright — `_snapshotForAI` emits handle-backed refs that cannot name a different element. Rejected here because it is underscore-private, its ref map is per-call so any internal snapshot invalidates the agent's refs, and the CDP fallback has no equivalent. That is a migration with its own design, not a patch, and it is where the ref format should eventually go.

## Validation

`tests/unit/ref-identity.test.ts`, 19 cases — most of them calling `recoverNode` and `snapshotDigest` with real node lists rather than matching source text, because the previous round's suite could not have seen the regression it shipped. `RI-008` is the two-Delete-rows case; `RI-006` pins that the digest does not depend on how the snapshot was requested.

157 pass across the browser and grounding suites under tsx. Typecheck clean, `gate:doc-drift` and `verify-counts` pass, `check:private-boundary` OK. Full local suite **NOT RUN**; CI on this head is the evidence.

Three audit rounds with the same reviewer: FAIL, FAIL, NEAR-PASS.
