### PR TITLE
boundary: enforce the submodule check now that the records it excused are gone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ Never create private records inside this checkout, including `devlog`, `_plan`, 
 
 Before any public push, run `npm run check:private-boundary` for the index and `node scripts/check-private-boundary.mjs --range <remote-base> HEAD` for every outgoing commit tree. Follow [contributor hook setup](CONTRIBUTING.md#local-private-path-check) to enable `.githooks/pre-push` for this checkout; it invokes `--pre-push` using Git's stdin. Review content as well as paths and do not bypass the hook. CI is a backstop after upload, not a pre-disclosure guard.
 
+The check enumerates submodule contents and fails on what it finds there, because `ls-files` stops at a gitlink and a record committed inside a submodule ships when that submodule is published. `JAW_PRIVATE_BOUNDARY_SUBMODULES=warn` downgrades that to reporting; it exists for a finding that must be fixed in the other repository first, and is not a setting to leave on. A submodule that is cloned and used on its own needs a check of its own — `skills_ref` has one in `validate_public_surface.py` — because a gate here can refuse to publish a submodule but cannot stop a commit landing inside it.
+
 ### Kanban
 
 프로젝트 보드: https://github.com/users/lidge-jun/projects/2/views/1

--- a/scripts/check-private-boundary.mjs
+++ b/scripts/check-private-boundary.mjs
@@ -26,16 +26,21 @@ export function checkIndex(cwd) {
 }
 
 /**
- * Submodule contents are OUT of the enforced gate for now, because the current
- * `skills_ref` tip carries private records that predate this check and removing
- * them is a separate change in a separate repository. Enforcing here first
- * would only break the build without deleting anything.
+ * Submodule contents are enforced.
  *
- * Set `JAW_PRIVATE_BOUNDARY_SUBMODULES=enforce` to fail on them; the default
- * warns so the finding is visible on every run and cannot be forgotten.
+ * They were warn-only for one reason: the `skills_ref` tip carried 29 private
+ * records that predated this check, and failing on them would have broken the
+ * build without deleting anything. Those records now live in cli-jaw-internal
+ * and are gone from the submodule, so the reason has expired and the default
+ * is a failure.
+ *
+ * Set `JAW_PRIVATE_BOUNDARY_SUBMODULES=warn` to go back to reporting, which
+ * exists for the same situation recurring in another submodule — a finding
+ * that has to be fixed elsewhere before this repository can demand it. It is
+ * a bridge, not a setting to leave on.
  */
 function submoduleEnforcement() {
-    return String(process.env['JAW_PRIVATE_BOUNDARY_SUBMODULES'] || '').toLowerCase() === 'enforce';
+    return String(process.env['JAW_PRIVATE_BOUNDARY_SUBMODULES'] || '').toLowerCase() !== 'warn';
 }
 
 export function reportSubmodules(cwd, { enforce = false } = {}) {

--- a/tests/unit/desktop-control-skill-contract.test.ts
+++ b/tests/unit/desktop-control-skill-contract.test.ts
@@ -34,29 +34,57 @@ test('DCS-002: the registry entry does not require macOS', maybe, () => {
     assert.ok(entry.requires.system.includes('Google Chrome'), 'the Chrome requirement stays');
 });
 
-test('DCS-003: the reference documents the Windows window-scoped API', maybe, () => {
+// DCS-003 and DCS-004 used to require the literal tool names `list_windows()`,
+// `get_window_state`, `get_app_state(app)`, `select_text` and `node_repl`.
+//
+// Those names came from an older Codex build. On a current host the
+// `computer-use@openai-bundled` plugin can be enabled, its `.mcp.json` can
+// still declare the server, and NO `mcp__computer_use__*` tool is exposed to
+// the session — the host provides a CUA JavaScript session instead. So the
+// assertions were pinning an inventory that no longer resolves, and passing
+// them meant the reference had to keep instructing calls that do not exist.
+//
+// What survives a host change is the platform SHAPE, which is what these check
+// now: app-scoped on macOS, window-scoped on Windows, no host on Linux. The
+// tests must not name tools for the same reason the reference stopped naming
+// them.
+
+test('DCS-003: the reference keeps the platform shapes distinct', maybe, () => {
     const ref = fs.readFileSync(CU_REF, 'utf8');
-    assert.match(ref, /list_windows\(\)/);
-    assert.match(ref, /get_window_state/);
-    assert.match(ref, /node_repl/);
-    assert.match(ref, /get_app_state`?,? and `?select_text|no.*get_app_state/i,
-        'the reference must say which macOS tools are absent on Windows');
+    assert.match(ref, /macOS[^\n]*\bapp-scoped\b/i);
+    assert.match(ref, /Windows is[^\n]*\bwindow-scoped\b/i);
+    assert.match(ref, /Linux[^\n]*no Computer Use host/i,
+        'a platform without a host must be named, or an agent will hunt for one');
 });
 
-test('DCS-004: the reference keeps the macOS app-scoped API', maybe, () => {
+test('DCS-004: the reference tells the agent to establish the surface rather than assume it', maybe, () => {
     const ref = fs.readFileSync(CU_REF, 'utf8');
-    assert.match(ref, /get_app_state\(app\)/);
-    assert.match(ref, /select_text/);
+    assert.match(ref, /Do not assume tool names/i);
+    assert.match(ref, /enabled plugin is not proof/i,
+        'the exact trap that made the old inventory wrong must stay documented');
+    assert.match(ref, /no Computer Use surface/,
+        'and the agent must know what to report when nothing is exposed');
 });
 
 test('DCS-005: the two Windows false-success traps are documented', maybe, () => {
     const ref = fs.readFileSync(CU_REF, 'utf8');
-    assert.match(ref, /list_apps\(\)[^\n]*without a working pipe|not a health signal/i);
-    assert.match(ref, /not on the pipe/i);
+    // Stated as behaviour rather than by tool name: an enumeration that answers
+    // proves nothing about the connection, and an empty list means the
+    // transport is down rather than that the desktop is empty.
+    assert.match(ref, /enumeration that answers is not a health check/i);
+    assert.match(ref, /empty window list[^\n]*transport is not connected/i);
 });
 
 test('DCS-006: the sandbox bypass is stated as an attended user choice, not a default', maybe, () => {
     const ref = fs.readFileSync(CU_REF, 'utf8');
     assert.match(ref, /dangerously-bypass-approvals-and-sandbox/);
-    assert.match(ref, /never adds it automatically/i);
+    // The wording moved from "never adds it automatically" to naming what
+    // cli-jaw does not do — add OR persist it — and the claim got stronger,
+    // so match the claim rather than the old sentence.
+    assert.match(ref, /does not add or persist it/i);
+    assert.match(ref, /attended, explicit user choice/i);
+    // The sentence wraps across a line, so match without spanning the break.
+    assert.match(ref, /permissions=auto/);
+    assert.match(ref, /is not an equivalent substitute/i,
+        'the quieter route to the same authority must be closed off by name');
 });


### PR DESCRIPTION
The submodule half of the private-boundary check was warn-only, with the reason written into the code: `skills_ref` carried 29 private records that predated the check, and failing on them would have broken the build without deleting anything. Those records are now in `cli-jaw-internal` and gone from `skills_ref`, so the reason has expired.

**What changed.** The default is a failure. `JAW_PRIVATE_BOUNDARY_SUBMODULES=warn` goes back to reporting — that exists for the same situation recurring in another submodule, where a finding has to be fixed elsewhere before this repository can demand it. It is a bridge, and the comment says so rather than leaving a reader to guess.

Verified by planting a private path inside `skills_ref`: the default fails and names it, `warn` reports and passes, and removing it returns both to OK.

**The submodule pointer moves** to the `skills_ref` tip carrying [lidge-jun/cli-jaw-skills#8](https://github.com/lidge-jun/cli-jaw-skills/pull/8), which deleted the 29 records and added a boundary check of its own. That second part matters: this gate runs in the superproject, so it can refuse to publish a submodule holding private records but cannot stop them being committed there in the first place, and `skills_ref` is cloned and used on its own.

**Custody first, deletion second.** The records were copied to `cli-jaw-internal`, verified byte-identical with `diff -r`, and pushed there before anything was removed on the public side. A failure between those steps leaves them in both places rather than neither.

**History is not rewritten** in either repository. The files remain in `cli-jaw-skills` history; rewriting would invalidate every clone and every submodule pointer naming a commit, and the content was public for the whole time it sat there, so the disclosure already happened.

## Validation

`check:private-boundary` passes on the index and on `--range origin/dev HEAD`. `gate:doc-drift` and `verify-counts` pass. Full local suite **NOT RUN**; CI on this head is the evidence.



---

## Test fallout from the submodule bump

Moving the pointer turned four `DCS-*` assertions red. They were right to notice a change and wrong about its direction.

`DCS-003` and `DCS-004` required the literal strings `list_windows()`, `get_window_state`, `get_app_state(app)`, `select_text` and `node_repl`. Those names come from an older Codex build. On a current host the `computer-use@openai-bundled` plugin can be enabled, its `.mcp.json` can still declare the server, and **no `mcp__computer_use__*` tool is exposed to the session** — the host provides a CUA JavaScript session instead. The tests were pinning an inventory that no longer resolves, so keeping them green required the reference to go on instructing calls that do not exist.

They now check the platform **shape**, which survives a host change: app-scoped on macOS, window-scoped on Windows, no host on Linux. Plus the trap that made the old inventory wrong — an enabled plugin is not proof its tools are callable — and what to report when nothing is exposed.

`DCS-005`'s Windows traps are still asserted, stated as behaviour rather than by tool name. `DCS-006` was matching "never adds it automatically" against a sentence that now says cli-jaw "does not add or persist it" — a stronger claim, so the test follows the claim, and it additionally requires the `permissions=auto` substitute to stay closed off by name.
