### PR TITLE
fix(code): show the models Codex can actually run, not a frozen list of seven

### DIFF
--- a/src/code-mode/manager.ts
+++ b/src/code-mode/manager.ts
@@ -77,10 +77,22 @@ export class CodeSessionManager {
         return provider.describe();
     }
 
-    private validate(input: CodeCreateSessionRequest, fixed?: CodeCapabilities): CodeProviderCatalog {
+    /**
+     * `fixed` carries an existing session's stored capabilities. `accepted`
+     * names the values that session already runs with: a Codex catalog is live
+     * now, so its model list can shift under a running session, and rejecting a
+     * value that was legal at creation would break prompt, attach and patch for
+     * a reason the user can neither see nor act on. A value the caller is
+     * newly choosing is always checked against what the runtime serves today.
+     */
+    private validate(input: CodeCreateSessionRequest, fixed?: CodeCapabilities,
+        accepted?: Pick<CodeCreateSessionRequest, 'model' | 'effort'>): CodeProviderCatalog {
         const catalog = this.catalog(input.provider);
         if (!catalog.available) throw new CodeServiceError('provider_unavailable', 'Code provider is unavailable');
-        if (!catalog.models.includes(input.model)) throw new CodeStoreError('unsupported_model', 'Code model is unsupported', 400);
+        const keptModel = accepted !== undefined && accepted.model === input.model;
+        if (!keptModel && !catalog.models.includes(input.model)) {
+            throw new CodeStoreError('unsupported_model', 'Code model is unsupported', 400);
+        }
         for (const capabilities of fixed ? [fixed, catalog.capabilities] : [catalog.capabilities]) {
             if (!capabilities.permissionModes.includes(input.permissionMode)) {
                 throw new CodeStoreError('unsupported_policy', 'Code permission mode is unsupported', 400);
@@ -93,7 +105,8 @@ export class CodeSessionManager {
         // per-model set, narrow to it: routed models often accept no effort at
         // all while a sibling model reaches `ultra`, and the chosen value is
         // forwarded to the native wire.
-        const perModel = catalog.effortsByModel?.[input.model];
+        const keptEffort = keptModel && accepted !== undefined && accepted.effort === input.effort;
+        const perModel = keptEffort ? undefined : catalog.effortsByModel?.[input.model];
         if (input.effort !== null && perModel && !perModel.includes(input.effort)) {
             throw new CodeStoreError('unsupported_effort', 'Code effort is unsupported', 400);
         }
@@ -205,7 +218,7 @@ export class CodeSessionManager {
             const duplicate = this.storage(() => this.options.store.admitTurn({ ...input, sessionId: id }));
             return { receipt: duplicate.receipt, duplicate: true };
         }
-        this.validate(record, record.capabilities);
+        this.validate(record, record.capabilities, record);
         const session = this.reserve(record);
         try {
             const result = this.storage(() => this.options.store.admitTurn({ ...input, sessionId: id,
@@ -237,7 +250,7 @@ export class CodeSessionManager {
     async attach(id: string): Promise<CodeSessionInfo> {
         this.ready();
         const record = this.record(id);
-        this.validate(record, record.capabilities);
+        this.validate(record, record.capabilities, record);
         const session = this.reserve(record);
         try {
             const result = this.storage(() => this.options.store.beginAttach(id, record.revision));
@@ -259,7 +272,7 @@ export class CodeSessionManager {
             || (input.effort !== undefined && input.effort !== record.effort)
             || (input.permissionMode !== undefined && input.permissionMode !== record.permissionMode);
         if (policy) {
-            this.validate({ ...record, ...input }, record.capabilities);
+            this.validate({ ...record, ...input }, record.capabilities, record);
             if (policyChanged && record.nativeStarted && (!record.nativeCursor || !record.capabilities.resume)) {
                 throw new CodeStoreError('resume_unavailable', 'Code policy change requires resumable native history', 409);
             }

--- a/src/code-mode/manager.ts
+++ b/src/code-mode/manager.ts
@@ -93,11 +93,17 @@ export class CodeSessionManager {
         if (!keptModel && !catalog.models.includes(input.model)) {
             throw new CodeStoreError('unsupported_model', 'Code model is unsupported', 400);
         }
+        const keptEffort = keptModel && accepted !== undefined && accepted.effort === input.effort;
         for (const capabilities of fixed ? [fixed, catalog.capabilities] : [catalog.capabilities]) {
             if (!capabilities.permissionModes.includes(input.permissionMode)) {
                 throw new CodeStoreError('unsupported_policy', 'Code permission mode is unsupported', 400);
             }
-            if (input.effort !== null && !capabilities.efforts.includes(input.effort)) {
+            // A kept effort skips the live union for the same reason a kept model
+            // skips the live model list: the catalog moves under a running session.
+            // The session's own stored capabilities still apply, since those are
+            // the contract the native runtime was opened with.
+            const live = capabilities === catalog.capabilities;
+            if (input.effort !== null && !(keptEffort && live) && !capabilities.efforts.includes(input.effort)) {
                 throw new CodeStoreError('unsupported_effort', 'Code effort is unsupported', 400);
             }
         }
@@ -105,7 +111,6 @@ export class CodeSessionManager {
         // per-model set, narrow to it: routed models often accept no effort at
         // all while a sibling model reaches `ultra`, and the chosen value is
         // forwarded to the native wire.
-        const keptEffort = keptModel && accepted !== undefined && accepted.effort === input.effort;
         const perModel = keptEffort ? undefined : catalog.effortsByModel?.[input.model];
         if (input.effort !== null && perModel && !perModel.includes(input.effort)) {
             throw new CodeStoreError('unsupported_effort', 'Code effort is unsupported', 400);

--- a/src/code-mode/manager.ts
+++ b/src/code-mode/manager.ts
@@ -89,6 +89,14 @@ export class CodeSessionManager {
                 throw new CodeStoreError('unsupported_effort', 'Code effort is unsupported', 400);
             }
         }
+        // The union above is the widest legal set. When the runtime publishes a
+        // per-model set, narrow to it: routed models often accept no effort at
+        // all while a sibling model reaches `ultra`, and the chosen value is
+        // forwarded to the native wire.
+        const perModel = catalog.effortsByModel?.[input.model];
+        if (input.effort !== null && perModel && !perModel.includes(input.effort)) {
+            throw new CodeStoreError('unsupported_effort', 'Code effort is unsupported', 400);
+        }
         return catalog;
     }
 

--- a/src/code-mode/providers/catalog.ts
+++ b/src/code-mode/providers/catalog.ts
@@ -12,6 +12,7 @@ import { createCodexCodeProvider } from './codex-app.js';
 import { createClaudeCodeProvider } from './claude.js';
 import { createCursorCodeProvider } from './cursor.js';
 import { createGrokCodeProvider } from './grok.js';
+import { readCodexLiveModels, type CodexLiveModels } from './live-models.js';
 
 const MODES: Record<CodeProviderId, CodePermissionMode[]> = {
     'codex-app': ['ask', 'auto', 'read-only'], claude: ['ask', 'auto'], cursor: ['ask', 'auto'], grok: ['auto'],
@@ -34,6 +35,18 @@ export interface CodeProviderFactories {
     cursor?: Parameters<typeof createCursorCodeProvider>[1];
     grok?: Parameters<typeof createGrokCodeProvider>[1];
     detect?: (binary: string) => CliDetection;
+    /** Live Codex catalog reader; defaults to the opencodex snapshot. */
+    liveModels?: () => CodexLiveModels | null;
+}
+
+/**
+ * Codex runs behind opencodex, which advertises a routed catalog far wider than
+ * the static registry list (routed `anthropic/*`, `xai/*`, newer GPT ids) and a
+ * DIFFERENT effort set per model. Only `codex-app` is proxied this way; the ACP
+ * and SDK runtimes keep their registry lists.
+ */
+function liveCatalogPatch(id: CodeProviderId, live: CodexLiveModels | null): CodexLiveModels | null {
+    return id === 'codex-app' && live && live.models.length > 0 ? live : null;
 }
 
 export function createCodeProviders(factories: CodeProviderFactories = {}): CodeProviders {
@@ -44,12 +57,24 @@ export function createCodeProviders(factories: CodeProviderFactories = {}): Code
         return {
             describe(): CodeProviderCatalog {
                 const found = detection();
-                return { id, label: entry.label, available: found.available && !!found.path,
+                const live = liveCatalogPatch(id, (factories.liveModels ?? readCodexLiveModels)());
+                const base: CodeProviderCatalog = { id, label: entry.label, available: found.available && !!found.path,
                     reason: found.available && found.path ? null : 'Native CLI executable unavailable',
                     models: [...entry.models], defaultModel: entry.defaultModel,
                     defaultEffort: entry.defaultEffort || null, modelSource: 'registry',
                     capabilities: { resume: true, interrupt: true, permissions: true,
                         setModelMidSession: false, efforts: [...entry.efforts], permissionModes: [...MODES[id]] } };
+                if (!live) return base;
+                // Never widen the effort union to empty: an all-routed catalog would
+                // otherwise strip the effort control for every model at once.
+                const efforts = live.efforts.length > 0 ? [...live.efforts] : base.capabilities.efforts;
+                return { ...base, models: [...live.models], modelSource: 'live',
+                    effortsByModel: structuredClone(live.effortsByModel),
+                    defaultEffortByModel: { ...live.defaultEffortByModel },
+                    capabilities: { ...base.capabilities, efforts },
+                    // A default the live catalog no longer serves would fail validate()
+                    // on the very first session, so fall back to its first model.
+                    defaultModel: live.models.includes(base.defaultModel) ? base.defaultModel : live.models[0] ?? base.defaultModel };
             },
             binary() {
                 const found = detection();

--- a/src/code-mode/providers/catalog.ts
+++ b/src/code-mode/providers/catalog.ts
@@ -45,8 +45,12 @@ export interface CodeProviderFactories {
  * DIFFERENT effort set per model. Only `codex-app` is proxied this way; the ACP
  * and SDK runtimes keep their registry lists.
  */
-function liveCatalogPatch(id: CodeProviderId, live: CodexLiveModels | null): CodexLiveModels | null {
-    return id === 'codex-app' && live && live.models.length > 0 ? live : null;
+function liveCatalogPatch(id: CodeProviderId, read: () => CodexLiveModels | null): CodexLiveModels | null {
+    // Read only for the proxied runtime. Calling first and filtering after would
+    // make a Claude or Cursor catalog read schedule a Codex probe.
+    if (id !== 'codex-app') return null;
+    const live = read();
+    return live && live.models.length > 0 ? live : null;
 }
 
 export function createCodeProviders(factories: CodeProviderFactories = {}): CodeProviders {
@@ -57,7 +61,7 @@ export function createCodeProviders(factories: CodeProviderFactories = {}): Code
         return {
             describe(): CodeProviderCatalog {
                 const found = detection();
-                const live = liveCatalogPatch(id, (factories.liveModels ?? readCodexLiveModels)());
+                const live = liveCatalogPatch(id, factories.liveModels ?? readCodexLiveModels);
                 const base: CodeProviderCatalog = { id, label: entry.label, available: found.available && !!found.path,
                     reason: found.available && found.path ? null : 'Native CLI executable unavailable',
                     models: [...entry.models], defaultModel: entry.defaultModel,

--- a/src/code-mode/providers/live-models.ts
+++ b/src/code-mode/providers/live-models.ts
@@ -21,9 +21,16 @@ export interface CodexLiveModels {
 
 /** How long a successful snapshot is served before a background refresh starts. */
 const REFRESH_AFTER_MS = 10_000;
+/**
+ * Floor between attempts after a failed or degraded probe. Without it a stale
+ * snapshot plus a persistently unreachable proxy would start a fresh probe on
+ * every catalog read, because only a success advances the freshness clock.
+ */
+const RETRY_AFTER_MS = 30_000;
 
 let snapshot: CodexLiveModels | null = null;
 let fetchedAt = 0;
+let attemptedAt = 0;
 let inFlight: Promise<void> | null = null;
 
 function toSnapshot(entries: OpenCodexModelEntry[], source: CodexLiveModels['source']): CodexLiveModels {
@@ -43,8 +50,10 @@ function toSnapshot(entries: OpenCodexModelEntry[], source: CodexLiveModels['sou
     return { models: entries.map(entry => entry.id), effortsByModel, defaultEffortByModel, efforts, source };
 }
 
-function refresh(): void {
+function refresh(force = false): void {
     if (inFlight) return;
+    if (!force && attemptedAt && Date.now() - attemptedAt < RETRY_AFTER_MS) return;
+    attemptedAt = Date.now();
     inFlight = resolveOpenCodexCodexModelsDetailed()
         .then(result => {
             // A degraded probe answers with the same static list the registry already
@@ -70,7 +79,7 @@ export function readCodexLiveModels(): CodexLiveModels | null {
 
 /** Warm the snapshot so the first catalog read after startup is already live. */
 export async function primeCodexLiveModels(): Promise<CodexLiveModels | null> {
-    refresh();
+    refresh(true);
     await inFlight;
     return snapshot;
 }
@@ -79,5 +88,6 @@ export async function primeCodexLiveModels(): Promise<CodexLiveModels | null> {
 export function resetCodexLiveModelsForTest(next?: CodexLiveModels): void {
     snapshot = next ?? null;
     fetchedAt = next ? Date.now() : 0;
+    attemptedAt = 0;
     inFlight = null;
 }

--- a/src/code-mode/providers/live-models.ts
+++ b/src/code-mode/providers/live-models.ts
@@ -1,0 +1,83 @@
+/**
+ * Live Codex model snapshot for the Code catalog.
+ *
+ * `CodeProvider.describe()` is synchronous and is called on every catalog read,
+ * so it cannot await opencodex. This module keeps the last successful
+ * `/v1/models` answer in memory and refreshes it in the background. A read
+ * returns whatever is already known; it never blocks and never returns an empty
+ * catalog, because an empty model list would make every model unselectable
+ * (`CodeSessionManager.validate` rejects models outside `catalog.models`).
+ */
+import { resolveOpenCodexCodexModelsDetailed, type OpenCodexModelEntry } from '../../cli/opencodex-models.js';
+
+export interface CodexLiveModels {
+    models: string[];
+    effortsByModel: Record<string, string[]>;
+    defaultEffortByModel: Record<string, string>;
+    /** Union of every per-model effort set, first-seen order preserved. */
+    efforts: string[];
+    source: 'opencodex' | 'static';
+}
+
+/** How long a successful snapshot is served before a background refresh starts. */
+const REFRESH_AFTER_MS = 10_000;
+
+let snapshot: CodexLiveModels | null = null;
+let fetchedAt = 0;
+let inFlight: Promise<void> | null = null;
+
+function toSnapshot(entries: OpenCodexModelEntry[], source: CodexLiveModels['source']): CodexLiveModels {
+    const effortsByModel: Record<string, string[]> = {};
+    const defaultEffortByModel: Record<string, string> = {};
+    const efforts: string[] = [];
+    const seen = new Set<string>();
+    for (const entry of entries) {
+        effortsByModel[entry.id] = [...entry.efforts];
+        if (entry.defaultEffort) defaultEffortByModel[entry.id] = entry.defaultEffort;
+        for (const effort of entry.efforts) {
+            if (seen.has(effort)) continue;
+            seen.add(effort);
+            efforts.push(effort);
+        }
+    }
+    return { models: entries.map(entry => entry.id), effortsByModel, defaultEffortByModel, efforts, source };
+}
+
+function refresh(): void {
+    if (inFlight) return;
+    inFlight = resolveOpenCodexCodexModelsDetailed()
+        .then(result => {
+            // A degraded probe answers with the same static list the registry already
+            // holds. Keeping the previous live snapshot is better than overwriting it
+            // with a fallback that hides routed models for one failed poll.
+            if (result.source === 'static' && snapshot?.source === 'opencodex') return;
+            if (result.entries.length === 0) return;
+            snapshot = toSnapshot(result.entries, result.source);
+            fetchedAt = Date.now();
+        })
+        .catch(() => { /* the previous snapshot stays authoritative */ })
+        .finally(() => { inFlight = null; });
+}
+
+/**
+ * Last known live catalog, or null before the first successful read.
+ * Always schedules a refresh when the snapshot is missing or stale.
+ */
+export function readCodexLiveModels(): CodexLiveModels | null {
+    if (!snapshot || Date.now() - fetchedAt > REFRESH_AFTER_MS) refresh();
+    return snapshot;
+}
+
+/** Warm the snapshot so the first catalog read after startup is already live. */
+export async function primeCodexLiveModels(): Promise<CodexLiveModels | null> {
+    refresh();
+    await inFlight;
+    return snapshot;
+}
+
+/** @internal exported for unit tests */
+export function resetCodexLiveModelsForTest(next?: CodexLiveModels): void {
+    snapshot = next ?? null;
+    fetchedAt = next ? Date.now() : 0;
+    inFlight = null;
+}

--- a/src/code-mode/wire.ts
+++ b/src/code-mode/wire.ts
@@ -169,7 +169,15 @@ export interface CodeProviderCatalog {
     defaultModel: string;
     defaultEffort: string | null;
     capabilities: CodeCapabilities;
-    modelSource: 'registry' | 'cache' | 'native';
+    modelSource: 'registry' | 'cache' | 'native' | 'live';
+    /**
+     * Per-model reasoning-effort sets, when the runtime advertises them.
+     * An entry may be an EMPTY array, which means the model takes no effort at
+     * all — that is different from an absent entry, which means "unknown, fall
+     * back to `capabilities.efforts`".
+     */
+    effortsByModel?: Record<string, string[]>;
+    defaultEffortByModel?: Record<string, string>;
 }
 
 export interface CodeModelCatalog {

--- a/tests/unit/code-live-models.test.ts
+++ b/tests/unit/code-live-models.test.ts
@@ -1,0 +1,60 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+let resolved: Array<() => Promise<{ models: string[]; entries: Array<{ id: string; efforts: string[]; defaultEffort?: string }>; source: 'opencodex' | 'static' }>> = [];
+let calls = 0;
+mock.module('../../src/cli/opencodex-models.js', {
+    namedExports: {
+        resolveOpenCodexCodexModelsDetailed: async () => {
+            const next = resolved[Math.min(calls, resolved.length - 1)];
+            calls += 1;
+            if (!next) throw new Error('no fixture');
+            return next();
+        },
+    },
+});
+const { primeCodexLiveModels, readCodexLiveModels, resetCodexLiveModelsForTest } =
+    await import('../../src/code-mode/providers/live-models.ts');
+
+const entry = (id: string, efforts: string[] = ['low', 'high']) => ({ id, efforts });
+const live = (ids: string[]) => async () => ({ models: ids, entries: ids.map(id => entry(id)), source: 'opencodex' as const });
+const staticResult = async () => ({ models: ['gpt-5.5'], entries: [entry('gpt-5.5')], source: 'static' as const });
+const boom = async () => { throw new Error('proxy unreachable'); };
+
+function scenario(steps: typeof resolved) {
+    resolved = steps;
+    calls = 0;
+    resetCodexLiveModelsForTest();
+}
+
+test('a successful probe becomes the readable snapshot with a per-model effort map', async () => {
+    scenario([live(['gpt-6-astra', 'anthropic/claude-opus-5'])]);
+    const snapshot = await primeCodexLiveModels();
+    assert.equal(snapshot?.source, 'opencodex');
+    assert.deepEqual(snapshot?.models, ['gpt-6-astra', 'anthropic/claude-opus-5']);
+    assert.deepEqual(snapshot?.efforts, ['low', 'high'], 'the union preserves first-seen order without duplicates');
+    assert.deepEqual(snapshot?.effortsByModel['gpt-6-astra'], ['low', 'high']);
+});
+
+test('a failing probe is not retried on every read', async () => {
+    scenario([boom]);
+    await primeCodexLiveModels();
+    assert.equal(calls, 1);
+    // A stale-and-empty snapshot used to restart the probe on each catalog read.
+    for (let i = 0; i < 20; i += 1) assert.equal(readCodexLiveModels(), null);
+    assert.equal(calls, 1, 'reads after a failure must respect the retry floor');
+});
+
+test('a degraded probe never replaces a live snapshot', async () => {
+    scenario([live(['gpt-6-astra']), staticResult]);
+    await primeCodexLiveModels();
+    await primeCodexLiveModels();
+    assert.equal(calls, 2);
+    assert.deepEqual(readCodexLiveModels()?.models, ['gpt-6-astra']);
+    assert.equal(readCodexLiveModels()?.source, 'opencodex');
+});
+
+test('an empty answer is not stored as a catalog', async () => {
+    scenario([async () => ({ models: [], entries: [], source: 'opencodex' as const })]);
+    assert.equal(await primeCodexLiveModels(), null);
+});

--- a/tests/unit/code-native-providers.test.ts
+++ b/tests/unit/code-native-providers.test.ts
@@ -183,6 +183,17 @@ test('an empty or degraded live snapshot leaves the registry catalog intact', ()
     assert.ok(routed.capabilities.efforts.length > 0);
 });
 
+test('only the proxied runtime reads the live snapshot', () => {
+    let reads = 0;
+    const providers = createCodeProviders({ detect: detection, codex: forbidden, claude: forbidden,
+        cursor: forbidden, grok: forbidden, liveModels: () => { reads += 1; return null; } });
+    // Reading a Claude or Cursor catalog must not schedule a Codex probe.
+    for (const id of ['claude', 'cursor', 'grok'] as const) providers[id].describe();
+    assert.equal(reads, 0);
+    providers['codex-app'].describe();
+    assert.equal(reads, 1);
+});
+
 test('missing binaries remain unavailable without native factory calls', async () => {
     const providers = createCodeProviders({ detect: () => ({ available: false, path: null }),
         codex: forbidden, claude: forbidden, cursor: forbidden, grok: forbidden });

--- a/tests/unit/code-native-providers.test.ts
+++ b/tests/unit/code-native-providers.test.ts
@@ -130,7 +130,7 @@ async function codexFixture(patch: Partial<CodeOpenOptions> = {}, configure?: (c
 test('catalog is exhaustive, detached from native factories, and honest about registry and policies', () => {
     const lookedUp: string[] = [];
     const providers = createCodeProviders({ detect: binary => { lookedUp.push(binary); return detection(binary); },
-        codex: forbidden, claude: forbidden, cursor: forbidden, grok: forbidden });
+        codex: forbidden, claude: forbidden, cursor: forbidden, grok: forbidden, liveModels: () => null });
     assert.deepEqual(Object.keys(providers), ['codex-app', 'claude', 'cursor', 'grok']);
     const catalogs = Object.values(providers).map(provider => provider.describe());
     assert.deepEqual(lookedUp, ['codex', 'claude', 'cursor-agent', 'grok']);
@@ -142,6 +142,45 @@ test('catalog is exhaustive, detached from native factories, and honest about re
     catalogs[0]!.models.length = 0;
     assert.ok(providers['codex-app'].describe().models.length > 0);
     assert.equal(jawEffects, 0);
+});
+
+test('a live Codex catalog replaces the static model list for codex-app only', () => {
+    const live = { models: ['gpt-6-astra', 'anthropic/claude-opus-5'], source: 'opencodex' as const,
+        effortsByModel: { 'gpt-6-astra': ['low', 'ultra'], 'anthropic/claude-opus-5': [] },
+        defaultEffortByModel: { 'gpt-6-astra': 'low' }, efforts: ['low', 'ultra'] };
+    const providers = createCodeProviders({ detect: detection, codex: forbidden, claude: forbidden,
+        cursor: forbidden, grok: forbidden, liveModels: () => live });
+    const codex = providers['codex-app'].describe();
+    assert.equal(codex.modelSource, 'live');
+    assert.deepEqual(codex.models, ['gpt-6-astra', 'anthropic/claude-opus-5']);
+    assert.deepEqual(codex.capabilities.efforts, ['low', 'ultra']);
+    assert.deepEqual(codex.effortsByModel?.['anthropic/claude-opus-5'], []);
+    // The static default (gpt-5.5) is not in the live catalog, so it must not survive.
+    assert.equal(codex.defaultModel, 'gpt-6-astra');
+    // A shared snapshot must not leak into the ACP/SDK runtimes.
+    for (const id of ['claude', 'cursor', 'grok'] as const) {
+        assert.equal(providers[id].describe().modelSource, 'registry');
+    }
+    // Callers must not be able to mutate the shared snapshot through the catalog.
+    codex.models.length = 0;
+    assert.equal(providers['codex-app'].describe().models.length, 2);
+});
+
+test('an empty or degraded live snapshot leaves the registry catalog intact', () => {
+    const empty = { models: [], effortsByModel: {}, defaultEffortByModel: {}, efforts: [], source: 'static' as const };
+    const noEfforts = { models: ['routed/only'], effortsByModel: { 'routed/only': [] },
+        defaultEffortByModel: {}, efforts: [], source: 'opencodex' as const };
+    const build = (liveModels: () => typeof empty | typeof noEfforts | null) => createCodeProviders({
+        detect: detection, codex: forbidden, claude: forbidden, cursor: forbidden, grok: forbidden, liveModels,
+    })['codex-app'].describe();
+    const fallback = build(() => empty);
+    assert.equal(fallback.modelSource, 'registry');
+    assert.ok(fallback.models.length > 0);
+    // An all-routed catalog offers no effort at all; the union must not go empty
+    // or every model loses its effort control at once.
+    const routed = build(() => noEfforts);
+    assert.deepEqual(routed.models, ['routed/only']);
+    assert.ok(routed.capabilities.efforts.length > 0);
 });
 
 test('missing binaries remain unavailable without native factory calls', async () => {

--- a/tests/unit/code-native-session.test.ts
+++ b/tests/unit/code-native-session.test.ts
@@ -830,6 +830,25 @@ test('a catalog that drops an effort keeps the running session usable', async t 
     assert.throws(() => f.create('cursor', { effort: 'high' }), errorCode('unsupported_effort', 400));
 });
 
+test('drift exemption covers only the values a session actually kept', async t => {
+    const f = fixture(t);
+    const row = f.create('cursor', { model: 'model-b', effort: 'high' });
+    // The whole catalog moves: this session's model and effort both disappear.
+    f.providers.cursor.catalog = { ...f.providers.cursor.catalog, models: ['model-a'],
+        capabilities: { ...f.providers.cursor.catalog.capabilities, efforts: ['low'] } };
+    // Keeping both is the only combination the session is allowed to carry
+    // forward; the exemption must not leak into a partial change.
+    assert.doesNotThrow(() => f.manager.prompt(row.sessionId, { text: 'both kept', clientTurnKey: 'k-both' }));
+    const live = f.manager.snapshot(row.sessionId).session;
+    // Changing the model forfeits the effort exemption too, because the pair is
+    // what the runtime was opened with.
+    await assert.rejects(f.manager.patch(row.sessionId, { expectedRevision: live.revision, model: 'model-a' }),
+        errorCode('unsupported_effort', 400));
+    // And a value that was never accepted is refused even while the rest is kept.
+    await assert.rejects(f.manager.patch(row.sessionId, { expectedRevision: live.revision, effort: 'medium' }),
+        errorCode('unsupported_effort', 400));
+});
+
 test('dispose is idempotent during pending open and later closes orphaned startup without replay', async t => {
     const f = fixture(t);
     const gate = deferred<void>();

--- a/tests/unit/code-native-session.test.ts
+++ b/tests/unit/code-native-session.test.ts
@@ -802,6 +802,22 @@ test('unsupported model, effort and permission mode fail before provider open', 
     assert.equal(f.providers.cursor.calls.length, 0);
 });
 
+test('a catalog that drops a model keeps the running session usable but blocks new choices', async t => {
+    const f = fixture(t);
+    const row = f.create('cursor', { model: 'model-b' });
+    // A live catalog can change under a running session. Its own model must stay
+    // legal, or prompt and attach would fail for a reason the user cannot act on.
+    f.providers.cursor.catalog = { ...f.providers.cursor.catalog, models: ['model-a'] };
+    assert.doesNotThrow(() => f.manager.prompt(row.sessionId, { text: 'still works', clientTurnKey: 'k-drift' }));
+    // Choosing something the runtime no longer serves is still refused.
+    assert.throws(() => f.create('cursor', { model: 'model-b' }), errorCode('unsupported_model', 400));
+    const idle = f.create('cursor', { model: 'model-a' });
+    await assert.rejects(f.manager.patch(idle.sessionId, { expectedRevision: idle.revision, model: 'model-b' }),
+        errorCode('unsupported_model', 400));
+    // Re-selecting the value the session already runs with is not a new choice.
+    await assert.doesNotReject(f.manager.patch(idle.sessionId, { expectedRevision: idle.revision, model: 'model-a' }));
+});
+
 test('dispose is idempotent during pending open and later closes orphaned startup without replay', async t => {
     const f = fixture(t);
     const gate = deferred<void>();

--- a/tests/unit/code-native-session.test.ts
+++ b/tests/unit/code-native-session.test.ts
@@ -818,6 +818,18 @@ test('a catalog that drops a model keeps the running session usable but blocks n
     await assert.doesNotReject(f.manager.patch(idle.sessionId, { expectedRevision: idle.revision, model: 'model-a' }));
 });
 
+test('a catalog that drops an effort keeps the running session usable', async t => {
+    const f = fixture(t);
+    const row = f.create('cursor', { effort: 'high' });
+    // Same drift, one level down: the live union can lose an effort the session
+    // was opened with. Its own stored capabilities still bound it, so the value
+    // stays legal; a newly chosen one is checked against the current catalog.
+    f.providers.cursor.catalog = { ...f.providers.cursor.catalog,
+        capabilities: { ...f.providers.cursor.catalog.capabilities, efforts: ['low'] } };
+    assert.doesNotThrow(() => f.manager.prompt(row.sessionId, { text: 'still works', clientTurnKey: 'k-effort' }));
+    assert.throws(() => f.create('cursor', { effort: 'high' }), errorCode('unsupported_effort', 400));
+});
+
 test('dispose is idempotent during pending open and later closes orphaned startup without replay', async t => {
     const f = fixture(t);
     const gate = deferred<void>();


### PR DESCRIPTION
## Problem

Code mode's model picker offered the same seven ids on every machine — `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` — regardless of what the local Codex runtime could actually serve. `describe()` in `src/code-mode/providers/catalog.ts` copies `CLI_REGISTRY['codex-app'].models` verbatim.

The live catalog was already being resolved elsewhere. `buildLiveCliRegistry()` replaces that list from opencodex `/v1/models`, but its only consumer is `src/routes/settings.ts`, so Code mode never saw it.

Against a running opencodex on this machine the picker was missing 21 of 28 available models, including `gpt-6-astra` and every routed id (`anthropic/claude-opus-5`, `xai/grok-4.6`, `cursor/*`). Those models were not merely hidden from the list: `CodeSessionManager.validate` rejects anything outside `catalog.models` with `unsupported_model`, so a user could not type one in either.

Before / after against the same running proxy:

| | models | source | default |
|---|---|---|---|
| before | 7 | `registry` | `gpt-5.5` |
| after | 28 | `live` | `gpt-6-astra` |

## How

`CodeProvider.describe()` is synchronous and runs on every catalog read, so it cannot await opencodex. `src/code-mode/providers/live-models.ts` keeps the last successful `/v1/models` answer in memory and refreshes it in the background; a read returns whatever is already known and never blocks.

Three properties matter for correctness:

- A degraded probe answers with the same static list the registry already holds, so it leaves an existing live snapshot alone instead of overwriting it for one failed poll.
- A snapshot with no models falls back to the registry list. An empty catalog would make every model unselectable at once.
- Only `codex-app` is proxied this way. The ACP and SDK runtimes keep their registry lists, and the snapshot is cloned into each catalog so a caller cannot mutate shared state.

Effort follows the same shape. opencodex advertises a different effort set per model — `gpt-5.6-sol` reaches `ultra`, routed `anthropic/*` take `low..xhigh` — so the catalog now carries `effortsByModel`/`defaultEffortByModel` and `validate()` narrows to the per-model set when it exists. The union stays as the widest legal set for consumers with no per-model view, and never widens to empty.

## Validation

- `tsc --noEmit -p tsconfig.json` clean.
- `code-native-providers`, `code-native-session`, `code-native-host`, `code-native-routes`: 168 tests pass, 0 fail.
- Two new provider cases cover the live swap (routed models present, ACP runtimes untouched, stale default replaced, snapshot immutable) and the degraded fallbacks (empty snapshot keeps the registry, all-routed catalog keeps a non-empty effort union).
- Live check against opencodex on :10100 returned 28 models with `modelSource: 'live'` and per-model effort sets.

This is the first PR in a stack; the composer layout and transcript changes follow on top of it.

---

### Follow-up commits on this PR

**stop re-probing opencodex on every catalog read after it fails** — an independent audit found that only a *successful* probe advanced the freshness clock, so a stale-or-absent snapshot plus an unreachable proxy restarted the probe on every catalog read. `inFlight` prevented concurrent duplicates but not the back-to-back sequence. Failed and degraded attempts now record their own timestamp and hold a 30s floor; `primeCodexLiveModels()` forces past it because startup warming is an explicit request. The snapshot reader also ran for every runtime and was filtered afterwards, so listing a Claude or Cursor catalog scheduled a Codex probe — it now reads only for the proxied runtime.

**do not let a live catalog invalidate a session already running** — making the catalog live introduced a failure the static list could not have. `validate()` is called again on prompt, attach and patch with the session's stored values, so a model legal at creation could start returning `unsupported_model` the moment opencodex stopped advertising it, breaking a working session for a reason the user cannot see or act on. `validate()` now takes the values the session already accepted: a kept value is not rechecked against today's catalog, a newly chosen one still is.

Test count is now 239 across the Code suites.