### PR TITLE
fix(code): keep a submitted prompt on screen, and collapse tool calls to one line

### DIFF
--- a/public/manager/src/code/CodeTranscript.tsx
+++ b/public/manager/src/code/CodeTranscript.tsx
@@ -4,6 +4,8 @@ import { useCodeTranscriptVirtualRows } from './useCodeTranscriptVirtualRows';
 import { useCodeTranscriptScroll } from './use-code-transcript-scroll';
 import { useThrottledMarkdown } from './use-throttled-markdown';
 import { CODE_RUNTIME_LABELS, codeItemStatus } from './code-types';
+import { noteworthyStatus, toolSummary } from './tool-summary';
+import { PENDING_USER_ITEM_ID } from './pending-user-item';
 
 const MarkdownRenderer = lazy(() => import('../notes/rendering/MarkdownRenderer').then(m => ({ default: m.MarkdownRenderer })));
 function ItemMarkdown({ item, identity, onOpenLocalFile }: { item: CodeItem; identity: string; onOpenLocalFile?: ((path: string) => void) | undefined }) {
@@ -14,32 +16,38 @@ function ItemMarkdown({ item, identity, onOpenLocalFile }: { item: CodeItem; ide
     </Suspense>;
 }
 
-export function CodeTranscriptItem({ item, provider, sessionKey, onOpenLocalFile }: {
-    item: CodeItem; provider: CodeProviderId; sessionKey: string; onOpenLocalFile?: ((path: string) => void) | undefined;
+export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = '', onOpenLocalFile }: {
+    item: CodeItem; provider: CodeProviderId; sessionKey: string; workingDir?: string;
+    onOpenLocalFile?: ((path: string) => void) | undefined;
 }) {
     const tool = item.kind === 'tool_call' || item.kind === 'file_change';
     const reasoning = item.kind === 'reasoning';
     const assistant = item.kind === 'assistant_message';
     const user = item.kind === 'user_message';
     const status = codeItemStatus(item);
+    // A completed turn should read as prose, not as a status board: only
+    // states the reader can act on are worth a visible badge.
+    const note = noteworthyStatus(item);
+    const unsent = item.itemId === PENDING_USER_ITEM_ID;
     const label = user ? 'You' : assistant ? CODE_RUNTIME_LABELS[provider] : reasoning ? 'Reasoning'
         : item.kind === 'turn_started' ? 'Turn started' : item.kind === 'session_runtime' ? 'Runtime'
             : item.kind === 'permission_request' ? 'Permission record' : item.kind === 'notice' ? 'Notice' : status;
-    return <article className={`code-message code-message-${tool ? 'tool' : assistant ? 'assistant' : user ? 'user' : 'system'} is-${item.status}`}
+    return <article className={`code-message code-message-${tool ? 'tool' : assistant ? 'assistant' : user ? 'user' : 'system'} is-${item.status}${unsent ? ' is-unsent' : ''}`}
         data-code-item-id={item.itemId} aria-label={`${label} · ${status}`}>
-        {tool ? <details className={`code-tool-card code-tool-${item.status}`}>
+        {tool ? <details className={`code-tool-card code-tool-${item.status}`} open={item.status === 'error'}>
             <summary className="code-tool-summary"><span className="code-tool-chevron" aria-hidden="true">›</span>
-                <span className="code-tool-name">{item.tool?.name ?? (item.kind === 'file_change' ? 'File change' : 'Tool')}</span>
-                <span className="code-tool-status">{status}</span></summary>
+                <span className="code-tool-name">{toolSummary(item, workingDir)}</span>
+                {note && <span className="code-tool-status">{note}</span>}</summary>
             {item.tool?.detail !== undefined && <p className="code-tool-text">{item.tool.detail}</p>}
             {item.tool?.input !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Input</span><pre className="code-tool-args">{item.tool.input}</pre></section>}
             {item.tool?.output !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Output</span><pre className="code-tool-output">{item.tool.output}</pre></section>}
             {item.text !== undefined && <pre className="code-tool-text">{item.text}</pre>}
         </details> : reasoning ? <details className="code-thinking">
-            <summary className="code-thinking-summary">Reasoning · {status}</summary><div className="code-thinking-text">{item.text}</div>
+            <summary className="code-thinking-summary">{item.status === 'running' ? 'Thinking…' : 'Reasoning'}</summary>
+            <div className="code-thinking-text">{item.text}</div>
         </details> : <>
-            <span className="code-message-role">{label}{assistant && item.phase && item.phase !== 'unknown' ? ` · ${item.phase === 'final' ? 'Final' : 'Commentary'}` : ''}
-                {(assistant || user || item.kind === 'permission_request') && ` · ${status}`}</span>
+            <span className="code-message-role">{label}{assistant && item.phase === 'commentary' ? ' · Commentary' : ''}
+                {note && ` · ${unsent ? 'Sending' : note}`}</span>
             <div className="code-message-text">{assistant ? <ItemMarkdown item={item} identity={`${sessionKey}:${item.itemId}`} onOpenLocalFile={onOpenLocalFile} />
                 : <span className="code-plain-text">{item.text ?? item.permission?.title ?? ''}</span>}</div>
             {item.permission?.detail && <p className="code-plain-text">{item.permission.detail}</p>}
@@ -63,7 +71,10 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
     const getItemKey = useCallback((index: number) => `${sessionKey}:${itemsRef.current[index]?.itemId ?? index}`, [sessionKey, firstId]);
     const estimateSize = useCallback((index: number) => {
         const item = itemsRef.current[index];
-        return item?.kind === 'tool_call' || item?.kind === 'reasoning' ? 64 : 64 + Math.min(420, (item?.text?.length ?? 0) / 6);
+        // Tool and reasoning rows are collapsed to one line, so they measure
+        // far shorter than a message of the same text length.
+        return item?.kind === 'tool_call' || item?.kind === 'file_change' || item?.kind === 'reasoning'
+            ? 44 : 64 + Math.min(420, (item?.text?.length ?? 0) / 6);
     }, []);
     const virtual = useCodeTranscriptVirtualRows({ count: items.length, resetKey: sessionKey, scrollElementRef: transcriptRef, getItemKey, estimateSize });
     const { showJump, jumpToLatest } = useCodeTranscriptScroll({ items, sessionKey, transcriptRef, virtual });
@@ -99,7 +110,8 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
                         const item = items[row.index];
                         return item ? <div key={row.key} ref={virtual.measureElement} className="code-transcript-virtual-row"
                             data-code-transcript-idx={row.index} style={{ transform: `translateY(${row.start}px)` }}>
-                            <CodeTranscriptItem item={item} provider={provider} sessionKey={sessionKey} onOpenLocalFile={onOpenLocalFile} />
+                            <CodeTranscriptItem item={item} provider={provider} sessionKey={sessionKey}
+                                workingDir={workingDir} onOpenLocalFile={onOpenLocalFile} />
                         </div> : null;
                     })}
                 </div>}

--- a/public/manager/src/code/code-controller-runtime.ts
+++ b/public/manager/src/code/code-controller-runtime.ts
@@ -9,6 +9,7 @@ import {
     acknowledgeCodeSend, catalogSelection, codeDraftBook, createCodeDraft, persistCodeDraftBook, sessionSelection,
     type CodeDraft, type CodeDraftBook,
 } from './code-controller-drafts';
+import { withPendingUserItem } from './pending-user-item';
 
 const MAX_DETAILS = 6;
 const MAX_INDEX = 1000;
@@ -198,7 +199,8 @@ export class CodeController {
                 const row = this.info(id), detail = this.details.get(id);
                 return row && detail?.synced ? { ...row, pendingPermissionCount: detail.permissions.length } : row;
             }).filter((row): row is CodeSessionInfo => !!row),
-            selectedId: id, session, items: detail?.items ?? [], permissions: detail?.permissions ?? [],
+            selectedId: id, session, items: withPendingUserItem(draft, detail?.items ?? []),
+            permissions: detail?.permissions ?? [],
             input: draft.input, selection: session ? sessionSelection(session) : draft.selection,
             gitInfo: this.gitInfo, loading: this.indexLoading || !!detail?.hydrating || (!!id && !detail?.hydrated && !detail?.error),
             pending, busy: codeSessionBusy(session), synced, transport: this.transport,

--- a/public/manager/src/code/code.css
+++ b/public/manager/src/code/code.css
@@ -382,8 +382,25 @@
     color: var(--text-secondary);
     margin-bottom: 4px; display: block;
 }
-.code-message-user .code-message-role { color: var(--text-primary); }
 .code-message-assistant .code-message-role { color: var(--status-success); }
+
+/*
+ * The user's own text is the one thing on this surface they wrote themselves,
+ * so it gets a right-aligned bubble and the assistant keeps the full column as
+ * plain prose. Asymmetry does the role separation that a repeated label
+ * otherwise has to do in words.
+ */
+.code-message-user { display: flex; flex-direction: column; align-items: flex-end; }
+.code-message-user .code-message-role { color: var(--text-dim); }
+.code-message-user .code-message-text {
+    max-width: min(78%, 36rem);
+    padding: 10px 14px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px 12px 4px 12px;
+    background: var(--bg-raised);
+}
+/* A prompt the server has not echoed yet is dimmed, never hidden. */
+.code-message-user.is-unsent .code-message-text { opacity: 0.72; border-style: dashed; }
 .code-message-text {
     font-size: 13px; line-height: 1.6; color: var(--text-primary);
 }

--- a/public/manager/src/code/pending-user-item.ts
+++ b/public/manager/src/code/pending-user-item.ts
@@ -1,0 +1,46 @@
+import type { CodeItem } from '../../../../src/code-mode/wire';
+import type { CodeDraft } from './code-controller-drafts';
+
+/**
+ * A submitted prompt used to vanish between Send and the server's echo.
+ *
+ * The server does emit a `user_message` as soon as it accepts a turn, but that
+ * arrives after an HTTP round trip and an SSE hop, and when acceptance is
+ * unknown it may never arrive at all. Until then the transcript showed nothing,
+ * so the text the user just wrote was simply gone from the screen.
+ *
+ * This is derived at read time rather than pushed into the session reducer:
+ * that reducer applies strictly sequence-ordered server events, and inserting a
+ * client-invented item would desynchronize its cursor. `clientTurnKey` is the
+ * join key, so the real item replaces this one the moment it lands.
+ */
+export const PENDING_USER_ITEM_ID = 'pending:user';
+
+export function pendingUserItem(draft: CodeDraft, items: CodeItem[], now = Date.now()): CodeItem | null {
+    const retry = draft.retry;
+    if (!retry) return null;
+    // The authoritative item is here: show that one instead.
+    if (items.some(item => item.kind === 'user_message' && item.clientTurnKey === retry.key)) return null;
+    const unknown = draft.operation.kind === 'unknown-send';
+    return {
+        itemId: PENDING_USER_ITEM_ID,
+        turnId: null,
+        kind: 'user_message',
+        // An unconfirmed send is not a failure and must not read as one; it is
+        // still pending until the user retries or the echo arrives.
+        status: 'pending',
+        text: retry.text,
+        clientTurnKey: retry.key,
+        // Sorting is by firstSequence, so a large value keeps this last.
+        firstSequence: Number.MAX_SAFE_INTEGER,
+        createdAt: now,
+        updatedAt: now,
+        ...(unknown ? { phase: 'unknown' as const } : {}),
+    };
+}
+
+/** Items to render: server history plus the not-yet-echoed prompt. */
+export function withPendingUserItem(draft: CodeDraft, items: CodeItem[], now = Date.now()): CodeItem[] {
+    const pending = pendingUserItem(draft, items, now);
+    return pending ? [...items, pending] : items;
+}

--- a/public/manager/src/code/tool-summary.ts
+++ b/public/manager/src/code/tool-summary.ts
@@ -1,0 +1,83 @@
+import type { CodeItem } from '../../../../src/code-mode/wire';
+
+/**
+ * One line that says what a tool call did, in the user's terms.
+ *
+ * A raw tool name plus a JSON blob forces the reader to decode the call before
+ * they can tell whether it matters. `Read src/app.ts` is legible at a glance,
+ * so the body can stay collapsed until someone actually wants it.
+ */
+const VERBS: Array<[RegExp, string]> = [
+    [/^(read|read_file|get_file|open_file|view|cat)$/i, 'Read'],
+    [/^(write|write_file|create_file|edit|edit_file|apply_patch|str_replace\w*|update_file)$/i, 'Edit'],
+    [/^(bash|shell|exec|exec_command|run|run_command|terminal)$/i, 'Bash'],
+    [/^(search|grep|rg|ripgrep|glob|find|codebase_search)$/i, 'Search'],
+    [/^(fetch|browser\w*|web_\w*|open_url|http)$/i, 'Open'],
+    [/^(list|ls|list_dir|list_files)$/i, 'List'],
+];
+
+/** Longest-suffix workspace-relative path, so the row stays scannable. */
+export function shortenPath(value: string, workingDir: string): string {
+    const trimmed = value.trim();
+    if (workingDir && trimmed.startsWith(workingDir)) {
+        const relative = trimmed.slice(workingDir.length).replace(/^[\\/]+/, '');
+        if (relative) return relative;
+    }
+    if (trimmed.length <= 64) return trimmed;
+    const parts = trimmed.split(/[\\/]/).filter(Boolean);
+    return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : `…${trimmed.slice(-60)}`;
+}
+
+function firstLine(value: string): string {
+    const line = value.split(/\r?\n/).find(row => row.trim()) ?? '';
+    const collapsed = line.replace(/\s+/g, ' ').trim();
+    return collapsed.length > 96 ? `${collapsed.slice(0, 95)}…` : collapsed;
+}
+
+/**
+ * A tool argument may be a JSON object, a bare command, or a path. Pull the
+ * one field a reader would recognise, and fall back to the first line rather
+ * than printing an object.
+ */
+export function summariseToolInput(input: string | undefined, workingDir: string): string {
+    if (!input) return '';
+    const raw = input.trim();
+    if (!raw) return '';
+    if (raw.startsWith('{')) {
+        try {
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            for (const key of ['command', 'cmd', 'path', 'file_path', 'file', 'url', 'query', 'pattern']) {
+                const value = parsed[key];
+                if (typeof value === 'string' && value.trim()) {
+                    return key === 'path' || key === 'file' || key === 'file_path'
+                        ? shortenPath(value, workingDir) : firstLine(value);
+                }
+            }
+            return '';
+        } catch { /* not JSON after all; fall through to the raw text */ }
+    }
+    return raw.includes('/') && !raw.includes(' ') ? shortenPath(raw, workingDir) : firstLine(raw);
+}
+
+export function toolSummary(item: CodeItem, workingDir: string): string {
+    if (item.kind === 'file_change') {
+        const target = summariseToolInput(item.tool?.input, workingDir) || item.tool?.detail || '';
+        return target ? `Edit ${target}` : 'File change';
+    }
+    const name = item.tool?.name?.trim() || 'Tool';
+    const verb = VERBS.find(([pattern]) => pattern.test(name))?.[1];
+    const detail = summariseToolInput(item.tool?.input, workingDir);
+    if (verb) return detail ? `${verb} ${detail}` : verb;
+    // An unrecognised tool keeps its own name; renaming it would hide which
+    // tool actually ran, including MCP tools whose names are the useful part.
+    return detail ? `${name} ${detail}` : name;
+}
+
+/** Only states worth interrupting the reader for. `done` is the default. */
+export function noteworthyStatus(item: CodeItem): string | null {
+    if (item.kind === 'turn_cancelled' || item.status === 'cancelled') return 'Stopped';
+    if (item.kind === 'turn_failed' || item.status === 'error') return 'Failed';
+    if (item.status === 'running') return 'Running';
+    if (item.status === 'pending') return 'Pending';
+    return null;
+}

--- a/tests/unit/code-transcript-summary.test.ts
+++ b/tests/unit/code-transcript-summary.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { CodeItem } from '../../src/code-mode/wire.ts';
+import { noteworthyStatus, shortenPath, summariseToolInput, toolSummary } from '../../public/manager/src/code/tool-summary.ts';
+import { pendingUserItem, withPendingUserItem, PENDING_USER_ITEM_ID } from '../../public/manager/src/code/pending-user-item.ts';
+import { createCodeDraft } from '../../public/manager/src/code/code-controller-drafts.ts';
+
+const CWD = '/work/repo';
+function item(patch: Partial<CodeItem> = {}): CodeItem {
+    return { itemId: 'i-1', turnId: 't-1', kind: 'tool_call', status: 'done', createdAt: 1, updatedAt: 1, ...patch };
+}
+function draft(text: string, kind: 'idle' | 'sending' | 'unknown-send' = 'sending') {
+    const d = createCodeDraft({ provider: 'codex-app', cwd: CWD, model: 'm', effort: null, permissionMode: 'ask' });
+    d.retry = { text, key: 'key-1', edit: 0 };
+    d.operation = { kind, error: null };
+    return d;
+}
+
+test('a tool call reads as an action, not a function signature', () => {
+    const cases: Array<[string, string, string]> = [
+        ['read', JSON.stringify({ path: '/work/repo/src/app.ts' }), 'Read src/app.ts'],
+        ['apply_patch', JSON.stringify({ file_path: '/work/repo/src/app.ts' }), 'Edit src/app.ts'],
+        ['bash', JSON.stringify({ command: 'npm test -- --watch' }), 'Bash npm test -- --watch'],
+        ['rg', JSON.stringify({ pattern: 'composer' }), 'Search composer'],
+        ['browser_open', JSON.stringify({ url: 'https://example.com' }), 'Open https://example.com'],
+    ];
+    for (const [name, input, expected] of cases) {
+        assert.equal(toolSummary(item({ tool: { name, input } }), CWD), expected);
+    }
+    // An unrecognised tool keeps its own name: renaming an MCP tool would hide
+    // which tool actually ran.
+    assert.equal(toolSummary(item({ tool: { name: 'github.create_pr', input: '{}' } }), CWD), 'github.create_pr');
+    assert.equal(toolSummary(item({ kind: 'file_change', tool: { name: 'x', input: '/work/repo/a/b.ts' } }), CWD), 'Edit a/b.ts');
+    assert.equal(toolSummary(item({ tool: { name: 'read' } }), CWD), 'Read', 'a missing argument still names the action');
+});
+
+test('summaries stay one short line whatever the argument shape is', () => {
+    assert.equal(summariseToolInput('not json at all\nsecond line', CWD), 'not json at all');
+    assert.equal(summariseToolInput('{bad json', CWD), '{bad json');
+    assert.equal(summariseToolInput(JSON.stringify({ unrelated: 'x' }), CWD), '');
+    assert.equal(summariseToolInput(undefined, CWD), '');
+    const long = summariseToolInput('a'.repeat(300), CWD);
+    assert.ok(long.length <= 96 && long.endsWith('…'));
+    assert.equal(shortenPath('/work/repo/src/deep/file.ts', CWD), 'src/deep/file.ts');
+    assert.equal(shortenPath('/elsewhere/short.ts', CWD), '/elsewhere/short.ts');
+    assert.equal(shortenPath(`/elsewhere/${'d'.repeat(80)}/x/y.ts`, CWD), '…/x/y.ts');
+});
+
+test('only actionable states are worth a badge', () => {
+    assert.equal(noteworthyStatus(item({ status: 'done' })), null, 'success is the default and needs no label');
+    assert.equal(noteworthyStatus(item({ status: 'running' })), 'Running');
+    assert.equal(noteworthyStatus(item({ status: 'error' })), 'Failed');
+    assert.equal(noteworthyStatus(item({ kind: 'turn_cancelled', status: 'done' })), 'Stopped');
+});
+
+test('a submitted prompt is visible before the server echoes it', () => {
+    const d = draft('what did I just type');
+    const pending = pendingUserItem(d, []);
+    assert.equal(pending?.text, 'what did I just type');
+    assert.equal(pending?.kind, 'user_message');
+    assert.equal(pending?.status, 'pending');
+    assert.equal(pending?.itemId, PENDING_USER_ITEM_ID);
+    // It must sort last so it appears where the user expects it.
+    assert.equal(pending?.firstSequence, Number.MAX_SAFE_INTEGER);
+});
+
+test('the server echo replaces the local copy rather than duplicating it', () => {
+    const d = draft('hello');
+    const echoed = item({ itemId: 't-1:user', kind: 'user_message', text: 'hello', clientTurnKey: 'key-1' });
+    assert.equal(pendingUserItem(d, [echoed]), null);
+    assert.deepEqual(withPendingUserItem(d, [echoed]), [echoed]);
+    // A different turn's echo must not suppress this one.
+    const other = item({ itemId: 't-0:user', kind: 'user_message', text: 'earlier', clientTurnKey: 'key-0' });
+    assert.equal(withPendingUserItem(d, [other]).length, 2);
+});
+
+test('an unconfirmed send keeps the text on screen instead of dropping it', () => {
+    const d = draft('did this send?', 'unknown-send');
+    const pending = pendingUserItem(d, []);
+    // Unconfirmed is not failed: the turn may still be running on the server.
+    assert.equal(pending?.status, 'pending');
+    assert.equal(pending?.text, 'did this send?');
+});
+
+test('with no pending send the item list is returned untouched', () => {
+    const d = createCodeDraft({ provider: 'codex-app', cwd: CWD, model: 'm', effort: null, permissionMode: 'ask' });
+    const items = [item()];
+    assert.equal(withPendingUserItem(d, items), items);
+});

--- a/tests/unit/code-transcript-summary.test.ts
+++ b/tests/unit/code-transcript-summary.test.ts
@@ -87,3 +87,28 @@ test('with no pending send the item list is returned untouched', () => {
     const items = [item()];
     assert.equal(withPendingUserItem(d, items), items);
 });
+
+test('the reserved pending id cannot collide with a server item id', () => {
+    // The pending item is keyed by a fixed string, and the transcript keys its
+    // virtual rows on itemId. Nothing in the wire type stops a server id from
+    // being any string, so the two id shapes the store actually produces are
+    // asserted here rather than assumed.
+    //   normalize.ts id():  'code-' + sha256(...)      -> /^code-[0-9a-f]{64}$/
+    //   store.ts admitTurn: `${turnId}:user`, `${turnId}:started`
+    const shapes = [
+        `code-${'a'.repeat(64)}`,
+        'turn-0199:user',
+        'turn-0199:started',
+    ];
+    for (const id of shapes) {
+        assert.notEqual(id, PENDING_USER_ITEM_ID);
+    }
+    // A turn id would have to be literally 'pending' to produce the reserved
+    // string, and turn ids are generated, never client-supplied.
+    assert.equal(PENDING_USER_ITEM_ID, 'pending:user');
+    const d = draft('hello');
+    // Even given a hostile server item carrying the reserved id, the join is on
+    // clientTurnKey, so a mismatched key never suppresses the local copy.
+    const hostile = item({ itemId: PENDING_USER_ITEM_ID, kind: 'user_message', text: 'not mine', clientTurnKey: 'other' });
+    assert.equal(pendingUserItem(d, [hostile])?.text, 'hello');
+});


### PR DESCRIPTION
## Problem

**A submitted prompt disappeared.** The server emits a `user_message` as soon as it accepts a turn, but that arrives only after an HTTP round trip and an SSE hop, and when acceptance is unknown it may never arrive at all. Between pressing Send and the echo the transcript showed nothing — the text the user had just written was gone from the screen with no indication it had been sent.

**Tool calls were unreadable at a glance.** Every call rendered its raw tool name plus fully expanded `Input` and `Output` sections, so one turn filled the viewport and the reader had to decode JSON to learn whether the call mattered.

## How

`pending-user-item.ts` derives the pending item from the draft's retry record at read time. It is deliberately not pushed into the session reducer: that reducer applies strictly sequence-ordered server events, and inserting a client-invented item would desynchronize its cursor. `clientTurnKey` is the join key, so the real item replaces the local one the moment it lands, and an unconfirmed send stays `pending` rather than reading as failed.

`tool-summary.ts` turns a call into one action line with workspace-relative paths, and the body stays collapsed unless the call failed:

| tool + argument | row |
|---|---|
| `read {"path":"/work/repo/src/app.ts"}` | `Read src/app.ts` |
| `bash {"command":"npm test"}` | `Bash npm test` |
| `apply_patch {"file_path":"…/src/app.ts"}` | `Edit src/app.ts` |
| `github.create_pr` | `github.create_pr` |

An unrecognised tool keeps its own name, since renaming an MCP tool would hide which tool actually ran.

The rest quiets the row:

- `Done` is no longer printed. Success is the default; only Running, Pending, Failed and Stopped get a badge.
- Reasoning shows `Thinking…` while streaming and `Reasoning` when finished, instead of appending a status word.
- User messages become a right-aligned bubble while the assistant keeps the full column as plain prose, so asymmetry carries the role separation a repeated label otherwise carries in words.
- Collapsed tool and reasoning rows estimate 44px rather than 64px+, which is what they measure once collapsed. A wrong estimate makes the virtualizer place absolute rows at the wrong offsets during streaming.

## Validation

Rendered the real `CodeTranscriptItem` against the shipped stylesheet with a user message, reasoning, three tool states, an assistant reply, and a pending prompt: the pending bubble appears last with a dashed border and a `You · Sending` label, tool rows collapse to one action line, and only the failed call opens by default.

- `tsc --noEmit` clean on both projects.
- New `code-transcript-summary` suite: 7 pass — summary formatting across JSON/bare-command/path/malformed arguments, path shortening, the status filter, echo replacement, and the unconfirmed-send case.
- `code-native-components`, `code-native-controller`, `code-native-ui-state`: 56 pass, 0 fail.

Stacked on #624.
