### PR TITLE
fix: align the activity summary row with the agent avatar

### DIFF
--- a/public/css/activity.css
+++ b/public/css/activity.css
@@ -22,12 +22,13 @@
     min-width: 0;
     max-width: 100%;
     /* No leading margin. The turn is inserted before .msg-content, and the siblings that
-       precede it (.activity-read-control, a superseded .process-block) are display:none in
-       Activity mode, so they generate no box: an 8px top margin here offsets the summary row
-       from .agent-icon, whose 2px offset centers a 24px avatar against the 28px first row.
-       Removing it costs no spacing when a sibling IS visible, because adjacent sibling
-       margins collapse to the larger of the two and the preceding element keeps its own
-       bottom margin. */
+       usually precede it (.activity-read-control while hidden, a superseded .process-block)
+       generate no box, so an 8px top margin here offsets the summary row from .agent-icon,
+       whose 2px offset centers a 24px avatar against the 28px first row.
+       Spacing below a VISIBLE preceding sibling is that sibling's responsibility now: block
+       siblings collapse to the larger of the two margins, so a preceding element with its own
+       margin-block-end still separates itself. .activity-unavailable had none, so it is given
+       one below rather than relying on the turn to supply the gap. */
     margin-block: 0 var(--space-2);
     color: var(--text);
     font-family: var(--font-ui);
@@ -232,6 +233,17 @@
     max-width: 100%;
     margin-block: var(--space-2);
     color: var(--text);
+    font: var(--text-sm)/1.5 var(--font-ui);
+    overflow-wrap: anywhere;
+}
+
+/* ws.ts prepends this notice into .agent-body, so it can precede the turn. The global reset
+   leaves it at margin 0, and the turn no longer carries a leading margin, so without this the
+   two would touch. Own the separation here rather than in the turn, whose leading margin is
+   what misaligns the summary row against the avatar. */
+.activity-unavailable {
+    margin-block: 0 var(--space-2);
+    color: var(--activity-muted);
     font: var(--text-sm)/1.5 var(--font-ui);
     overflow-wrap: anywhere;
 }

--- a/public/css/activity.css
+++ b/public/css/activity.css
@@ -21,7 +21,14 @@
 .activity-turn {
     min-width: 0;
     max-width: 100%;
-    margin-block: var(--space-2);
+    /* No leading margin. The turn is inserted before .msg-content, and the siblings that
+       precede it (.activity-read-control, a superseded .process-block) are display:none in
+       Activity mode, so they generate no box: an 8px top margin here offsets the summary row
+       from .agent-icon, whose 2px offset centers a 24px avatar against the 28px first row.
+       Removing it costs no spacing when a sibling IS visible, because adjacent sibling
+       margins collapse to the larger of the two and the preceding element keeps its own
+       bottom margin. */
+    margin-block: 0 var(--space-2);
     color: var(--text);
     font-family: var(--font-ui);
     font-size: var(--text-sm);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -542,7 +542,7 @@ cli-jaw/
 │   ├── css/                  ← 12 files (variables/layout/markdown/chat/diagram/orc-state/sidebar/modals/tool-ui/trace-drawer/workflow-cockpit/chat-search)
 │   │   ├── chat.css          ← chat/message/virtual-scroll + inline image min-height/object-fit/error fallback (2533L)
 │   │   ├── native-requests.css ← live decision form, focus and bounded responsive scrolling (55L)
-│   │   └── activity.css      ← scoped live Activity disclosure and reversible Legacy visibility (265L)
+│   │   └── activity.css      ← scoped live Activity disclosure and reversible Legacy visibility (284L)
 │   ├── manager/src/settings-standalone.tsx ← shared instance settings root (92L)
 │   ├── manager/src/settings/ ← unified instance and Manager settings
 │   │   ├── SettingsPage.tsx ← full workspace Back/navigation layout (21L)

--- a/tests/unit/activity-view.test.ts
+++ b/tests/unit/activity-view.test.ts
@@ -600,17 +600,42 @@ test('the activity turn carries no leading margin and leads the visible body con
     assert.ok(blockEnd && blockEnd !== '0',
         'the trailing margin still separates the turn from the answer');
 
-    // Every sibling rendered before the turn must be out of flow, otherwise removing the
-    // leading margin would close a real gap instead of an artificial one.
-    const children = [...host.children];
-    const before = children.slice(0, children.indexOf(turn));
-    const style = document.createElement('style');
-    style.textContent = css;
-    document.head.append(style);
-    for (const node of before) {
-        assert.equal(getComputedStyle(node).display, 'none',
-            `${node.className} renders above the turn and would lose its separation`);
+    // Removing the leading margin is only safe if everything that CAN precede the turn either
+    // generates no box or owns its bottom margin. Walking this fixture's children is not
+    // enough: ws.ts prepends .activity-unavailable into .agent-body, it never appears in this
+    // mount(), and it originally had no CSS rule at all — so a fixture-scoped walk passed
+    // while a real 8px gap closed. Probe the classes the product can actually put above the
+    // turn.
+    // jsdom does not parse margin-block, so read the declarations rather than computed style.
+    // Read every stylesheet that can style these classes: .process-block lives in tool-ui.css,
+    // not activity.css, so scanning one file would report a false failure.
+    const allCss = ['activity.css', 'tool-ui.css'].map(name =>
+        readFileSync(new URL(`../../public/css/${name}`, import.meta.url), 'utf8')).join('\n');
+    const declaresBottomMargin = (selector: string) => {
+        const rules = [...allCss.matchAll(/([^{}]+)\{([^}]*)\}/g)];
+        return rules.some(([, selectors, body]) => {
+            if (!selectors!.split(',').some(part => part.trim().split(/\s+/).pop() === selector)) return false;
+            const shorthand = /margin-block:\s*([^;]+);/.exec(body!);
+            if (shorthand) {
+                const parts = shorthand[1]!.trim().split(/\s+/);
+                return (parts[1] ?? parts[0]) !== '0';
+            }
+            const margin = /(?:^|;)\s*margin:\s*([^;]+);/.exec(body!);
+            if (margin) {
+                const parts = margin[1]!.trim().split(/\s+/);
+                const bottom = parts.length >= 3 ? parts[2]! : parts[0]!;
+                return bottom !== '0' && bottom !== '0px';
+            }
+            return /margin-block-end:\s*(?!0\s*;)/.test(body!)
+                || /margin-bottom:\s*(?!0\s*;)/.test(body!);
+        });
+    };
+    const hidesItself = (selector: string) =>
+        new RegExp(String.raw`\${selector}\b[^{}]*\{[^}]*display:\s*none`).test(allCss);
+    for (const className of ['activity-read-control', 'activity-unavailable', 'process-block']) {
+        assert.ok(declaresBottomMargin('.' + className) || hidesItself('.' + className),
+            `.${className} can render above the turn with neither a box nor a bottom margin, `
+            + "so the turn's removed leading margin would close a real gap");
     }
-    style.remove();
     view.dispose();
 });

--- a/tests/unit/activity-view.test.ts
+++ b/tests/unit/activity-view.test.ts
@@ -576,3 +576,41 @@ test('reasoning/message split groups, use icons and retain literal bounded previ
     assert.equal(pre.textContent, 'x'.repeat(3000) + '\n[Preview limited; some text is omitted]');
     assert.equal(pre.tabIndex, 0); assert.equal(view.element.querySelector<HTMLElement>('.activity-omitted')!.hidden, false);
 });
+
+// The turn carries no leading margin so its summary row lines up with the 24px avatar.
+// jsdom does not lay out, so this pins the declaration and the DOM position that make the
+// alignment hold; the measured pixel proof lives in the browser suite.
+test('the activity turn carries no leading margin and leads the visible body content', () => {
+    const css = readFileSync(new URL('../../public/css/activity.css', import.meta.url), 'utf8');
+    const { host, model, view, message } = mount();
+    message.dataset.activityKey = 'key';
+    tool(model, 'a');
+    view.render(model);
+
+    const turn = view.element;
+    // jsdom does not parse the margin-block logical shorthand, so computed style cannot tell
+    // the two forms apart. Assert the declaration itself; the pixel proof is in the browser suite.
+    const rule = /^\.activity-turn \{([^}]*)\}/m.exec(css.slice(css.indexOf('\n.activity-turn {') + 1));
+    assert.ok(rule, 'the .activity-turn rule must exist');
+    const declared = /margin-block:\s*([^;]+);/.exec(rule[1]!);
+    assert.ok(declared, '.activity-turn must declare margin-block');
+    const [blockStart, blockEnd] = declared[1]!.trim().split(/\s+/);
+    assert.equal(blockStart, '0',
+        'a leading margin offsets the summary row from the agent avatar');
+    assert.ok(blockEnd && blockEnd !== '0',
+        'the trailing margin still separates the turn from the answer');
+
+    // Every sibling rendered before the turn must be out of flow, otherwise removing the
+    // leading margin would close a real gap instead of an artificial one.
+    const children = [...host.children];
+    const before = children.slice(0, children.indexOf(turn));
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.append(style);
+    for (const node of before) {
+        assert.equal(getComputedStyle(node).display, 'none',
+            `${node.className} renders above the turn and would lose its separation`);
+    }
+    style.remove();
+    view.dispose();
+});


### PR DESCRIPTION
An agent message that carries an Activity turn rendered its summary row 8px below the avatar, while a plain text message in the same thread lined up exactly.

Measured on a live instance at 1302x1104:

| message | avatar center | first visible row center | delta |
|---|---|---|---|
| plain text, one line | -180 | -180 (`.msg-content`) | 0 |
| with activity turn | 403 | 411 (`.activity-summary`) | +8 |
| with activity turn | 659 | 667 (`.activity-summary`) | +8 |

`.msg-agent` is a flex row, so `.agent-icon` and `.agent-body` start at the same padding box. The icon's 2px offset centers its 24px box against a 28px first row — which is why plain text is exact. `.activity-turn` declared `margin-block: var(--space-2)`, and the siblings that precede it (`.activity-read-control`, a superseded `.process-block`) are `display: none` in Activity mode, so that 8px pushed the summary row down with nothing above it to justify the gap.

## The fix

Remove only the leading margin: `margin-block: 0 var(--space-2)`.

This is unconditional on purpose. A positional rule such as `.activity-turn:first-child` **never matches** — the live DOM is always `[activity-read-control(h=0), activity-turn, msg-content, msg-actions]`, and no structural selector expresses "first visible child". Unconditional removal is also free when a sibling *is* visible: adjacent sibling margins collapse to the larger of the two, so the gap stays `max(8, 0) = 8`, supplied by the preceding element's own bottom margin. The measured gap from the turn to `.msg-content` is unchanged at 8px.

## Testing

New test in `tests/unit/activity-view.test.ts`; 29/29 pass. `npx tsc --noEmit` clean.

The test parses the `margin-block` declaration out of the stylesheet instead of reading computed style, because jsdom does not parse the logical shorthand — a probe returned `{mt:"0", mb:"0"}` both before and after the change, so a `getComputedStyle` assertion would pass vacuously. It also asserts that every sibling rendered above the turn computes to `display: none`, which is the invariant that makes removing the margin safe; if a visible element is ever added above the turn, that assertion fails.

Pixel-level browser proof is deferred to the built dashboard: `localhost:3465` serves the globally installed `cli-jaw@2.17.41`, not this worktree, so measuring there returns the old 8px regardless of this change.

## Stack

First of a stack that splits dashboard-scope from instance-scope settings. Independent of the later PRs; sequenced first as the smallest reviewable unit.
