### PR TITLE
refactor: make scope the only visibility axis in the settings registry

### DIFF
--- a/public/manager/src/settings/pages/DashboardMeta.tsx
+++ b/public/manager/src/settings/pages/DashboardMeta.tsx
@@ -95,7 +95,26 @@ export type DashboardMetaProps = SettingsPageProps & {
     managerClient?: ManagerClient;
 };
 
-export default function DashboardMeta({
+/**
+ * No selected instance. SettingsShell passes `port={port ?? 0}`, and this page writes to the
+ * MANAGER registry keyed by port, so rendering the form here would let a save PATCH
+ * /api/dashboard/registry under instance key "0". This is a separate component rather than an
+ * early return because the form below calls hooks before its first return: an early return
+ * above them breaks the rules of hooks, and one below them has already issued the fetch.
+ */
+function DashboardMetaEmpty() {
+    return (
+        <p className="settings-empty" role="status">
+            Select an instance to edit its dashboard metadata.
+        </p>
+    );
+}
+
+export default function DashboardMeta(props: DashboardMetaProps) {
+    return props.port ? <DashboardMetaForm {...props} /> : <DashboardMetaEmpty />;
+}
+
+function DashboardMetaForm({
     port,
     client,
     dirty,

--- a/public/manager/src/settings/settings-registry.ts
+++ b/public/manager/src/settings/settings-registry.ts
@@ -3,7 +3,7 @@ import type { ComponentType } from 'react';
 import type { DashboardLocale } from '../types';
 import { DASHBOARD_SETTINGS_COPY } from '../dashboard-settings/DashboardSettingsSidebar';
 type Entry = { id: SettingsCategoryId; scope: SettingsScope; group: SettingsCategoryGroup;
-    label: string | ((locale: DashboardLocale) => string); requiresInstance?: boolean; hidden?: boolean; load: () => Promise<{ default: ComponentType<SettingsPageProps> }> };
+    label: string | ((locale: DashboardLocale) => string); hidden?: boolean; load: () => Promise<{ default: ComponentType<SettingsPageProps> }> };
 export const SETTINGS_REGISTRY: readonly Entry[] = [
     { id:'agent', scope:'instance', group:'runtime', label:'Agent', load:()=>import('./pages/Agent') },
     { id:'model', scope:'instance', group:'runtime', label:'Model defaults', load:()=>import('./pages/ModelProvider') },
@@ -27,9 +27,9 @@ export const SETTINGS_REGISTRY: readonly Entry[] = [
     { id:'manager-developer', scope:'manager', group:'advanced', label:locale=>DASHBOARD_SETTINGS_COPY[locale].sections.developer.label, load:()=>import('./pages/manager/Developer') },
     { id:'manager-embedding', scope:'manager', group:'automation', label:locale=>DASHBOARD_SETTINGS_COPY[locale].sections.embedding.label, load:()=>import('./pages/manager/Embedding') },
     { id:'telegram-hub', scope:'manager', group:'channels', label:locale=>DASHBOARD_SETTINGS_COPY[locale].sections.telegramHub.label, load:()=>import('./pages/manager/TelegramHub') },
-    { id:'dashboard-meta', scope:'manager', requiresInstance:true, group:'advanced', label:'Dashboard meta', load:()=>import('./pages/DashboardMeta') },
+    { id:'dashboard-meta', scope:'manager', group:'advanced', label:'Dashboard meta', load:()=>import('./pages/DashboardMeta') },
 ];
 export const entriesForScopes = (scopes: readonly SettingsScope[], hasInstance: boolean, locale: DashboardLocale) =>
     SETTINGS_REGISTRY.filter(entry => !entry.hidden && scopes.includes(entry.scope)
-        && (hasInstance || (entry.scope !== 'instance' && !entry.requiresInstance)))
+        && (hasInstance || entry.scope !== 'instance'))
         .map(entry => ({...entry, label:typeof entry.label==='function' ? entry.label(locale) : entry.label}));

--- a/tests/unit/manager-frontend-contract.test.ts
+++ b/tests/unit/manager-frontend-contract.test.ts
@@ -682,6 +682,18 @@ test('unified registry filters scopes, localizes navigation, and preserves Manag
     assert.ok(classic.some(e => e.id === 'channels-slack'));
     assert.ok(classic.every(e => e.scope === 'instance' && !e.hidden));
     assert.ok(!classic.some(e => e.id === 'telegram-hub' || e.id === 'dashboard-meta'));
+    // Scope is the only visibility axis: the retired requiresInstance flag added a third,
+    // undocumented state (manager-scoped but instance-gated) that hid a real bug.
+    for (const entry of SETTINGS_REGISTRY) {
+        assert.equal(Object.prototype.hasOwnProperty.call(entry, 'requiresInstance'), false,
+            `registry entry ${entry.id} must not carry the removed requiresInstance flag`);
+    }
+    assert.equal(read('public/manager/src/settings/settings-registry.ts').includes('requiresInstance'), false,
+        'settings-registry must not mention requiresInstance in type, entries, or filter');
+    const managerOnly = entriesForScopes(['manager'], false, 'en');
+    assert.ok(managerOnly.some(e => e.id === 'dashboard-meta'),
+        'dashboard-meta is manager-scoped: the manager server owns /api/dashboard/registry');
+    assert.ok(managerOnly.every(e => e.scope === 'manager' && !e.hidden));
     assert.ok(SETTINGS_REGISTRY.every(e => typeof e.load === 'function'));
     const saved = defaultDashboardRegistry().ui;
     let ui = { ...saved, locale: 'en' as const as import('../../public/manager/src/types').DashboardLocale,

--- a/tests/unit/settings-page-contract.test.ts
+++ b/tests/unit/settings-page-contract.test.ts
@@ -116,3 +116,35 @@ test('settings CSS specifies the measured card, row and responsive navigation ge
     sheet.walkAtRules('media', at => { if (at.params === '(max-width: 1023px)') at.walkRules('.settings-shell', rule => { rule.walkDecls('grid-template-columns', decl => { mobileGrid = decl.value; }); }); });
     assert.equal(mobileGrid, '40px minmax(0, 1fr)');
 });
+
+test('Dashboard meta refuses to load or write without a selected instance', async () => {
+    // SettingsShell passes port ?? 0, and this page PATCHes the MANAGER registry keyed by
+    // port. A port-0 render would write under instance key "0", so the guard must run
+    // before any hook fires — not as an early return inside the form.
+    const { default: DashboardMeta } = await import('../../public/manager/src/settings/pages/DashboardMeta');
+    const { createDirtyStore } = await import('../../public/manager/src/settings/dirty-store');
+    const managerCalls: string[] = [];
+    const managerClient = {
+        async get<T>(path: string) { managerCalls.push('GET ' + path); return { registry: { instances: {} } } as T; },
+        async patch<T>(path: string) { managerCalls.push('PATCH ' + path); return {} as T; },
+    };
+    const instanceCalls: string[] = [];
+    const spyClient: SettingsClient = {
+        async get<T>(path: string) { instanceCalls.push(path); return {} as T; },
+        async put<T>() { return {} as T; }, async post<T>() { return {} as T; }, async delete<T>() { return {} as T; },
+    };
+    const container = document.createElement('div'); document.body.append(container);
+    const root = createRoot(container);
+    try {
+        await act(async () => root.render(createElement(DashboardMeta, {
+            port: 0, instanceUrl: '', client: spyClient, dirty: createDirtyStore(), managerClient,
+        })));
+        assert.deepEqual(managerCalls, [], 'no instance selected must mean no registry read or write');
+        assert.deepEqual(instanceCalls, []);
+        assert.equal(container.querySelector('form, input, .settings-form'), null,
+            'the form must not mount, otherwise a save could target instance key "0"');
+        const empty = container.querySelector('.settings-empty');
+        assert.ok(empty && /select an instance/i.test(empty.textContent || ''),
+            'the guard must say why the page is empty');
+    } finally { await act(async () => root.unmount()); container.remove(); }
+});


### PR DESCRIPTION
The settings registry declared two scopes but had three visibility states. `requiresInstance` added an undocumented case — a manager-scoped entry that is *also* gated on a selected instance — and exactly one entry used it. It was suppressing a symptom rather than expressing a rule.

## The bug it was hiding

`SettingsShell` passes `port={port ?? 0}`. Remove the flag and Dashboard meta renders with `port === 0`, so a save would `PATCH /api/dashboard/registry` under instance key `"0"` — writing metadata to a port that does not exist. The flag hid the entry instead of fixing the write.

## What changed

```
- && (hasInstance || (entry.scope !== 'instance' && !entry.requiresInstance)))
+ && (hasInstance || entry.scope !== 'instance'))
```

Dashboard meta **stays** `scope: 'manager'`. Scope describes who owns the storage, and the manager server owns `/api/dashboard/registry` — an instance-scoped page is served by the instance and by the Classic standalone bundle, neither of which can reach that endpoint. The page being *about* one instance does not make it instance-scoped.

The bug is fixed where it lives: `DashboardMeta` renders an explicit "Select an instance" state when no instance is selected.

## Why the empty state is a component, not an early return

The form calls six hooks before its first `return` (`usePageSnapshot`, three `useState`, three `useEffect`, two `useCallback`). An early return above them breaks the rules of hooks; one below them has already issued `mClient.get('/api/dashboard/registry')`. The component boundary is what makes "zero requests" true rather than "no form visible".

## Testing

```
tests/unit/manager-frontend-contract.test.ts   28/28
tests/unit/settings-page-contract.test.ts       5/5
tests/unit/manager-settings-polish.test.ts + 4 more   78/78
npx tsc --noEmit                                clean
```

The new contract test asserts both the manager and instance call logs are empty at `port: 0`, plus that no form element mounts. A refactor back to an early return fails it. A second assertion pins that no registry entry carries `requiresInstance` and that the string is absent from the file, so the third visibility state cannot quietly return.

## Stack

Builds on #626. Later PRs make the rail gear manager-scope-only and give the instance its own settings page.
