### PR TITLE
docs(structure): record what the Code catalog and composer now do

### DIFF
--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -562,6 +562,29 @@ request uncertainty; it stores no transcript, native cursor or permission answer
 Uncertain creation/send recovery requires explicit action and never auto-submits. Auto (YOLO) is an explicit
 provider capability, and opening the catalog never launches a process.
 
+The composer dock groups its controls by how often each is touched:
+`[runtime glyph] [permission] ····· [model] [effort]` on one row, with dictation
+and send trailing the input. Runtime is icon-only and carries its name on the
+button (`aria-label="Runtime: Codex"` plus a title) while the brand SVG stays
+`aria-hidden`; the marks come from `public/assets/providers`, inlined in
+`ProviderGlyph.tsx` because the Manager bundle has no `?raw` convention.
+Model is a filterable dropdown rather than free text — a newly chosen model
+outside the catalog is rejected, so typing could only produce a 400 — and a live Codex
+catalog carries 28+ routed ids. Effort offers the intersection of the selected
+model's advertised set and, for an open session, the capabilities it stored at
+creation; the server checks both. Dictation records through `MediaRecorder` and
+posts to `/api/voice` with `x-stt-only`, appending the transcript to the draft
+instead of sending it, and stays disabled with a stated reason when the browser
+has no `mediaDevices`.
+
+A submitted prompt is visible before the server echoes it. The pending item is
+derived from the draft at read time, not inserted into the session reducer,
+which applies strictly sequence-ordered server events; `clientTurnKey` joins the
+two so the real item replaces the local one. Tool calls collapse to one action
+line (`Read src/app.ts`, `Bash npm test`) and open only on failure, `Done` is
+not printed, and user messages use a right-aligned bubble while the assistant
+keeps the full column as plain prose.
+
 `useCodeController` owns requests and selection fencing. A single Code SSE
 subscription reconciles a full snapshot at watermark H and contiguous events
 after H. Opening transport does not mean synchronization has completed. Compact

--- a/structure/runtime-integration.md
+++ b/structure/runtime-integration.md
@@ -268,6 +268,26 @@ Wire limits are explicit: terminal-plus-late-content in one chunk and content in
   싣고 평평한 키는 싣지 않는다. codex/codex-app은 provider 개념이 없어 평평한 맵을 유지한다.
   해석 우선순위: provider 스코프 모델 → 평평한 모델 → provider 목록 → registry 목록.
   스코프 맵이 있어도 **모델 키가 없으면 provider 목록으로 폴백**한다(근거 없는 축소 금지).
+- **Code 카탈로그도 같은 배선을 읽는다** (`src/code-mode/providers/live-models.ts`).
+  `registry-live.ts`의 소비자는 설정 라우트뿐이라 Code 모드는 오랫동안 `CLI_REGISTRY`의
+  정적 목록에 갇혀 있었다. `CodeProvider.describe()`는 동기 함수라 ocx를 await 할 수 없으므로,
+  마지막으로 확보한 `/v1/models` 응답을 메모리에 두고 백그라운드로 갱신하는 스냅샷을 읽는다.
+  (첫 probe가 저하되면 스냅샷은 static fallback이고, 이후 live 응답이 이를 대체한다.)
+  read는 절대 블로킹하지 않고 이미 아는 값을 돌려준다. 규칙:
+  - 저하된 probe(`source:'static'`)는 기존 live 스냅샷을 덮지 않는다. 한 번의 실패로 routed 모델이 사라지면 안 된다.
+  - 빈 목록은 저장하지 않는다. 카탈로그가 비면 `validate()`가 모든 모델을 거절한다.
+  - 실패/저하 시도도 자체 타임스탬프를 남기고 30초 재시도 하한을 지킨다. 성공만 시계를 돌리면
+    stale 스냅샷 + 죽은 proxy 조합에서 카탈로그를 읽을 때마다 probe가 재시작된다.
+  - 스냅샷 read는 proxy를 타는 `codex-app`에서만 일어난다. 필터를 나중에 하면 Claude/Cursor
+    카탈로그 조회가 Codex probe를 예약한다.
+  카탈로그는 `modelSource:'live'`와 `effortsByModel`/`defaultEffortByModel`을 실어 보낸다.
+- **라이브 카탈로그는 이미 도는 세션을 무효화하지 않는다.** `validate()`는 prompt/attach/patch에서
+  세션의 저장된 값으로 다시 호출된다. 목록이 세션 아래에서 바뀔 수 있으므로, 생성 시점에 합법이었던
+  모델이 갑자기 `unsupported_model`이 되면 사용자가 보거나 고칠 수 없는 이유로 세션이 죽는다.
+  그래서 `validate(input, fixed, accepted)`의 `accepted`가 세션이 이미 쓰는 model/effort를 지목하고,
+  **유지되는 값은 오늘의 카탈로그로 재검사하지 않는다** — 모델은 현재 목록을, effort는 현재 union과
+  모델별 집합을 건너뛴다. 다만 세션이 생성 시점에 저장한 capabilities는 계속 적용된다.
+  그것이 네이티브 런타임을 연 계약이기 때문이다. 새로 고르는 값은 여전히 현재 카탈로그로 검사한다.
 - `/effort` 슬래시 명령과 TUI 셀렉터도 같은 소스를 쓴다. 과거에는
   `['off','low','medium','high','max']`를 하드코딩해 `xhigh`가 아예 없고 `ultra`를
   거부했다. 지금은 `resolveEffortLevelsForCli(cli, model)`이 codex 계열이면 ocx

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -72,15 +72,16 @@ cli-jaw/
 │   │   └── skill-cache.ts    ← 활성 스킬 슬래시 커맨드 캐시 (registerSkillLoader, getSkillCommandsCache, invalidateSkillCommandsCache) (44L)
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
 │   │   ├── host.ts ← per-backend lazy composition and storage (64L)
-│   │   ├── manager.ts ← session index, admission and resource capacity (296L)
+│   │   ├── manager.ts ← session index, admission and resource capacity (322L)
 │   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (623L)
 │   │   ├── normalize.ts ← redacted materialized transcript and coalescing (534L)
 │   │   ├── store.ts ← SQLite ownership, replay, snapshots and byte budgets (794L)
 │   │   ├── provider.ts ← native handle and turn-context contracts (53L)
 │   │   ├── types.ts ← internal session and store contracts (12L)
-│   │   ├── wire.ts ← public request/event DTOs (178L)
+│   │   ├── wire.ts ← public request/event DTOs (186L)
 │   │   └── providers/        ← direct native adapters and capabilities
-│   │       ├── catalog.ts ← model/capability descriptions (71L)
+│   │       ├── catalog.ts ← model/capability descriptions (100L)
+│   │       ├── live-models.ts ← last-known opencodex catalog, refreshed in background (93L)
 │   │       ├── codex-app.ts ← Codex app-server adapter (320L)
 │   │       ├── claude.ts ← Claude native adapter (93L)
 │   │       ├── acp.ts ← shared ACP resource ownership (134L)
@@ -532,7 +533,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 598 files source/assets, ~101821L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 602 files source/assets, ~102302L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── settings/ ← standalone instance settings entry
 │   │   └── index.html ← Classic settings iframe HTML (13L)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)


### PR DESCRIPTION
## Why

Root `AGENTS.md` requires the architecture docs to move whenever command, API or orchestration surfaces change. The three Code PRs in this stack moved all three, and left alone `structure/verify-counts.sh` reported five mismatches while the prose still described a Code mode that reads a static model list.

## What changed

**`str_func.md`** — adds `providers/live-models.ts` to the tree and syncs the counts this work changed:

| file | documented | actual |
|---|---|---|
| `src/code-mode/manager.ts` | 296L | 317L |
| `src/code-mode/wire.ts` | 178L | 186L |
| `src/code-mode/providers/catalog.ts` | 71L | 100L |
| `public/` | ~101821L / 598 files | ~102302L / 602 files |

**`runtime-integration.md`** — the model-discovery section documented the live opencodex wiring only for the settings/registry path. It now states that the Code catalog reads the same wiring through a background snapshot, why `describe()` cannot await it, and the four rules that keep the snapshot honest: a degraded probe never overwrites a live one, an empty answer is not stored, failures hold a retry floor, and only the proxied runtime reads it. It also records the accepted-value rule that keeps a running session valid when the catalog drifts underneath it.

**`frontend.md`** — the Native Code workbench section now describes the composer grouping, why the model control is a filtered dropdown rather than free text, how effort intersects catalog and session capabilities, what dictation actually does, and the transcript contract for pending prompts and collapsed tool rows.

## Validation

- `bash structure/verify-counts.sh` — 580/580 items match.
- `bash structure/check-doc-drift.sh` — 4/4 checks pass, 0 skipped.

Documentation only; no source changes. Stacked on #625.
