### PR TITLE
feat: let the manager open an instance's own settings page

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -562,10 +562,15 @@ body.right-collapsed .sidebar-right {
     .chat-header { height: auto; min-height: 44px; }
 }
 
-/* Full settings workspace keeps the existing header and spans the right rail. */
+/* Full settings workspace keeps the existing header and fills the whole viewport. */
 body[data-settings-open="true"] .chat-area,
+body[data-settings-open="true"] .sidebar-left,
 body[data-settings-open="true"] .sidebar-right { display: none; }
-#settingsPage { grid-column: 2 / 4; grid-row: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
+/* The mobile drawer scrim is a pseudo-element of body, not of the sidebar, so hiding
+   .sidebar-left above does not remove it: a drawer left open would scrim the settings page. */
+body[data-settings-open="true"].left-expanded::after,
+body[data-settings-open="true"].right-expanded::after { content: none; }
+#settingsPage { grid-column: 1 / -1; grid-row: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
 #settingsPage[hidden] { display: none; }
 #settingsPage > iframe { flex: 1; display: block; width: 100%; height: 100%; min-height: 0; border: 0; }
 #settingsPage > .chat-header { width: 100%; }
@@ -574,6 +579,5 @@ body[data-settings-open="true"] .sidebar-right { display: none; }
 .header-icon-btn:hover { background: var(--surface-3); color: var(--text); }
 .header-icon-btn[aria-pressed="true"] { color: var(--accent); background: var(--surface-2); }
 .header-icon-btn:focus-visible { outline: none; box-shadow: var(--focus-ring-shadow); }
-@media (max-width: 900px) { #settingsPage { grid-column: 1 / -1; } }
 @media (prefers-reduced-motion: no-preference) { #settingsPage:not([hidden]) { animation: settingsPageEnter 120ms ease; } }
 @keyframes settingsPageEnter { from { opacity: 0; } to { opacity: 1; } }

--- a/public/js/features/settings.ts
+++ b/public/js/features/settings.ts
@@ -1,4 +1,5 @@
 // settings.ts — barrel re-export (preserves all import paths)
+import { isLocalPreviewRelayOrigin } from '../preview-parent-origin.js';
 export { loadSettings, updateSettings, setPerm, onCliChange, saveActiveCliSettings, onFlushCliChange, loadFlushAgentSidebar } from './settings-core.js';
 export { setTelegram, setForwardAll, setTelegramMentionOnly, saveTelegramSettings } from './settings-telegram.js';
 export { setDiscord, setDiscordForwardAll, setDiscordAllowBots, setDiscordMentionOnly, saveDiscordSettings } from './settings-discord.js';
@@ -66,12 +67,27 @@ export function initSettingsFrame(): () => void {
         if (event.data?.type === 'jaw-settings-ready') sendTheme();
         if (event.data?.type === 'settings:back') closeSettingsPage();
     };
+    // The manager asks this instance to open its own settings page. Two guards live fifteen
+    // lines apart on purpose and must NOT be collapsed into one:
+    //   receive() above talks to our OWN iframe, which is same-origin by construction.
+    //   relay() below talks to the manager, which under the default origin-port preview
+    //   transport runs on a different loopback PORT — so a strict origin equality check
+    //   would silently drop every message. isLocalPreviewRelayOrigin accepts any loopback
+    //   origin, which is the same predicate the STT and capability relays already use.
+    const relay = (event: MessageEvent): void => {
+        if (event.source !== window.parent) return;
+        if (!isLocalPreviewRelayOrigin(event.origin)) return;
+        if (event.data?.type !== 'jaw-preview-settings-open') return;
+        toggleSettingsPage(true);
+    };
     frame.addEventListener('load', sendTheme);
     window.addEventListener('message', receive);
+    window.addEventListener('message', relay);
     sendTheme();
     return () => {
         observer.disconnect();
         frame.removeEventListener('load', sendTheme);
         window.removeEventListener('message', receive);
+        window.removeEventListener('message', relay);
     };
 }

--- a/public/manager/src/InstancePreview.tsx
+++ b/public/manager/src/InstancePreview.tsx
@@ -20,6 +20,9 @@ type InstancePreviewProps = {
     docPanelCapable?: boolean;
     previewInsertTextRequest?: PreviewInsertTextRequest | null;
     onPreviewInsertTextResult?: (id: string, result: PreviewInsertTextResult) => void;
+    /** One-shot id; a new value asks the mounted preview to open its own settings page. */
+    previewSettingsOpenRequest?: string | null;
+    onPreviewSettingsOpenResult?: (id: string, result: PreviewInsertTextResult) => void;
 };
 
 const PREVIEW_IFRAME_SANDBOX = 'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads';
@@ -149,6 +152,23 @@ function postPreviewSttToggle(frame: HTMLIFrameElement | null, src: string): voi
     }
 }
 
+/**
+ * Ask the instance to open ITS OWN settings page. The manager never renders instance settings;
+ * it only sends this request, and the instance decides. Fire-and-forget like the STT toggle:
+ * there is nothing to await, and the instance owns the outcome.
+ */
+function postPreviewSettingsOpen(frame: HTMLIFrameElement | null, src: string): void {
+    const targetWindow = frame?.contentWindow;
+    if (!targetWindow) return;
+    const targetOrigin = previewTargetOrigin(src, frame);
+    if (!targetOrigin || targetOrigin === 'null') return;
+    try {
+        targetWindow.postMessage({ type: 'jaw-preview-settings-open' }, targetOrigin);
+    } catch (error) {
+        console.warn('[manager-preview] settings open request skipped', error);
+    }
+}
+
 function postPreviewVisible(frame: HTMLIFrameElement | null, src: string): void {
     const targetWindow = frame?.contentWindow;
     if (!targetWindow) return;
@@ -252,6 +272,7 @@ export function InstancePreview(props: InstancePreviewProps) {
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const loadedSrcRef = useRef<string | null>(null);
     const handledInsertRequestRef = useRef<string | null>(null);
+    const handledSettingsRequestRef = useRef<string | null>(null);
     const [pathDropStatus, setPathDropStatus] = useState<string | null>(null);
     const [folderDragActive, setFolderDragActive] = useState(false);
     const state = buildPreviewState(
@@ -294,6 +315,32 @@ export function InstancePreview(props: InstancePreviewProps) {
             .then(finish)
             .catch(error => finish({ ok: false, error: (error as Error).message }));
     }, [disabledReason, props.enabled, props.instance, props.onPreviewInsertTextResult, props.previewInsertTextRequest, state.canPreview, state.src]);
+
+    useEffect(() => {
+        const id = props.previewSettingsOpenRequest;
+        if (!id || handledSettingsRequestRef.current === id) return;
+        handledSettingsRequestRef.current = id;
+        const finish = (result: PreviewInsertTextResult): void => {
+            props.onPreviewSettingsOpenResult?.(id, result);
+        };
+        // Deliberately independent of props.active: the preview iframe stays mounted when the
+        // Preview tab is not showing, so the request still lands. What it cannot survive is an
+        // unmounted or still-loading frame, which is what these guards report.
+        if (!props.instance?.ok) {
+            finish({ ok: false, error: 'selected instance is not online' });
+            return;
+        }
+        if (!props.enabled || !state.canPreview || !state.src) {
+            finish({ ok: false, error: disabledReason || 'turn Preview on to open this instance\u2019s settings' });
+            return;
+        }
+        if (loadedSrcRef.current !== state.src) {
+            finish({ ok: false, error: 'selected instance preview is still loading' });
+            return;
+        }
+        postPreviewSettingsOpen(iframeRef.current, state.src);
+        finish({ ok: true });
+    }, [disabledReason, props.enabled, props.instance, props.onPreviewSettingsOpenResult, props.previewSettingsOpenRequest, state.canPreview, state.src]);
 
     const handleFolderPathDrop = useCallback(async (event: React.DragEvent): Promise<void> => {
         if (!hasFolderPanelDragPayload(event.dataTransfer)) return;

--- a/public/manager/src/SidebarRailRouter.tsx
+++ b/public/manager/src/SidebarRailRouter.tsx
@@ -299,6 +299,11 @@ export function SidebarRailRouter(props: Props) {
     const [previewInsertTextRequest, setPreviewInsertTextRequest] = useState<PreviewInsertTextRequest | null>(null);
     const previewInsertSeqRef = useRef(0);
     const previewInsertResolversRef = useRef(new Map<string, (result: PreviewInsertTextResult) => void>());
+    // Instance settings live in the instance. The manager only asks the mounted preview to
+    // open its own page; a one-shot id keeps repeat clicks addressable.
+    const [previewSettingsOpenRequest, setPreviewSettingsOpenRequest] = useState<string | null>(null);
+    const previewSettingsSeqRef = useRef(0);
+    const [instanceSettingsNotice, setInstanceSettingsNotice] = useState<string | null>(null);
     // 030 v2/v3: keep the server registry in sync, deliver shares to the
     // selected instance's runtime-context, and relay screenshot commands.
     useEmbeddedBrowserTargetSync(isElectron, props.selectedInstance?.port ?? null);
@@ -336,6 +341,16 @@ export function SidebarRailRouter(props: Props) {
         previewInsertResolversRef.current.delete(id);
         setPreviewInsertTextRequest(current => current?.id === id ? null : current);
         resolve(result);
+    }, []);
+
+    const requestInstanceSettings = useCallback((): void => {
+        setInstanceSettingsNotice(null);
+        previewSettingsSeqRef.current += 1;
+        setPreviewSettingsOpenRequest(`settings-open-${previewSettingsSeqRef.current}`);
+    }, []);
+    const handlePreviewSettingsOpenResult = useCallback((id: string, result: PreviewInsertTextResult): void => {
+        setPreviewSettingsOpenRequest(current => current === id ? null : current);
+        setInstanceSettingsNotice(result.ok ? null : result.error);
     }, []);
 
     // CEO: handled through right sidebar tab system now. CEO is hidden in v1,
@@ -577,10 +592,16 @@ export function SidebarRailRouter(props: Props) {
                             <button type="button" className="state-dismiss" aria-label="Dismiss dropped file message" onClick={() => setDropNotice(null)}>X</button>
                         </section>
                     )}
+                    {instanceSettingsNotice && (
+                        <section className="state lifecycle-state" role="status">
+                            <span>{instanceSettingsNotice}</span>
+                            <button type="button" className="state-dismiss" aria-label="Dismiss instance settings message" onClick={() => setInstanceSettingsNotice(null)}>X</button>
+                        </section>
+                    )}
                     <div className="workspace-surface-layer">
                         <WorkspaceSurface active={props.sidebarMode === 'instances' && props.viewMode === 'jaw'}>
-                            <Workbench mode={props.activeDetailTab} onModeChange={props.onDetailTabChange} header={props.workbenchHeader} modeActions={props.jawCeoWorkbenchButton} active={props.sidebarMode === 'instances' && props.viewMode === 'jaw'} overview={props.detailContent('overview')} preview={(
-                                <InstancePreview instance={props.selectedInstance} data={props.data} enabled={props.previewEnabled} active={props.sidebarMode === 'instances' && props.activeDetailTab === 'preview'} refreshKey={props.previewRefreshKey} theme={props.previewTheme} {...(props.onOpenNotesFromPreview ? { onOpenNotesFromPreview: props.onOpenNotesFromPreview } : {})} onOpenDocFromPreview={handleRightPreviewFile} onPreviewDroppedFiles={handlePreviewDroppedFiles} docPanelCapable={desktopPanelsAvailable} previewInsertTextRequest={previewInsertTextRequest} onPreviewInsertTextResult={handlePreviewInsertTextResult} />
+                            <Workbench mode={props.activeDetailTab} onModeChange={props.onDetailTabChange} header={props.workbenchHeader} modeActions={(<>{props.jawCeoWorkbenchButton}<button type="button" className="workbench-instance-settings-request" aria-label="Instance settings" title="Open this instance's own settings page" disabled={!props.selectedInstance?.ok} onClick={requestInstanceSettings}>Settings</button></>)} active={props.sidebarMode === 'instances' && props.viewMode === 'jaw'} overview={props.detailContent('overview')} preview={(
+                                <InstancePreview instance={props.selectedInstance} data={props.data} enabled={props.previewEnabled} active={props.sidebarMode === 'instances' && props.activeDetailTab === 'preview'} refreshKey={props.previewRefreshKey} theme={props.previewTheme} {...(props.onOpenNotesFromPreview ? { onOpenNotesFromPreview: props.onOpenNotesFromPreview } : {})} onOpenDocFromPreview={handleRightPreviewFile} onPreviewDroppedFiles={handlePreviewDroppedFiles} docPanelCapable={desktopPanelsAvailable} previewInsertTextRequest={previewInsertTextRequest} onPreviewInsertTextResult={handlePreviewInsertTextResult} previewSettingsOpenRequest={previewSettingsOpenRequest} onPreviewSettingsOpenResult={handlePreviewSettingsOpenResult} />
                             )} logs={props.detailContent('logs')} />
                         </WorkspaceSurface>
                         {props.viewMode === 'code' && props.sidebarMode === 'instances' ? (

--- a/tests/unit/slack-surfaces.test.ts
+++ b/tests/unit/slack-surfaces.test.ts
@@ -239,3 +239,45 @@ test('no two-channel enumeration remains in src or the frontend', () => {
         );
     }
 });
+
+test('the manager settings-open relay accepts a cross-port loopback parent and rejects the rest', async t => {
+    // Under the default origin-port preview transport the manager runs on a DIFFERENT loopback
+    // port than the instance, so a strict same-origin check would silently drop every request.
+    // This is the guard that must stay loose, while the iframe guard above stays strict.
+    const { setupWebUiDom, resetWebUiDom } = await import('./web-ui-test-dom.ts');
+    setupWebUiDom();
+    t.after(resetWebUiDom);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('{}', { headers: { 'content-type': 'application/json' } });
+    t.after(() => { globalThis.fetch = originalFetch; });
+    document.head.innerHTML = '<base href="http://127.0.0.1/i/3465/">';
+    document.body.innerHTML = '<div class="chat-area"><div class="chat-header"><button id="btnSettings" aria-pressed="false">Settings</button></div><textarea id="chatInput"></textarea></div><section id="settingsPage" hidden><iframe></iframe></section>';
+    t.mock.module('../../public/js/provider-icons.js', { namedExports: { providerIcon: () => '', providerLabel: (value: string) => value } });
+    const { initSettingsFrame } = await import('../../public/js/features/settings.ts');
+    const dispose = initSettingsFrame();
+    const page = document.getElementById('settingsPage')!;
+    const frame = document.querySelector<HTMLIFrameElement>('iframe')!;
+    frame.contentWindow!.postMessage = () => {};
+    const ask = (source: Window | null, origin: string) => window.dispatchEvent(
+        new window.MessageEvent('message', { source, origin, data: { type: 'jaw-preview-settings-open' } }),
+    );
+
+    // A non-loopback origin must never open the page, whatever it claims to be.
+    ask(window.parent, 'https://evil.invalid');
+    assert.equal(page.hidden, true, 'a remote origin must not open instance settings');
+
+    // Our own iframe is not the manager; the relay only listens to the parent.
+    ask(frame.contentWindow, 'http://127.0.0.1');
+    assert.equal(page.hidden, true, 'the settings iframe is not the request source');
+
+    // The manager on another loopback port is the real case.
+    ask(window.parent, 'http://localhost:24576');
+    assert.equal(page.hidden, false, 'a loopback manager on another port must be accepted');
+    assert.equal(document.body.dataset['settingsOpen'], 'true');
+
+    dispose();
+    document.body.removeAttribute('data-settings-open');
+    page.hidden = true;
+    ask(window.parent, 'http://localhost:24576');
+    assert.equal(page.hidden, true, 'the disposer must detach the relay listener');
+});


### PR DESCRIPTION
The instance settings page existed but did not fill the instance viewport, and after #629 removed the manager's in-document panel there was no way to reach it from the dashboard.

## Full viewport

`#settingsPage` was `grid-column: 2 / 4`, spanning the chat column and the right rail but leaving `.sidebar-left` visible. It now spans `1 / -1`, and `.sidebar-left` joins the hidden set.

The mobile drawer scrim needed a rule of its own:

```css
body[data-settings-open="true"].left-expanded::after { content: none; }
```

`body.left-expanded::after` is a pseudo-element of **body**, not of the sidebar, so hiding `.sidebar-left` does not remove it. Without this, opening settings on a phone with the drawer open leaves a full-screen scrim over the "full viewport" page.

## The relay is three hops, not two

```
manager InstancePreview  --jaw-preview-settings-open-->  Classic document
Classic document         --toggleSettingsPage(true)-->   settings iframe
```

The settings iframe accepts messages only from its immediate parent under strict same-origin, and that parent is the Classic document, not the manager. The manager cannot post to it directly.

**The two guards now sit fifteen lines apart in `settings.ts` and must not be collapsed.** The iframe guard stays strict because that frame is same-origin by construction. The manager guard uses `isLocalPreviewRelayOrigin`, because under the default origin-port preview transport the manager runs on a *different loopback port* — a strict equality check drops every request silently. A comment on the relay says exactly this.

## Testing

```
tests/unit/slack-surfaces.test.ts       14/14
+ settings-page, manager-frontend, manager-instance-settings, responsive   82/82
npm run gate:all                        23/23
npm run typecheck:frontend              clean
```

Both failure directions are mutation-verified rather than asserted:

| mutation | result |
|---|---|
| relay tightened to `event.origin !== location.origin` | fails *"a loopback manager on another port must be accepted"* |
| relay origin guard deleted | fails *"a remote origin must not open instance settings"* |

## On the Settings button reappearing in the workbench

#629 removed the command-bar gear because it was unnecessary. This adds a button to the workbench **mode bar**, which is a different thing and worth stating plainly: the old gear portalled into the command centre and toggled a manager-rendered settings panel; this one is scoped to the selected instance and its only effect is to post a message. The manager still renders no instance settings.

Failures surface in the existing lifecycle notice instead of disappearing. The request effect deliberately does not depend on the preview being the active tab, since the iframe stays mounted across tab changes.

## Stack

Fourth of the stack, on #629. Next and last: the settings page absorbs the sidebar permission and runtime controls while both sidebars keep working.
