### PR TITLE
fix(boundary): an ignored private directory is still a private directory

### DIFF
--- a/scripts/check-private-boundary.mjs
+++ b/scripts/check-private-boundary.mjs
@@ -22,7 +22,28 @@ function rejectPaths(paths, label) {
 
 export function checkIndex(cwd) {
     rejectPaths(git(cwd, ['ls-files', '-z']).split('\0').filter(Boolean), 'index');
+    rejectWorkingTree(cwd);
     reportSubmodules(cwd, { enforce: submoduleEnforcement() });
+}
+
+/**
+ * An ignored private directory is still a private directory.
+ *
+ * `ls-files` sees the index, so a `devlog/` that `.gitignore` covers reports
+ * OK here while sitting in the checkout — which is exactly how one survived in
+ * a working tree until a human noticed. The rule is about where records live,
+ * not about whether Git happens to be tracking them: an ignored path is one
+ * `git add -f` or one archive away from shipping, and it is already visible to
+ * every tool and agent working in the directory.
+ *
+ * `--directory` reports the containing directory rather than each file inside
+ * it, so a large private tree produces one actionable line.
+ */
+function rejectWorkingTree(cwd) {
+    const untracked = git(cwd, ['ls-files', '-z', '--others', '--directory', '--no-empty-directory'])
+        .split('\0').filter(Boolean)
+        .map(entry => entry.replace(/\/$/, ''));
+    rejectPaths(untracked, 'working tree');
 }
 
 /**

--- a/scripts/check-private-boundary.mjs
+++ b/scripts/check-private-boundary.mjs
@@ -71,8 +71,13 @@ export function reportSubmodules(cwd, { enforce = false } = {}) {
             findings.push({ path, absent: true, files: [] });
             continue;
         }
-        const files = git(subCwd, ['ls-files', '-z']).split('\0').filter(Boolean)
-            .map(f => path + '/' + f).filter(isPrivatePath);
+        // Same reasoning as rejectWorkingTree: a submodule's own .gitignore can
+        // hide a private tree from its index while it sits in the checkout and
+        // ships with any archive of that submodule.
+        const tracked = git(subCwd, ['ls-files', '-z']).split('\0').filter(Boolean);
+        const untracked = git(subCwd, ['ls-files', '-z', '--others', '--directory', '--no-empty-directory'])
+            .split('\0').filter(Boolean).map(entry => entry.replace(/\/$/, ''));
+        const files = [...tracked, ...untracked].map(f => path + '/' + f).filter(isPrivatePath);
         if (files.length) findings.push({ path, absent: false, files });
     }
     for (const finding of findings) {

--- a/tests/unit/private-boundary-submodule.test.ts
+++ b/tests/unit/private-boundary-submodule.test.ts
@@ -102,3 +102,32 @@ test('PBS-004: the private-path predicate is unchanged by submodule prefixing', 
     // A path merely containing the word is not a private record.
     assert.equal(isPrivatePath('src/devlogger/index.ts'), false);
 });
+
+test('PBS-005: a submodule .gitignore cannot hide a private tree from the scan', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pbs-'));
+    try {
+        const sub = repo(path.join(root, 'sub'));
+        commitFile(sub, 'skills/example/SKILL.md', 'public skill\n');
+        // The submodule ignores its own devlog/, so its index is clean while
+        // the directory sits in the checkout and ships with any archive of it.
+        commitFile(sub, '.gitignore', 'devlog\n');
+        fs.mkdirSync(path.join(sub, 'devlog/_plan/260908_x'), { recursive: true });
+        fs.writeFileSync(path.join(sub, 'devlog/_plan/260908_x/000_index.md'), 'private record\n');
+        assert.equal(git(sub, ['status', '--porcelain']).trim(), '', 'the submodule index is clean');
+
+        const parent = repo(path.join(root, 'parent'));
+        commitFile(parent, 'README.md', 'public\n');
+        git(parent, ['-c', 'protocol.file.allow=always', 'submodule', 'add', '-q', sub, 'skills_ref']);
+        git(parent, ['commit', '-q', '-m', 'add submodule']);
+        // The superproject's copy needs the same ignored tree to reproduce it.
+        fs.mkdirSync(path.join(parent, 'skills_ref/devlog/_plan/260908_x'), { recursive: true });
+        fs.writeFileSync(path.join(parent, 'skills_ref/devlog/_plan/260908_x/000_index.md'), 'private record\n');
+
+        const findings = reportSubmodules(parent);
+        assert.equal(findings.length, 1, 'an ignored private tree must still be reported');
+        assert.deepEqual(findings[0].files, ['skills_ref/devlog']);
+        assert.throws(() => checkIndex(parent), /skills_ref\/devlog/);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/tests/unit/private-boundary.test.ts
+++ b/tests/unit/private-boundary.test.ts
@@ -32,6 +32,33 @@ test('private paths at any depth and case are rejected without hiding public pro
     }
 });
 
+test('an ignored private directory is reported once, by directory, and public untracked work is not', t => {
+    const root = fixture(t);
+    copyFileSync(join(project, '.gitignore'), join(root, '.gitignore'));
+    put(root, 'README.md');
+    git(root, 'add', '.'); git(root, 'commit', '-qm', 'base');
+    // Ordinary untracked work must stay silent, or the check becomes noise and
+    // gets ignored for the case it exists to catch.
+    put(root, 'src/scratch.ts');
+    put(root, 'notes.md');
+    assert.doesNotThrow(() => checkIndex(root));
+    // This is the shape that survived in a real checkout: gitignore hid a whole
+    // private plan tree from the index scan while it sat in the working tree.
+    put(root, 'devlog/_plan/260908_slug/000_plan.md');
+    put(root, 'devlog/_plan/260908_slug/010_phase1.md');
+    try {
+        checkIndex(root);
+        assert.fail('an ignored private tree must fail the boundary check');
+    } catch (error) {
+        const message = (error as Error).message;
+        assert.match(message, /working tree: private paths/);
+        // --directory collapses the tree to one actionable line rather than
+        // one line per file.
+        const listed = message.split('\n').filter(line => line.includes('devlog'));
+        assert.deepEqual(listed, ['devlog']);
+    }
+});
+
 test('Git ignore blocks accidental staging; forced additions and private gitlinks fail the index guard', t => {
     const root = fixture(t);
     copyFileSync(join(project, '.gitignore'), join(root, '.gitignore'));
@@ -41,7 +68,12 @@ test('Git ignore blocks accidental staging; forced additions and private gitlink
         assert.equal(git(root, 'check-ignore', '--', name), name);
     }
     git(root, 'add', '.');
+    // An ignored private directory is still a private directory: the rule is
+    // about where records live, not about whether Git tracks them.
+    assert.throws(() => checkIndex(root), /working tree: private paths/);
+    for (const name of names) rmSync(join(root, name.split('/')[0]), { recursive: true, force: true });
     assert.doesNotThrow(() => checkIndex(root));
+    put(root, 'devlog/note.md');
     git(root, 'add', '-f', 'devlog/note.md');
     assert.throws(() => checkIndex(root), /private paths/);
     git(root, 'rm', '--cached', 'devlog/note.md');

--- a/tests/unit/slack-lifecycle.test.ts
+++ b/tests/unit/slack-lifecycle.test.ts
@@ -487,6 +487,13 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
         child.stderr.setEncoding('utf8');
         child.stderr.on('data', chunk => { stderrTail = (stderrTail + chunk).slice(-2000); });
         const waiters: Array<(value: Record<string, unknown>) => void> = [];
+        // A line that arrives before its next() call must be kept, not dropped.
+        // The child emits FIXTURE lines on its own schedule: when a claim is
+        // replaced, the losing home prints its status while the test is still
+        // awaiting the winner. Without this queue that line met an empty
+        // waiters array, was discarded, and the following next() then waited
+        // out the full 60s CI bound for a message that had already been sent.
+        const pending: Array<Record<string, unknown>> = [];
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', chunk => {
             buffered += chunk;
@@ -494,10 +501,14 @@ test('l real lifecycle: late hello loses a replaced presence claim', async t => 
             buffered = lines.pop()!;
             for (const line of lines) {
                 if (!line.startsWith('FIXTURE ')) continue;
-                waiters.shift()?.(JSON.parse(line.slice(8)));
+                const value = JSON.parse(line.slice(8)) as Record<string, unknown>;
+                const waiter = waiters.shift();
+                if (waiter) waiter(value); else pending.push(value);
             }
         });
         const next = () => new Promise<Record<string, unknown>>((resolve, reject) => {
+            const queued = pending.shift();
+            if (queued) { resolve(queued); return; }
             // A cold tsx boot of the whole server graph under module mocks takes
             // several seconds on a loaded CI runner (preview run 34196670148 hit
             // the 10s bound with nothing printed yet). The bound is a hang guard,


### PR DESCRIPTION
## Problem

`npm run check:private-boundary` reads the index. A `devlog/` that `.gitignore` already covers is not in the index, so the check reports OK while the directory sits in the checkout.

That is how a private plan tree survived in a working tree here until a human noticed it. The automated gate said `[private-boundary] OK` the entire time, because the tree was ignored rather than tracked.

The rule `AGENTS.md` states is about where records live, not about whether Git happens to track them. An ignored private path is one `git add -f` or one archive away from shipping, and it is already visible to every tool and agent working in the directory.

## How

`checkIndex` now also scans untracked entries:

```
git ls-files --others --directory --no-empty-directory
```

`--directory` collapses a private tree to its containing directory, so a large one produces a single actionable line rather than one per file. Ordinary untracked work stays silent — a check that fires on scratch files gets ignored for the case it exists to catch.

Demonstrated against the real gap:

```
$ mkdir -p devlog/_plan/probe && echo x > devlog/_plan/probe/note.md
$ npm run check:private-boundary
[private-boundary] working tree: private paths must live outside cli-jaw:
devlog
```

## Tests

The existing index test asserted the old behaviour — ignored private files present, `checkIndex` passes — so it is updated to the corrected contract rather than deleted. A new case covers the exact shape that survived here: a gitignored `devlog/_plan` tree, reported once by directory, with public untracked files proven silent first.

`private-boundary` + `private-boundary-submodule`: 13 pass, 0 fail. `tsc --noEmit` clean.

Based on `dev` at 340a47d99.
