### PR TITLE
feat(cli): discover Claude models from the installed bundle

### DIFF
--- a/src/cli/claude-model-discovery.ts
+++ b/src/cli/claude-model-discovery.ts
@@ -1,0 +1,190 @@
+/**
+ * Live Claude model catalog, read from the installed Claude Code bundle.
+ *
+ * Claude Code exposes no `--list-models` command and `claude models` does not
+ * exist, so the only observation available is the bundle itself. It carries the
+ * provider mapping table for every model it accepts (`first_party:"claude-..."`),
+ * the short-alias table it resolves `opus`/`sonnet`/`haiku`/`fable` through, and
+ * a literal `<id>[1m]` for each model whose 1M context window it enables.
+ *
+ * Reading a 190MB binary sounds expensive; measured against Claude Code 2.1.263 a
+ * streaming scan finishes in ~105ms, which fits the background-refresh pattern the
+ * Codex catalog already uses. This is a file read, so it does not violate the
+ * "catalogs must never execute a CLI" rule in code-mode/providers/catalog.ts.
+ */
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+
+export interface ClaudeBundleCatalog {
+    /** Full first-party model ids the bundle maps to a provider. */
+    firstParty: string[];
+    /** Short alias -> full id, as the bundle resolves them. */
+    aliases: Record<string, string>;
+    /** Model ids for which the bundle carries a literal `<id>[1m]`. */
+    oneMillion: string[];
+}
+
+/**
+ * Generations old enough that the bundle keeps them only for compatibility. They
+ * are real ids the CLI would accept, but offering `claude-3-5-sonnet-20241022` in
+ * a picker is noise, so discovery keeps the modern families and lets the static
+ * seed decide anything older.
+ */
+const LEGACY_ID_PATTERN = /^claude-(?:3-|opus-4-(?:0|1|20|5)|sonnet-4-(?:0|20|5)|haiku-(?:3|4-5-2))/;
+
+/**
+ * `mythos` ids appear in the bundle's provider table but are not offered as coding
+ * models by the CLI, so they are excluded rather than surfaced as selectable.
+ */
+const EXCLUDED_FAMILY_PATTERN = /^claude-mythos-/;
+
+const FIRST_PARTY = /first_party:"(claude-[a-z0-9.-]+)"/g;
+const ALIAS_TABLE = /\{fable:"([^"]+)",opus:"([^"]+)",sonnet:"([^"]+)",haiku:"([^"]+)"\}/;
+const ONE_MILLION = /"(claude-[a-z0-9.-]+)\[1m\]"/g;
+
+/** Longest pattern we must not split across chunk boundaries. */
+const OVERLAP_BYTES = 512;
+
+function isOfferable(id: string): boolean {
+    return !LEGACY_ID_PATTERN.test(id) && !EXCLUDED_FAMILY_PATTERN.test(id);
+}
+
+/**
+ * Accumulate catalog evidence across a chunk sequence.
+ *
+ * Exported for tests: the parse is a pure fold over strings, so a fixture can
+ * exercise it without a 190MB binary. Callers must feed overlapping chunks (see
+ * `readClaudeBundleCatalog`) or a pattern spanning a boundary is missed.
+ */
+export function createClaudeCatalogScanner() {
+    const firstParty = new Set<string>();
+    const oneMillion = new Set<string>();
+    let aliases: Record<string, string> | null = null;
+
+    return {
+        push(chunk: string): void {
+            FIRST_PARTY.lastIndex = 0;
+            for (let m = FIRST_PARTY.exec(chunk); m; m = FIRST_PARTY.exec(chunk)) {
+                if (m[1]) firstParty.add(m[1]);
+            }
+            ONE_MILLION.lastIndex = 0;
+            for (let m = ONE_MILLION.exec(chunk); m; m = ONE_MILLION.exec(chunk)) {
+                if (m[1]) oneMillion.add(m[1]);
+            }
+            if (!aliases) {
+                const table = ALIAS_TABLE.exec(chunk);
+                if (table) {
+                    aliases = {
+                        fable: table[1]!, opus: table[2]!,
+                        sonnet: table[3]!, haiku: table[4]!,
+                    };
+                }
+            }
+        },
+        result(): ClaudeBundleCatalog {
+            const offerable = [...firstParty].filter(isOfferable).sort();
+            return {
+                firstParty: offerable,
+                aliases: aliases ?? {},
+                // A 1M literal for a model we do not offer is not useful, and it would
+                // otherwise let a filtered legacy id back in through the variant list.
+                oneMillion: [...oneMillion].filter(isOfferable).sort(),
+            };
+        },
+    };
+}
+
+/** @internal exported for unit tests */
+export function parseClaudeBundleCatalog(chunks: readonly string[]): ClaudeBundleCatalog {
+    const scanner = createClaudeCatalogScanner();
+    for (const chunk of chunks) scanner.push(chunk);
+    return scanner.result();
+}
+
+/**
+ * Expand a catalog into the model list cli-jaw offers.
+ *
+ * `[1m]` variants are derived from observation rather than listed by hand: the
+ * bundle carries the literal only for models whose 1M window it enables, which is
+ * why Haiku has no variant. Aliases come first because Claude Code resolves them
+ * to the current snapshot, then pinned ids for callers who want a stable cache
+ * prefix across CLI updates.
+ */
+export function claudeCatalogToChoices(catalog: ClaudeBundleCatalog): string[] {
+    const oneMillion = new Set(catalog.oneMillion);
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const push = (value: string) => {
+        if (!value || seen.has(value)) return;
+        seen.add(value);
+        out.push(value);
+    };
+
+    for (const alias of ['opus', 'sonnet', 'haiku', 'fable']) {
+        if (catalog.aliases[alias]) push(alias);
+    }
+    for (const id of catalog.firstParty) {
+        push(id);
+        if (oneMillion.has(id)) push(`${id}[1m]`);
+    }
+    return out;
+}
+
+/**
+ * Stream the bundle and extract its catalog. Returns null on any read failure so
+ * the caller keeps whatever it already had.
+ */
+export async function readClaudeBundleCatalog(binaryPath: string): Promise<ClaudeBundleCatalog | null> {
+    if (!binaryPath) return null;
+    try {
+        const scanner = createClaudeCatalogScanner();
+        const stream = createReadStream(binaryPath, { highWaterMark: 1 << 20 });
+        let tail = '';
+        for await (const chunk of stream) {
+            // latin1 keeps one byte per char, so a regex offset cannot desynchronize
+            // from the file the way a multi-byte decode would.
+            const text = tail + (chunk as Buffer).toString('latin1');
+            scanner.push(text);
+            tail = text.slice(-OVERLAP_BYTES);
+        }
+        const catalog = scanner.result();
+        // An empty scan means the bundle shape changed. Reporting null lets the
+        // static seed stand instead of emptying the picker.
+        return catalog.firstParty.length > 0 ? catalog : null;
+    } catch {
+        return null;
+    }
+}
+
+interface CachedCatalog {
+    key: string;
+    catalog: ClaudeBundleCatalog;
+}
+
+let cached: CachedCatalog | null = null;
+
+/**
+ * Cached read keyed on the bundle's size and mtime. Claude Code replaces the whole
+ * file on update, so that pair changes exactly when the catalog can change, and a
+ * steady-state install pays the scan once.
+ */
+export async function resolveClaudeBundleCatalog(binaryPath: string): Promise<ClaudeBundleCatalog | null> {
+    if (!binaryPath) return null;
+    let key: string;
+    try {
+        const info = await stat(binaryPath);
+        key = `${binaryPath}:${info.size}:${info.mtimeMs}`;
+    } catch {
+        return null;
+    }
+    if (cached && cached.key === key) return cached.catalog;
+    const catalog = await readClaudeBundleCatalog(binaryPath);
+    if (!catalog) return null;
+    cached = { key, catalog };
+    return catalog;
+}
+
+/** @internal exported for unit tests */
+export function resetClaudeBundleCatalogCacheForTest(): void {
+    cached = null;
+}

--- a/src/cli/registry-live.ts
+++ b/src/cli/registry-live.ts
@@ -1,8 +1,10 @@
 import { fetchKiroModelInventory } from '../agent/kiro-models.js';
 import { CLI_REGISTRY } from './registry.js';
+import { claudeCatalogToChoices, resolveClaudeBundleCatalog } from './claude-model-discovery.js';
 import { resolveOpenCodexCodexModelsDetailed } from './opencodex-models.js';
 import { diagnoseOpenCodexExecution, resolveOpenCodexRuntime } from './opencodex-runtime.js';
 import { readCodexRootOpenAiBaseUrl } from '../core/codex-config.js';
+import { detectCli } from '../core/cli-detection.js';
 
 /** Union of every per-model effort set, first-seen order preserved. */
 function unionEfforts(effortsByModel: Record<string, string[]>): string[] {
@@ -21,9 +23,10 @@ function unionEfforts(effortsByModel: Record<string, string[]>): string[] {
 export async function buildLiveCliRegistry() {
     const registry = structuredClone(CLI_REGISTRY) as Record<string, Record<string, unknown>>;
 
-    const [kiroInventory, openCodexRuntime] = await Promise.all([
+    const [kiroInventory, openCodexRuntime, claudeCatalog] = await Promise.all([
         fetchKiroModelInventory(),
         resolveOpenCodexRuntime(),
+        resolveClaudeCatalogForRegistry(),
     ]);
     const codexResult = await resolveOpenCodexCodexModelsDetailed(openCodexRuntime);
 
@@ -101,5 +104,60 @@ export async function buildLiveCliRegistry() {
         };
     }
 
+    if (claudeCatalog) {
+        // `defaultModel` stays static for the same reason it does for Codex:
+        // buildDefaultPerCli() seeds user settings from it, so a bundle update must
+        // not silently repoint a user's default. The one exception is a default the
+        // live catalog no longer offers, which would be unselectable.
+        const claudePatch: Record<string, unknown> = {
+            models: claudeCatalog.models,
+            modelSource: 'claude-bundle',
+            modelAliases: claudeCatalog.aliases,
+        };
+        for (const cli of ['claude', 'claude-e'] as const) {
+            const entry = registry[cli];
+            if (!entry) continue;
+            const staticDefault = entry['defaultModel'];
+            registry[cli] = {
+                ...entry,
+                ...claudePatch,
+                ...(typeof staticDefault === 'string' && !claudeCatalog.models.includes(staticDefault)
+                    ? { defaultModel: claudeCatalog.models[0] }
+                    : {}),
+            };
+        }
+        const aiE = registry['ai-e'];
+        if (aiE) {
+            const modelsByProvider: Record<string, string[]> = {
+                ...((aiE['modelsByProvider'] as Record<string, string[]> | undefined) || {}),
+                claude: claudeCatalog.models,
+            };
+            const providers = Array.isArray(aiE['providers'])
+                ? aiE['providers'] as string[]
+                : Object.keys(modelsByProvider);
+            registry['ai-e'] = {
+                ...aiE,
+                modelsByProvider,
+                models: providers.flatMap(provider => modelsByProvider[provider] || []),
+            };
+        }
+    }
+
     return registry;
+}
+
+/**
+ * Read the installed Claude Code bundle's catalog, if one is installed.
+ *
+ * A missing binary, an unreadable file or an unrecognized bundle shape all answer
+ * null, which leaves the static seed in `claude-models.ts` in place. Discovery
+ * never empties the picker.
+ */
+async function resolveClaudeCatalogForRegistry(): Promise<{ models: string[]; aliases: Record<string, string> } | null> {
+    const detection = detectCli('claude');
+    if (!detection.available || !detection.path) return null;
+    const catalog = await resolveClaudeBundleCatalog(detection.path);
+    if (!catalog) return null;
+    const models = claudeCatalogToChoices(catalog);
+    return models.length > 0 ? { models, aliases: catalog.aliases } : null;
 }

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -268,7 +268,7 @@ cli-jaw/
 │   │   ├── claude-models.ts  ← Claude 정규 모델셋 (CLAUDE_CANONICAL_MODELS, CLAUDE_LEGACY_VALUE_MAP) + migration/validation helpers (100L)
 │   │   ├── compact.ts        ← /compact 슬래시 커맨드 핸들러 (Claude native + managed 경로 분기) + working_dir scoped (185L)
 │   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (305L)
-│   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (105L)
+│   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (163L)
 │   │   ├── readiness.ts      ← CLI별 인증/설치 상태 점검 + Pi npm-exec readiness + AGY runtime auth hint + `claude-e` underlying Claude auth/readiness bridge (CliReadiness[]) (174L)
 │   │   ├── acp-client.ts     ← Copilot ACP JSON-RPC 클라이언트 (391L)
 │   │   ├── command-context.ts ← 공유 커맨드 컨텍스트 팩토리 + runSkillReset 위임 + regenerateB 유지 (160L)

--- a/tests/unit/claude-model-discovery.test.ts
+++ b/tests/unit/claude-model-discovery.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    claudeCatalogToChoices,
+    createClaudeCatalogScanner,
+    parseClaudeBundleCatalog,
+} from '../../src/cli/claude-model-discovery.ts';
+
+/**
+ * Shaped after the real Claude Code 2.1.263 bundle: a provider mapping row per
+ * model, one short-alias table, and a `<id>[1m]` literal for each model whose 1M
+ * window the CLI enables.
+ */
+const BUNDLE = [
+    '{first_party:"claude-opus-5",bedrock:"us.anthropic.claude-opus-5",vertex:"claude-opus-5"}',
+    '{first_party:"claude-sonnet-5",bedrock:"us.anthropic.claude-sonnet-5"}',
+    '{first_party:"claude-fable-5-1",bedrock:"us.anthropic.claude-fable-5-1"}',
+    '{first_party:"claude-haiku-4-5-20251001",bedrock:"us.anthropic.claude-haiku-4-5-20251001-v1:0"}',
+    '{first_party:"claude-3-5-sonnet-20241022",bedrock:"us.anthropic.claude-3-5-sonnet-20241022-v2:0"}',
+    '{first_party:"claude-mythos-5",bedrock:"anthropic.claude-mythos-5"}',
+    '{fable:"claude-fable-5-1",opus:"claude-opus-5",sonnet:"claude-sonnet-5",haiku:"claude-haiku-4-5"}',
+    'var x=["claude-opus-5[1m]","claude-sonnet-5[1m]"]',
+].join(';');
+
+test('CMD-001: parses first-party ids, the alias table and 1M variants', () => {
+    const catalog = parseClaudeBundleCatalog([BUNDLE]);
+    assert.ok(catalog.firstParty.includes('claude-opus-5'));
+    assert.ok(catalog.firstParty.includes('claude-sonnet-5'));
+    assert.ok(catalog.firstParty.includes('claude-fable-5-1'));
+    assert.deepEqual(catalog.aliases, {
+        fable: 'claude-fable-5-1', opus: 'claude-opus-5',
+        sonnet: 'claude-sonnet-5', haiku: 'claude-haiku-4-5',
+    });
+    assert.deepEqual(catalog.oneMillion, ['claude-opus-5', 'claude-sonnet-5']);
+});
+
+test('CMD-002: drops compatibility-only legacy generations', () => {
+    const catalog = parseClaudeBundleCatalog([BUNDLE]);
+    assert.equal(catalog.firstParty.includes('claude-3-5-sonnet-20241022'), false);
+});
+
+test('CMD-003: drops non-coding mythos family', () => {
+    const catalog = parseClaudeBundleCatalog([BUNDLE]);
+    assert.equal(catalog.firstParty.includes('claude-mythos-5'), false);
+});
+
+test('CMD-004: derives [1m] variants instead of listing them by hand', () => {
+    const choices = claudeCatalogToChoices(parseClaudeBundleCatalog([BUNDLE]));
+    assert.ok(choices.includes('claude-opus-5[1m]'));
+    assert.ok(choices.includes('claude-sonnet-5[1m]'));
+    // Haiku stays at 200k, so the bundle carries no literal and no variant is
+    // invented for it.
+    assert.equal(choices.some(c => c.startsWith('claude-haiku') && c.endsWith('[1m]')), false);
+});
+
+test('CMD-005: aliases lead the choice list', () => {
+    const choices = claudeCatalogToChoices(parseClaudeBundleCatalog([BUNDLE]));
+    assert.deepEqual(choices.slice(0, 4), ['opus', 'sonnet', 'haiku', 'fable']);
+});
+
+test('CMD-006: a variant is only offered for a model that is itself offered', () => {
+    const catalog = parseClaudeBundleCatalog([
+        '{first_party:"claude-opus-5"};"claude-3-5-sonnet-20241022[1m]"',
+    ]);
+    assert.deepEqual(catalog.oneMillion, []);
+    assert.deepEqual(claudeCatalogToChoices(catalog), ['claude-opus-5']);
+});
+
+test('CMD-007: an unrecognized bundle yields an empty catalog rather than junk', () => {
+    const catalog = parseClaudeBundleCatalog(['no model table here at all']);
+    assert.deepEqual(catalog.firstParty, []);
+    assert.deepEqual(catalog.aliases, {});
+    assert.deepEqual(claudeCatalogToChoices(catalog), []);
+});
+
+test('CMD-008: overlapping chunks recover a match split across a boundary', () => {
+    const split = 'prefix{first_party:"claude-opus-5",bedrock:"x"}suffix';
+    const cut = split.indexOf('opus');
+    const scanner = createClaudeCatalogScanner();
+    const head = split.slice(0, cut);
+    scanner.push(head);
+    // Mirrors readClaudeBundleCatalog: the next push repeats the tail of the last.
+    scanner.push(head.slice(-512) + split.slice(cut));
+    assert.deepEqual(scanner.result().firstParty, ['claude-opus-5']);
+});
+
+test('CMD-009: duplicate rows across chunks collapse to one entry', () => {
+    const row = '{first_party:"claude-opus-5",bedrock:"x"}';
+    assert.deepEqual(parseClaudeBundleCatalog([row, row, row]).firstParty, ['claude-opus-5']);
+});
+
+test('CMD-010: the first alias table wins when the bundle carries several', () => {
+    const catalog = parseClaudeBundleCatalog([
+        '{fable:"claude-fable-5-1",opus:"claude-opus-5",sonnet:"claude-sonnet-5",haiku:"claude-haiku-4-5"}',
+        '{fable:"stale",opus:"stale",sonnet:"stale",haiku:"stale"}',
+    ]);
+    assert.equal(catalog.aliases['opus'], 'claude-opus-5');
+});


### PR DESCRIPTION
Stacked on #633 (base is `codex/model-registry-wp1-roadmap`). Review the second commit only.

## What

Claude's model list was 16 hand-maintained ids in `CLAUDE_PINNED_FULL_IDS`, and the comments were a manual sync log — "claude-fable-5-1 added 2026-09-02 from opencodex ANTHROPIC_MODELS". Every `[1m]` variant was spelled out separately, and which models actually support a 1M window lived only in prose.

This reads the catalog from the bundle cli-jaw already spawns.

## Why the bundle, and not opencodex

Claude Code has no `--list-models`; `claude models` does not exist and `--model` requires an argument. The bundle itself is the only observation available, and it is the *right* one: it is the binary that receives `--model`, whereas opencodex's `ANTHROPIC_MODELS` describes proxied routing.

Three things are recoverable from it:

- `first_party:"claude-..."` — one provider-mapping row per model the CLI accepts
- the short-alias table — `{fable, opus, sonnet, haiku}` resolved to full ids
- `"<id>[1m]"` literals — present exactly for models whose 1M window it enables

A streaming scan of the 190MB binary measures ~105ms, so it fits the background-refresh shape `live-models.ts` already uses. The result is cached on the bundle's size and mtime, which change exactly when Claude Code is replaced.

## Result against Claude Code 2.1.263

```
modelSource  claude-bundle
count        19
aliases      {opus: claude-opus-5, sonnet: claude-sonnet-5,
              fable: claude-fable-5-1, haiku: claude-haiku-4-5}
```

The aliases are now resolved rather than assumed. `[1m]` variants are derived from the observed literals instead of listed, which is why Haiku still has none — the same rule the old comment stated in prose.

## Safety

Discovery never empties the picker. A missing binary, an unreadable file, or an unrecognized bundle shape each answer null and leave the static seed standing. Compatibility-only generations (`claude-3-5-*`, dated `claude-opus-4-20250514`) and the non-coding `mythos` family are filtered out.

`defaultModel` stays static because `buildDefaultPerCli()` seeds user settings from it; the one exception is a default the live catalog no longer offers, which would fail `validate()` on the first session.

Reading the bundle is a file read, so the "catalogs must never execute a CLI" rule in `code-mode/providers/catalog.ts` still holds.

## Verification

- `npm run gate:all` — **23/23 pass**
- `npx tsx --experimental-test-module-mocks --test` on `claude-model-discovery`, `claude-models`, `cli-registry` — 52 pass, 0 fail
- `npm run typecheck` — clean
- `buildLiveCliRegistry()` run against the real install produced the output above
- `check-private-boundary --range origin/dev HEAD` — OK

`structure/str_func.md` line counts regenerated with `verify-counts.sh --fix` per AGENTS.md, since `registry-live.ts` grew.

The 10 new tests exercise the parse as a pure fold over strings — no 190MB fixture — covering chunk-boundary recovery, duplicate collapsing, legacy filtering, and the empty-catalog fallback.
