### PR TITLE
feat(cli): discover Cursor and Grok models from their CLIs

### DIFF
--- a/src/agent/cursor-model-inventory.ts
+++ b/src/agent/cursor-model-inventory.ts
@@ -1,0 +1,152 @@
+/**
+ * Live Cursor model inventory, read from `cursor-agent --list-models`.
+ *
+ * Cursor keeps two lists in `cursor-runtime.ts`: the wire ids the account accepts
+ * (effort encoded in the id, since the CLI has no `--effort`) and the base models
+ * the UI offers. Their agreement IS the correctness property — #394 was that
+ * agreement breaking, where `grok-4.6` + `high` produced an id the account does
+ * not have and the resolver silently degraded to the bare base.
+ *
+ * The CLI prints exactly the first list, so this module takes it as the
+ * observation and DERIVES the second from it rather than maintaining both.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { detectCli } from '../core/cli-detection.js';
+import { CURSOR_EFFORT_CHOICES } from './cursor-runtime.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface CursorModelInventory {
+    /** Wire ids exactly as the account names them, effort suffix included. */
+    modelIds: string[];
+    /** Base models for the picker, derived by stripping known effort suffixes. */
+    baseModels: string[];
+    /** Effort rungs observed per base model, in canonical ladder order. */
+    effortsByModel: Record<string, string[]>;
+    source: string;
+}
+
+/**
+ * Suffix spellings the account uses, longest first so `extra-high-fast` is matched
+ * before `high-fast` would strip the wrong half of it.
+ *
+ * The mapping is the inverse of `CURSOR_EFFORT_SUFFIX` in cursor-runtime.ts; the
+ * only entry that is not an identity is Cursor spelling xhigh as `extra-high`.
+ */
+const SUFFIX_TO_EFFORT: Array<[string, string]> = [
+    ['extra-high-fast', 'xhigh-fast'],
+    ['extra-high', 'xhigh'],
+    ['medium-fast', 'medium-fast'],
+    ['none-fast', 'none-fast'],
+    ['high-fast', 'high-fast'],
+    ['xhigh-fast', 'xhigh-fast'],
+    ['low-fast', 'low-fast'],
+    ['max-fast', 'max-fast'],
+    ['medium', 'medium'],
+    ['xhigh', 'xhigh'],
+    ['none', 'none'],
+    ['high', 'high'],
+    ['low', 'low'],
+    ['max', 'max'],
+    // A bare `-fast` carries no rung of its own. Cursor uses it for the id whose
+    // rung is implicit — `gpt-5.3-codex-fast` is the fast form of
+    // `gpt-5.3-codex`, not a base model in its own right — so it maps onto the
+    // same medium-fast the resolver already emits for that case.
+    ['fast', 'medium-fast'],
+];
+
+const EFFORT_ORDER = new Map(CURSOR_EFFORT_CHOICES.map((effort, index) => [effort as string, index]));
+
+/**
+ * Cursor names its own Grok routing with a `cursor-` prefix, but the picker's
+ * vocabulary is unprefixed and `resolveCursorModelVariant` re-applies the prefix
+ * when building the wire id. Leaving it on a derived base would reproduce #394 in
+ * the opposite direction: `cursor-cursor-grok-4.6-high`.
+ */
+function stripAccountPrefix(id: string): string {
+    return id.startsWith('cursor-') ? id.slice('cursor-'.length) : id;
+}
+
+/** Split a wire id into its base model and effort rung, if it carries one. */
+export function splitCursorModelId(id: string): { base: string; effort?: string } {
+    const value = id.trim();
+    if (!value) return { base: '' };
+    for (const [suffix, effort] of SUFFIX_TO_EFFORT) {
+        const tail = '-' + suffix;
+        if (value.endsWith(tail) && value.length > tail.length) {
+            return { base: stripAccountPrefix(value.slice(0, -tail.length)), effort };
+        }
+    }
+    return { base: stripAccountPrefix(value) };
+}
+
+/**
+ * Parse `cursor-agent --list-models` output.
+ *
+ * Each model is one `<id> - <label>` line. The header, the trailing usage tip and
+ * blank lines carry no dash-separated id and are skipped by the shape check rather
+ * than by matching their exact text, so a wording change does not break parsing.
+ */
+export function parseCursorModelList(stdout: string): CursorModelInventory | null {
+    const modelIds: string[] = [];
+    const seenIds = new Set<string>();
+    for (const rawLine of stdout.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('Tip:')) continue;
+        const match = /^([A-Za-z0-9][A-Za-z0-9._-]*) - \S/.exec(line);
+        if (!match) continue;
+        const id = match[1]!;
+        if (seenIds.has(id)) continue;
+        seenIds.add(id);
+        modelIds.push(id);
+    }
+    if (modelIds.length === 0) return null;
+
+    const baseModels: string[] = [];
+    const seenBases = new Set<string>();
+    const effortSets = new Map<string, Set<string>>();
+    for (const id of modelIds) {
+        const { base, effort } = splitCursorModelId(id);
+        if (!base) continue;
+        if (!seenBases.has(base)) {
+            seenBases.add(base);
+            baseModels.push(base);
+        }
+        if (!effort) continue;
+        const set = effortSets.get(base) ?? new Set<string>();
+        set.add(effort);
+        effortSets.set(base, set);
+    }
+
+    const effortsByModel: Record<string, string[]> = {};
+    for (const [base, efforts] of effortSets) {
+        effortsByModel[base] = [...efforts].sort(
+            (a, b) => (EFFORT_ORDER.get(a) ?? 99) - (EFFORT_ORDER.get(b) ?? 99),
+        );
+    }
+
+    return {
+        modelIds, baseModels, effortsByModel,
+        source: 'cursor-agent --list-models',
+    };
+}
+
+/**
+ * Run the CLI and parse its inventory. Any failure answers null so the caller
+ * keeps the static list; discovery never empties the picker.
+ */
+export async function fetchCursorModelInventory(binary?: string): Promise<CursorModelInventory | null> {
+    const resolvedBinary = binary || detectCli('cursor').path;
+    if (!resolvedBinary) return null;
+    try {
+        const { stdout } = await execFileAsync(resolvedBinary, ['--list-models'], {
+            encoding: 'utf8',
+            timeout: 15000,
+            env: { ...process.env, NO_COLOR: '1' },
+        });
+        return parseCursorModelList(stdout);
+    } catch {
+        return null;
+    }
+}

--- a/src/agent/grok-models.ts
+++ b/src/agent/grok-models.ts
@@ -1,0 +1,88 @@
+/**
+ * Live Grok model inventory, read from `grok models`.
+ *
+ * The registry carried two ids by hand. The CLI lists what the signed-in account
+ * actually serves, which includes opencodex-routed `ocx-*` entries that no static
+ * list could have predicted.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { detectCli } from '../core/cli-detection.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface GrokModelInventory {
+    models: string[];
+    /** The id the CLI marks as its default, when it names one. */
+    defaultModel?: string;
+    source: string;
+}
+
+/**
+ * Parse `grok models` output.
+ *
+ * The listing is human-formatted: a `Default model: <id>` line, then bullets where
+ * the default is starred and the rest are dashed.
+ *
+ *   Default model: grok-4.6
+ *   Available models:
+ *     * grok-4.6 (default)
+ *     - grok-4.5
+ *
+ * The bullet is the authority for membership; the header line only names which of
+ * them is default, and a listing without it still parses.
+ */
+export function parseGrokModelList(stdout: string): GrokModelInventory | null {
+    const models: string[] = [];
+    const seen = new Set<string>();
+    let starred = '';
+    let declaredDefault = '';
+
+    for (const rawLine of stdout.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        const header = /^Default model:\s*(\S+)/i.exec(line);
+        if (header) {
+            declaredDefault = header[1]!;
+            continue;
+        }
+
+        const bullet = /^([*-])\s+([A-Za-z0-9][A-Za-z0-9._\/-]*)/.exec(line);
+        if (!bullet) continue;
+        const id = bullet[2]!;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        models.push(id);
+        if (bullet[1] === '*' && !starred) starred = id;
+    }
+
+    if (models.length === 0) return null;
+
+    // Prefer the starred row: it is inside the list, so it cannot name a model the
+    // account does not serve. The header is the fallback, and only when it does.
+    const defaultModel = starred
+        || (declaredDefault && seen.has(declaredDefault) ? declaredDefault : '');
+
+    return {
+        models,
+        ...(defaultModel ? { defaultModel } : {}),
+        source: 'grok models',
+    };
+}
+
+/** Run the CLI and parse its listing. Any failure answers null. */
+export async function fetchGrokModelInventory(binary?: string): Promise<GrokModelInventory | null> {
+    const resolvedBinary = binary || detectCli('grok').path;
+    if (!resolvedBinary) return null;
+    try {
+        const { stdout } = await execFileAsync(resolvedBinary, ['models'], {
+            encoding: 'utf8',
+            timeout: 15000,
+            env: { ...process.env, NO_COLOR: '1' },
+        });
+        return parseGrokModelList(stdout);
+    } catch {
+        return null;
+    }
+}

--- a/src/cli/registry-live.ts
+++ b/src/cli/registry-live.ts
@@ -1,4 +1,6 @@
 import { fetchKiroModelInventory } from '../agent/kiro-models.js';
+import { fetchCursorModelInventory } from '../agent/cursor-model-inventory.js';
+import { fetchGrokModelInventory } from '../agent/grok-models.js';
 import { CLI_REGISTRY } from './registry.js';
 import { claudeCatalogToChoices, resolveClaudeBundleCatalog } from './claude-model-discovery.js';
 import { buildClaudeEffortsByModel } from './claude-models.js';
@@ -24,10 +26,12 @@ function unionEfforts(effortsByModel: Record<string, string[]>): string[] {
 export async function buildLiveCliRegistry() {
     const registry = structuredClone(CLI_REGISTRY) as Record<string, Record<string, unknown>>;
 
-    const [kiroInventory, openCodexRuntime, claudeCatalog] = await Promise.all([
+    const [kiroInventory, openCodexRuntime, claudeCatalog, cursorInventory, grokInventory] = await Promise.all([
         fetchKiroModelInventory(),
         resolveOpenCodexRuntime(),
         resolveClaudeCatalogForRegistry(),
+        fetchCursorModelInventory(),
+        fetchGrokModelInventory(),
     ]);
     const codexResult = await resolveOpenCodexCodexModelsDetailed(openCodexRuntime);
 
@@ -102,6 +106,35 @@ export async function buildLiveCliRegistry() {
             defaultModel: kiroInventory.defaultModel,
             modelSource: kiroInventory.source,
             modelDetails: kiroInventory.entries,
+        };
+    }
+
+    if (cursorInventory?.baseModels.length) {
+        // The picker gets the derived base models, not the ~220 wire ids: effort is
+        // a separate control, and listing every suffixed id would ask the user to
+        // pick the same model a dozen times.
+        //
+        // `resolveCursorModelVariant` still resolves wire ids from its static set.
+        // It runs synchronously on the spawn path, so feeding it a discovered list
+        // would make spawning depend on a CLI probe.
+        registry['cursor'] = {
+            ...registry['cursor'],
+            models: cursorInventory.baseModels,
+            modelSource: cursorInventory.source,
+            effortsByModel: cursorInventory.effortsByModel,
+            modelIds: cursorInventory.modelIds,
+        };
+    }
+
+    if (grokInventory?.models.length) {
+        // `defaultModel` stays static even though the CLI names one, for the same
+        // buildDefaultPerCli() seeding reason as everywhere else; the observed
+        // default is reported separately for diagnostics.
+        registry['grok'] = {
+            ...registry['grok'],
+            models: grokInventory.models,
+            modelSource: grokInventory.source,
+            ...(grokInventory.defaultModel ? { observedDefaultModel: grokInventory.defaultModel } : {}),
         };
     }
 

--- a/structure/model-registry.md
+++ b/structure/model-registry.md
@@ -32,13 +32,31 @@ aliases: [model registry, 모델 레지스트리, live model discovery]
 |---|---|---|
 | `codex` / `codex-app` | opencodex `GET /v1/models` | `src/cli/opencodex-models.ts` |
 | `kiro-code` | `kiro-cli chat --list-models --format json` | `src/agent/kiro-models.ts` |
-| `claude` / `claude-e` | 정적 (`src/cli/claude-models.ts`) | — |
-| `cursor` | 정적 (`CURSOR_REGISTRY_MODELS`) | — |
-| `grok` | 정적 | — |
+| `claude` / `claude-e` | 설치된 Claude Code 번들 | `src/cli/claude-model-discovery.ts` |
+| `cursor` | `cursor-agent --list-models` | `src/agent/cursor-model-inventory.ts` |
+| `grok` | `grok models` | `src/agent/grok-models.ts` |
 | `agy` / `pi` / `opencode` | 정적 | — |
 
-정적으로 남은 런타임도 발견 가능한 소스를 갖고 있다: `cursor-agent --list-models`와
-`grok models`가 그것이다. 이들을 라이브 층으로 옮기는 것이 현재 진행 중인 작업이다.
+정적으로 남은 것은 AGY, Pi, OpenCode 세 런타임이다.
+
+## Cursor: 하나의 관측에서 두 목록을 파생한다
+
+Cursor CLI에는 `--effort`가 없다. effort가 모델 id 안에 들어 있어
+(`claude-opus-5-xhigh-fast`), `cursor-runtime.ts`가 두 목록을 갖는다: 계정이 받는
+wire id 전체와 picker가 보여주는 base 모델. **두 목록의 일치가 곧 정확성이다.**
+#394가 그 일치가 깨진 사고였다 — 계정은 Grok을 `cursor-` 접두사로 부르는데 picker
+어휘는 접두사가 없어서, `grok-4.6` + `high`가 계정에 없는 id를 만들고 resolver가
+조용히 base로 물러났다.
+
+`--list-models`가 출력하는 것이 정확히 첫 번째 목록이다. 그래서 그것을 관측으로
+받고 base와 effort 사다리는 거기서 역산한다. 접미사 어휘는
+`CURSOR_EFFORT_SUFFIX`의 역이며, 항등이 아닌 항목은 Cursor가 xhigh를
+`extra-high`로 적는 것 하나뿐이다. 역산할 때 `cursor-` 접두사를 벗기는 것이
+중요하다 — 남겨두면 resolver가 접두사를 다시 붙여 #394가 반대 방향으로 재현된다.
+
+한계가 하나 있다. `resolveCursorModelVariant()`는 여전히 정적 wire id 집합으로
+해석한다. 이 함수는 spawn 경로의 동기 함수라, 라이브 목록을 주입하면 프로세스를
+띄우는 일이 CLI 프로브에 의존하게 된다. 라이브가 된 것은 레지스트리 표면이다.
 
 ## effort는 모델별로 좁힌다
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -268,7 +268,7 @@ cli-jaw/
 │   │   ├── claude-models.ts  ← Claude 정규 모델셋 (CLAUDE_CANONICAL_MODELS, CLAUDE_LEGACY_VALUE_MAP) + migration/validation helpers (151L)
 │   │   ├── compact.ts        ← /compact 슬래시 커맨드 핸들러 (Claude native + managed 경로 분기) + working_dir scoped (185L)
 │   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (308L)
-│   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (177L)
+│   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (210L)
 │   │   ├── readiness.ts      ← CLI별 인증/설치 상태 점검 + Pi npm-exec readiness + AGY runtime auth hint + `claude-e` underlying Claude auth/readiness bridge (CliReadiness[]) (174L)
 │   │   ├── acp-client.ts     ← Copilot ACP JSON-RPC 클라이언트 (391L)
 │   │   ├── command-context.ts ← 공유 커맨드 컨텍스트 팩토리 + runSkillReset 위임 + regenerateB 유지 (160L)

--- a/tests/unit/cursor-grok-model-inventory.test.ts
+++ b/tests/unit/cursor-grok-model-inventory.test.ts
@@ -1,0 +1,130 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCursorModelList, splitCursorModelId } from '../../src/agent/cursor-model-inventory.ts';
+import { parseGrokModelList } from '../../src/agent/grok-models.ts';
+
+// Shaped after real `cursor-agent --list-models` output.
+const CURSOR_OUTPUT = [
+    'Available models',
+    '',
+    'auto - Auto (default)',
+    'composer-2.5 - Composer 2.5',
+    'composer-2.5-fast - Composer 2.5 Fast',
+    'claude-opus-5-low - Claude Opus 5 1M Low',
+    'claude-opus-5-high - Claude Opus 5 1M',
+    'claude-opus-5-max-fast - Claude Opus 5 1M Max Fast',
+    'gpt-5.5-extra-high - GPT-5.5 Extra High',
+    'gpt-5.5-extra-high-fast - GPT-5.5 Extra High Fast',
+    'cursor-grok-4.6-high - Cursor Grok 4.6',
+    'cursor-grok-4.6-xhigh-fast - Cursor Grok 4.6 Extra High Fast',
+    '',
+    "Tip: use --model <id> to switch.",
+].join('\n');
+
+// ─── Cursor id splitting ─────────────────────────────
+
+test('CI-001: strips the effort suffix to recover the base model', () => {
+    assert.deepEqual(splitCursorModelId('claude-opus-5-low'), { base: 'claude-opus-5', effort: 'low' });
+    assert.deepEqual(splitCursorModelId('claude-opus-5-max-fast'), { base: 'claude-opus-5', effort: 'max-fast' });
+});
+
+test('CI-002: reads Cursor spelling of xhigh', () => {
+    assert.deepEqual(splitCursorModelId('gpt-5.5-extra-high'), { base: 'gpt-5.5', effort: 'xhigh' });
+    assert.deepEqual(splitCursorModelId('gpt-5.5-extra-high-fast'), { base: 'gpt-5.5', effort: 'xhigh-fast' });
+});
+
+test('CI-003: drops the account prefix so the base matches the picker vocabulary', () => {
+    // Leaving it on would make resolveCursorModelVariant build cursor-cursor-grok-...
+    assert.deepEqual(splitCursorModelId('cursor-grok-4.6-high'), { base: 'grok-4.6', effort: 'high' });
+});
+
+test('CI-004: composer encodes speed, not a ladder rung', () => {
+    assert.deepEqual(splitCursorModelId('composer-2.5'), { base: 'composer-2.5' });
+    assert.deepEqual(splitCursorModelId('composer-2.5-fast'), { base: 'composer-2.5', effort: 'medium-fast' });
+});
+
+test('CI-005: an id with no suffix is its own base', () => {
+    assert.deepEqual(splitCursorModelId('auto'), { base: 'auto' });
+});
+
+// ─── Cursor listing ──────────────────────────────────
+
+test('CI-006: keeps every wire id verbatim', () => {
+    const inventory = parseCursorModelList(CURSOR_OUTPUT)!;
+    assert.ok(inventory.modelIds.includes('cursor-grok-4.6-high'));
+    assert.ok(inventory.modelIds.includes('gpt-5.5-extra-high-fast'));
+    assert.equal(inventory.modelIds.includes('Available'), false);
+});
+
+test('CI-007: derives base models instead of listing them separately', () => {
+    const inventory = parseCursorModelList(CURSOR_OUTPUT)!;
+    assert.deepEqual(inventory.baseModels, [
+        'auto', 'composer-2.5', 'claude-opus-5', 'gpt-5.5', 'grok-4.6',
+    ]);
+});
+
+test('CI-008: collects observed rungs per base, in ladder order', () => {
+    const inventory = parseCursorModelList(CURSOR_OUTPUT)!;
+    assert.deepEqual(inventory.effortsByModel['claude-opus-5'], ['low', 'high', 'max-fast']);
+    assert.deepEqual(inventory.effortsByModel['gpt-5.5'], ['xhigh', 'xhigh-fast']);
+});
+
+test('CI-009: the header and the trailing tip are not models', () => {
+    const inventory = parseCursorModelList(CURSOR_OUTPUT)!;
+    assert.equal(inventory.baseModels.some(m => m.startsWith('Tip')), false);
+});
+
+test('CI-010: unrecognized output answers null so the static list stands', () => {
+    assert.equal(parseCursorModelList('command not found'), null);
+    assert.equal(parseCursorModelList(''), null);
+});
+
+// ─── Grok listing ────────────────────────────────────
+
+const GROK_OUTPUT = [
+    'You are logged in with grok.com.',
+    '',
+    'Default model: grok-4.6',
+    '',
+    'Available models:',
+    '  * grok-4.6 (default)',
+    '  - grok-4.5',
+    '  - ocx-gpt-6-astra',
+].join('\n');
+
+test('CI-011: reads the bullet list, including routed ids', () => {
+    const inventory = parseGrokModelList(GROK_OUTPUT)!;
+    assert.deepEqual(inventory.models, ['grok-4.6', 'grok-4.5', 'ocx-gpt-6-astra']);
+});
+
+test('CI-012: the starred row names the default', () => {
+    assert.equal(parseGrokModelList(GROK_OUTPUT)!.defaultModel, 'grok-4.6');
+});
+
+test('CI-013: a listing with no star falls back to the header', () => {
+    const inventory = parseGrokModelList('Default model: grok-4.5\n  - grok-4.5\n  - grok-4.6')!;
+    assert.equal(inventory.defaultModel, 'grok-4.5');
+});
+
+test('CI-014: a header naming a model the account does not serve is ignored', () => {
+    const inventory = parseGrokModelList('Default model: grok-9\n  - grok-4.6')!;
+    assert.equal(inventory.defaultModel, undefined);
+    assert.deepEqual(inventory.models, ['grok-4.6']);
+});
+
+test('CI-015: unrecognized output answers null', () => {
+    assert.equal(parseGrokModelList('not logged in'), null);
+});
+
+test('CI-016: a bare -fast is the fast form of its base, not a separate model', () => {
+    // gpt-5.3-codex-fast is gpt-5.3-codex at speed; treating it as its own base
+    // put a duplicate in the picker.
+    assert.deepEqual(splitCursorModelId('gpt-5.3-codex-fast'), { base: 'gpt-5.3-codex', effort: 'medium-fast' });
+});
+
+test('CI-017: -thinking is part of the base, not a rung', () => {
+    assert.deepEqual(
+        splitCursorModelId('claude-opus-5-thinking-xhigh'),
+        { base: 'claude-opus-5-thinking', effort: 'xhigh' },
+    );
+});


### PR DESCRIPTION
Stacked on #635 (base is `codex/model-registry-wp3-ultracode`). Review the fourth commit only.

## Cursor: two lists, one observation

`cursor-runtime.ts` carried two hand-maintained lists — the ~220 wire ids the account accepts (effort is encoded in the id, since the CLI has no `--effort`) and the ~40 base models the picker offers.

Their agreement *is* the correctness property: `resolveCursorModelVariant` builds an id from base + effort and looks it up in the id set. [#394](https://github.com/lidge-jun/cli-jaw/issues/394) was that agreement breaking — `grok-4.6` + `high` produced `grok-4.6-high`, which the account does not have, and the resolver silently degraded to the bare base.

`cursor-agent --list-models` prints exactly the first list. So this takes it as the observation and *derives* the second from it. The suffix vocabulary is the inverse of `CURSOR_EFFORT_SUFFIX`; the only non-identity entry is Cursor spelling xhigh as `extra-high`.

Stripping the `cursor-` prefix when deriving a base matters: the picker's vocabulary is unprefixed and the resolver re-applies it, so leaving it on would produce `cursor-cursor-grok-4.6-high` — #394 in the opposite direction.

## Measured against the real CLIs

```
cursor  217 wire ids -> 48 bases
        grok-4.6         low..xhigh (+ -fast pairs)
        claude-opus-5    low, medium, high only
grok    grok-4.6, grok-4.5, and 8 opencodex-routed ocx-* ids
```

The per-base rungs match the account rather than a uniform ladder: `claude-opus-5` really does stop at high while `claude-opus-5-thinking` reaches max. Grok's `ocx-*` entries are routing no static list could have predicted.

## A bug the live check caught

The first draft special-cased `composer-` for its bare `-fast` suffix, which left `gpt-5.3-codex-fast` looking like its own base — a duplicate of `gpt-5.3-codex` in the picker. Bases dropped from 50 to the correct 48 once `-fast` was handled as a general rung.

## Deliberate limit

`resolveCursorModelVariant` still resolves against its static id set. It runs synchronously on the spawn path, so feeding it a discovered list would make spawning a process depend on a CLI probe. What became live here is the registry surface; connecting the two is wp5's problem.

## Safety

Both parsers answer null on anything unrecognized, so a missing CLI or changed output leaves the static list standing. Grok's `defaultModel` stays static for the usual `buildDefaultPerCli()` seeding reason — the observed default is reported separately as `observedDefaultModel`.

## Verification

- `npm run gate:all` — **23/23 pass**
- 17 new unit tests, fixture-based, no CLI required
- `npm run typecheck` — clean
- `buildLiveCliRegistry()` against the real installs produced the numbers above
- `check-private-boundary --range origin/dev HEAD` — OK
