### PR TITLE
feat(code): extend the live catalog to Claude, Cursor and Grok

### DIFF
--- a/src/code-mode/host.ts
+++ b/src/code-mode/host.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { publish } from '../core/event-bus.js';
 import { CodeSessionManager } from './manager.js';
 import { createCodeProviders } from './providers/catalog.js';
+import { primeProviderLiveModels } from './providers/provider-live-models.js';
 import { CodeStore } from './store.js';
 import type { CodeProviders } from './provider.js';
 
@@ -44,6 +45,11 @@ export function createCodeHost(options: CodeHostOptions): { get(): CodeSessionMa
                 service.recover();
                 database = candidate;
                 manager = service;
+                // Fill the Cursor and Grok snapshots once, here rather than on a
+                // catalog read: they are the two providers whose discovery spawns a
+                // CLI, and a catalog read must never do that. Failure is silent by
+                // design — the static registry list stands.
+                void primeProviderLiveModels().catch(() => { /* static lists stand */ });
                 return service;
             } catch (error) {
                 candidate.close();

--- a/src/code-mode/providers/catalog.ts
+++ b/src/code-mode/providers/catalog.ts
@@ -13,6 +13,7 @@ import { createClaudeCodeProvider } from './claude.js';
 import { createCursorCodeProvider } from './cursor.js';
 import { createGrokCodeProvider } from './grok.js';
 import { readCodexLiveModels, type CodexLiveModels } from './live-models.js';
+import { readProviderLiveModels, type LiveCatalogProviderId, type ProviderLiveModels } from './provider-live-models.js';
 
 const MODES: Record<CodeProviderId, CodePermissionMode[]> = {
     'codex-app': ['ask', 'auto', 'read-only'], claude: ['ask', 'auto'], cursor: ['ask', 'auto'], grok: ['auto'],
@@ -37,19 +38,35 @@ export interface CodeProviderFactories {
     detect?: (binary: string) => CliDetection;
     /** Live Codex catalog reader; defaults to the opencodex snapshot. */
     liveModels?: () => CodexLiveModels | null;
+    /** Live catalog reader for the other providers; defaults to the shared snapshots. */
+    providerLiveModels?: (id: LiveCatalogProviderId) => ProviderLiveModels | null;
 }
 
 /**
  * Codex runs behind opencodex, which advertises a routed catalog far wider than
  * the static registry list (routed `anthropic/*`, `xai/*`, newer GPT ids) and a
- * DIFFERENT effort set per model. Only `codex-app` is proxied this way; the ACP
- * and SDK runtimes keep their registry lists.
+ * DIFFERENT effort set per model.
  */
 function liveCatalogPatch(id: CodeProviderId, read: () => CodexLiveModels | null): CodexLiveModels | null {
     // Read only for the proxied runtime. Calling first and filtering after would
     // make a Claude or Cursor catalog read schedule a Codex probe.
     if (id !== 'codex-app') return null;
     const live = read();
+    return live && live.models.length > 0 ? live : null;
+}
+
+/**
+ * The other three runtimes now have observed catalogs too — Claude from its
+ * installed bundle, Cursor and Grok from their CLIs. Reading them here is a memory
+ * lookup: `provider-live-models.ts` keeps the rule that a catalog read never spawns
+ * a CLI, so Cursor and Grok are only filled by an explicit prime.
+ */
+function providerCatalogPatch(
+    id: CodeProviderId,
+    read: (id: LiveCatalogProviderId) => ProviderLiveModels | null,
+): ProviderLiveModels | null {
+    if (id === 'codex-app') return null;
+    const live = read(id);
     return live && live.models.length > 0 ? live : null;
 }
 
@@ -62,12 +79,24 @@ export function createCodeProviders(factories: CodeProviderFactories = {}): Code
             describe(): CodeProviderCatalog {
                 const found = detection();
                 const live = liveCatalogPatch(id, factories.liveModels ?? readCodexLiveModels);
+                const providerLive = providerCatalogPatch(id, factories.providerLiveModels ?? readProviderLiveModels);
                 const base: CodeProviderCatalog = { id, label: entry.label, available: found.available && !!found.path,
                     reason: found.available && found.path ? null : 'Native CLI executable unavailable',
                     models: [...entry.models], defaultModel: entry.defaultModel,
                     defaultEffort: entry.defaultEffort || null, modelSource: 'registry',
                     capabilities: { resume: true, interrupt: true, permissions: true,
                         setModelMidSession: false, efforts: [...entry.efforts], permissionModes: [...MODES[id]] } };
+                if (providerLive) {
+                    return { ...base, models: [...providerLive.models], modelSource: 'live',
+                        ...(providerLive.effortsByModel
+                            ? { effortsByModel: structuredClone(providerLive.effortsByModel) }
+                            : {}),
+                        // Same rule as Codex: a default the live catalog no longer
+                        // serves would fail validate() on the very first session.
+                        defaultModel: providerLive.models.includes(base.defaultModel)
+                            ? base.defaultModel
+                            : providerLive.models[0] ?? base.defaultModel };
+                }
                 if (!live) return base;
                 // Never widen the effort union to empty: an all-routed catalog would
                 // otherwise strip the effort control for every model at once.

--- a/src/code-mode/providers/provider-live-models.ts
+++ b/src/code-mode/providers/provider-live-models.ts
@@ -1,0 +1,141 @@
+/**
+ * Live model snapshots for the Code catalog's non-Codex providers.
+ *
+ * `CodeProvider.describe()` is synchronous and runs on every catalog read, so it
+ * cannot await a discovery probe. `live-models.ts` already solved that for Codex
+ * with an in-memory snapshot plus a background refresh; this is the same shape for
+ * Claude, Cursor and Grok.
+ *
+ * The difference is what filling a snapshot costs. Codex reads HTTP and Claude
+ * reads a file, but Cursor and Grok SPAWN THEIR CLI. catalog.ts states the rule
+ * that makes that unacceptable on a read path: "catalogs must never execute a CLI
+ * or a login probe". A catalog render must not start a process, wait on a login
+ * prompt, or block on a slow binary.
+ *
+ * So the two are separated. A read never probes for Cursor or Grok; only an
+ * explicit prime does, and `describe()` returns whatever is already in memory.
+ */
+import { claudeCatalogToChoices, resolveClaudeBundleCatalog } from '../../cli/claude-model-discovery.js';
+import { buildClaudeEffortsByModel } from '../../cli/claude-models.js';
+import { fetchCursorModelInventory } from '../../agent/cursor-model-inventory.js';
+import { fetchGrokModelInventory } from '../../agent/grok-models.js';
+import { detectCli } from '../../core/cli-detection.js';
+
+/** Providers whose catalog this module can fill. Codex keeps its own module. */
+export type LiveCatalogProviderId = 'claude' | 'cursor' | 'grok';
+
+export interface ProviderLiveModels {
+    models: string[];
+    effortsByModel?: Record<string, string[]>;
+    source: string;
+}
+
+/**
+ * Whether a read is allowed to schedule a refresh for this provider.
+ *
+ * Claude's source is a file read, which is safe to trigger from a render. Cursor
+ * and Grok spawn a CLI, so only an explicit prime may fill them.
+ */
+const REFRESH_ON_READ: Record<LiveCatalogProviderId, boolean> = {
+    claude: true, cursor: false, grok: false,
+};
+
+/** How long a snapshot is served before a read schedules a refresh. */
+const REFRESH_AFTER_MS = 60_000;
+/**
+ * Floor between attempts after a failed probe, so a permanently absent CLI does
+ * not start work on every catalog read.
+ */
+const RETRY_AFTER_MS = 300_000;
+
+interface SnapshotSlot {
+    value: ProviderLiveModels | null;
+    fetchedAt: number;
+    attemptedAt: number;
+    inFlight: Promise<void> | null;
+}
+
+const slots = new Map<LiveCatalogProviderId, SnapshotSlot>();
+
+function slotOf(id: LiveCatalogProviderId): SnapshotSlot {
+    let slot = slots.get(id);
+    if (!slot) {
+        slot = { value: null, fetchedAt: 0, attemptedAt: 0, inFlight: null };
+        slots.set(id, slot);
+    }
+    return slot;
+}
+
+async function probe(id: LiveCatalogProviderId): Promise<ProviderLiveModels | null> {
+    if (id === 'claude') {
+        const detection = detectCli('claude');
+        if (!detection.available || !detection.path) return null;
+        const catalog = await resolveClaudeBundleCatalog(detection.path);
+        if (!catalog) return null;
+        const models = claudeCatalogToChoices(catalog);
+        return models.length > 0
+            ? { models, effortsByModel: buildClaudeEffortsByModel(models), source: 'claude-bundle' }
+            : null;
+    }
+    if (id === 'cursor') {
+        const inventory = await fetchCursorModelInventory();
+        return inventory && inventory.baseModels.length > 0
+            ? { models: inventory.baseModels, effortsByModel: inventory.effortsByModel, source: inventory.source }
+            : null;
+    }
+    const inventory = await fetchGrokModelInventory();
+    return inventory && inventory.models.length > 0
+        ? { models: inventory.models, source: inventory.source }
+        : null;
+}
+
+function refresh(id: LiveCatalogProviderId, force: boolean): Promise<void> | null {
+    const slot = slotOf(id);
+    if (slot.inFlight) return slot.inFlight;
+    if (!force && slot.attemptedAt && Date.now() - slot.attemptedAt < RETRY_AFTER_MS) return null;
+    slot.attemptedAt = Date.now();
+    slot.inFlight = probe(id)
+        .then(result => {
+            // A failed probe keeps the previous snapshot: one unreachable poll
+            // should not empty a picker that was working a moment ago.
+            if (!result) return;
+            slot.value = result;
+            slot.fetchedAt = Date.now();
+        })
+        .catch(() => { /* the previous snapshot stays authoritative */ })
+        .finally(() => { slot.inFlight = null; });
+    return slot.inFlight;
+}
+
+/**
+ * Last known catalog for a provider, or null before the first successful prime.
+ * Never blocks, and never spawns a CLI.
+ */
+export function readProviderLiveModels(id: LiveCatalogProviderId): ProviderLiveModels | null {
+    const slot = slotOf(id);
+    if (REFRESH_ON_READ[id] && (!slot.value || Date.now() - slot.fetchedAt > REFRESH_AFTER_MS)) {
+        refresh(id, false);
+    }
+    return slot.value;
+}
+
+/**
+ * Fill every provider snapshot, including the ones a read will not fill on its
+ * own. This is the only path that spawns Cursor's or Grok's CLI.
+ */
+export async function primeProviderLiveModels(): Promise<void> {
+    const ids: LiveCatalogProviderId[] = ['claude', 'cursor', 'grok'];
+    await Promise.all(ids.map(id => refresh(id, true) ?? Promise.resolve()));
+}
+
+/** @internal exported for unit tests */
+export function resetProviderLiveModelsForTest(
+    seed?: Partial<Record<LiveCatalogProviderId, ProviderLiveModels>>,
+): void {
+    slots.clear();
+    for (const [id, value] of Object.entries(seed ?? {})) {
+        slots.set(id as LiveCatalogProviderId, {
+            value: value ?? null, fetchedAt: Date.now(), attemptedAt: Date.now(), inFlight: null,
+        });
+    }
+}

--- a/structure/model-registry.md
+++ b/structure/model-registry.md
@@ -119,6 +119,28 @@ cli-jaw는 그보다 단순한 규칙을 쓴다. 성공한 프로브의 결과�
 바꾸면 안 된다. 예외는 하나다: 라이브 카탈로그가 더 이상 제공하지 않는 기본값은 첫
 세션에서 `validate()`에 걸리므로, 그때는 라이브 목록의 첫 모델로 물러선다.
 
+## Code 카탈로그
+
+`/api/code`의 카탈로그는 같은 라이브 결과를 쓰지만 경로가 다르다.
+`CodeProvider.describe()`가 **동기**이고 카탈로그 읽기마다 호출되므로 프로브를
+await할 수 없다. 그래서 메모리 스냅샷을 읽는다:
+`src/code-mode/providers/live-models.ts`(Codex)와
+`provider-live-models.ts`(claude/cursor/grok).
+
+스냅샷을 채우는 비용이 프로바이더마다 다르고, 그 차이가 규칙을 만든다.
+
+| 프로바이더 | 채우는 비용 | 읽기가 갱신을 예약하는가 |
+|---|---|---|
+| codex-app | HTTP | 예 |
+| claude | 번들 파일 읽기 | 예 |
+| cursor | `cursor-agent` 실행 | **아니오** |
+| grok | `grok` 실행 | **아니오** |
+
+`catalog.ts`가 규칙을 명시한다: "catalogs must never execute a CLI or a login
+probe." 카탈로그 렌더 한 번이 프로세스를 띄우면 로그인 프롬프트나 느린 바이너리가
+읽기 경로에 들어온다. 그래서 cursor/grok 스냅샷은 **명시적 프라임만** 채운다.
+`createCodeHost()`가 서비스 초기화 때 한 번 호출하고, 실패는 조용히 무시한다 —
+정적 목록이 그대로 남는다.
 ## 관련 문서
 
 - [runtime integration](runtime-integration.md) — transport 선택과 native adapter

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -71,7 +71,7 @@ cli-jaw/
 │   │   ├── settings-merge.ts ← perCli/activeOverrides/pi deep merge (258L)
 │   │   └── skill-cache.ts    ← 활성 스킬 슬래시 커맨드 캐시 (registerSkillLoader, getSkillCommandsCache, invalidateSkillCommandsCache) (44L)
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
-│   │   ├── host.ts ← per-backend lazy composition and storage (64L)
+│   │   ├── host.ts ← per-backend lazy composition and storage (70L)
 │   │   ├── manager.ts ← session index, admission and resource capacity (322L)
 │   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (623L)
 │   │   ├── normalize.ts ← redacted materialized transcript and coalescing (534L)
@@ -80,7 +80,7 @@ cli-jaw/
 │   │   ├── types.ts ← internal session and store contracts (12L)
 │   │   ├── wire.ts ← public request/event DTOs (186L)
 │   │   └── providers/        ← direct native adapters and capabilities
-│   │       ├── catalog.ts ← model/capability descriptions (100L)
+│   │       ├── catalog.ts ← model/capability descriptions (129L)
 │   │       ├── live-models.ts ← last-known opencodex catalog, refreshed in background (93L)
 │   │       ├── codex-app.ts ← Codex app-server adapter (320L)
 │   │       ├── claude.ts ← Claude native adapter (93L)

--- a/tests/unit/code-provider-live-models.test.ts
+++ b/tests/unit/code-provider-live-models.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createCodeProviders } from '../../src/code-mode/providers/catalog.ts';
+import type { ProviderLiveModels } from '../../src/code-mode/providers/provider-live-models.ts';
+
+const available = () => ({ available: true, path: '/usr/local/bin/stub', rejected: [] });
+
+function providersWith(live: Partial<Record<string, ProviderLiveModels>>) {
+    return createCodeProviders({
+        detect: available as never,
+        liveModels: () => null,
+        providerLiveModels: (id) => live[id] ?? null,
+    });
+}
+
+test('PLM-001: a live snapshot replaces the registry list and marks the source', () => {
+    const providers = providersWith({
+        cursor: { models: ['composer-2.5', 'grok-4.6'], source: 'cursor-agent --list-models' },
+    });
+    const catalog = providers.cursor.describe();
+    assert.deepEqual(catalog.models, ['composer-2.5', 'grok-4.6']);
+    assert.equal(catalog.modelSource, 'live');
+});
+
+test('PLM-002: no snapshot leaves the registry list standing', () => {
+    const catalog = providersWith({}).cursor.describe();
+    assert.equal(catalog.modelSource, 'registry');
+    assert.ok(catalog.models.length > 0);
+});
+
+test('PLM-003: an empty snapshot is treated as no snapshot', () => {
+    // Adopting it would make every model unselectable, since validate() checks
+    // the requested model against catalog.models.
+    const catalog = providersWith({ cursor: { models: [], source: 'x' } }).cursor.describe();
+    assert.equal(catalog.modelSource, 'registry');
+    assert.ok(catalog.models.length > 0);
+});
+
+test('PLM-004: per-model efforts ride along when the source has them', () => {
+    const catalog = providersWith({
+        claude: {
+            models: ['claude-opus-5', 'claude-haiku-4-5'],
+            effortsByModel: {
+                'claude-opus-5': ['low', 'high', 'ultracode'],
+                'claude-haiku-4-5': ['low', 'high'],
+            },
+            source: 'claude-bundle',
+        },
+    }).claude.describe();
+    assert.deepEqual(catalog.effortsByModel?.['claude-opus-5'], ['low', 'high', 'ultracode']);
+    assert.equal(catalog.effortsByModel?.['claude-haiku-4-5']?.includes('ultracode'), false);
+});
+
+test('PLM-005: a default the live catalog dropped falls back to its first model', () => {
+    // Keeping it would fail validate() on the very first session.
+    const catalog = providersWith({
+        cursor: { models: ['composer-9'], source: 'x' },
+    }).cursor.describe();
+    assert.equal(catalog.defaultModel, 'composer-9');
+});
+
+test('PLM-006: a default the live catalog still serves is preserved', () => {
+    const registryDefault = providersWith({}).cursor.describe().defaultModel;
+    const catalog = providersWith({
+        cursor: { models: ['other', registryDefault], source: 'x' },
+    }).cursor.describe();
+    assert.equal(catalog.defaultModel, registryDefault);
+});
+
+test('PLM-007: codex-app keeps its own Codex snapshot path', () => {
+    // Passing a provider snapshot for codex-app must not hijack the opencodex
+    // reader, whose per-model efforts and routed ids are shaped differently.
+    const catalog = providersWith({
+        'codex-app': { models: ['hijacked'], source: 'x' },
+    })['codex-app'].describe();
+    assert.equal(catalog.models.includes('hijacked'), false);
+    assert.equal(catalog.modelSource, 'registry');
+});
+
+test('PLM-008: reading a catalog never spawns a CLI for cursor or grok', async () => {
+    // The rule catalog.ts states: catalogs must never execute a CLI or a login
+    // probe. Reads go through the shared snapshot, which only an explicit prime
+    // fills for these two.
+    const { readProviderLiveModels, resetProviderLiveModelsForTest } =
+        await import('../../src/code-mode/providers/provider-live-models.ts');
+    resetProviderLiveModelsForTest();
+    assert.equal(readProviderLiveModels('cursor'), null);
+    assert.equal(readProviderLiveModels('grok'), null);
+});
+
+test('PLM-009: a seeded snapshot is readable without any probe', async () => {
+    const { readProviderLiveModels, resetProviderLiveModelsForTest } =
+        await import('../../src/code-mode/providers/provider-live-models.ts');
+    resetProviderLiveModelsForTest({ grok: { models: ['grok-4.6'], source: 'grok models' } });
+    assert.deepEqual(readProviderLiveModels('grok')?.models, ['grok-4.6']);
+    resetProviderLiveModelsForTest();
+});


### PR DESCRIPTION
Stacked on #636 (base is `codex/model-registry-wp4-cursor-grok`). Review the fifth commit only. Final PR of the series.

## What

`liveCatalogPatch` returned early for anything but `codex-app`, with a comment explaining that the ACP and SDK runtimes keep their registry lists. That was accurate until #634–#636 gave Claude, Cursor and Grok observed catalogs of their own.

Until now the Code API could not see any of it. `/api/code` still served the static `CLI_REGISTRY` list, and `CodeSessionManager.validate` rejects any model outside `catalog.models` — so a newly discovered model was unselectable there even though the CLI registry knew about it.

## The constraint, and what it decides

`describe()` is synchronous and runs on every catalog read, so it cannot await a probe. Codex already solved that with an in-memory snapshot plus a background refresh; `provider-live-models.ts` is the same shape for the other three.

What differs is the cost of *filling* a snapshot, and that difference sets the rule:

| provider | fill cost | may a read schedule a refresh? |
|---|---|---|
| `codex-app` | HTTP | yes |
| `claude` | bundle file read | yes |
| `cursor` | spawns `cursor-agent` | **no** |
| `grok` | spawns `grok` | **no** |

`catalog.ts` states the rule that makes the last two different: *"catalogs must never execute a CLI or a login probe."* A catalog render must not start a process or block on a login prompt.

So reads and probes are separated. A read may schedule a refresh for Claude; Cursor and Grok are filled once by `createCodeHost()` when the service initializes. Failure is silent by design and the static list stands. PLM-008 pins this: a read returns null for those two rather than probing.

## Measured end to end

```
before prime   cursor -> null
after prime    claude  claude-bundle             n=19
               cursor  cursor-agent --list-models n=48
               grok    grok models                n=10

catalog        claude     live      19  default claude-opus-4-8
               cursor     live      48  default composer-2.5
               grok       live      10  default grok-4.6
               codex-app  registry   7  default gpt-5.5
```

`codex-app` keeps its own opencodex path untouched — PLM-007 asserts a provider snapshot cannot hijack it, since its per-model efforts and routed ids are shaped differently.

## Verification

- `npm run gate:all` — **23/23 pass**
- 9 new tests plus the existing `code-live-models` suite — 13 pass, 0 fail
- `npm run typecheck` — clean
- `check-private-boundary --range origin/dev HEAD` — OK

An empty live snapshot is treated as no snapshot (PLM-003), because adopting it would make every model unselectable. A default the live catalog no longer serves falls back to its first model (PLM-005), which would otherwise fail `validate()` on the first session.
