### PR TITLE
fix(code): stop printing turn bookkeeping and let tool rows collapse

### DIFF
--- a/public/manager/src/code/CodeTranscript.tsx
+++ b/public/manager/src/code/CodeTranscript.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense, useCallback, useRef, useState, type KeyboardEvent } from 'react';
-import type { CodeItem, CodeProviderId } from '../../../../src/code-mode/wire';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import type { CodeItem, CodeItemKind, CodeProviderId } from '../../../../src/code-mode/wire';
 import { useCodeTranscriptVirtualRows } from './useCodeTranscriptVirtualRows';
 import { useCodeTranscriptScroll } from './use-code-transcript-scroll';
 import { useThrottledMarkdown } from './use-throttled-markdown';
@@ -8,6 +8,25 @@ import { noteworthyStatus, toolSummary } from './tool-summary';
 import { PENDING_USER_ITEM_ID } from './pending-user-item';
 
 const MarkdownRenderer = lazy(() => import('../notes/rendering/MarkdownRenderer').then(m => ({ default: m.MarkdownRenderer })));
+
+/**
+ * Turn boundaries are bookkeeping, not conversation. A one-line answer framed by
+ * "Turn started" and "Completed" reads as a status board, and neither line tells
+ * the reader anything the answer itself does not.
+ *
+ * They stay in the store and on the wire: history replay, the failed-input
+ * recovery lookup in CodeWorkbench and the transcript-limit accounting all still
+ * see them. Only this view drops them. Failure and cancellation are kept,
+ * because those are states a reader can act on.
+ */
+const HIDDEN_KINDS: ReadonlySet<CodeItemKind> = new Set<CodeItemKind>(['turn_started', 'turn_completed']);
+
+/** A collapsed tool row against the same row expanded, for the virtualizer. */
+const COLLAPSED_ROW_PX = 44;
+const EXPANDED_ROW_PX = 260;
+/** Same bound the scroll anchors use, for the same reason. */
+const MAX_OPEN_ROWS = 64;
+
 function ItemMarkdown({ item, identity, onOpenLocalFile }: { item: CodeItem; identity: string; onOpenLocalFile?: ((path: string) => void) | undefined }) {
     const text = useThrottledMarkdown(item.text ?? '', item.status !== 'running' && item.status !== 'pending', identity);
     if (!text.trim()) return <span className="code-plain-text">{text}</span>;
@@ -16,9 +35,11 @@ function ItemMarkdown({ item, identity, onOpenLocalFile }: { item: CodeItem; ide
     </Suspense>;
 }
 
-export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = '', onOpenLocalFile }: {
+export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = '', onOpenLocalFile, expanded, onExpandedChange }: {
     item: CodeItem; provider: CodeProviderId; sessionKey: string; workingDir?: string;
     onOpenLocalFile?: ((path: string) => void) | undefined;
+    expanded?: boolean;
+    onExpandedChange?: ((itemId: string, open: boolean) => void) | undefined;
 }) {
     const tool = item.kind === 'tool_call' || item.kind === 'file_change';
     const reasoning = item.kind === 'reasoning';
@@ -29,22 +50,37 @@ export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = ''
     // states the reader can act on are worth a visible badge.
     const note = noteworthyStatus(item);
     const unsent = item.itemId === PENDING_USER_ITEM_ID;
+    // A failed call opens itself, because the reader has to see why. Otherwise
+    // the disclosure is owned by the transcript, which remembers it across the
+    // virtualizer unmounting the row.
+    const open = expanded ?? item.status === 'error';
+    const running = item.status === 'running' || item.status === 'pending';
+    // The verb already says the call is in flight; a second badge saying
+    // "Running" next to "Reading src/app.ts" is the same fact twice. Failure
+    // and cancellation still get a word, because those change what to do next.
+    const toolNote = note === 'Running' || note === 'Pending' ? null : note;
     const label = user ? 'You' : assistant ? CODE_RUNTIME_LABELS[provider] : reasoning ? 'Reasoning'
         : item.kind === 'turn_started' ? 'Turn started' : item.kind === 'session_runtime' ? 'Runtime'
             : item.kind === 'permission_request' ? 'Permission record' : item.kind === 'notice' ? 'Notice' : status;
     return <article className={`code-message code-message-${tool ? 'tool' : assistant ? 'assistant' : user ? 'user' : 'system'} is-${item.status}${unsent ? ' is-unsent' : ''}`}
         data-code-item-id={item.itemId} aria-label={`${label} · ${status}`}>
-        {tool ? <details className={`code-tool-card code-tool-${item.status}`} open={item.status === 'error'}>
+        {tool ? <details className={`code-tool-card code-tool-${item.status}`} open={open}
+            onToggle={event => onExpandedChange?.(item.itemId, event.currentTarget.open)}>
             <summary className="code-tool-summary"><span className="code-tool-chevron" aria-hidden="true">›</span>
-                <span className="code-tool-name">{toolSummary(item, workingDir)}</span>
-                {note && <span className="code-tool-status">{note}</span>}</summary>
-            {item.tool?.detail !== undefined && <p className="code-tool-text">{item.tool.detail}</p>}
-            {item.tool?.input !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Input</span><pre className="code-tool-args">{item.tool.input}</pre></section>}
-            {item.tool?.output !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Output</span><pre className="code-tool-output">{item.tool.output}</pre></section>}
-            {item.text !== undefined && <pre className="code-tool-text">{item.text}</pre>}
-        </details> : reasoning ? <details className="code-thinking">
-            <summary className="code-thinking-summary">{item.status === 'running' ? 'Thinking…' : 'Reasoning'}</summary>
-            <div className="code-thinking-text">{item.text}</div>
+                <span className={`code-tool-name${running ? ' code-tool-name-running' : ''}`}>{toolSummary(item, workingDir)}</span>
+                {toolNote && <span className="code-tool-status">{toolNote}</span>}</summary>
+            {/* Built only while open: a collapsed call's output can be megabytes,
+                and constructing it costs the same whether or not it is painted. */}
+            {open && <>
+                {item.tool?.detail !== undefined && <p className="code-tool-text">{item.tool.detail}</p>}
+                {item.tool?.input !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Input</span><pre className="code-tool-args">{item.tool.input}</pre></section>}
+                {item.tool?.output !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Output</span><pre className="code-tool-output">{item.tool.output}</pre></section>}
+                {item.text !== undefined && <pre className="code-tool-text">{item.text}</pre>}
+            </>}
+        </details> : reasoning ? <details className="code-thinking" open={expanded ?? false}
+            onToggle={event => onExpandedChange?.(item.itemId, event.currentTarget.open)}>
+            <summary className={`code-thinking-summary${item.status === 'running' ? ' code-tool-name-running' : ''}`}>{item.status === 'running' ? 'Thinking…' : 'Reasoning'}</summary>
+            {(expanded ?? false) && <div className="code-thinking-text">{item.text}</div>}
         </details> : <>
             <span className="code-message-role">{label}{assistant && item.phase === 'commentary' ? ' · Commentary' : ''}
                 {note && ` · ${unsent ? 'Sending' : note}`}</span>
@@ -63,21 +99,49 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
     onOpenLocalFile?: ((path: string) => void) | undefined;
 }) {
     const transcriptRef = useRef<HTMLDivElement>(null);
-    const itemsRef = useRef(items); itemsRef.current = items;
+    const visible = useMemo(() => items.filter(item => !HIDDEN_KINDS.has(item.kind)), [items]);
+    const itemsRef = useRef(visible); itemsRef.current = visible;
+    // Scoped by session so the reserved pending-user id cannot carry one
+    // session's disclosure into another, and bounded so a long-lived tab does
+    // not accumulate ids for sessions it will never show again.
+    const [openRows, setOpenRows] = useState<ReadonlySet<string>>(() => new Set());
     const [historyPending, setHistoryPending] = useState(false);
     const [historyError, setHistoryError] = useState<{ sessionKey: string; message: string } | null>(null);
     const historyGuard = useRef(false);
-    const firstId = items[0]?.itemId;
+    const firstId = visible[0]?.itemId;
     const getItemKey = useCallback((index: number) => `${sessionKey}:${itemsRef.current[index]?.itemId ?? index}`, [sessionKey, firstId]);
     const estimateSize = useCallback((index: number) => {
         const item = itemsRef.current[index];
-        // Tool and reasoning rows are collapsed to one line, so they measure
-        // far shorter than a message of the same text length.
-        return item?.kind === 'tool_call' || item?.kind === 'file_change' || item?.kind === 'reasoning'
-            ? 44 : 64 + Math.min(420, (item?.text?.length ?? 0) / 6);
-    }, []);
-    const virtual = useCodeTranscriptVirtualRows({ count: items.length, resetKey: sessionKey, scrollElementRef: transcriptRef, getItemKey, estimateSize });
-    const { showJump, jumpToLatest } = useCodeTranscriptScroll({ items, sessionKey, transcriptRef, virtual });
+        const collapsible = item?.kind === 'tool_call' || item?.kind === 'file_change' || item?.kind === 'reasoning';
+        // A collapsible row is one line until someone opens it. Estimating an
+        // open row at one line is what makes the scrollbar disagree with the
+        // content, so the estimate has to follow the disclosure.
+        if (!collapsible) return 64 + Math.min(420, (item?.text?.length ?? 0) / 6);
+        return item && openRows.has(`${sessionKey}:${item.itemId}`) ? EXPANDED_ROW_PX : COLLAPSED_ROW_PX;
+    }, [openRows, sessionKey]);
+    const virtual = useCodeTranscriptVirtualRows({ count: visible.length, resetKey: sessionKey, scrollElementRef: transcriptRef, getItemKey, estimateSize });
+    const { showJump, jumpToLatest } = useCodeTranscriptScroll({ items: visible, sessionKey, transcriptRef, virtual });
+    const setExpanded = useCallback((itemId: string, open: boolean) => {
+        const key = `${sessionKey}:${itemId}`;
+        setOpenRows(current => {
+            if (current.has(key) === open) return current;
+            const next = new Set(current);
+            if (open) next.add(key); else next.delete(key);
+            // Same bound as the scroll anchors: remembering every row a reader
+            // ever opened is not worth an unbounded set.
+            if (next.size > MAX_OPEN_ROWS) {
+                const oldest = next.values().next().value;
+                if (oldest !== undefined) next.delete(oldest);
+            }
+            return next;
+        });
+        // The virtualizer measured this row at its old height, and nothing about
+        // a toggle changes item count or identity, so no option update reaches
+        // it. Hand it the new estimate directly; it corrects the scroll offset
+        // when the row sits above the viewport.
+        const index = itemsRef.current.findIndex(entry => entry.itemId === itemId);
+        if (index >= 0) virtual.resizeItem(index, open ? EXPANDED_ROW_PX : COLLAPSED_ROW_PX);
+    }, [sessionKey, virtual]);
     async function older() {
         if (historyGuard.current) return;
         historyGuard.current = true; setHistoryPending(true); setHistoryError(null);
@@ -103,15 +167,17 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
             {historyError?.sessionKey === sessionKey && <span className="code-action-error" role="alert">{historyError.message}</span>}
         </div>
         <div ref={transcriptRef} className="code-transcript" role="log" aria-label="Code transcript" aria-live="off" tabIndex={0} onKeyDown={keyboard}>
-            {!items.length ? <div className="code-transcript-empty"><p>{loading ? 'Loading conversation…' : 'Type a prompt below to start this conversation.'}</p>
+            {!visible.length ? <div className="code-transcript-empty"><p>{loading ? 'Loading conversation…' : 'Type a prompt below to start this conversation.'}</p>
                 <p className="code-transcript-cwd">Workspace: {workingDir || 'not set'}</p></div>
                 : <div className="code-transcript-virtual-spacer" style={{ height: virtual.totalSize }}>
                     {virtual.virtualItems.map(row => {
-                        const item = items[row.index];
+                        const item = visible[row.index];
                         return item ? <div key={row.key} ref={virtual.measureElement} className="code-transcript-virtual-row"
                             data-code-transcript-idx={row.index} style={{ transform: `translateY(${row.start}px)` }}>
                             <CodeTranscriptItem item={item} provider={provider} sessionKey={sessionKey}
-                                workingDir={workingDir} onOpenLocalFile={onOpenLocalFile} />
+                                workingDir={workingDir} onOpenLocalFile={onOpenLocalFile}
+                                expanded={openRows.has(`${sessionKey}:${item.itemId}`) || (item.status === 'error' && item.kind !== 'reasoning')}
+                                onExpandedChange={setExpanded} />
                         </div> : null;
                     })}
                 </div>}

--- a/public/manager/src/code/CodeTranscript.tsx
+++ b/public/manager/src/code/CodeTranscript.tsx
@@ -27,6 +27,17 @@ const EXPANDED_ROW_PX = 260;
 /** Same bound the scroll anchors use, for the same reason. */
 const MAX_OPEN_ROWS = 64;
 
+/**
+ * A failed call opens itself, because the reader has to see why it failed. That
+ * is a default, not a lock: once the reader has said what they want for this
+ * row, their choice wins, including closing a failure they have already read.
+ */
+function isRowOpen(chosen: ReadonlyMap<string, boolean>, sessionKey: string, item: CodeItem): boolean {
+    const choice = chosen.get(`${sessionKey}:${item.itemId}`);
+    if (choice !== undefined) return choice;
+    return item.status === 'error' && item.kind !== 'reasoning';
+}
+
 function ItemMarkdown({ item, identity, onOpenLocalFile }: { item: CodeItem; identity: string; onOpenLocalFile?: ((path: string) => void) | undefined }) {
     const text = useThrottledMarkdown(item.text ?? '', item.status !== 'running' && item.status !== 'pending', identity);
     if (!text.trim()) return <span className="code-plain-text">{text}</span>;
@@ -50,10 +61,10 @@ export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = ''
     // states the reader can act on are worth a visible badge.
     const note = noteworthyStatus(item);
     const unsent = item.itemId === PENDING_USER_ITEM_ID;
-    // A failed call opens itself, because the reader has to see why. Otherwise
-    // the disclosure is owned by the transcript, which remembers it across the
-    // virtualizer unmounting the row.
-    const open = expanded ?? item.status === 'error';
+    // The transcript owns the disclosure, because the virtualizer unmounts rows
+    // and per-row state would be lost on scroll. Rendered standalone (tests, a
+    // future embed) it falls back to the same failure default.
+    const open = expanded ?? (item.status === 'error' && item.kind !== 'reasoning');
     const running = item.status === 'running' || item.status === 'pending';
     // The verb already says the call is in flight; a second badge saying
     // "Running" next to "Reading src/app.ts" is the same fact twice. Failure
@@ -77,10 +88,10 @@ export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = ''
                 {item.tool?.output !== undefined && <section className="code-tool-section"><span className="code-tool-section-label">Output</span><pre className="code-tool-output">{item.tool.output}</pre></section>}
                 {item.text !== undefined && <pre className="code-tool-text">{item.text}</pre>}
             </>}
-        </details> : reasoning ? <details className="code-thinking" open={expanded ?? false}
+        </details> : reasoning ? <details className="code-thinking" open={open}
             onToggle={event => onExpandedChange?.(item.itemId, event.currentTarget.open)}>
             <summary className={`code-thinking-summary${item.status === 'running' ? ' code-tool-name-running' : ''}`}>{item.status === 'running' ? 'Thinking…' : 'Reasoning'}</summary>
-            {(expanded ?? false) && <div className="code-thinking-text">{item.text}</div>}
+            {open && <div className="code-thinking-text">{item.text}</div>}
         </details> : <>
             <span className="code-message-role">{label}{assistant && item.phase === 'commentary' ? ' · Commentary' : ''}
                 {note && ` · ${unsent ? 'Sending' : note}`}</span>
@@ -101,10 +112,13 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
     const transcriptRef = useRef<HTMLDivElement>(null);
     const visible = useMemo(() => items.filter(item => !HIDDEN_KINDS.has(item.kind)), [items]);
     const itemsRef = useRef(visible); itemsRef.current = visible;
+    // What the reader chose, which is not the same as what is open: a failed
+    // call opens itself, so "not in the map" and "the reader closed it" have to
+    // be different states or the auto-open reopens it on the next render.
     // Scoped by session so the reserved pending-user id cannot carry one
     // session's disclosure into another, and bounded so a long-lived tab does
     // not accumulate ids for sessions it will never show again.
-    const [openRows, setOpenRows] = useState<ReadonlySet<string>>(() => new Set());
+    const [openRows, setOpenRows] = useState<ReadonlyMap<string, boolean>>(() => new Map());
     const [historyPending, setHistoryPending] = useState(false);
     const [historyError, setHistoryError] = useState<{ sessionKey: string; message: string } | null>(null);
     const historyGuard = useRef(false);
@@ -117,20 +131,21 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
         // open row at one line is what makes the scrollbar disagree with the
         // content, so the estimate has to follow the disclosure.
         if (!collapsible) return 64 + Math.min(420, (item?.text?.length ?? 0) / 6);
-        return item && openRows.has(`${sessionKey}:${item.itemId}`) ? EXPANDED_ROW_PX : COLLAPSED_ROW_PX;
+        return item && isRowOpen(openRows, sessionKey, item) ? EXPANDED_ROW_PX : COLLAPSED_ROW_PX;
     }, [openRows, sessionKey]);
     const virtual = useCodeTranscriptVirtualRows({ count: visible.length, resetKey: sessionKey, scrollElementRef: transcriptRef, getItemKey, estimateSize });
     const { showJump, jumpToLatest } = useCodeTranscriptScroll({ items: visible, sessionKey, transcriptRef, virtual });
     const setExpanded = useCallback((itemId: string, open: boolean) => {
         const key = `${sessionKey}:${itemId}`;
         setOpenRows(current => {
-            if (current.has(key) === open) return current;
-            const next = new Set(current);
-            if (open) next.add(key); else next.delete(key);
+            if (current.get(key) === open) return current;
+            const next = new Map(current);
+            next.delete(key); next.set(key, open);
             // Same bound as the scroll anchors: remembering every row a reader
-            // ever opened is not worth an unbounded set.
+            // ever touched is not worth an unbounded map. Re-inserting above
+            // keeps the row just acted on newest, so it is never the one evicted.
             if (next.size > MAX_OPEN_ROWS) {
-                const oldest = next.values().next().value;
+                const oldest = next.keys().next().value;
                 if (oldest !== undefined) next.delete(oldest);
             }
             return next;
@@ -176,7 +191,7 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
                             data-code-transcript-idx={row.index} style={{ transform: `translateY(${row.start}px)` }}>
                             <CodeTranscriptItem item={item} provider={provider} sessionKey={sessionKey}
                                 workingDir={workingDir} onOpenLocalFile={onOpenLocalFile}
-                                expanded={openRows.has(`${sessionKey}:${item.itemId}`) || (item.status === 'error' && item.kind !== 'reasoning')}
+                                expanded={isRowOpen(openRows, sessionKey, item)}
                                 onExpandedChange={setExpanded} />
                         </div> : null;
                     })}

--- a/public/manager/src/code/CodeTranscript.tsx
+++ b/public/manager/src/code/CodeTranscript.tsx
@@ -21,9 +21,15 @@ const MarkdownRenderer = lazy(() => import('../notes/rendering/MarkdownRenderer'
  */
 const HIDDEN_KINDS: ReadonlySet<CodeItemKind> = new Set<CodeItemKind>(['turn_started', 'turn_completed']);
 
-/** A collapsed tool row against the same row expanded, for the virtualizer. */
+/**
+ * What a collapsible row measures before it has been measured. Collapsed is one
+ * line and exact. Expanded is a guess and deliberately only that: the panes are
+ * capped at 200px each by `.code-tool-output` / `.code-tool-args`, so a call
+ * with both is far taller, and the real number arrives from the ResizeObserver
+ * a frame later. This only has to be closer than one line.
+ */
 const COLLAPSED_ROW_PX = 44;
-const EXPANDED_ROW_PX = 260;
+const EXPANDED_ROW_PX = 320;
 /** Same bound the scroll anchors use, for the same reason. */
 const MAX_OPEN_ROWS = 64;
 
@@ -66,10 +72,12 @@ export function CodeTranscriptItem({ item, provider, sessionKey, workingDir = ''
     // future embed) it falls back to the same failure default.
     const open = expanded ?? (item.status === 'error' && item.kind !== 'reasoning');
     const running = item.status === 'running' || item.status === 'pending';
-    // The verb already says the call is in flight; a second badge saying
-    // "Running" next to "Reading src/app.ts" is the same fact twice. Failure
-    // and cancellation still get a word, because those change what to do next.
-    const toolNote = note === 'Running' || note === 'Pending' ? null : note;
+    // The verb already says the call is in flight; a second badge next to
+    // "Reading src/app.ts" is the same fact twice. Keyed off the status rather
+    // than the badge text, so renaming either vocabulary cannot quietly bring
+    // the duplicate back. Failure and cancellation still get a word, because
+    // those change what to do next.
+    const toolNote = running ? null : note;
     const label = user ? 'You' : assistant ? CODE_RUNTIME_LABELS[provider] : reasoning ? 'Reasoning'
         : item.kind === 'turn_started' ? 'Turn started' : item.kind === 'session_runtime' ? 'Runtime'
             : item.kind === 'permission_request' ? 'Permission record' : item.kind === 'notice' ? 'Notice' : status;
@@ -119,11 +127,26 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
     // session's disclosure into another, and bounded so a long-lived tab does
     // not accumulate ids for sessions it will never show again.
     const [openRows, setOpenRows] = useState<ReadonlyMap<string, boolean>>(() => new Map());
+    // `getItemKey` is called by the virtualizer outside render, so it reads the
+    // choice through a ref; the callback identity is refreshed below so the
+    // virtualizer actually re-keys after a toggle.
+    const openRef = useRef(openRows); openRef.current = openRows;
     const [historyPending, setHistoryPending] = useState(false);
     const [historyError, setHistoryError] = useState<{ sessionKey: string; message: string } | null>(null);
     const historyGuard = useRef(false);
     const firstId = visible[0]?.itemId;
-    const getItemKey = useCallback((index: number) => `${sessionKey}:${itemsRef.current[index]?.itemId ?? index}`, [sessionKey, firstId]);
+    // The disclosure is part of the key, because a measured size always beats an
+    // estimate: without it a row measured while collapsed would keep that height
+    // after it expands, and no better estimate could correct it. Opening a row
+    // gives it a key that has never been measured, so it falls back to the
+    // estimate until the ResizeObserver reports the real height. The identity
+    // that has to stay stable is the DOM node's, which comes from the React
+    // `key` on the row, and that is unchanged.
+    const getItemKey = useCallback((index: number) => {
+        const item = itemsRef.current[index];
+        if (!item) return `${sessionKey}:${index}`;
+        return `${sessionKey}:${item.itemId}${isRowOpen(openRef.current, sessionKey, item) ? ':open' : ''}`;
+    }, [sessionKey, firstId, openRows]);
     const estimateSize = useCallback((index: number) => {
         const item = itemsRef.current[index];
         const collapsible = item?.kind === 'tool_call' || item?.kind === 'file_change' || item?.kind === 'reasoning';
@@ -150,13 +173,7 @@ export function CodeTranscript({ items, provider, sessionKey, workingDir, loadin
             }
             return next;
         });
-        // The virtualizer measured this row at its old height, and nothing about
-        // a toggle changes item count or identity, so no option update reaches
-        // it. Hand it the new estimate directly; it corrects the scroll offset
-        // when the row sits above the viewport.
-        const index = itemsRef.current.findIndex(entry => entry.itemId === itemId);
-        if (index >= 0) virtual.resizeItem(index, open ? EXPANDED_ROW_PX : COLLAPSED_ROW_PX);
-    }, [sessionKey, virtual]);
+    }, [sessionKey]);
     async function older() {
         if (historyGuard.current) return;
         historyGuard.current = true; setHistoryPending(true); setHistoryError(null);

--- a/public/manager/src/code/code-workbench.css
+++ b/public/manager/src/code/code-workbench.css
@@ -135,8 +135,43 @@
 }
 .code-tool-summary::-webkit-details-marker { display: none; }
 .code-tool-summary:hover { background: var(--accent-soft); }
-.code-tool-chevron { flex-shrink: 0; font-weight: 800; line-height: 1; color: var(--text-dim); }
+.code-tool-chevron {
+    flex-shrink: 0; font-weight: 800; line-height: 1; color: var(--text-dim);
+    /* Dimmed rather than hidden: a chevron that only appears on hover is
+       undiscoverable by touch and gives a keyboard user nothing to aim at. */
+    opacity: 0.35;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.code-tool-summary:hover .code-tool-chevron,
+.code-tool-summary:focus-visible .code-tool-chevron { opacity: 1; }
+.code-tool-card[open] > .code-tool-summary .code-tool-chevron { transform: rotate(90deg); opacity: 1; }
 .code-tool-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 650; line-height: 1.15; }
+/* A call in flight reads as in-flight. The verb already says so; this keeps the
+   row alive while it streams, and stopping is what marks completion -- no chip
+   that says "Done" on every successful row. */
+.code-tool-name-running {
+    background: linear-gradient(90deg,
+        var(--text-dim) 0%, var(--text-dim) 34%,
+        var(--text-primary) 50%,
+        var(--text-dim) 66%, var(--text-dim) 100%);
+    background-size: 300% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: code-tool-shimmer 4s linear infinite;
+}
+@keyframes code-tool-shimmer {
+    from { background-position: 150% 0; }
+    to { background-position: -150% 0; }
+}
+/* Transparent text has no fallback under a forced palette, and a reader who
+   asked for less motion should not get a looping gradient either. */
+@media (prefers-reduced-motion: reduce) {
+    .code-tool-name-running { animation: none; background: none; color: var(--text-primary); }
+}
+@media (forced-colors: active) {
+    .code-tool-name-running { animation: none; background: none; color: CanvasText; forced-color-adjust: none; }
+}
 .code-tool-status {
     margin-left: auto;
     flex-shrink: 0;

--- a/public/manager/src/code/code-workbench.css
+++ b/public/manager/src/code/code-workbench.css
@@ -149,16 +149,22 @@
 /* A call in flight reads as in-flight. The verb already says so; this keeps the
    row alive while it streams, and stopping is what marks completion -- no chip
    that says "Done" on every successful row. */
-.code-tool-name-running {
-    background: linear-gradient(90deg,
-        var(--text-dim) 0%, var(--text-dim) 34%,
-        var(--text-primary) 50%,
-        var(--text-dim) 66%, var(--text-dim) 100%);
-    background-size: 300% 100%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    animation: code-tool-shimmer 4s linear infinite;
+/* The label is clipped with an ellipsis, and transparent text over a clipped
+   background is invisible rather than dim wherever the clip does not apply, so
+   the gradient is opted into only where it is supported. */
+.code-tool-name-running { color: var(--text-dim); }
+@supports (background-clip: text) or (-webkit-background-clip: text) {
+    .code-tool-name-running {
+        background: linear-gradient(90deg,
+            var(--text-dim) 0%, var(--text-dim) 34%,
+            var(--text-primary) 50%,
+            var(--text-dim) 66%, var(--text-dim) 100%);
+        background-size: 300% 100%;
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        animation: code-tool-shimmer 4s linear infinite;
+    }
 }
 @keyframes code-tool-shimmer {
     from { background-position: 150% 0; }
@@ -167,10 +173,10 @@
 /* Transparent text has no fallback under a forced palette, and a reader who
    asked for less motion should not get a looping gradient either. */
 @media (prefers-reduced-motion: reduce) {
-    .code-tool-name-running { animation: none; background: none; color: var(--text-primary); }
+    .code-tool-name-running { animation: none; background: none; color: var(--text-primary); -webkit-text-fill-color: currentColor; }
 }
 @media (forced-colors: active) {
-    .code-tool-name-running { animation: none; background: none; color: CanvasText; forced-color-adjust: none; }
+    .code-tool-name-running { animation: none; background: none; color: CanvasText; -webkit-text-fill-color: currentColor; forced-color-adjust: none; }
 }
 .code-tool-status {
     margin-left: auto;

--- a/public/manager/src/code/tool-summary.ts
+++ b/public/manager/src/code/tool-summary.ts
@@ -7,14 +7,29 @@ import type { CodeItem } from '../../../../src/code-mode/wire';
  * they can tell whether it matters. `Read src/app.ts` is legible at a glance,
  * so the body can stay collapsed until someone actually wants it.
  */
-const VERBS: Array<[RegExp, string]> = [
-    [/^(read|read_file|get_file|open_file|view|cat)$/i, 'Read'],
-    [/^(write|write_file|create_file|edit|edit_file|apply_patch|str_replace\w*|update_file)$/i, 'Edit'],
-    [/^(bash|shell|exec|exec_command|run|run_command|terminal)$/i, 'Bash'],
-    [/^(search|grep|rg|ripgrep|glob|find|codebase_search)$/i, 'Search'],
-    [/^(fetch|browser\w*|web_\w*|open_url|http)$/i, 'Open'],
-    [/^(list|ls|list_dir|list_files)$/i, 'List'],
+/**
+ * [pattern, settled, active]. The settled word is what a finished call reads as
+ * and is deliberately unchanged: it is asserted across the summary tests and is
+ * the vocabulary the transcript has always used.
+ *
+ * The active word exists because a running call and a finished one otherwise
+ * look identical once the status badge is gone. Tense carries completion, the
+ * way it does in a native transcript, instead of a chip that says "Done" on
+ * every successful row.
+ */
+const VERBS: Array<[RegExp, string, string]> = [
+    [/^(read|read_file|get_file|open_file|view|cat)$/i, 'Read', 'Reading'],
+    [/^(write|write_file|create_file|edit|edit_file|apply_patch|str_replace\w*|update_file)$/i, 'Edit', 'Editing'],
+    [/^(bash|shell|exec|exec_command|run|run_command|terminal)$/i, 'Bash', 'Running'],
+    [/^(search|grep|rg|ripgrep|glob|find|codebase_search)$/i, 'Search', 'Searching'],
+    [/^(fetch|browser\w*|web_\w*|open_url|http)$/i, 'Open', 'Opening'],
+    [/^(list|ls|list_dir|list_files)$/i, 'List', 'Listing'],
 ];
+
+/** A call that has not settled yet reads in the present tense. */
+function isActive(status: CodeItem['status']): boolean {
+    return status === 'running' || status === 'pending';
+}
 
 /** Longest-suffix workspace-relative path, so the row stays scannable. */
 export function shortenPath(value: string, workingDir: string): string {
@@ -60,12 +75,15 @@ export function summariseToolInput(input: string | undefined, workingDir: string
 }
 
 export function toolSummary(item: CodeItem, workingDir: string): string {
+    const active = isActive(item.status);
     if (item.kind === 'file_change') {
         const target = summariseToolInput(item.tool?.input, workingDir) || item.tool?.detail || '';
-        return target ? `Edit ${target}` : 'File change';
+        const verb = active ? 'Editing' : 'Edit';
+        return target ? `${verb} ${target}` : 'File change';
     }
     const name = item.tool?.name?.trim() || 'Tool';
-    const verb = VERBS.find(([pattern]) => pattern.test(name))?.[1];
+    const match = VERBS.find(([pattern]) => pattern.test(name));
+    const verb = match ? (active ? match[2] : match[1]) : undefined;
     const detail = summariseToolInput(item.tool?.input, workingDir);
     if (verb) return detail ? `${verb} ${detail}` : verb;
     // An unrecognised tool keeps its own name; renaming it would hide which

--- a/public/manager/src/code/useCodeTranscriptVirtualRows.ts
+++ b/public/manager/src/code/useCodeTranscriptVirtualRows.ts
@@ -21,14 +21,6 @@ export type CodeTranscriptVirtualRows = {
     virtualItems: VirtualItem[];
     totalSize: number;
     restoreAnchor: (index: number, offset: number) => void;
-    /**
-     * Discard one row's measured height. A collapsed tool row and the same row
-     * expanded differ by hundreds of pixels, and `estimateSize` alone cannot
-     * correct a size the virtualizer already measured: nothing about a toggle
-     * changes `count` or item identity, so no option update fires. Without
-     * this the stale height survives until the whole session is switched.
-     */
-    resizeItem: (index: number, size: number) => void;
 };
 
 export function useCodeTranscriptVirtualRows(args: {
@@ -103,10 +95,6 @@ export function useCodeTranscriptVirtualRows(args: {
             const position = virtualizer.getOffsetForIndex(index, 'start');
             if (position) virtualizer.scrollToOffset(position[0] + offset, { behavior: 'auto' });
         },
-        // `resizeItem` also adjusts the scroll offset when the row sits above the
-        // viewport, so expanding an off-screen row does not shift what the reader
-        // is looking at.
-        resizeItem: (index, size) => { virtualizer.resizeItem(index, size); },
         measureElement: element => {
             if (element) virtualizer.measureElement(element);
         },

--- a/public/manager/src/code/useCodeTranscriptVirtualRows.ts
+++ b/public/manager/src/code/useCodeTranscriptVirtualRows.ts
@@ -21,6 +21,14 @@ export type CodeTranscriptVirtualRows = {
     virtualItems: VirtualItem[];
     totalSize: number;
     restoreAnchor: (index: number, offset: number) => void;
+    /**
+     * Discard one row's measured height. A collapsed tool row and the same row
+     * expanded differ by hundreds of pixels, and `estimateSize` alone cannot
+     * correct a size the virtualizer already measured: nothing about a toggle
+     * changes `count` or item identity, so no option update fires. Without
+     * this the stale height survives until the whole session is switched.
+     */
+    resizeItem: (index: number, size: number) => void;
 };
 
 export function useCodeTranscriptVirtualRows(args: {
@@ -95,6 +103,10 @@ export function useCodeTranscriptVirtualRows(args: {
             const position = virtualizer.getOffsetForIndex(index, 'start');
             if (position) virtualizer.scrollToOffset(position[0] + offset, { behavior: 'auto' });
         },
+        // `resizeItem` also adjusts the scroll offset when the row sits above the
+        // viewport, so expanding an off-screen row does not shift what the reader
+        // is looking at.
+        resizeItem: (index, size) => { virtualizer.resizeItem(index, size); },
         measureElement: element => {
             if (element) virtualizer.measureElement(element);
         },

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -613,6 +613,20 @@ line (`Read src/app.ts`, `Bash npm test`) and open only on failure, `Done` is
 not printed, and user messages use a right-aligned bubble while the assistant
 keeps the full column as plain prose.
 
+Turn boundaries are bookkeeping and never become transcript rows: `turn_started`
+and `turn_completed` stay in the store and on the wire, where history replay and
+the failed-input recovery lookup still read them, but the transcript filters them
+out. `turn_failed` and `turn_cancelled` remain visible because a reader can act
+on them. A call that has not settled reads in the present tense (`Reading`,
+`Running`, `Searching`) with a streaming marker on the summary line, and settling
+changes only the tense, so no badge repeats what the verb already says; the
+settled vocabulary and an unrecognised tool's own name are unchanged. Tool and
+reasoning detail is built only while its disclosure is open, and the transcript
+owns that open state, scoped per session and bounded, because the virtualizer
+unmounts rows. Toggling hands the virtualizer a new size for that row directly:
+a toggle changes neither item count nor identity, so no option update would
+otherwise reach it and the measured height would stay stale.
+
 `useCodeController` owns requests and selection fencing. A single Code SSE
 subscription reconciles a full snapshot at watermark H and contiguous events
 after H. Opening transport does not mean synchronization has completed. Compact

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -623,9 +623,11 @@ changes only the tense, so no badge repeats what the verb already says; the
 settled vocabulary and an unrecognised tool's own name are unchanged. Tool and
 reasoning detail is built only while its disclosure is open, and the transcript
 owns that open state, scoped per session and bounded, because the virtualizer
-unmounts rows. Toggling hands the virtualizer a new size for that row directly:
-a toggle changes neither item count nor identity, so no option update would
-otherwise reach it and the measured height would stay stale.
+unmounts rows. A reader's choice outlives the failure default, so a failed call
+that has been read can be closed. The disclosure is part of the virtualizer's
+item key: a measured size always wins over an estimate, so a row measured while
+collapsed would keep that height once expanded, and re-keying hands it back to
+the estimate until its real height is observed.
 
 `useCodeController` owns requests and selection fencing. A single Code SSE
 subscription reconciles a full snapshot at watermark H and contiguous events

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -533,7 +533,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 602 files source/assets, ~102302L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 602 files source/assets, ~102542L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── settings/ ← standalone instance settings entry
 │   │   └── index.html ← Classic settings iframe HTML (13L)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)

--- a/tests/unit/code-native-components.test.ts
+++ b/tests/unit/code-native-components.test.ts
@@ -330,7 +330,10 @@ test('unknown-send retry previews original text and never submits the edited dra
 function item(patch: Partial<CodeItem>): CodeItem { return { itemId: 'item-a', turnId: 't-a', kind: 'user_message', status: 'done', createdAt: 1, updatedAt: 1, ...patch }; }
 test('timeline retains stable item ID, escaped tool output, truncation and distinct stopped/failed states', bounded, async t => {
     const h = await surface(t);
-    const render = (value: CodeItem) => h.render(createElement(CodeTranscriptItem, { item: value, provider: 'cursor', sessionKey: '43225:s-a' }));
+    // Tool detail is built only while the disclosure is open, so this asserts
+    // the escaping contract on an expanded row -- the state where the output is
+    // actually shown to a reader.
+    const render = (value: CodeItem) => h.render(createElement(CodeTranscriptItem, { item: value, provider: 'cursor', sessionKey: '43225:s-a', expanded: true }));
     await render(item({ kind: 'tool_call', status: 'cancelled', tool: { name: 'read', output: '<script>bad()</script>partial' },
         truncation: { storedChars: 12, sourceChars: 500, reason: 'field_limit' } }));
     assert.equal(h.container.querySelector('article')?.getAttribute('data-code-item-id'), 'item-a');
@@ -339,6 +342,29 @@ test('timeline retains stable item ID, escaped tool output, truncation and disti
     assert.equal(h.container.querySelector('pre')?.textContent, '<script>bad()</script>partial');
     await render(item({ kind: 'turn_failed', status: 'error', text: 'Runtime closed unexpectedly' }));
     assert.match(h.container.textContent ?? '', /Failed/); assert.doesNotMatch(h.container.textContent ?? '', /Stopped/);
+});
+
+test('a collapsed tool call keeps its output out of the document', bounded, async t => {
+    const h = await surface(t);
+    const call = item({ kind: 'tool_call', status: 'done', tool: { name: 'read', input: '{"path":"/a.ts"}', output: 'secret-output-body' } });
+    await h.render(createElement(CodeTranscriptItem, { item: call, provider: 'cursor', sessionKey: '43225:s-a' }));
+    assert.match(h.container.textContent ?? '', /Read/, 'the summary line still says what ran');
+    assert.doesNotMatch(h.container.textContent ?? '', /secret-output-body/);
+    assert.equal(h.container.querySelector('pre'), null);
+    await h.render(createElement(CodeTranscriptItem, { item: call, provider: 'cursor', sessionKey: '43225:s-a', expanded: true }));
+    assert.match(h.container.textContent ?? '', /secret-output-body/);
+});
+
+test('a running tool call reads in the present tense without a duplicate status badge', bounded, async t => {
+    const h = await surface(t);
+    const running = item({ kind: 'tool_call', status: 'running', tool: { name: 'bash', input: '{"command":"npm test"}' } });
+    await h.render(createElement(CodeTranscriptItem, { item: running, provider: 'cursor', sessionKey: '43225:s-a' }));
+    assert.match(h.container.textContent ?? '', /Running npm test/);
+    // The verb already carries the state; the badge would repeat it.
+    assert.equal(h.container.querySelector('.code-tool-status'), null);
+    assert.ok(h.container.querySelector('.code-tool-name-running'), 'the row is marked as streaming');
+    await h.render(createElement(CodeTranscriptItem, { item: item({ kind: 'tool_call', status: 'error', tool: { name: 'bash', input: '{"command":"npm test"}' } }), provider: 'cursor', sessionKey: '43225:s-a' }));
+    assert.match(h.container.textContent ?? '', /Failed/, 'failure still gets a word');
 });
 
 test('throttled text flushes empty, whitespace and final replacements immediately across identities', bounded, async t => {
@@ -449,6 +475,30 @@ test('real virtualizer keeps item DOM identity through equal text, updates and p
     await render(many);
     const rows = h.container.querySelectorAll('[data-code-item-id]');
     assert.ok(rows.length > 0 && rows.length < 40, `virtualized DOM must stay bounded, got ${rows.length}`);
+});
+
+test('turn bookkeeping stays out of the transcript while actionable endings remain', bounded, async t => {
+    const h = await surface(t); virtualGeometry(t);
+    const render = (items: CodeItem[]) => h.render(createElement(CodeTranscript, {
+        items, provider: 'codex-app', sessionKey: 'turn-session', workingDir: '/tmp/work', loading: false,
+        hasOlderHistory: false, async loadOlderHistory() {}, permissionCount: 0,
+    }));
+    await render([
+        item({ itemId: 'started', kind: 'turn_started', firstSequence: 1 }),
+        item({ itemId: 'answer', kind: 'assistant_message', firstSequence: 2, text: 'hello' }),
+        item({ itemId: 'done', kind: 'turn_completed', firstSequence: 3 }),
+    ]);
+    assert.equal(h.container.querySelector('[data-code-item-id="started"]'), null);
+    assert.equal(h.container.querySelector('[data-code-item-id="done"]'), null);
+    assert.ok(h.container.querySelector('[data-code-item-id="answer"]'), 'the answer itself still renders');
+    assert.doesNotMatch(h.container.textContent ?? '', /Turn started/);
+    assert.doesNotMatch(h.container.textContent ?? '', /Completed/);
+    // A turn that failed or was stopped is something the reader can act on.
+    await render([
+        item({ itemId: 'answer', kind: 'assistant_message', firstSequence: 1, text: 'hello' }),
+        item({ itemId: 'failed', kind: 'turn_failed', status: 'error', firstSequence: 2, text: 'Runtime closed' }),
+    ]);
+    assert.ok(h.container.querySelector('[data-code-item-id="failed"]'), 'failure is not bookkeeping');
 });
 
 test('CodeCanvas uses the sidebar portal and forwards workspace and explicit file-open callbacks', bounded, async t => {

--- a/tests/unit/code-native-components.test.ts
+++ b/tests/unit/code-native-components.test.ts
@@ -501,6 +501,29 @@ test('turn bookkeeping stays out of the transcript while actionable endings rema
     assert.ok(h.container.querySelector('[data-code-item-id="failed"]'), 'failure is not bookkeeping');
 });
 
+test('a reader can close a failed call and it stays closed', bounded, async t => {
+    const h = await surface(t); virtualGeometry(t);
+    const failed = item({ itemId: 'boom', kind: 'tool_call', status: 'error', firstSequence: 1,
+        tool: { name: 'bash', input: '{"command":"npm test"}', output: 'stack trace body' } });
+    const render = () => h.render(createElement(CodeTranscript, {
+        items: [failed], provider: 'codex-app', sessionKey: 'fail-session', workingDir: '/tmp/work', loading: false,
+        hasOlderHistory: false, async loadOlderHistory() {}, permissionCount: 0,
+    }));
+    await render();
+    const card = h.container.querySelector('details.code-tool-card') as HTMLDetailsElement | null;
+    assert.ok(card?.open, 'a failure opens itself, because the reader has to see why');
+    assert.match(h.container.textContent ?? '', /stack trace body/);
+    // Closing is a choice about this row, and a choice outlives the default.
+    await act(async () => {
+        card!.open = false;
+        card!.dispatchEvent(new dom.window.Event('toggle', { bubbles: false }));
+    });
+    await render();
+    const after = h.container.querySelector('details.code-tool-card') as HTMLDetailsElement | null;
+    assert.equal(after?.open, false, 'the reader closed it; the failure default must not reopen it');
+    assert.doesNotMatch(h.container.textContent ?? '', /stack trace body/);
+});
+
 test('CodeCanvas uses the sidebar portal and forwards workspace and explicit file-open callbacks', bounded, async t => {
     const h = await surface(t); virtualGeometry(t);
     await import('../../public/manager/src/notes/rendering/MarkdownRenderer');

--- a/tests/unit/code-transcript-summary.test.ts
+++ b/tests/unit/code-transcript-summary.test.ts
@@ -34,6 +34,23 @@ test('a tool call reads as an action, not a function signature', () => {
     assert.equal(toolSummary(item({ tool: { name: 'read' } }), CWD), 'Read', 'a missing argument still names the action');
 });
 
+test('a call in flight reads in the present tense, and settling changes only the tense', () => {
+    const running = (name: string, input: string) => toolSummary(item({ status: 'running', tool: { name, input } }), CWD);
+    assert.equal(running('read', JSON.stringify({ path: '/work/repo/src/app.ts' })), 'Reading src/app.ts');
+    assert.equal(running('bash', JSON.stringify({ command: 'npm test' })), 'Running npm test');
+    assert.equal(running('rg', JSON.stringify({ pattern: 'composer' })), 'Searching composer');
+    assert.equal(running('apply_patch', JSON.stringify({ file_path: '/work/repo/a.ts' })), 'Editing a.ts');
+    assert.equal(running('browser_open', JSON.stringify({ url: 'https://example.com' })), 'Opening https://example.com');
+    assert.equal(running('ls', JSON.stringify({ path: '/work/repo/src' })), 'Listing src');
+    assert.equal(toolSummary(item({ kind: 'file_change', status: 'running', tool: { name: 'x', input: '/work/repo/a/b.ts' } }), CWD), 'Editing a/b.ts');
+    // A queued call has not run yet either, so it reads the same way.
+    assert.equal(toolSummary(item({ status: 'pending', tool: { name: 'read', input: '{}' } }), CWD), 'Reading');
+    // Tense is the only thing that moves: an unrecognised tool still keeps its
+    // own name while running, and a settled call keeps the original vocabulary.
+    assert.equal(running('github.create_pr', '{}'), 'github.create_pr');
+    assert.equal(toolSummary(item({ status: 'error', tool: { name: 'bash', input: JSON.stringify({ command: 'x' }) } }), CWD), 'Bash x');
+});
+
 test('summaries stay one short line whatever the argument shape is', () => {
     assert.equal(summariseToolInput('not json at all\nsecond line', CWD), 'not json at all');
     assert.equal(summariseToolInput('{bad json', CWD), '{bad json');


### PR DESCRIPTION
## Problem

A one-line answer in the Code transcript arrived framed by two rows that said nothing about it:

```
Turn started
Codex
하이! 오늘은 뭘 도와줄까?
Completed
```

Tool calls had the opposite problem. Their `Input` and `Output` sections were built into the DOM whether or not anyone opened the card, so a collapsed call still carried its full output, and a call in flight looked the same as a finished one apart from a small status chip.

## What changed

**Turn boundaries stop being rows.** `turn_started` and `turn_completed` remain in the store and on the wire — history replay and the failed-input recovery lookup in `CodeWorkbench` still read them — and only the transcript view drops them. `turn_failed` and `turn_cancelled` keep rendering, because those are states a reader can act on.

**Tool and reasoning detail is built only while its disclosure is open.** The transcript owns that open state rather than the row, because the virtualizer unmounts rows on scroll. Keys are scoped per session so the reserved pending-user id cannot carry one session's disclosure into another, and the set is bounded at 64 the way the scroll anchors already are.

**Expanding a row now reaches the virtualizer.** `estimateSize` hardcoded 44px on the stated assumption that tool rows never expand. Nothing about a toggle changes item count or identity, so no option update fires and the stale measurement would survive until the session switched. `useCodeTranscriptVirtualRows` exposes `resizeItem`, which hands the new size over directly and corrects the scroll offset when the row sits above the viewport.

**Tense replaces the badge.** A call reads `Reading src/app.ts` while it runs and `Read src/app.ts` once it settles, with a shimmer on the summary line while it streams:

| state | before | after |
|---|---|---|
| running | `Read src/app.ts` + `Running` chip | `Reading src/app.ts` (shimmer) |
| settled | `Read src/app.ts` | `Read src/app.ts` |
| failed | `Read src/app.ts` + `Failed` | unchanged |

The settled vocabulary is deliberately unchanged, and an unrecognised tool still keeps its own name — `github.create_pr` is not relabelled into something it did not do.

## Accessibility

The chevron sits at `opacity: 0.35` rather than hidden until hover, so it stays discoverable by touch and gives a keyboard user something to aim at. The shimmer uses transparent text, which has no fallback under a forced palette, so it is disabled under both `prefers-reduced-motion` and `forced-colors`.

## Validation

- `tsc --noEmit` clean on both the root and frontend projects
- 393 Code unit tests pass, 0 fail (`tests/unit/code-*.test.ts`)
- `structure/check-doc-drift.sh` 4/4, `verify-counts.sh` 580/580, `check:private-boundary` OK

New tests cover the collapsed-output contract, the present-tense summary including the MCP-name invariant, and turn filtering with failure still visible. One existing assertion moved to an expanded row, since it verifies output escaping and that output is now only present when shown.
