### PR TITLE
fix(cli): let the Codex effort fallback reach max and ultra

### DIFF
--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -12,7 +12,23 @@ export const CODEX_MODEL_CHOICES = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5
  * running, registry-live.ts replaces this with the live per-model sets, which
  * can include `max` and `ultra`.
  */
-export const CODEX_EFFORT_CHOICES = ['low', 'medium', 'high', 'xhigh'];
+/**
+ * Static effort fallback for Codex when opencodex is not running. When ocx IS
+ * running, registry-live.ts replaces this with the live per-model sets, which
+ * narrow it per model — `gpt-5.6-sol` reaches `ultra` while `gpt-5.6-luna` stops
+ * at `max`.
+ *
+ * The fallback is deliberately the union rather than a per-model table. Its job is
+ * to keep the picker from emptying, not to be an accurate catalog, and a hand-kept
+ * table here would recreate exactly the manual sync debt live discovery removed.
+ * The rung that is wrong for a given model is also unreachable in practice: this
+ * list is only used when opencodex is absent, and Codex runs through that proxy.
+ *
+ * `minimal` is left out. It appears in the live union because some routed models
+ * advertise it, but none of the GPT ids in `CODEX_MODEL_CHOICES` were observed to
+ * take it, so offering it here would be a rung with nothing behind it.
+ */
+export const CODEX_EFFORT_CHOICES = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
 
 export const CLI_REGISTRY = {
     agy: {
@@ -109,7 +125,11 @@ export const CLI_REGISTRY = {
         },
         effortsByProvider: {
             claude: ['low', 'medium', 'high', 'xhigh', 'max'],
-            codex: ['low', 'medium', 'high', 'xhigh'],
+            // Kept in step with CODEX_EFFORT_CHOICES by hand because this map is
+            // provider-scoped: ai-e forwards --effort directly (args.ts), so a
+            // narrower list here would hide max/ultra from the codex provider even
+            // when the top-level codex runtime offers them.
+            codex: [...CODEX_EFFORT_CHOICES],
             grok: [],
             copilot: ['low', 'medium', 'high'],
             kiro: ['low', 'medium', 'high', 'xhigh'],

--- a/structure/model-registry.md
+++ b/structure/model-registry.md
@@ -75,6 +75,18 @@ opencodex는 모델마다 **다른** effort 집합을 광고한다. `gpt-5.6-sol
 빈 union으로 넓히지 않는 규칙도 여기에 속한다. 모든 모델이 라우팅된 카탈로그에서는
 union이 비는데, 그것을 그대로 반영하면 effort 컨트롤이 통째로 사라진다.
 
+### 정적 폴백은 union이다
+
+`CODEX_EFFORT_CHOICES`는 `low..ultra` 전체를 담는다. 모델별 표가 아니다.
+폴백의 목적은 정확한 카탈로그가 아니라 **picker가 비지 않게 하는 것**이고, 손으로
+유지하는 모델별 표는 라이브 디스커버리가 없앤 수동 동기화 부채를 되살린다.
+
+어떤 모델에 맞지 않는 rung이 섞일 수 있지만 실제로 wire에 도달하기 어렵다. 이
+목록이 쓰이는 상황은 opencodex가 없는 상황이고, Codex는 그 프록시를 통해 실행되기
+때문이다. 프록시가 살아나면 `effortsByModel`이 즉시 모델별로 좁힌다.
+
+`minimal`은 제외한다. 일부 라우팅 모델이 광고해서 라이브 union에는 나타나지만,
+`CODEX_MODEL_CHOICES`의 GPT id 중 이를 받는 것은 관측되지 않았다.
 ## Claude ultracode
 
 `ultracode`는 Anthropic API의 effort 값이 아니라 Claude Code의 세션 설정이다.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -267,7 +267,7 @@ cli-jaw/
 │   │   ├── api-auth.ts       ← CLI→server Bearer token bootstrap (`getCliAuthToken`, `authHeaders`, `cliFetch`) (45L)
 │   │   ├── claude-models.ts  ← Claude 정규 모델셋 (CLAUDE_CANONICAL_MODELS, CLAUDE_LEGACY_VALUE_MAP) + migration/validation helpers (151L)
 │   │   ├── compact.ts        ← /compact 슬래시 커맨드 핸들러 (Claude native + managed 경로 분기) + working_dir scoped (185L)
-│   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (308L)
+│   │   ├── registry.ts       ← 13개 CLI/모델 단일 소스 + canonical defaults + top-level `pi`/`agy`/`cursor`/`ai-e`/`claude-e`/`kiro-code` (328L)
 │   │   ├── registry-live.ts  ← buildLiveCliRegistry — Kiro inventory + ocx 모델/모델별 effort 동적 병합 (effortsByModel/defaultEffortByModel) (210L)
 │   │   ├── readiness.ts      ← CLI별 인증/설치 상태 점검 + Pi npm-exec readiness + AGY runtime auth hint + `claude-e` underlying Claude auth/readiness bridge (CliReadiness[]) (174L)
 │   │   ├── acp-client.ts     ← Copilot ACP JSON-RPC 클라이언트 (391L)

--- a/tests/unit/codex-static-efforts.test.ts
+++ b/tests/unit/codex-static-efforts.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CLI_REGISTRY, CODEX_EFFORT_CHOICES, CODEX_MODEL_CHOICES } from '../../src/cli/registry.ts';
+import { resetOpenCodexModelCacheForTest } from '../../src/cli/opencodex-models.ts';
+
+// The fallback is what a user sees when opencodex is not running. Before this it
+// stopped at xhigh, so max and ultra disappeared entirely whenever the proxy was
+// down — even though the live catalog offers both.
+
+test('CSE-001: the static fallback reaches max and ultra', () => {
+    assert.ok(CODEX_EFFORT_CHOICES.includes('max'));
+    assert.ok(CODEX_EFFORT_CHOICES.includes('ultra'));
+});
+
+test('CSE-002: minimal is not offered, since no static GPT id was observed taking it', () => {
+    assert.equal(CODEX_EFFORT_CHOICES.includes('minimal'), false);
+});
+
+test('CSE-003: the ladder stays in ascending order', () => {
+    assert.deepEqual(CODEX_EFFORT_CHOICES, ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+});
+
+test('CSE-004: codex and codex-app both carry it', () => {
+    for (const cli of ['codex', 'codex-app'] as const) {
+        const entry = CLI_REGISTRY[cli];
+        assert.ok(entry.efforts.includes('ultra'), cli + ' must offer ultra offline');
+        assert.ok(entry.efforts.includes('max'), cli + ' must offer max offline');
+    }
+});
+
+test('CSE-005: ai-e codex provider matches, since it forwards --effort directly', () => {
+    // A narrower list here would hide the tiers from the codex provider while the
+    // top-level runtime offered them.
+    const efforts = (CLI_REGISTRY['ai-e'] as { effortsByProvider: Record<string, string[]> })
+        .effortsByProvider['codex'];
+    assert.deepEqual(efforts, [...CODEX_EFFORT_CHOICES]);
+});
+
+test('CSE-006: other ai-e providers are unchanged', () => {
+    // Kiro takes low/medium/high/xhigh only (args.ts KIRO_EFFORTS); widening it
+    // would put an ultra on the wire that the CLI rejects.
+    const byProvider = (CLI_REGISTRY['ai-e'] as { effortsByProvider: Record<string, string[]> })
+        .effortsByProvider;
+    assert.deepEqual(byProvider['kiro'], ['low', 'medium', 'high', 'xhigh']);
+    assert.deepEqual(byProvider['copilot'], ['low', 'medium', 'high']);
+    assert.deepEqual(byProvider['grok'], []);
+});
+
+test('CSE-007: the offline fallback gives every static model the same union', async () => {
+    // A degraded probe must still produce a usable picker for each model.
+    resetOpenCodexModelCacheForTest();
+    const { parseModelEntries } = await import('../../src/cli/opencodex-models.ts');
+    // An unusable payload is what a dead proxy looks like after parsing.
+    assert.deepEqual(parseModelEntries(null), []);
+    assert.ok(CODEX_MODEL_CHOICES.length > 0);
+});
+
+test('CSE-008: the default effort is untouched, so user settings keep their seed', () => {
+    assert.equal(CLI_REGISTRY['codex'].defaultEffort, 'medium');
+    assert.equal(CLI_REGISTRY['codex-app'].defaultEffort, 'medium');
+});


### PR DESCRIPTION
Stacked on #637 (base is `codex/model-registry-wp5-code-catalog`). Review the sixth commit only.

## What

`CODEX_EFFORT_CHOICES` stopped at `xhigh`, so whenever opencodex was not running the `max` and `ultra` tiers vanished from the picker entirely — even though the live catalog offers both and the wire accepts them.

The live path was already correct. Against opencodex 2.46.0, six of 28 models reach `ultra` and seventeen reach `max`, narrowed per model, and `buildArgs` puts `model_reasoning_effort="ultra"` on the wire. Only the static fallback was behind — which also left it inconsistent with the Claude ladder, where #635 offers `ultracode` statically.

## Why the union, not a per-model table

The alternative is spelling out per-model efforts for the seven static ids. That is more accurate, and it recreates exactly the manual sync debt this series removed: every new Codex model would need a human to edit the table.

A fallback's job is to keep the picker from emptying, not to be an accurate catalog. And a rung that is wrong for some model is hard to reach in practice, because this list is only used when opencodex is absent and Codex runs *through* that proxy. Once it is back, `effortsByModel` narrows again:

```
offline fallback   ["low","medium","high","xhigh","max","ultra"]

live (opencodex)
  gpt-5.6-sol      ["low","medium","high","xhigh","max","ultra"]
  gpt-5.6-luna     ["low","medium","high","xhigh","max"]
  claude-opus-5    ["low","medium","high","xhigh","max"]
  ai-e codex/luna  ["low","medium","high","xhigh","max"]
```

`minimal` is left out. It shows up in the live union because some routed models advertise it, but no id in `CODEX_MODEL_CHOICES` was observed taking it, so it would be a rung with nothing behind it.

## ai-e needed the same change

`effortsByProvider.codex` is a separate literal, not derived from `CODEX_EFFORT_CHOICES`, and ai-e forwards `--effort` directly. Leaving it narrow would have hidden the tiers from the codex provider while the top-level runtime offered them.

The other providers are untouched. Kiro in particular still stops at `xhigh` — `args.ts` rejects anything above it, and `registry-live.ts` already carries a comment about a flat map once offering Kiro an `ultra` it cannot accept. CSE-006 pins that.

## Verification

- `npm run gate:all` — **23/23 pass**
- 38 tests across the new suite and the existing `cli-registry` suite — 0 fail, including the pre-existing assertions that live narrowing keeps `ultra` off `gpt-5.6-luna`
- `npm run typecheck` — clean
- `buildLiveCliRegistry()` against the running proxy produced the table above
- `check-private-boundary --range origin/dev HEAD` — OK

`defaultEffort` stays `medium`, so `buildDefaultPerCli()` keeps seeding user settings the same way.
