### PR TITLE
feat(code): move transient notices into a toast over the transcript

### DIFF
--- a/public/manager/src/code/CodeToastHost.tsx
+++ b/public/manager/src/code/CodeToastHost.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { codeToastAutoDismisses, codeToastIsAssertive, type CodeToast } from './code-toasts';
+
+function ToastCard({ toast, onDismiss }: { toast: CodeToast; onDismiss(id: string): void }) {
+    useEffect(() => {
+        if (!codeToastAutoDismisses(toast)) return;
+        const timer = setTimeout(() => onDismiss(toast.id), toast.durationMs);
+        return () => clearTimeout(timer);
+        // The revision restarts the timer when the same notice is pushed again.
+    }, [toast.id, toast.revision, toast.durationMs, onDismiss]);
+    return <div className={`code-toast code-toast-${toast.variant}`}>
+        <span className="code-toast-message">{toast.message}</span>
+        <button type="button" className="code-toast-dismiss" aria-label={`Dismiss: ${toast.message}`}
+            onClick={() => onDismiss(toast.id)}>×</button>
+    </div>;
+}
+
+/**
+ * Notices float over the top of the transcript rather than pushing the composer
+ * down, so reading one never moves the thing the reader is typing into.
+ *
+ * Two regions, not one: an assertive live region interrupts, and mixing an
+ * alert into a polite region is unreliable because the container's politeness
+ * is what applies to an insertion. Errors go in the assertive one.
+ */
+export function CodeToastHost({ toasts, onDismiss }: { toasts: readonly CodeToast[]; onDismiss(id: string): void }) {
+    const polite = toasts.filter(toast => !codeToastIsAssertive(toast));
+    const assertive = toasts.filter(codeToastIsAssertive);
+    if (!toasts.length) return null;
+    return <div className="code-toast-host">
+        <div className="code-toast-region" role="status" aria-live="polite">
+            {polite.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
+        </div>
+        <div className="code-toast-region" role="alert" aria-live="assertive">
+            {assertive.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
+        </div>
+    </div>;
+}
+

--- a/public/manager/src/code/CodeToastHost.tsx
+++ b/public/manager/src/code/CodeToastHost.tsx
@@ -26,7 +26,11 @@ function ToastCard({ toast, onDismiss }: { toast: CodeToast; onDismiss(id: strin
 export function CodeToastHost({ toasts, onDismiss }: { toasts: readonly CodeToast[]; onDismiss(id: string): void }) {
     const polite = toasts.filter(toast => !codeToastIsAssertive(toast));
     const assertive = toasts.filter(codeToastIsAssertive);
-    if (!toasts.length) return null;
+    // The regions are always mounted, even empty. A live region that arrives in
+    // the DOM together with its first content is not announced -- assistive tech
+    // has to already be observing the region when the insertion happens, which
+    // is also why they are not hidden while empty. An empty host renders nothing
+    // visible and does not take pointer events.
     return <div className="code-toast-host">
         <div className="code-toast-region" role="status" aria-live="polite">
             {polite.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
@@ -36,4 +40,3 @@ export function CodeToastHost({ toasts, onDismiss }: { toasts: readonly CodeToas
         </div>
     </div>;
 }
-

--- a/public/manager/src/code/CodeToastHost.tsx
+++ b/public/manager/src/code/CodeToastHost.tsx
@@ -1,16 +1,27 @@
-import { useEffect } from 'react';
-import { codeToastAutoDismisses, codeToastIsAssertive, type CodeToast } from './code-toasts';
+import { useEffect, useRef, useState } from 'react';
+import { codeToastAutoDismisses, type CodeToast } from './code-toasts';
 
 function ToastCard({ toast, onDismiss }: { toast: CodeToast; onDismiss(id: string): void }) {
+    const [held, setHeld] = useState(false);
+    const card = useRef<HTMLDivElement>(null);
     useEffect(() => {
-        if (!codeToastAutoDismisses(toast)) return;
+        // Held while the reader is pointing at it or has tabbed into it: a
+        // notice that expires mid-read is worse than one that lingers, and
+        // unmounting a card that owns focus drops the caret to the document
+        // body and loses the reader's place in the composer.
+        if (held || !codeToastAutoDismisses(toast)) return;
         const timer = setTimeout(() => onDismiss(toast.id), toast.durationMs);
         return () => clearTimeout(timer);
         // The revision restarts the timer when the same notice is pushed again.
-    }, [toast.id, toast.revision, toast.durationMs, onDismiss]);
-    return <div className={`code-toast code-toast-${toast.variant}`}>
+    }, [toast.id, toast.revision, toast.durationMs, onDismiss, held]);
+    return <div ref={card} className={`code-toast code-toast-${toast.variant}`}
+        onPointerEnter={() => setHeld(true)} onPointerLeave={() => setHeld(false)}
+        onFocusCapture={() => setHeld(true)}
+        onBlurCapture={event => { if (!card.current?.contains(event.relatedTarget as Node | null)) setHeld(false); }}>
         <span className="code-toast-message">{toast.message}</span>
-        <button type="button" className="code-toast-dismiss" aria-label={`Dismiss: ${toast.message}`}
+        {/* A short static name: the button sits inside the live region, so a
+            label repeating the message would announce the whole notice twice. */}
+        <button type="button" className="code-toast-dismiss" aria-label="Dismiss notice"
             onClick={() => onDismiss(toast.id)}>×</button>
     </div>;
 }
@@ -24,19 +35,15 @@ function ToastCard({ toast, onDismiss }: { toast: CodeToast; onDismiss(id: strin
  * is what applies to an insertion. Errors go in the assertive one.
  */
 export function CodeToastHost({ toasts, onDismiss }: { toasts: readonly CodeToast[]; onDismiss(id: string): void }) {
-    const polite = toasts.filter(toast => !codeToastIsAssertive(toast));
-    const assertive = toasts.filter(codeToastIsAssertive);
-    // The regions are always mounted, even empty. A live region that arrives in
+    // The region is always mounted, even empty. A live region that arrives in
     // the DOM together with its first content is not announced -- assistive tech
-    // has to already be observing the region when the insertion happens, which
-    // is also why they are not hidden while empty. An empty host renders nothing
-    // visible and does not take pointer events.
+    // has to already be observing it when the insertion happens, which is also
+    // why it is not hidden while empty. One region, because every notice this
+    // surface raises is polite; anything that must interrupt stays inline where
+    // it can also stay on screen.
     return <div className="code-toast-host">
-        <div className="code-toast-region" role="status" aria-live="polite">
-            {polite.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
-        </div>
-        <div className="code-toast-region" role="alert" aria-live="assertive">
-            {assertive.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
+        <div className="code-toast-region" role="status">
+            {toasts.map(toast => <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />)}
         </div>
     </div>;
 }

--- a/public/manager/src/code/CodeWorkbench.tsx
+++ b/public/manager/src/code/CodeWorkbench.tsx
@@ -5,7 +5,7 @@ import { ComposerFooter } from './ComposerFooter';
 import { CodePermissionQueue } from './CodePermissionQueue';
 import { CodeTranscript } from './CodeTranscript';
 import { CodeToastHost } from './CodeToastHost';
-import { CODE_TOAST_DEFAULT_MS, dismissCodeToast, pushCodeToast, type CodeToast } from './code-toasts';
+import { applyCodeNotice, dismissCodeToast, type CodeNotice, type CodeToast } from './code-toasts';
 import { CodeWorkspaceHeader } from './CodeWorkspaceHeader';
 import { codeCanResume } from './code-types';
 
@@ -16,16 +16,12 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
     const [retrying, setRetrying] = useState<string | null>(null);
     const retryGuard = useRef(new Set<string>());
     const [toasts, setToasts] = useState<readonly CodeToast[]>([]);
-    // A notice is about the session that raised it. Carrying a permission
-    // warning into another session would state something about that session
-    // which may not be true, so the stack is dropped when the session changes.
-    const toastSession = useRef(sessionKey);
-    if (toastSession.current !== sessionKey) {
-        toastSession.current = sessionKey;
-        if (toasts.length) setToasts([]);
-    }
-    const notify = useCallback((notice: { id: string; message: string; variant: 'info' | 'warning' | 'error' }) => {
-        setToasts(current => pushCodeToast(current, { ...notice, durationMs: CODE_TOAST_DEFAULT_MS }));
+    // Notices are not cleared on a session change. The one notice that exists
+    // is derived from the current policy and re-raised by the footer on every
+    // mount, so wiping the stack here would delete it at the moment a draft
+    // becomes a running session -- exactly when it matters most.
+    const notify = useCallback((notice: CodeNotice) => {
+        setToasts(current => applyCodeNotice(current, notice));
     }, []);
     const dismiss = useCallback((id: string) => setToasts(current => dismissCodeToast(current, id)), []);
     const archived = c.session?.archivedAt != null;
@@ -55,7 +51,6 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
     }
     return <div className="code-canvas-main">
         <CodeWorkspaceHeader key={sessionKey} controller={c} />
-        <CodeToastHost toasts={toasts} onDismiss={dismiss} />
         {(c.transport !== 'connected' || (c.selectedId !== null && !c.synced)) && <section className={`code-transport-status is-${c.transport}`} role="status">
             {c.transport === 'reconnecting' ? 'Live updates reconnecting. History may be out of date.'
                 : c.transport === 'disconnected' ? 'Live updates disconnected. History may be out of date.' : 'Updating conversation…'}
@@ -85,6 +80,9 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
             {canResume ? <button type="button" onClick={() => perform(c.resume)}>Resume session</button>
                 : <><span>{c.session.resume.reason ?? 'Resume is not currently available.'}</span><button type="button" onClick={c.newSession}>New session</button></>}
         </section>}
+        {/* Directly above the transcript, so a notice sits over the conversation
+            rather than over the workspace header and its picker. */}
+        <CodeToastHost toasts={toasts} onDismiss={dismiss} />
         <CodeTranscript items={c.items} provider={c.session?.provider ?? c.selection.provider} sessionKey={sessionKey}
             workingDir={c.session?.cwd ?? c.selection.cwd} loading={c.loading} hasOlderHistory={c.hasOlderHistory}
             loadOlderHistory={c.loadOlderHistory} permissionCount={c.permissions.length} onOpenLocalFile={onOpenLocalFile} />

--- a/public/manager/src/code/CodeWorkbench.tsx
+++ b/public/manager/src/code/CodeWorkbench.tsx
@@ -1,9 +1,11 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { CodeControllerModel } from './code-controller-types';
 import { CodeComposer } from './CodeComposer';
 import { ComposerFooter } from './ComposerFooter';
 import { CodePermissionQueue } from './CodePermissionQueue';
 import { CodeTranscript } from './CodeTranscript';
+import { CodeToastHost } from './CodeToastHost';
+import { CODE_TOAST_DEFAULT_MS, dismissCodeToast, pushCodeToast, type CodeToast } from './code-toasts';
 import { CodeWorkspaceHeader } from './CodeWorkspaceHeader';
 import { codeCanResume } from './code-types';
 
@@ -13,6 +15,11 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
     const [actionError, setActionError] = useState<{ key: string; message: string } | null>(null);
     const [retrying, setRetrying] = useState<string | null>(null);
     const retryGuard = useRef(new Set<string>());
+    const [toasts, setToasts] = useState<readonly CodeToast[]>([]);
+    const notify = useCallback((notice: { id: string; message: string; variant: 'info' | 'warning' | 'error' }) => {
+        setToasts(current => pushCodeToast(current, { ...notice, durationMs: CODE_TOAST_DEFAULT_MS }));
+    }, []);
+    const dismiss = useCallback((id: string) => setToasts(current => dismissCodeToast(current, id)), []);
     const archived = c.session?.archivedAt != null;
     const stopping = c.session?.status === 'stopping' || c.operation.kind === 'stopping';
     const busy = c.busy || stopping || c.session?.status === 'starting' || c.session?.status === 'streaming';
@@ -40,6 +47,7 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
     }
     return <div className="code-canvas-main">
         <CodeWorkspaceHeader key={sessionKey} controller={c} />
+        <CodeToastHost toasts={toasts} onDismiss={dismiss} />
         {(c.transport !== 'connected' || (c.selectedId !== null && !c.synced)) && <section className={`code-transport-status is-${c.transport}`} role="status">
             {c.transport === 'reconnecting' ? 'Live updates reconnecting. History may be out of date.'
                 : c.transport === 'disconnected' ? 'Live updates disconnected. History may be out of date.' : 'Updating conversation…'}
@@ -82,7 +90,7 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
             <div className="code-composer-surface" aria-label="Code composer controls">
                 <CodeComposer key={`composer:${sessionKey}`} inputText={c.input} canSend={canSend} busy={busy} canStop={canStop} stopping={stopping}
                     pending={c.pending} readOnly={archived} onInputChange={c.setInput} onSubmit={c.send} onStop={c.stop} />
-                <ComposerFooter key={`footer:${sessionKey}`} controller={c} />
+                <ComposerFooter key={`footer:${sessionKey}`} controller={c} onNotice={notify} />
             </div>
         </div>
     </div>;

--- a/public/manager/src/code/CodeWorkbench.tsx
+++ b/public/manager/src/code/CodeWorkbench.tsx
@@ -16,6 +16,14 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
     const [retrying, setRetrying] = useState<string | null>(null);
     const retryGuard = useRef(new Set<string>());
     const [toasts, setToasts] = useState<readonly CodeToast[]>([]);
+    // A notice is about the session that raised it. Carrying a permission
+    // warning into another session would state something about that session
+    // which may not be true, so the stack is dropped when the session changes.
+    const toastSession = useRef(sessionKey);
+    if (toastSession.current !== sessionKey) {
+        toastSession.current = sessionKey;
+        if (toasts.length) setToasts([]);
+    }
     const notify = useCallback((notice: { id: string; message: string; variant: 'info' | 'warning' | 'error' }) => {
         setToasts(current => pushCodeToast(current, { ...notice, durationMs: CODE_TOAST_DEFAULT_MS }));
     }, []);

--- a/public/manager/src/code/ComposerFooter.tsx
+++ b/public/manager/src/code/ComposerFooter.tsx
@@ -137,9 +137,6 @@ export function ComposerFooter({ controller: c, onNotice }: {
         noticeRef.current?.({ id: 'code:permission-mode', variant: 'warning',
             message: 'Auto (YOLO): actions may run without approval.' });
     }, [selection.permissionMode]);
-    useEffect(() => {
-        if (error) noticeRef.current?.({ id: 'code:footer-error', variant: 'error', message: error });
-    }, [error]);
     async function change(patch: Partial<CodeCreateSessionRequest>) {
         if (disabled || guard.current) return;
         guard.current = true; setSaving(true); setError(null);
@@ -197,5 +194,9 @@ export function ComposerFooter({ controller: c, onNotice }: {
             <button type="button" className="code-inline-action" onClick={() => { void c.refresh().catch(err => setError(err instanceof Error ? err.message : String(err))); }}>Refresh availability</button>
         </div>}
         {(saving || c.operation.kind === 'patching') && <span role="status">Saving settings…</span>}
+        {/* Stays inline. A failed setting change is something the reader has to
+            act on -- the control reverted and this is the only account of why --
+            and it must not leave on a timer before they have read it. */}
+        {error && <div className="code-action-error" role="alert">{error}</div>}
     </>;
 }

--- a/public/manager/src/code/ComposerFooter.tsx
+++ b/public/manager/src/code/ComposerFooter.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import type { CodeControllerModel } from './code-controller-types';
 import type { CodeCreateSessionRequest } from '../../../../src/code-mode/wire';
 import { CODE_POLICY_DETAILS, CODE_POLICY_LABELS, CODE_RUNTIME_LABELS } from './code-types';
+import type { CodeNotice } from './code-toasts';
 import { CheckGlyph, ProviderGlyph } from './ProviderGlyph';
 
 type MenuOption<T extends string> = {
@@ -114,7 +115,7 @@ export function CodeFooterMenu<T extends string>({ label, value, options, disabl
 
 export function ComposerFooter({ controller: c, onNotice }: {
     controller: CodeControllerModel;
-    onNotice?: ((notice: { id: string; message: string; variant: 'info' | 'warning' | 'error' }) => void) | undefined;
+    onNotice?: ((notice: CodeNotice) => void) | undefined;
 }) {
     const selection = c.selection;
     const provider = c.catalog?.providers.find(entry => entry.id === selection.provider);
@@ -129,13 +130,21 @@ export function ComposerFooter({ controller: c, onNotice }: {
     // stops being read after the first time; the moment it is switched on is
     // the moment worth interrupting for. What the policy currently is stays
     // legible on the Permission control itself.
-    const previousMode = useRef(selection.permissionMode);
     useEffect(() => {
-        const previous = previousMode.current;
-        previousMode.current = selection.permissionMode;
-        if (previous === selection.permissionMode || selection.permissionMode !== 'auto') return;
+        if (selection.permissionMode !== 'auto') {
+            // Leaving auto retires the warning immediately. A notice that
+            // outlived the policy would be stating something false about what
+            // the session is allowed to do.
+            noticeRef.current?.({ id: 'code:permission-mode', clear: true });
+            return;
+        }
+        // Derived from the current policy, not from a transition. The footer
+        // remounts when the draft becomes a real session, and a transition
+        // detector reads that remount as "no change" -- which deleted the
+        // warning at the exact moment the session started acting on it.
         noticeRef.current?.({ id: 'code:permission-mode', variant: 'warning',
-            message: 'Auto (YOLO): actions may run without approval.' });
+            message: 'Auto (YOLO): actions may run without approval.',
+            durationMs: Number.POSITIVE_INFINITY });
     }, [selection.permissionMode]);
     async function change(patch: Partial<CodeCreateSessionRequest>) {
         if (disabled || guard.current) return;

--- a/public/manager/src/code/ComposerFooter.tsx
+++ b/public/manager/src/code/ComposerFooter.tsx
@@ -112,7 +112,10 @@ export function CodeFooterMenu<T extends string>({ label, value, options, disabl
     </div>;
 }
 
-export function ComposerFooter({ controller: c }: { controller: CodeControllerModel }) {
+export function ComposerFooter({ controller: c, onNotice }: {
+    controller: CodeControllerModel;
+    onNotice?: ((notice: { id: string; message: string; variant: 'info' | 'warning' | 'error' }) => void) | undefined;
+}) {
     const selection = c.selection;
     const provider = c.catalog?.providers.find(entry => entry.id === selection.provider);
     const capabilities = c.session?.capabilities ?? provider?.capabilities;
@@ -121,6 +124,22 @@ export function ComposerFooter({ controller: c }: { controller: CodeControllerMo
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const guard = useRef(false);
+    const noticeRef = useRef(onNotice); noticeRef.current = onNotice;
+    // Announce the change, not the state. "Auto (YOLO)" as a permanent line
+    // stops being read after the first time; the moment it is switched on is
+    // the moment worth interrupting for. What the policy currently is stays
+    // legible on the Permission control itself.
+    const previousMode = useRef(selection.permissionMode);
+    useEffect(() => {
+        const previous = previousMode.current;
+        previousMode.current = selection.permissionMode;
+        if (previous === selection.permissionMode || selection.permissionMode !== 'auto') return;
+        noticeRef.current?.({ id: 'code:permission-mode', variant: 'warning',
+            message: 'Auto (YOLO): actions may run without approval.' });
+    }, [selection.permissionMode]);
+    useEffect(() => {
+        if (error) noticeRef.current?.({ id: 'code:footer-error', variant: 'error', message: error });
+    }, [error]);
     async function change(patch: Partial<CodeCreateSessionRequest>) {
         if (disabled || guard.current) return;
         guard.current = true; setSaving(true); setError(null);
@@ -177,8 +196,6 @@ export function ComposerFooter({ controller: c }: { controller: CodeControllerMo
         {!provider?.available && <div className="code-selection-notice">{provider?.reason ?? 'Runtime availability has not been confirmed.'}
             <button type="button" className="code-inline-action" onClick={() => { void c.refresh().catch(err => setError(err instanceof Error ? err.message : String(err))); }}>Refresh availability</button>
         </div>}
-        {selection.permissionMode === 'auto' && <p className="code-policy-note">Auto (YOLO): actions may run without approval.</p>}
         {(saving || c.operation.kind === 'patching') && <span role="status">Saving settings…</span>}
-        {error && <div className="code-action-error" role="alert">{error}</div>}
     </>;
 }

--- a/public/manager/src/code/code-composer.css
+++ b/public/manager/src/code/code-composer.css
@@ -260,7 +260,7 @@
 .code-footer-floating { position: fixed; z-index: 1000; box-sizing: border-box; }
 .code-footer-floating .code-footer-option-text small { white-space: normal; overflow-wrap: anywhere; }
 
-.code-policy-note, .code-selection-notice { margin: 0; color: var(--text-secondary); font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
+.code-selection-notice { margin: 0; color: var(--text-secondary); font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
 .code-composer-status { grid-column: 1 / -1; color: var(--text-dim); font-size: 11px; }
 .code-input-recovery { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; max-width: 980px; margin: 0 auto 6px; color: var(--text-secondary); font-size: 11px; }
 .code-action-error { color: var(--status-error); font-size: 12px; overflow-wrap: anywhere; grid-column: 1 / -1; }

--- a/public/manager/src/code/code-toasts.ts
+++ b/public/manager/src/code/code-toasts.ts
@@ -1,0 +1,55 @@
+/**
+ * A transient notice that appears over the transcript and leaves on its own.
+ *
+ * The composer footer used to carry these inline, which pushed the input down
+ * and left a policy line sitting there long after it had been read. What
+ * belongs here is news -- a setting saved, a policy changed, an action failed.
+ * What does not belong here is anything the reader still has to act on: an
+ * unconfirmed send or an archived session has to stay on screen until it is
+ * resolved, and a notice that dismisses itself would strand them.
+ */
+export type CodeToastVariant = 'info' | 'warning' | 'error';
+
+export type CodeToast = {
+    /** Stable per source, so a repeated notice replaces rather than stacks. */
+    id: string;
+    message: string;
+    variant: CodeToastVariant;
+    /** Non-finite or <= 0 stays until dismissed. */
+    durationMs: number;
+    /** Distinguishes two pushes of the same id, so the timer restarts. */
+    revision: number;
+};
+
+export const CODE_TOAST_DEFAULT_MS = 4000;
+/** Three is enough to see a burst; more would cover the transcript. */
+export const CODE_TOAST_MAX = 3;
+
+export function codeToastAutoDismisses(toast: CodeToast): boolean {
+    return Number.isFinite(toast.durationMs) && toast.durationMs > 0;
+}
+
+/**
+ * Newest last, one entry per id. Re-pushing an id refreshes its content and
+ * restarts its timer through a bumped revision, and moves it to the end so a
+ * notice the reader just triggered is never the one dropped by the cap.
+ */
+export function pushCodeToast(
+    list: readonly CodeToast[],
+    next: Omit<CodeToast, 'revision'>,
+): CodeToast[] {
+    const previous = list.find(toast => toast.id === next.id);
+    const kept = list.filter(toast => toast.id !== next.id);
+    kept.push({ ...next, revision: (previous?.revision ?? 0) + 1 });
+    return kept.slice(Math.max(0, kept.length - CODE_TOAST_MAX));
+}
+
+export function dismissCodeToast(list: readonly CodeToast[], id: string): CodeToast[] {
+    const next = list.filter(toast => toast.id !== id);
+    return next.length === list.length ? list as CodeToast[] : next;
+}
+
+/** An error is announced assertively; everything else waits its turn. */
+export function codeToastIsAssertive(toast: CodeToast): boolean {
+    return toast.variant === 'error';
+}

--- a/public/manager/src/code/code-toasts.ts
+++ b/public/manager/src/code/code-toasts.ts
@@ -8,7 +8,13 @@
  * unconfirmed send or an archived session has to stay on screen until it is
  * resolved, and a notice that dismisses itself would strand them.
  */
-export type CodeToastVariant = 'info' | 'warning' | 'error';
+/**
+ * Only `warning` exists today, because the one notice this surface raises is a
+ * permission warning; an error the reader must act on stays inline instead. The
+ * union is kept because the shape of a second variant is already decided, but
+ * nothing in the app produces one, so there is no assertive region to route to.
+ */
+export type CodeToastVariant = 'warning';
 
 export type CodeToast = {
     /** Stable per source, so a repeated notice replaces rather than stacks. */
@@ -49,7 +55,19 @@ export function dismissCodeToast(list: readonly CodeToast[], id: string): CodeTo
     return next.length === list.length ? list as CodeToast[] : next;
 }
 
-/** An error is announced assertively; everything else waits its turn. */
-export function codeToastIsAssertive(toast: CodeToast): boolean {
-    return toast.variant === 'error';
+/**
+ * What a producer says: either raise this notice, or retire it.
+ *
+ * Retiring matters for anything derived from current state. A warning about a
+ * permission policy has to leave when the policy does, or it goes on asserting
+ * something about the session that is no longer true.
+ */
+export type CodeNotice =
+    | { id: string; message: string; variant: CodeToastVariant; durationMs?: number }
+    | { id: string; clear: true };
+
+export function applyCodeNotice(list: readonly CodeToast[], notice: CodeNotice): CodeToast[] {
+    if ('clear' in notice) return dismissCodeToast(list, notice.id);
+    return pushCodeToast(list, { id: notice.id, message: notice.message, variant: notice.variant,
+        durationMs: notice.durationMs ?? CODE_TOAST_DEFAULT_MS });
 }

--- a/public/manager/src/code/code.css
+++ b/public/manager/src/code/code.css
@@ -298,6 +298,65 @@
     min-height: 0;
     height: 100%;
     overflow: hidden;
+    /* Anchors the toast stack to this pane rather than the window, so a notice
+       sits over the transcript it belongs to and not over another panel. */
+    position: relative;
+}
+
+/* Notices float above the transcript instead of pushing the composer down. The
+   host itself ignores pointer events so it never blocks the text underneath;
+   the cards take them back. */
+.code-toast-host {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    max-width: min(560px, calc(100% - 32px));
+    pointer-events: none;
+}
+.code-toast-region { display: flex; flex-direction: column; gap: 8px; align-items: center; }
+.code-toast {
+    pointer-events: auto;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-panel);
+    box-shadow: 0 6px 20px rgb(0 0 0 / 28%);
+    font-size: 12px;
+    line-height: 1.35;
+    color: var(--text-primary);
+    animation: code-toast-enter 0.2s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.code-toast-message { min-width: 0; overflow-wrap: anywhere; }
+.code-toast-dismiss {
+    flex-shrink: 0;
+    min-width: 20px;
+    min-height: 20px;
+    padding: 0;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-dim);
+    cursor: pointer;
+    line-height: 1;
+}
+.code-toast-dismiss:hover { background: var(--bg-raised); color: var(--text-primary); }
+.code-toast-warning { border-color: color-mix(in srgb, var(--status-warn) 48%, var(--border-subtle)); }
+.code-toast-error { border-color: color-mix(in srgb, var(--status-error) 52%, var(--border-subtle)); }
+@keyframes code-toast-enter {
+    from { opacity: 0; transform: translateY(-6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .code-toast { animation: none; }
 }
 
 /* Session header (title + context meter + plan) */

--- a/public/manager/src/code/code.css
+++ b/public/manager/src/code/code.css
@@ -298,28 +298,37 @@
     min-height: 0;
     height: 100%;
     overflow: hidden;
-    /* Anchors the toast stack to this pane rather than the window, so a notice
-       sits over the transcript it belongs to and not over another panel. */
+    /* Contains the toast stack: a stacking context, not just a positioning
+       origin, so the notice cannot paint over the mobile drawer or its scrim,
+       which sit at z-index 21 and 20 on the window. */
     position: relative;
+    z-index: 0;
 }
 
-/* Notices float above the transcript instead of pushing the composer down. The
-   host itself ignores pointer events so it never blocks the text underneath;
-   the cards take them back. */
+/* Notices sit over the transcript, not over the workspace header. The host is a
+   zero-height flow element placed directly above the transcript, so "top" means
+   the top of the conversation rather than the top of the pane; absolute
+   positioning from the pane would land the card inside the header band and
+   swallow clicks meant for the workspace picker. The host ignores pointer
+   events so it never blocks the text underneath; the cards take them back. */
 .code-toast-host {
-    position: absolute;
-    top: 12px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 30;
+    position: relative;
+    z-index: 3;
+    height: 0;
+    overflow: visible;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
+    margin: 0 auto;
     max-width: min(560px, calc(100% - 32px));
     pointer-events: none;
 }
 .code-toast-region { display: flex; flex-direction: column; gap: 8px; align-items: center; }
+/* An empty live region has to stay in the DOM to be observed when content
+   arrives, but it should not reserve layout while it holds nothing. */
+.code-toast-region:empty { display: none; }
+.code-toast-region:not(:empty) { margin-top: 12px; }
 .code-toast {
     pointer-events: auto;
     display: flex;

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -629,18 +629,25 @@ item key: a measured size always wins over an estimate, so a row measured while
 collapsed would keep that height once expanded, and re-keying hands it back to
 the estimate until its real height is observed.
 
-Transient notices float over the top of the transcript rather than sitting under
-the composer, so reading one never moves the input. They are keyed per source, so
-repeating a notice replaces it and restarts its timer instead of stacking, and the
-stack is capped at three with the oldest dropped; re-raising an existing notice
-moves it newest so the cap cannot evict what the reader just triggered. A notice
-with no finite duration waits for an explicit dismiss. Errors go in an assertive
-live region and everything else in a polite one, because a container's politeness
-is what applies to an insertion. The permission notice announces the switch to
-Auto (YOLO), not the standing state, which the Permission control already shows.
-Anything the reader has to act on stays on screen instead: transport status, the
-recovery strips for unconfirmed creation and unconfirmed send, archived sessions
-and the approval queue would all be lost if they dismissed themselves.
+Notices sit over the transcript, directly above it rather than absolutely
+positioned from the pane, which would place them inside the workspace header and
+swallow clicks meant for its picker. They are keyed per source, so repeating one
+replaces it and restarts its timer instead of stacking; the stack is capped at
+three, and re-raising a notice moves it newest so the cap cannot evict what was
+just triggered. A notice with no finite duration waits for an explicit dismiss,
+and the timer is held while the pointer is over the card or focus is inside it,
+because unmounting a card that owns focus drops it to the document body.
+
+The permission warning is derived from the current policy rather than from a
+transition, and it does not expire: it is re-raised on every mount, so it
+survives a draft becoming a real session, and it is retired when the policy
+leaves Auto rather than outliving what it describes. One polite live region,
+mounted before there is anything to say, since a region that arrives together
+with its first message is not announced. Anything the reader must act on stays
+inline instead, including footer errors, transport status, the recovery strips
+for unconfirmed creation and unconfirmed send, archived sessions and the
+approval queue; each carries a recovery path a self-dismissing notice would take
+with it.
 
 `useCodeController` owns requests and selection fencing. A single Code SSE
 subscription reconciles a full snapshot at watermark H and contiguous events

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -629,6 +629,19 @@ item key: a measured size always wins over an estimate, so a row measured while
 collapsed would keep that height once expanded, and re-keying hands it back to
 the estimate until its real height is observed.
 
+Transient notices float over the top of the transcript rather than sitting under
+the composer, so reading one never moves the input. They are keyed per source, so
+repeating a notice replaces it and restarts its timer instead of stacking, and the
+stack is capped at three with the oldest dropped; re-raising an existing notice
+moves it newest so the cap cannot evict what the reader just triggered. A notice
+with no finite duration waits for an explicit dismiss. Errors go in an assertive
+live region and everything else in a polite one, because a container's politeness
+is what applies to an insertion. The permission notice announces the switch to
+Auto (YOLO), not the standing state, which the Permission control already shows.
+Anything the reader has to act on stays on screen instead: transport status, the
+recovery strips for unconfirmed creation and unconfirmed send, archived sessions
+and the approval queue would all be lost if they dismissed themselves.
+
 `useCodeController` owns requests and selection fencing. A single Code SSE
 subscription reconciles a full snapshot at watermark H and contiguous events
 after H. Opening transport does not mean synchronization has completed. Compact

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -533,7 +533,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 602 files source/assets, ~102542L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 604 files source/assets, ~102746L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── settings/ ← standalone instance settings entry
 │   │   └── index.html ← Classic settings iframe HTML (13L)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)

--- a/tests/unit/code-native-components.test.ts
+++ b/tests/unit/code-native-components.test.ts
@@ -607,3 +607,35 @@ test('unknown creation recovery warns, preserves the draft and choices, and requ
     assert.equal(sends, 0, 'recovery and rerender must not send automatically');
     await click(button(h.container, 'Send prompt')); assert.equal(sends, 1);
 });
+
+test('switching to Auto (YOLO) announces the change over the transcript, not under the composer', bounded, async t => {
+    const h = await surface(t); virtualGeometry(t);
+    const c = model();
+    await h.render(createElement(CodeWorkbench, { controller: c, endpointKey: '43225' }));
+    // The policy is legible on its own control; a permanent line under the
+    // composer is not what tells the reader it just changed.
+    assert.equal(h.container.querySelector('.code-toast-host'), null);
+    assert.doesNotMatch(h.container.textContent ?? '', /actions may run without approval/);
+    const auto = model({ selection: { ...c.selection, permissionMode: 'auto' } });
+    await h.render(createElement(CodeWorkbench, { controller: auto, endpointKey: '43225' }));
+    const toast = h.container.querySelector('.code-toast');
+    assert.ok(toast, 'the switch is announced');
+    assert.match(toast?.textContent ?? '', /Auto \(YOLO\)/);
+    // Warning, not alert: it is news, and it must not interrupt a screen reader
+    // mid-sentence the way an error should.
+    assert.ok(h.container.querySelector('.code-toast-warning'));
+    await click(h.container.querySelector('.code-toast-dismiss') as HTMLButtonElement);
+    assert.equal(h.container.querySelector('.code-toast'), null, 'a notice can be dismissed from the keyboard');
+});
+
+test('states the reader must act on stay on screen instead of becoming a toast', bounded, async t => {
+    const h = await surface(t); virtualGeometry(t);
+    // An unconfirmed send has a recovery path attached to it. A notice that
+    // dismisses itself after a few seconds would take that path with it.
+    await h.render(createElement(CodeWorkbench, { controller: model({ operation: { kind: 'unknown-send', error: null }, retryText: 'original request', canRetrySameSend: true }), endpointKey: '43225' }));
+    assert.match(h.container.textContent ?? '', /Send outcome not confirmed/);
+    assert.ok(h.container.querySelector('[aria-label="Original prompt"]'));
+    await h.render(createElement(CodeWorkbench, { controller: model({ transport: 'disconnected' }), endpointKey: '43225' }));
+    assert.match(h.container.textContent ?? '', /Live updates disconnected/);
+});
+

--- a/tests/unit/code-native-components.test.ts
+++ b/tests/unit/code-native-components.test.ts
@@ -624,9 +624,18 @@ test('switching to Auto (YOLO) announces the change over the transcript, not und
     const toast = h.container.querySelector('.code-toast');
     assert.ok(toast, 'the switch is announced');
     assert.match(toast?.textContent ?? '', /Auto \(YOLO\)/);
-    // Warning, not alert: it is news, and it must not interrupt a screen reader
-    // mid-sentence the way an error should.
     assert.ok(h.container.querySelector('.code-toast-warning'));
+    // Derived from the policy, not from a transition: a new session that is
+    // already Auto still says so, because the footer remounts and re-raises it.
+    // A transition detector would read that remount as "nothing changed" and
+    // stay silent exactly when the session starts acting on the policy.
+    await h.render(createElement(CodeWorkbench, { controller: model({ selection: { ...c.selection, permissionMode: 'auto' } }), endpointKey: '43225', ...{} }));
+    assert.match(h.container.querySelector('.code-toast')?.textContent ?? '', /Auto \(YOLO\)/);
+    // Leaving the policy retires it rather than letting it assert something
+    // about the session that is no longer true.
+    await h.render(createElement(CodeWorkbench, { controller: model({ selection: { ...c.selection, permissionMode: 'read-only' } }), endpointKey: '43225' }));
+    assert.equal(h.container.querySelector('.code-toast'), null, 'the warning leaves with the policy');
+    await h.render(createElement(CodeWorkbench, { controller: auto, endpointKey: '43225' }));
     await click(h.container.querySelector('.code-toast-dismiss') as HTMLButtonElement);
     assert.equal(h.container.querySelector('.code-toast'), null, 'a notice can be dismissed from the keyboard');
 });

--- a/tests/unit/code-native-components.test.ts
+++ b/tests/unit/code-native-components.test.ts
@@ -613,8 +613,11 @@ test('switching to Auto (YOLO) announces the change over the transcript, not und
     const c = model();
     await h.render(createElement(CodeWorkbench, { controller: c, endpointKey: '43225' }));
     // The policy is legible on its own control; a permanent line under the
-    // composer is not what tells the reader it just changed.
-    assert.equal(h.container.querySelector('.code-toast-host'), null);
+    // composer is not what tells the reader it just changed. The live regions
+    // are mounted from the start -- one that appears together with its first
+    // message is not announced -- but they hold nothing yet.
+    assert.ok(h.container.querySelector('.code-toast-host'), 'the live regions exist before there is anything to say');
+    assert.equal(h.container.querySelector('.code-toast'), null);
     assert.doesNotMatch(h.container.textContent ?? '', /actions may run without approval/);
     const auto = model({ selection: { ...c.selection, permissionMode: 'auto' } });
     await h.render(createElement(CodeWorkbench, { controller: auto, endpointKey: '43225' }));
@@ -638,4 +641,3 @@ test('states the reader must act on stay on screen instead of becoming a toast',
     await h.render(createElement(CodeWorkbench, { controller: model({ transport: 'disconnected' }), endpointKey: '43225' }));
     assert.match(h.container.textContent ?? '', /Live updates disconnected/);
 });
-

--- a/tests/unit/code-toasts.test.ts
+++ b/tests/unit/code-toasts.test.ts
@@ -1,28 +1,39 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { CODE_TOAST_DEFAULT_MS, CODE_TOAST_MAX, codeToastAutoDismisses, codeToastIsAssertive,
+import { CODE_TOAST_DEFAULT_MS, applyCodeNotice, codeToastAutoDismisses,
     dismissCodeToast, pushCodeToast, type CodeToast } from '../../public/manager/src/code/code-toasts.ts';
 
-const notice = (id: string, message = id) => ({ id, message, variant: 'info' as const, durationMs: CODE_TOAST_DEFAULT_MS });
+const notice = (id: string, message = id) => ({ id, message, variant: 'warning' as const, durationMs: CODE_TOAST_DEFAULT_MS });
 
 test('a repeated notice replaces itself instead of stacking', () => {
     let list = pushCodeToast([], notice('policy', 'Auto (YOLO)'));
     list = pushCodeToast(list, notice('policy', 'Auto (YOLO) again'));
     assert.equal(list.length, 1);
     assert.equal(list[0]?.message, 'Auto (YOLO) again');
-    // The revision is what restarts the timer for a notice that is already up.
+    // The revision is what restarts the timer for a notice already on screen.
     assert.equal(list[0]?.revision, 2);
 });
 
-test('the stack is capped and drops the oldest, never the one just raised', () => {
-    let list: CodeToast[] = [];
-    for (const id of ['a', 'b', 'c', 'd']) list = pushCodeToast(list, notice(id));
-    assert.equal(list.length, CODE_TOAST_MAX);
-    assert.deepEqual(list.map(toast => toast.id), ['b', 'c', 'd']);
-    // Re-raising an existing notice moves it to the newest position, so the cap
-    // cannot evict the thing the reader just triggered.
-    list = pushCodeToast(list, notice('b'));
-    assert.deepEqual(list.map(toast => toast.id), ['c', 'd', 'b']);
+test('a policy notice is raised while the policy holds and retired when it changes', () => {
+    // Derived from current state, not from a transition: the footer remounts
+    // when a draft becomes a real session, and a transition detector reads that
+    // remount as "nothing changed" -- which deleted the warning at the exact
+    // moment the session started acting on it.
+    let list = applyCodeNotice([], { id: 'code:permission-mode', variant: 'warning',
+        message: 'Auto (YOLO): actions may run without approval.', durationMs: Number.POSITIVE_INFINITY });
+    assert.equal(list.length, 1);
+    assert.equal(codeToastAutoDismisses(list[0]!), false, 'a standing policy warning does not expire on a timer');
+    // Re-raising it on a remount is idempotent, so the warning survives the
+    // draft-to-session transition instead of being announced twice.
+    list = applyCodeNotice(list, { id: 'code:permission-mode', variant: 'warning',
+        message: 'Auto (YOLO): actions may run without approval.', durationMs: Number.POSITIVE_INFINITY });
+    assert.equal(list.length, 1);
+    // Leaving the policy retires it: a warning that outlived the policy would
+    // be asserting something false about what the session may do.
+    list = applyCodeNotice(list, { id: 'code:permission-mode', clear: true });
+    assert.deepEqual(list, []);
+    // Clearing something that was never raised is a no-op, not an error.
+    assert.deepEqual(applyCodeNotice(list, { id: 'code:permission-mode', clear: true }), []);
 });
 
 test('a notice with no finite duration waits for the reader', () => {
@@ -32,15 +43,20 @@ test('a notice with no finite duration waits for the reader', () => {
     assert.equal(codeToastAutoDismisses({ ...notice('x'), durationMs: -1, revision: 1 }), false);
 });
 
+test('the stack is capped and drops the oldest, never the one just raised', () => {
+    let list: CodeToast[] = [];
+    for (const id of ['a', 'b', 'c', 'd']) list = pushCodeToast(list, notice(id));
+    assert.equal(list.length, 3);
+    assert.deepEqual(list.map(toast => toast.id), ['b', 'c', 'd']);
+    // Re-raising an existing notice moves it newest, so the cap cannot evict
+    // the thing the reader just triggered.
+    list = pushCodeToast(list, notice('b'));
+    assert.deepEqual(list.map(toast => toast.id), ['c', 'd', 'b']);
+});
+
 test('dismissing is by id and leaves the list alone when nothing matches', () => {
     const list = pushCodeToast(pushCodeToast([], notice('a')), notice('b'));
     assert.deepEqual(dismissCodeToast(list, 'a').map(toast => toast.id), ['b']);
     assert.equal(dismissCodeToast(list, 'missing'), list, 'no match returns the same reference');
-});
-
-test('only an error interrupts', () => {
-    assert.equal(codeToastIsAssertive({ ...notice('a'), revision: 1 }), false);
-    assert.equal(codeToastIsAssertive({ ...notice('a'), variant: 'warning', revision: 1 }), false);
-    assert.equal(codeToastIsAssertive({ ...notice('a'), variant: 'error', revision: 1 }), true);
 });
 

--- a/tests/unit/code-toasts.test.ts
+++ b/tests/unit/code-toasts.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CODE_TOAST_DEFAULT_MS, CODE_TOAST_MAX, codeToastAutoDismisses, codeToastIsAssertive,
+    dismissCodeToast, pushCodeToast, type CodeToast } from '../../public/manager/src/code/code-toasts.ts';
+
+const notice = (id: string, message = id) => ({ id, message, variant: 'info' as const, durationMs: CODE_TOAST_DEFAULT_MS });
+
+test('a repeated notice replaces itself instead of stacking', () => {
+    let list = pushCodeToast([], notice('policy', 'Auto (YOLO)'));
+    list = pushCodeToast(list, notice('policy', 'Auto (YOLO) again'));
+    assert.equal(list.length, 1);
+    assert.equal(list[0]?.message, 'Auto (YOLO) again');
+    // The revision is what restarts the timer for a notice that is already up.
+    assert.equal(list[0]?.revision, 2);
+});
+
+test('the stack is capped and drops the oldest, never the one just raised', () => {
+    let list: CodeToast[] = [];
+    for (const id of ['a', 'b', 'c', 'd']) list = pushCodeToast(list, notice(id));
+    assert.equal(list.length, CODE_TOAST_MAX);
+    assert.deepEqual(list.map(toast => toast.id), ['b', 'c', 'd']);
+    // Re-raising an existing notice moves it to the newest position, so the cap
+    // cannot evict the thing the reader just triggered.
+    list = pushCodeToast(list, notice('b'));
+    assert.deepEqual(list.map(toast => toast.id), ['c', 'd', 'b']);
+});
+
+test('a notice with no finite duration waits for the reader', () => {
+    assert.equal(codeToastAutoDismisses({ ...notice('x'), revision: 1 }), true);
+    assert.equal(codeToastAutoDismisses({ ...notice('x'), durationMs: Infinity, revision: 1 }), false);
+    assert.equal(codeToastAutoDismisses({ ...notice('x'), durationMs: 0, revision: 1 }), false);
+    assert.equal(codeToastAutoDismisses({ ...notice('x'), durationMs: -1, revision: 1 }), false);
+});
+
+test('dismissing is by id and leaves the list alone when nothing matches', () => {
+    const list = pushCodeToast(pushCodeToast([], notice('a')), notice('b'));
+    assert.deepEqual(dismissCodeToast(list, 'a').map(toast => toast.id), ['b']);
+    assert.equal(dismissCodeToast(list, 'missing'), list, 'no match returns the same reference');
+});
+
+test('only an error interrupts', () => {
+    assert.equal(codeToastIsAssertive({ ...notice('a'), revision: 1 }), false);
+    assert.equal(codeToastIsAssertive({ ...notice('a'), variant: 'warning', revision: 1 }), false);
+    assert.equal(codeToastIsAssertive({ ...notice('a'), variant: 'error', revision: 1 }), true);
+});
+


### PR DESCRIPTION
Stacked on #638. Review that first; this PR's diff is only the toast work.

## Problem

The composer footer carried three unrelated things in the same strip:

```
Auto (YOLO): actions may run without approval.
Saving settings…
<action error>
```

Each pushed the input further down, and the policy line stayed there forever. A permanent line is not what tells a reader the policy just changed — the moment it is switched on is the moment worth interrupting for, and what the policy currently *is* stays legible on the Permission control itself.

## What changed

Transient notices float over the top of the transcript instead of sitting under the composer, so reading one never moves the input.

- **Keyed per source.** Repeating a notice replaces it and restarts its timer rather than stacking a duplicate.
- **Capped at three**, oldest dropped. Re-raising an existing notice moves it newest, so the cap can never evict the one the reader just triggered.
- **A non-finite or non-positive duration waits** for an explicit dismiss.
- **Two live regions.** Errors are assertive, everything else polite. A container's politeness is what applies to an insertion, so a per-toast `role` on a shared region would not be reliable.

## What deliberately did not move

Anything the reader has to act on stays on screen, because it carries a recovery path that a self-dismissing notice would take with it:

| stays inline | why |
|---|---|
| transport status | reconnect state, not news |
| unconfirmed creation / unconfirmed send | the retry button lives in the strip |
| archived banner | restore action |
| approval queue | the decision itself |

A test asserts this rather than leaving it to convention.

## Accessibility

The dismiss button is keyboard reachable and labelled with the notice text, so it is not an anonymous `×`. The host ignores pointer events and the cards take them back, so a notice never blocks the transcript underneath. The entry transition is disabled under `prefers-reduced-motion`.

## Validation

- `tsc --noEmit` clean on both the root and frontend projects
- 399 Code unit tests pass, 0 fail
- `check-doc-drift.sh` 4/4, `verify-counts.sh` 580/580, `check:private-boundary` OK

New tests cover the replace-not-stack behaviour, the cap and its eviction order, non-finite durations, assertive-only-for-errors, the rendered switch-to-Auto announcement, and that the act-on-me states did not become toasts.
