### PR TITLE
fix(code): stop the session list rearranging itself while it is read

### DIFF
--- a/public/manager/src/code/CodeSessionList.tsx
+++ b/public/manager/src/code/CodeSessionList.tsx
@@ -2,6 +2,7 @@ import { useId, useRef, useState } from 'react';
 import type { CodeSessionInfo } from '../../../../src/code-mode/wire';
 import type { CodeControllerModel } from './code-controller-types';
 import { CODE_RUNTIME_LABELS, CODE_SESSION_LABELS, codeCanResume, codeSessionBusy } from './code-types';
+import { codeSessionAttention, codeSessionAttentionLabel, groupCodeSessions } from './session-order';
 
 function SessionRow({ session: s, controller: c }: { session: CodeSessionInfo; controller: CodeControllerModel }) {
     const [renaming, setRenaming] = useState(false);
@@ -14,6 +15,7 @@ function SessionRow({ session: s, controller: c }: { session: CodeSessionInfo; c
     const active = c.selectedId === s.sessionId;
     const busy = codeSessionBusy(s);
     const count = active && c.synced ? c.permissions.length : s.pendingPermissionCount;
+    const attention = codeSessionAttention(count);
     async function action(run: () => Promise<void>, after?: () => void) {
         if (guard.current) return;
         guard.current = true; setPending(true); setError(null);
@@ -27,8 +29,13 @@ function SessionRow({ session: s, controller: c }: { session: CodeSessionInfo; c
             aria-current={active ? 'true' : undefined} onClick={() => void action(() => c.selectSession(s.sessionId))}>
             <span className="code-session-cwd">{s.title || 'Untitled session'}</span>
             <span className="code-session-meta" title={s.cwd}>{CODE_RUNTIME_LABELS[s.provider]} · {s.cwd}</span>
-            <span className={`code-session-status code-session-status-${s.status}`}>{CODE_SESSION_LABELS[s.status]}</span>
-            <span className="code-session-attention">{count === undefined ? 'Approval status unknown' : count > 0 ? `${count} pending approval${count === 1 ? '' : 's'}` : 'No pending approvals'}</span>
+            {/* Ready is the common case and stays silent. A status on every row
+                is a status on no row, and it costs the one session that is
+                actually doing something its visibility. */}
+            <span className={`code-session-status code-session-status-${s.status}`}
+                data-quiet={s.status === 'idle' ? 'true' : undefined}>{CODE_SESSION_LABELS[s.status]}</span>
+            <span className={`code-session-attention code-session-attention-${attention.kind}`}
+                data-quiet={attention.kind === 'none' ? 'true' : undefined}>{codeSessionAttentionLabel(attention)}</span>
         </button>
         {renaming ? <form className="code-session-rename" onSubmit={event => {
             event.preventDefault(); if (title.trim()) void action(() => c.rename(s.sessionId, title.trim()), finishRename);
@@ -63,8 +70,19 @@ export function CodeSessionList({ controller: c }: { controller: CodeControllerM
     const [paging, setPaging] = useState(false);
     const pagingRef = useRef(false);
     const visible = c.sessions.filter(s => `${s.title ?? ''} ${s.cwd} ${CODE_RUNTIME_LABELS[s.provider]}`.toLowerCase().includes(search.toLowerCase()));
-    const groups = new Map<string, CodeSessionInfo[]>();
-    for (const s of visible) { const key = grouped ? s.cwd : ''; const rows = groups.get(key) ?? []; rows.push(s); groups.set(key, rows); }
+    // Two orderings, deliberately: by workspace when the reader asks for it,
+    // otherwise by lifecycle. Neither uses last activity, so answering a prompt
+    // in one session does not move it under the reader's cursor -- which is
+    // what the server's own last-used ordering would do.
+    const groups = grouped
+        ? [...visible.reduce((map, s) => {
+            const rows = map.get(s.cwd) ?? []; rows.push(s); map.set(s.cwd, rows); return map;
+        }, new Map<string, CodeSessionInfo[]>())].map(([cwd, sessions]) => ({ title: cwd, key: cwd, sessions }))
+        : groupCodeSessions(visible).map(group => ({
+            key: group.section,
+            title: group.section === 'archived' ? 'Archived' : '',
+            sessions: group.sessions,
+        }));
     async function loadMore() {
         if (pagingRef.current) return;
         pagingRef.current = true; setPaging(true); setError(null);
@@ -90,9 +108,9 @@ export function CodeSessionList({ controller: c }: { controller: CodeControllerM
         <button type="button" className={`code-session-item${c.selectedId === null ? ' active' : ''}`} aria-current={c.selectedId === null ? 'true' : undefined}
             onClick={c.newSession}><span className="code-session-cwd">New session draft</span><span className="code-session-meta">Preserved unsent draft</span></button>
         {c.loading && <div className="code-session-list-loading" role="status">Loading sessions…</div>}
-        {[...groups].map(([cwd, sessions]) => <section className="code-session-group" key={cwd}>
-            {grouped && <h3 className="code-session-group-title" title={cwd}>{cwd}</h3>}
-            <ul className="code-session-list-items">{sessions.map(s => <SessionRow key={s.sessionId} session={s} controller={c} />)}</ul>
+        {groups.map(group => <section className="code-session-group" key={group.key}>
+            {group.title && <h3 className="code-session-group-title" title={group.title}>{group.title}</h3>}
+            <ul className="code-session-list-items">{group.sessions.map(s => <SessionRow key={s.sessionId} session={s} controller={c} />)}</ul>
         </section>)}
         {!c.loading && !visible.length && <p className="code-session-list-empty">{search ? 'No loaded sessions match. Clear search or load more.' : 'No sessions here. Start with the new session draft.'}</p>}
         {c.hasMoreSessions && <button type="button" className="code-inline-action" disabled={paging} onClick={() => void loadMore()}>{paging ? 'Loading…' : 'Load more sessions'}</button>}

--- a/public/manager/src/code/code.css
+++ b/public/manager/src/code/code.css
@@ -579,6 +579,18 @@
 }
 
 .code-session-attention { grid-column: 1 / -1; color: var(--text-secondary); font-size: 10px; }
+.code-session-attention-approvals { color: var(--status-warn); font-weight: 650; }
+/* The uneventful cases stay readable to assistive technology and out of the
+   way visually. A label on every row is a label on no row, and it costs the
+   one session that is actually waiting its visibility. */
+.code-session-attention[data-quiet], .code-session-status[data-quiet] {
+    position: absolute;
+    width: 1px; height: 1px;
+    margin: -1px; padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
 .code-session-row { margin-bottom: 6px; }
 .code-session-actions { font-size: 11px; color: var(--text-secondary); margin: 0 8px; }
 .code-session-actions summary { cursor: pointer; min-height: 24px; }

--- a/public/manager/src/code/session-order.ts
+++ b/public/manager/src/code/session-order.ts
@@ -1,0 +1,70 @@
+import type { CodeSessionInfo } from '../../../../src/code-mode/wire';
+
+/**
+ * How the session list is ordered and grouped, kept apart from rendering so the
+ * rules can be stated and tested on their own.
+ *
+ * The server returns sessions by `last_used_at DESC`, which means answering a
+ * prompt in the third session moves it to the top while the reader is looking
+ * at it. Order here is anchored to creation instead: a row holds its place
+ * until something actually changes about it, so the list moves when a session
+ * is created or archived and not merely because it is busy. Which session is
+ * running is carried by the row's own status, which is where a changing fact
+ * belongs.
+ */
+export type CodeSessionSection = 'active' | 'archived';
+
+export function codeSessionSection(session: CodeSessionInfo): CodeSessionSection {
+    return session.archivedAt === null ? 'active' : 'archived';
+}
+
+/** Creation order, newest first. Ties break on id so the order is total. */
+export function compareCodeSessions(left: CodeSessionInfo, right: CodeSessionInfo): number {
+    return right.createdAt - left.createdAt || left.sessionId.localeCompare(right.sessionId);
+}
+
+export type CodeSessionGroup = {
+    section: CodeSessionSection;
+    sessions: CodeSessionInfo[];
+};
+
+/**
+ * Active first, then archived. Archived sessions are history: they are ordered
+ * by when they were archived, because "when did I put this away" is the
+ * question that section answers, and they fall back to creation order when a
+ * record predates the field.
+ */
+export function groupCodeSessions(sessions: readonly CodeSessionInfo[]): CodeSessionGroup[] {
+    const active = sessions.filter(session => codeSessionSection(session) === 'active').sort(compareCodeSessions);
+    const archived = sessions.filter(session => codeSessionSection(session) === 'archived')
+        .sort((left, right) => (right.archivedAt ?? right.createdAt) - (left.archivedAt ?? left.createdAt)
+            || left.sessionId.localeCompare(right.sessionId));
+    const groups: CodeSessionGroup[] = [];
+    if (active.length) groups.push({ section: 'active', sessions: active });
+    if (archived.length) groups.push({ section: 'archived', sessions: archived });
+    return groups;
+}
+
+/**
+ * What a row says about itself, beyond its title.
+ *
+ * Idle is the common case and says nothing: a label on every row is a label on
+ * no row, and it costs the one session that is actually waiting its visibility.
+ * Unknown stays unknown -- an unhydrated approval count is not zero approvals.
+ */
+export type CodeSessionAttention =
+    | { kind: 'none' }
+    | { kind: 'unknown' }
+    | { kind: 'approvals'; count: number };
+
+export function codeSessionAttention(count: number | undefined): CodeSessionAttention {
+    if (count === undefined) return { kind: 'unknown' };
+    return count > 0 ? { kind: 'approvals', count } : { kind: 'none' };
+}
+
+export function codeSessionAttentionLabel(attention: CodeSessionAttention): string {
+    if (attention.kind === 'unknown') return 'Approval status unknown';
+    if (attention.kind === 'none') return 'No pending approvals';
+    return `${attention.count} pending approval${attention.count === 1 ? '' : 's'}`;
+}
+

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -661,6 +661,18 @@ original key and text; reconnect never resends automatically. Each approval has
 its own pending/error state and forwards the native opaque choice. Session rows
 support rename, archive/restore, current-workspace filtering and paging.
 
+The session list is ordered by creation, newest first, with the id as a
+tiebreak. The server returns sessions by last activity, which would move a
+session to the top of the list while the reader is looking at it merely because
+it answered a prompt; which session is running is carried by the row's own
+status instead. Rows are partitioned into active and archived, and the archived
+tail orders by when each session was put away rather than when it was created.
+A section with nothing in it is not rendered. Grouping by workspace remains a
+separate explicit mode. Idle status and "no pending approvals" stay in the
+accessibility tree but are visually hidden, because a label on every row costs
+the one row that is actually waiting its visibility; an unhydrated approval
+count remains unknown rather than being shown as zero.
+
 The transcript renders sanitized Markdown, math and linear tables with stable
 virtual rows. Tool output stays escaped; local files open only after an explicit
 click. Endpoint/session changes reset measured heights and scroll ownership.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -533,7 +533,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 604 files source/assets, ~102746L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 605 files source/assets, ~102746L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── settings/ ← standalone instance settings entry
 │   │   └── index.html ← Classic settings iframe HTML (13L)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)

--- a/tests/unit/code-session-order.test.ts
+++ b/tests/unit/code-session-order.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { CodeSessionInfo } from '../../src/code-mode/wire.ts';
+import { codeSessionAttention, codeSessionAttentionLabel, codeSessionSection,
+    compareCodeSessions, groupCodeSessions } from '../../public/manager/src/code/session-order.ts';
+
+function session(patch: Partial<CodeSessionInfo> = {}): CodeSessionInfo {
+    return {
+        sessionId: 's-1', provider: 'codex-app', cwd: '/work', title: null, model: 'm', effort: null,
+        permissionMode: 'ask', status: 'idle', turnId: null, archivedAt: null, error: null,
+        resume: { available: true, reason: null },
+        capabilities: { resume: true, interrupt: true, permissions: true, setModelMidSession: false, efforts: [], permissionModes: ['ask'] },
+        epoch: 1, sequence: 1, revision: 1, createdAt: 100, lastUsedAt: 100, ...patch,
+    };
+}
+
+test('order is anchored to creation, so activity cannot move a row under the cursor', () => {
+    const older = session({ sessionId: 'a', createdAt: 100, lastUsedAt: 999 });
+    const newer = session({ sessionId: 'b', createdAt: 200, lastUsedAt: 1 });
+    // The server returns last_used_at DESC, which would put the busy session
+    // first. Answering a prompt is not a reason for the list to rearrange.
+    assert.deepEqual(groupCodeSessions([older, newer])[0]?.sessions.map(s => s.sessionId), ['b', 'a']);
+    assert.ok(compareCodeSessions(newer, older) < 0);
+});
+
+test('equal creation times still produce one definite order', () => {
+    const left = session({ sessionId: 'b', createdAt: 100 });
+    const right = session({ sessionId: 'a', createdAt: 100 });
+    assert.deepEqual(groupCodeSessions([left, right])[0]?.sessions.map(s => s.sessionId), ['a', 'b']);
+});
+
+test('archived sessions become a tail section ordered by when they were put away', () => {
+    const live = session({ sessionId: 'live', createdAt: 1 });
+    const early = session({ sessionId: 'early', createdAt: 500, archivedAt: 10 });
+    const late = session({ sessionId: 'late', createdAt: 2, archivedAt: 900 });
+    const groups = groupCodeSessions([early, live, late]);
+    assert.deepEqual(groups.map(g => g.section), ['active', 'archived']);
+    assert.deepEqual(groups[0]?.sessions.map(s => s.sessionId), ['live']);
+    // "When did I put this away" is the question the tail answers, not "when
+    // was it created" -- so a recently archived session comes first even though
+    // it is older.
+    assert.deepEqual(groups[1]?.sessions.map(s => s.sessionId), ['late', 'early']);
+    assert.equal(codeSessionSection(live), 'active');
+    assert.equal(codeSessionSection(late), 'archived');
+});
+
+test('an empty section is not rendered as an empty heading', () => {
+    assert.deepEqual(groupCodeSessions([]).map(g => g.section), []);
+    assert.deepEqual(groupCodeSessions([session()]).map(g => g.section), ['active']);
+    assert.deepEqual(groupCodeSessions([session({ archivedAt: 1 })]).map(g => g.section), ['archived']);
+});
+
+test('an unhydrated approval count is unknown, not zero', () => {
+    assert.deepEqual(codeSessionAttention(undefined), { kind: 'unknown' });
+    assert.deepEqual(codeSessionAttention(0), { kind: 'none' });
+    assert.deepEqual(codeSessionAttention(2), { kind: 'approvals', count: 2 });
+    assert.equal(codeSessionAttentionLabel({ kind: 'unknown' }), 'Approval status unknown');
+    assert.equal(codeSessionAttentionLabel({ kind: 'none' }), 'No pending approvals');
+    assert.equal(codeSessionAttentionLabel({ kind: 'approvals', count: 1 }), '1 pending approval');
+    assert.equal(codeSessionAttentionLabel({ kind: 'approvals', count: 3 }), '3 pending approvals');
+});
+


### PR DESCRIPTION
Stacked on #640. Review that first; this PR's diff is only the session-list work.

## Problem

The server returns sessions by `last_used_at DESC` (`src/code-mode/store.ts:322`) and bumps that column on every prompt, turn end, rename and archive. Answering a prompt in the third session moved it to the top of the list **while the reader was looking at it**, so the row they were about to click was somewhere else.

Which session is running is a fact about the row. It should not also decide where the row belongs.

## What changed

**Order is anchored to creation**, newest first with the session id as a tiebreak. The list now moves when a session is created or archived, not because one is busy.

**Archived sessions become a tail section** instead of an all-or-nothing checkbox, ordered by when they were put away rather than when they were created — "when did I archive this" is the question that section answers. An empty section renders nothing rather than a bare heading.

**The quiet cases stop shouting.** `Ready` appeared on every idle session and `No pending approvals` on every session with nothing pending. Both stay in the accessibility tree and are visually hidden, so the one session actually waiting for approval now carries the only coloured text in the list.

| row state | before | after |
|---|---|---|
| idle, nothing pending | `Ready` + `No pending approvals` | title and workspace only |
| 2 approvals waiting | same weight as every other row | `2 pending approvals`, warn colour |
| not hydrated | `Approval status unknown` | unchanged — unknown is not zero |

## Compatibility

The disclosure markup and its accessible names are unchanged, so the rename and archive/restore flows in [code-native-workbench.test.ts](tests/browser/code-native-workbench.test.ts) keep working against `Actions for …`, and `Approval status unknown` is still in `textContent` for [code-native-components.test.ts](tests/unit/code-native-components.test.ts).

Ordering and grouping live in a new `session-order.ts` with no DOM dependency, so the rules are testable on their own.

## Validation

- `tsc --noEmit` clean on both the root and frontend projects
- 415 Code unit tests pass, 0 fail
- `check-doc-drift.sh` 4/4, `verify-counts.sh` 580/580, `check:private-boundary` OK

New tests cover creation anchoring against a last-activity ordering, the total order on equal timestamps, the archived tail's own ordering, empty-section suppression, and unknown-vs-zero approval counts.
