### PR TITLE
feat(code): show how much of the context window a session is using

### DIFF
--- a/public/manager/src/code/ComposerFooter.tsx
+++ b/public/manager/src/code/ComposerFooter.tsx
@@ -5,6 +5,7 @@ import type { CodeCreateSessionRequest } from '../../../../src/code-mode/wire';
 import { CODE_POLICY_DETAILS, CODE_POLICY_LABELS, CODE_RUNTIME_LABELS } from './code-types';
 import type { CodeNotice } from './code-toasts';
 import { CheckGlyph, ProviderGlyph } from './ProviderGlyph';
+import { ContextUsageMeter } from './ContextUsageMeter';
 
 type MenuOption<T extends string> = {
     value: T; label: string; detail?: string | undefined; disabled?: boolean; icon?: ReactNode;
@@ -185,6 +186,7 @@ export function ComposerFooter({ controller: c, onNotice }: {
                 options={(capabilities?.permissionModes ?? []).map(value => ({ value, label: CODE_POLICY_LABELS[value], detail: CODE_POLICY_DETAILS[value] }))}
                 onChange={value => void change({ permissionMode: value })} />
             <span className="code-composer-footer-spacer" aria-hidden="true" />
+            <ContextUsageMeter usage={c.session?.contextUsage} />
             <CodeFooterMenu label="Model" value={selection.model} className="code-footer-model"
                 disabled={controlsDisabled || models.length === 0} filterable filterPlaceholder="Filter models…"
                 displayValue={selection.model || 'Select model'}

--- a/public/manager/src/code/ContextUsageMeter.tsx
+++ b/public/manager/src/code/ContextUsageMeter.tsx
@@ -16,7 +16,7 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
     const detailId = useId();
     if (view.state === 'hidden') return null;
     const label = contextUsageLabel(view);
-    const level = view.state === 'measured' ? contextUsageLevel(view.percent) : 'normal';
+    const level = view.state === 'measured' ? (view.over ? 'critical' : contextUsageLevel(view.percent)) : 'normal';
     const circumference = 2 * Math.PI * 7;
     const filled = view.state === 'measured' ? (view.percent / 100) * circumference : 0;
     return <div className="code-context-usage"
@@ -33,7 +33,7 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
                 </svg>
                 : null}
             <span className="code-context-value">
-                {view.state === 'measured' ? `${view.percent}%` : formatTokens(view.usedTokens)}
+                {view.state !== 'measured' ? formatTokens(view.usedTokens) : view.over ? 'over' : `${view.percent}%`}
             </span>
         </button>
         {open && <div id={detailId} className="code-context-detail" role="note">
@@ -42,6 +42,8 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
                     ? `${formatTokens(view.usedTokens)} of ${formatTokens(view.maxTokens)} tokens`
                     : `${formatTokens(view.usedTokens)} tokens used`}
             </p>
+            {view.state === 'measured' && view.over
+                && <p className="code-context-detail-note">Past the window the runtime last reported.</p>}
             {view.state === 'counted' && <p className="code-context-detail-note">This runtime did not report a context window.</p>}
             <dl className="code-context-breakdown">
                 <div><dt>Input</dt><dd>{formatOptionalTokens(usage?.inputTokens ?? null)}</dd></div>
@@ -49,7 +51,10 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
                 <div><dt>Output</dt><dd>{formatOptionalTokens(usage?.outputTokens ?? null)}</dd></div>
                 <div><dt>Reasoning</dt><dd>{formatOptionalTokens(usage?.reasoningOutputTokens ?? null)}</dd></div>
             </dl>
+            {/* Spend, not occupancy: it counts every turn's tokens including the
+                prompt resent each time, so it passes the window in ordinary use. */}
+            {usage?.processedTokens != null && <p className="code-context-detail-note">
+                Processed across the conversation: {formatTokens(usage.processedTokens)}</p>}
         </div>}
     </div>;
 }
-

--- a/public/manager/src/code/ContextUsageMeter.tsx
+++ b/public/manager/src/code/ContextUsageMeter.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react';
 import type { CodeContextUsage } from '../../../../src/code-mode/wire';
-import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalTokens, formatTokens } from './context-usage';
+import { contextUsageLabel, contextUsageLevel, contextUsageView, formatExactTokens, formatOptionalTokens, formatTokens } from './context-usage';
 
 /**
  * How full the context window is, as a ring beside the composer controls.
@@ -12,7 +12,12 @@ import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalT
  */
 export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefined }) {
     const view = contextUsageView(usage);
-    const [open, setOpen] = useState(false);
+    // Hover and focus are separate reasons to show the detail, tracked
+    // separately. One boolean made them fight: clicking closed a panel the
+    // pointer had opened, and blurring closed one the pointer was still over.
+    const [hovered, setHovered] = useState(false);
+    const [focused, setFocused] = useState(false);
+    const open = hovered || focused;
     const detailId = useId();
     if (view.state === 'hidden') return null;
     const label = contextUsageLabel(view);
@@ -20,11 +25,14 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
     const circumference = 2 * Math.PI * 7;
     const filled = view.state === 'measured' ? (view.percent / 100) * circumference : 0;
     return <div className="code-context-usage"
-        onPointerEnter={() => setOpen(true)} onPointerLeave={() => setOpen(false)}>
+        onPointerEnter={() => setHovered(true)} onPointerLeave={() => setHovered(false)}>
+        {/* Described by, not expanded: the panel is a role="note" description
+            and its numbers are already in this button's accessible name, so
+            announcing an expandable widget would offer a control that reveals
+            nothing new. */}
         <button type="button" className={`code-context-trigger is-${level}`}
-            aria-label={label} aria-expanded={open} aria-controls={open ? detailId : undefined}
-            onFocus={() => setOpen(true)} onBlur={() => setOpen(false)}
-            onClick={() => setOpen(current => !current)}>
+            aria-label={label} aria-describedby={open ? detailId : undefined}
+            onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
             {view.state === 'measured'
                 ? <svg className="code-context-ring" viewBox="0 0 18 18" aria-hidden="true">
                     <circle className="code-context-ring-track" cx="9" cy="9" r="7" />
@@ -46,6 +54,10 @@ export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefin
                 && <p className="code-context-detail-note">Past the window the runtime last reported.</p>}
             {view.state === 'counted' && <p className="code-context-detail-note">This runtime did not report a context window.</p>}
             <dl className="code-context-breakdown">
+                {/* Exact here, because the rounded form on the trigger cannot be
+                    reconstructed into it and this is the only place the real
+                    number appears. */}
+                <div><dt>Used</dt><dd>{formatExactTokens(usage?.totalTokens ?? null)}</dd></div>
                 <div><dt>Input</dt><dd>{formatOptionalTokens(usage?.inputTokens ?? null)}</dd></div>
                 <div><dt>Cached</dt><dd>{formatOptionalTokens(usage?.cachedInputTokens ?? null)}</dd></div>
                 <div><dt>Output</dt><dd>{formatOptionalTokens(usage?.outputTokens ?? null)}</dd></div>

--- a/public/manager/src/code/ContextUsageMeter.tsx
+++ b/public/manager/src/code/ContextUsageMeter.tsx
@@ -1,0 +1,55 @@
+import { useId, useState } from 'react';
+import type { CodeContextUsage } from '../../../../src/code-mode/wire';
+import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalTokens, formatTokens } from './context-usage';
+
+/**
+ * How full the context window is, as a ring beside the composer controls.
+ *
+ * It renders nothing when the runtime has not reported usage, rather than
+ * showing a zero that would read as measured. When a count arrives without a
+ * window there is no ring, because a proportion of an unknown total is not a
+ * proportion.
+ */
+export function ContextUsageMeter({ usage }: { usage: CodeContextUsage | undefined }) {
+    const view = contextUsageView(usage);
+    const [open, setOpen] = useState(false);
+    const detailId = useId();
+    if (view.state === 'hidden') return null;
+    const label = contextUsageLabel(view);
+    const level = view.state === 'measured' ? contextUsageLevel(view.percent) : 'normal';
+    const circumference = 2 * Math.PI * 7;
+    const filled = view.state === 'measured' ? (view.percent / 100) * circumference : 0;
+    return <div className="code-context-usage"
+        onPointerEnter={() => setOpen(true)} onPointerLeave={() => setOpen(false)}>
+        <button type="button" className={`code-context-trigger is-${level}`}
+            aria-label={label} aria-expanded={open} aria-controls={open ? detailId : undefined}
+            onFocus={() => setOpen(true)} onBlur={() => setOpen(false)}
+            onClick={() => setOpen(current => !current)}>
+            {view.state === 'measured'
+                ? <svg className="code-context-ring" viewBox="0 0 18 18" aria-hidden="true">
+                    <circle className="code-context-ring-track" cx="9" cy="9" r="7" />
+                    <circle className="code-context-ring-fill" cx="9" cy="9" r="7"
+                        strokeDasharray={`${filled} ${circumference}`} />
+                </svg>
+                : null}
+            <span className="code-context-value">
+                {view.state === 'measured' ? `${view.percent}%` : formatTokens(view.usedTokens)}
+            </span>
+        </button>
+        {open && <div id={detailId} className="code-context-detail" role="note">
+            <p className="code-context-detail-total">
+                {view.state === 'measured'
+                    ? `${formatTokens(view.usedTokens)} of ${formatTokens(view.maxTokens)} tokens`
+                    : `${formatTokens(view.usedTokens)} tokens used`}
+            </p>
+            {view.state === 'counted' && <p className="code-context-detail-note">This runtime did not report a context window.</p>}
+            <dl className="code-context-breakdown">
+                <div><dt>Input</dt><dd>{formatOptionalTokens(usage?.inputTokens ?? null)}</dd></div>
+                <div><dt>Cached</dt><dd>{formatOptionalTokens(usage?.cachedInputTokens ?? null)}</dd></div>
+                <div><dt>Output</dt><dd>{formatOptionalTokens(usage?.outputTokens ?? null)}</dd></div>
+                <div><dt>Reasoning</dt><dd>{formatOptionalTokens(usage?.reasoningOutputTokens ?? null)}</dd></div>
+            </dl>
+        </div>}
+    </div>;
+}
+

--- a/public/manager/src/code/code-session-state.ts
+++ b/public/manager/src/code/code-session-state.ts
@@ -61,7 +61,13 @@ function apply(state: CodeSessionState, event: CodeWireEvent): CodeSessionState 
     let { items, session, permissions } = state;
     if (event.event === 'code_session') {
         if (!event.session || event.session.sessionId !== state.sessionId) return { ...state, needsSnapshot: true, synced: false };
-        session = event.session;
+        // Usage is attached at read time, so a stored session event does not
+        // carry it. Replacing the record wholesale would blank the meter on
+        // every unrelated session change; the last figure stands until a
+        // snapshot or a listing supplies a newer one.
+        session = event.session.contextUsage === undefined && session?.contextUsage !== undefined
+            ? { ...event.session, contextUsage: session.contextUsage }
+            : event.session;
         permissions = permissions.filter(p => p.epoch === session!.epoch && p.turnId === session!.turnId);
     } else {
         const id = event.item?.itemId ?? event.update?.itemId;

--- a/public/manager/src/code/code.css
+++ b/public/manager/src/code/code.css
@@ -368,7 +368,7 @@
     .code-toast { animation: none; }
 }
 
-/* Session header (title + context meter + plan) */
+/* Session header (title + plan) */
 .code-session-header {
     display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
     padding: 6px 16px;
@@ -377,19 +377,37 @@
     font-size: 11px;
 }
 .code-session-title { font-weight: 600; color: var(--text-primary); }
-.code-context-meter {
-    width: 80px; height: 6px;
-    background: var(--bg-raised);
-    border-radius: 3px;
-    overflow: hidden;
-    display: inline-block;
+/* Context usage sits in the composer footer, next to the model it belongs to.
+   The ring appears only when the runtime reported a window: a proportion of an
+   unknown total is not a proportion. */
+.code-context-usage { position: relative; display: inline-flex; align-items: center; }
+.code-context-trigger {
+    display: inline-flex; align-items: center; gap: 4px;
+    height: 28px; padding: 0 8px;
+    border: 1px solid transparent; border-radius: 8px;
+    background: transparent; color: var(--text-secondary);
+    font-size: 11px; font-variant-numeric: tabular-nums; cursor: pointer;
 }
-.code-context-bar {
-    display: block; height: 100%;
-    background: var(--accent);
-    border-radius: 3px;
-    transition: width 0.3s ease;
+.code-context-trigger:hover, .code-context-trigger:focus-visible { background: var(--bg-raised); color: var(--text-primary); }
+.code-context-ring { width: 16px; height: 16px; transform: rotate(-90deg); flex-shrink: 0; }
+.code-context-ring-track { fill: none; stroke: var(--border-subtle); stroke-width: 2.5; }
+.code-context-ring-fill { fill: none; stroke: var(--accent); stroke-width: 2.5; stroke-linecap: round; }
+.code-context-trigger.is-high .code-context-ring-fill { stroke: var(--status-warn); }
+.code-context-trigger.is-critical .code-context-ring-fill { stroke: var(--status-error); }
+.code-context-trigger.is-critical .code-context-value { color: var(--status-error); }
+.code-context-detail {
+    position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%);
+    z-index: 4; min-width: 180px; padding: 8px 10px;
+    border: 1px solid var(--border-subtle); border-radius: 10px;
+    background: var(--bg-panel); box-shadow: 0 6px 20px rgb(0 0 0 / 28%);
+    font-size: 11px; color: var(--text-secondary);
 }
+.code-context-detail-total { margin: 0 0 4px; color: var(--text-primary); font-weight: 650; }
+.code-context-detail-note { margin: 0 0 6px; }
+.code-context-breakdown { display: grid; gap: 2px; margin: 0; }
+.code-context-breakdown > div { display: flex; justify-content: space-between; gap: 12px; }
+.code-context-breakdown dt, .code-context-breakdown dd { margin: 0; }
+.code-context-breakdown dd { font-variant-numeric: tabular-nums; color: var(--text-primary); }
 .code-plan-entries { display: flex; gap: 8px; flex-wrap: wrap; }
 .code-plan-entry { font-size: 10px; color: var(--text-secondary); }
 .code-plan-completed { color: var(--status-success); }

--- a/public/manager/src/code/context-usage.ts
+++ b/public/manager/src/code/context-usage.ts
@@ -11,17 +11,21 @@ import type { CodeContextUsage } from '../../../../src/code-mode/wire';
 export type ContextUsageView =
     | { state: 'hidden' }
     | { state: 'counted'; usedTokens: number }
-    | { state: 'measured'; usedTokens: number; maxTokens: number; percent: number };
+    | { state: 'measured'; usedTokens: number; maxTokens: number; percent: number; over: boolean };
 
 export function contextUsageView(usage: CodeContextUsage | undefined): ContextUsageView {
     if (!usage || !Number.isFinite(usage.totalTokens) || usage.totalTokens < 0) return { state: 'hidden' };
     const max = usage.modelContextWindow;
     if (max === null || !Number.isFinite(max) || max <= 0) return { state: 'counted', usedTokens: usage.totalTokens };
-    // A conversation can exceed the window the runtime last reported, after a
-    // model change or a compaction that has not landed yet. Showing 118% would
-    // be reporting the arithmetic rather than the situation.
-    const percent = Math.min(100, Math.round((usage.totalTokens / max) * 100));
-    return { state: 'measured', usedTokens: usage.totalTokens, maxTokens: max, percent };
+    // A count past the window is possible -- a model change moves the window
+    // under a conversation that is already large. The ring cannot draw past
+    // full, so the percentage is capped for the ring's sake, but the fact that
+    // it was capped is carried rather than hidden: a label reading "100% used,
+    // 533k of 258k" is self-contradictory, and quietly capping is how a wrong
+    // number would look exactly like a full context.
+    const raw = Math.round((usage.totalTokens / max) * 100);
+    return { state: 'measured', usedTokens: usage.totalTokens, maxTokens: max,
+        percent: Math.min(100, raw), over: raw > 100 };
 }
 
 /** Rounded to keep the control narrow; exact counts belong in the detail. */
@@ -54,6 +58,6 @@ export function contextUsageLevel(percent: number): 'normal' | 'high' | 'critica
 export function contextUsageLabel(view: ContextUsageView): string {
     if (view.state === 'hidden') return '';
     if (view.state === 'counted') return `Context: ${formatTokens(view.usedTokens)} tokens used, window unknown`;
+    if (view.over) return `Context: over the window, ${formatTokens(view.usedTokens)} of ${formatTokens(view.maxTokens)} tokens`;
     return `Context: ${view.percent}% used, ${formatTokens(view.usedTokens)} of ${formatTokens(view.maxTokens)} tokens`;
 }
-

--- a/public/manager/src/code/context-usage.ts
+++ b/public/manager/src/code/context-usage.ts
@@ -28,16 +28,27 @@ export function contextUsageView(usage: CodeContextUsage | undefined): ContextUs
         percent: Math.min(100, raw), over: raw > 100 };
 }
 
-/** Rounded to keep the control narrow; exact counts belong in the detail. */
+/**
+ * Rounded to keep the control narrow. Each unit is chosen after its own
+ * rounding: 999,999 in thousands rounds to 1000, which is a four-digit "k"
+ * that should have been "1.0M", and 999.5 rounds to 1000, which is not the
+ * bare small number that branch is for.
+ */
+function scaled(value: number, divisor: number): string {
+    const n = value / divisor;
+    return n < 10 ? n.toFixed(1) : String(Math.round(n));
+}
 export function formatTokens(value: number): string {
     if (!Number.isFinite(value) || value < 0) return '—';
-    if (value < 1000) return String(Math.round(value));
-    if (value < 1_000_000) {
-        const thousands = value / 1000;
-        return `${thousands < 10 ? thousands.toFixed(1) : Math.round(thousands)}k`;
-    }
-    const millions = value / 1_000_000;
-    return `${millions < 10 ? millions.toFixed(1) : Math.round(millions)}M`;
+    const rounded = Math.round(value);
+    if (rounded < 1000) return String(rounded);
+    const thousands = scaled(rounded, 1000);
+    return Number(thousands) < 1000 ? `${thousands}k` : `${scaled(rounded, 1_000_000)}M`;
+}
+
+/** The count itself, grouped. The rounded form cannot be reconstructed into it. */
+export function formatExactTokens(value: number | null): string {
+    return value === null || !Number.isFinite(value) || value < 0 ? '—' : value.toLocaleString('en-US');
 }
 
 /** An unreported part of the breakdown reads as absent, never as zero. */

--- a/public/manager/src/code/context-usage.ts
+++ b/public/manager/src/code/context-usage.ts
@@ -1,0 +1,59 @@
+import type { CodeContextUsage } from '../../../../src/code-mode/wire';
+
+/**
+ * How much of the model's context the conversation is using.
+ *
+ * The runtime may report a token count without a window, or nothing at all, so
+ * there are three answers and not one. A missing window is not an unlimited
+ * one and a missing count is not zero, which is why neither collapses into a
+ * number the reader would take as measured.
+ */
+export type ContextUsageView =
+    | { state: 'hidden' }
+    | { state: 'counted'; usedTokens: number }
+    | { state: 'measured'; usedTokens: number; maxTokens: number; percent: number };
+
+export function contextUsageView(usage: CodeContextUsage | undefined): ContextUsageView {
+    if (!usage || !Number.isFinite(usage.totalTokens) || usage.totalTokens < 0) return { state: 'hidden' };
+    const max = usage.modelContextWindow;
+    if (max === null || !Number.isFinite(max) || max <= 0) return { state: 'counted', usedTokens: usage.totalTokens };
+    // A conversation can exceed the window the runtime last reported, after a
+    // model change or a compaction that has not landed yet. Showing 118% would
+    // be reporting the arithmetic rather than the situation.
+    const percent = Math.min(100, Math.round((usage.totalTokens / max) * 100));
+    return { state: 'measured', usedTokens: usage.totalTokens, maxTokens: max, percent };
+}
+
+/** Rounded to keep the control narrow; exact counts belong in the detail. */
+export function formatTokens(value: number): string {
+    if (!Number.isFinite(value) || value < 0) return '—';
+    if (value < 1000) return String(Math.round(value));
+    if (value < 1_000_000) {
+        const thousands = value / 1000;
+        return `${thousands < 10 ? thousands.toFixed(1) : Math.round(thousands)}k`;
+    }
+    const millions = value / 1_000_000;
+    return `${millions < 10 ? millions.toFixed(1) : Math.round(millions)}M`;
+}
+
+/** An unreported part of the breakdown reads as absent, never as zero. */
+export function formatOptionalTokens(value: number | null): string {
+    return value === null ? '—' : formatTokens(value);
+}
+
+/**
+ * Thresholds are about when to start paying attention, so they are named rather
+ * than left as bare numbers at the call site.
+ */
+export function contextUsageLevel(percent: number): 'normal' | 'high' | 'critical' {
+    if (percent >= 90) return 'critical';
+    if (percent >= 75) return 'high';
+    return 'normal';
+}
+
+export function contextUsageLabel(view: ContextUsageView): string {
+    if (view.state === 'hidden') return '';
+    if (view.state === 'counted') return `Context: ${formatTokens(view.usedTokens)} tokens used, window unknown`;
+    return `Context: ${view.percent}% used, ${formatTokens(view.usedTokens)} of ${formatTokens(view.maxTokens)} tokens`;
+}
+

--- a/src/agent/codex-app-events.ts
+++ b/src/agent/codex-app-events.ts
@@ -34,12 +34,22 @@ export interface CodexAppEventResult {
 }
 
 export interface CodexAppContextUsage {
-    /** Whole-conversation total, the number a context window is measured against. */
+    /**
+     * What is resident in the context right now, taken from the last turn.
+     *
+     * Not `total`: that is a lifetime accumulator that adds each turn's usage
+     * to the running sum, so it re-counts the whole resent prompt every turn
+     * and passes the window many times over in an ordinary conversation. In a
+     * real 258,400-token session it reached 2,258,818 while the live context
+     * sat at 134,904. Only the second of those is a context measurement.
+     */
     totalTokens: number;
     inputTokens: number | null;
     cachedInputTokens: number | null;
     outputTokens: number | null;
     reasoningOutputTokens: number | null;
+    /** Tokens billed across the whole conversation. Cost, not occupancy. */
+    processedTokens: number | null;
     /** The model's window, when the runtime reports one. */
     modelContextWindow: number | null;
 }
@@ -531,17 +541,21 @@ function handleTokenUsageUpdated(params: EvRec, ctx: SpawnContext): CodexAppEven
             ...(last['cachedInputTokens'] ? { cached_input_tokens: last['cachedInputTokens'] as number } : {}),
         };
     }
-    // `total` is the running conversation, which is what a context window is
-    // measured against; `last` is one turn and belongs to cost accounting.
-    // They are read separately because they answer different questions.
+    // `last` is what currently occupies the context: it grows with the
+    // conversation and settles below the window. `total` adds every turn to a
+    // running sum, so it measures spend rather than occupancy and passes the
+    // window many times over in an ordinary session. The gauge reads `last`;
+    // `total` is carried separately as what it actually is.
+    const resident = usage ? f(usage, 'last') as EvRec | undefined : undefined;
     const total = usage ? f(usage, 'total') as EvRec | undefined : undefined;
-    const totalTokens = count(total?.['totalTokens']);
+    const totalTokens = count(resident?.['totalTokens']);
     const contextUsage: CodexAppContextUsage | undefined = totalTokens === null ? undefined : {
         totalTokens,
-        inputTokens: count(total?.['inputTokens']),
-        cachedInputTokens: count(total?.['cachedInputTokens']),
-        outputTokens: count(total?.['outputTokens']),
-        reasoningOutputTokens: count(total?.['reasoningOutputTokens']),
+        inputTokens: count(resident?.['inputTokens']),
+        cachedInputTokens: count(resident?.['cachedInputTokens']),
+        outputTokens: count(resident?.['outputTokens']),
+        reasoningOutputTokens: count(resident?.['reasoningOutputTokens']),
+        processedTokens: count(total?.['totalTokens']),
         modelContextWindow: count(usage?.['modelContextWindow']),
     };
     return {
@@ -550,9 +564,15 @@ function handleTokenUsageUpdated(params: EvRec, ctx: SpawnContext): CodexAppEven
     };
 }
 
-/** A measurement, or nothing. Absent must not read as zero. */
+/**
+ * A measurement, or nothing. Absent must not read as zero.
+ *
+ * The wire declares these int64, which outruns what a JS number can hold
+ * exactly; past that point the value has already lost digits in the JSON
+ * parse, so reporting it would be reporting noise.
+ */
 function count(value: unknown): number | null {
-    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function handleError(params: EvRec): CodexAppEventResult {

--- a/src/agent/codex-app-events.ts
+++ b/src/agent/codex-app-events.ts
@@ -22,8 +22,26 @@ export interface CodexAppEventResult {
     messageStarted?: boolean | undefined;
     sessionId?: string | undefined;
     tokens?: Record<string, number> | undefined;
+    /**
+     * Conversation-wide usage, as distinct from `tokens`, which carries the
+     * last turn only and is consumed by cost accounting. Absent fields stay
+     * absent: an unreported context window is not an unlimited one, and zero
+     * used tokens is a different claim from "the runtime did not say".
+     */
+    contextUsage?: CodexAppContextUsage | undefined;
     flushThinking?: boolean | undefined;
     turnStatus?: string | undefined;
+}
+
+export interface CodexAppContextUsage {
+    /** Whole-conversation total, the number a context window is measured against. */
+    totalTokens: number;
+    inputTokens: number | null;
+    cachedInputTokens: number | null;
+    outputTokens: number | null;
+    reasoningOutputTokens: number | null;
+    /** The model's window, when the runtime reports one. */
+    modelContextWindow: number | null;
 }
 
 export interface CodexAppTurnLeaseIdentity {
@@ -513,7 +531,28 @@ function handleTokenUsageUpdated(params: EvRec, ctx: SpawnContext): CodexAppEven
             ...(last['cachedInputTokens'] ? { cached_input_tokens: last['cachedInputTokens'] as number } : {}),
         };
     }
-    return ctx.tokens ? { tokens: ctx.tokens } : {};
+    // `total` is the running conversation, which is what a context window is
+    // measured against; `last` is one turn and belongs to cost accounting.
+    // They are read separately because they answer different questions.
+    const total = usage ? f(usage, 'total') as EvRec | undefined : undefined;
+    const totalTokens = count(total?.['totalTokens']);
+    const contextUsage: CodexAppContextUsage | undefined = totalTokens === null ? undefined : {
+        totalTokens,
+        inputTokens: count(total?.['inputTokens']),
+        cachedInputTokens: count(total?.['cachedInputTokens']),
+        outputTokens: count(total?.['outputTokens']),
+        reasoningOutputTokens: count(total?.['reasoningOutputTokens']),
+        modelContextWindow: count(usage?.['modelContextWindow']),
+    };
+    return {
+        ...(ctx.tokens ? { tokens: ctx.tokens } : {}),
+        ...(contextUsage ? { contextUsage } : {}),
+    };
+}
+
+/** A measurement, or nothing. Absent must not read as zero. */
+function count(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 function handleError(params: EvRec): CodexAppEventResult {

--- a/src/code-mode/manager.ts
+++ b/src/code-mode/manager.ts
@@ -129,7 +129,12 @@ export class CodeSessionManager {
     list(options?: CodeSessionListOptions): CodeSessionInfo[] {
         this.ready();
         return this.storage(() => this.options.store.list(options)).map(row => {
-            try { return { ...row, pendingPermissionCount: this.sessions.get(row.sessionId)?.pendingPermissions().length ?? 0 }; }
+            try {
+                const service = this.sessions.get(row.sessionId);
+                const usage = service?.contextUsage() ?? null;
+                return { ...row, pendingPermissionCount: service?.pendingPermissions().length ?? 0,
+                    ...(usage ? { contextUsage: usage } : {}) };
+            }
             catch { return row; } // An unavailable attention read stays unknown, never inferred zero.
         });
     }
@@ -143,7 +148,9 @@ export class CodeSessionManager {
         const snapshot = this.storage(() => this.options.store.snapshot(id));
         const current = pendingPermissions.filter(permission =>
             permission.turnId === snapshot.session.turnId && permission.epoch === snapshot.session.epoch);
-        return { ...snapshot, session: { ...snapshot.session, pendingPermissionCount: current.length }, pendingPermissions: current };
+        const usage = session?.contextUsage() ?? null;
+        return { ...snapshot, session: { ...snapshot.session, pendingPermissionCount: current.length,
+            ...(usage ? { contextUsage: usage } : {}) }, pendingPermissions: current };
     }
 
     history(id: string, beforeSequence?: number, limit?: number): CodeHistoryPage {

--- a/src/code-mode/provider.ts
+++ b/src/code-mode/provider.ts
@@ -2,7 +2,7 @@ import type { RuntimeEvent, RuntimeEventBody, RuntimeTurnOutcome } from '../shar
 import type { RuntimeEventContext } from '../agent/runtime/events.js';
 import type { RuntimeRequests } from '../agent/runtime/requests.js';
 import type { RuntimeTranscriptObserver } from '../agent/runtime/projection.js';
-import type { CodePermissionMode, CodeProviderCatalog, CodeProviderId } from './wire.js';
+import type { CodeContextUsage, CodePermissionMode, CodeProviderCatalog, CodeProviderId } from './wire.js';
 
 export interface CodeTurnContext extends RuntimeEventContext {
     epoch: number;
@@ -31,6 +31,12 @@ export interface CodeOpenOptions {
     transcript(context: RuntimeEventContext): RuntimeTranscriptObserver;
     resolveTranscriptParent(context: RuntimeEventContext, nativeToolRef: string): string | null;
     onNativeCursor(cursor: string | null, context?: RuntimeEventContext): void;
+    /**
+     * Latest conversation-wide usage the runtime reported. Held in memory only:
+     * it describes a live native process, so a value that outlived that process
+     * would be a claim about a session that no longer holds.
+     */
+    onContextUsage(usage: CodeContextUsage): void;
     onExit(error: Error | null): void;
 }
 

--- a/src/code-mode/providers/codex-app.ts
+++ b/src/code-mode/providers/codex-app.ts
@@ -146,6 +146,12 @@ class CodeCodexSession implements CodeProviderSession {
                     if (parsed.text !== undefined && state.codexAppActiveChannel !== 'commentary') sawAnswer = true;
                 }
                 mapper.observe(method, params, parsed, state.codexAppActiveChannel ?? '');
+                // Conversation size, reported alongside the turn but not part of
+                // it: it is a property of the session, so it is handed to the
+                // session rather than folded into this turn's transcript.
+                if (parsed?.contextUsage) {
+                    this.options.onContextUsage({ ...parsed.contextUsage, updatedAt: Date.now() });
+                }
                 if (method === 'item/completed' && item['type'] === 'agentMessage'
                     && typeof item['id'] === 'string' && item['id'].length > 0 && item['id'].length <= 1024
                     && typeof item['text'] === 'string') {

--- a/src/code-mode/session.ts
+++ b/src/code-mode/session.ts
@@ -6,7 +6,7 @@ import { CodeTurnNormalizer, redactCodeText } from './normalize.js';
 import type { CodeOpenOptions, CodeProvider, CodeProviderSession, CodeRuntimeResource, CodeTurnContext } from './provider.js';
 import { CodeStore, CodeStoreError, type CodeSessionRecord, type CodeStoreOwner } from './store.js';
 import type {
-    CodeCancelRequest, CodeItem, CodePermissionAnswer, CodePermissionRequest,
+    CodeCancelRequest, CodeContextUsage, CodeItem, CodePermissionAnswer, CodePermissionRequest,
     CodeSessionError, CodeWireEvent,
 } from './wire.js';
 
@@ -77,6 +77,13 @@ export interface CodeSessionOptions {
 export class CodeSession {
     private operation: Operation | null = null;
     private binding: HandleBinding | null = null;
+    /**
+     * Latest usage the live runtime reported, held only for as long as this
+     * service is up. It is not persisted: it describes a native process, and a
+     * number that outlived that process would be a claim about a session that
+     * no longer holds.
+     */
+    private usage: CodeContextUsage | null = null;
     private readonly bindings = new Set<HandleBinding>();
     private readonly registry = new RuntimeRequests(() => {
         if (this.operation) this.syncPermissions(this.operation);
@@ -392,8 +399,19 @@ export class CodeSession {
                     this.publish(result.events);
                 } catch (error) { this.failPersistence(op, error); }
             },
+            onContextUsage: usage => {
+                // Only the handle that currently owns this session may speak
+                // for it; a late report from a replaced runtime is not news
+                // about the session that is running now.
+                if (this.binding !== binding) return;
+                this.usage = usage;
+            },
             onExit: () => this.onExit(binding),
         };
+    }
+
+    contextUsage(): CodeContextUsage | null {
+        return this.usage;
     }
 
     private record(op: Operation, context: RuntimeEventContext, body: RuntimeEventBody) {

--- a/src/code-mode/session.ts
+++ b/src/code-mode/session.ts
@@ -229,6 +229,10 @@ export class CodeSession {
         };
         if (previous && !reuse) previous.retiring = true;
         this.binding = binding;
+        // A usage figure belongs to the runtime that reported it. Replacing the
+        // runtime without reusing it means the numbers describe a process that
+        // is being retired, so they stop being an answer about this session.
+        if (previous && !reuse) this.usage = null;
         this.bindings.add(binding);
         const owner = { sessionId: record.sessionId, turnId: record.turnId, epoch: record.epoch };
         let wake!: () => void;
@@ -314,6 +318,9 @@ export class CodeSession {
 
     private onExit(binding: HandleBinding): void {
         if (binding.retiring || binding.exited || this.binding !== binding || this.disposed) return;
+        // The process that measured this is gone; its last figure is history,
+        // not the current size of anything.
+        this.usage = null;
         const op = this.operation;
         if (!op || op.binding !== binding) return;
         if (!op.settled) {

--- a/src/code-mode/session.ts
+++ b/src/code-mode/session.ts
@@ -122,6 +122,7 @@ export class CodeSession {
             // Physical proof retires residency without changing the cached close result.
             binding.closed = true;
             binding.retiring = true;
+            if (this.binding === binding) this.usage = null;
             this.bindings.delete(binding);
         }
     }
@@ -304,6 +305,10 @@ export class CodeSession {
 
     private async cleanup(binding: HandleBinding, cancel: boolean): Promise<boolean> {
         binding.retiring = true;
+        // Retiring the runtime that produced the figure retires the figure.
+        // Disposal, an idle reap and a model change all arrive here, and none
+        // of them reach onExit's clear because they set `retiring` first.
+        if (this.binding === binding) this.usage = null;
         binding.controller.abort();
         const handle = binding.handle;
         if (cancel && handle && !handle.closed && !binding.cancelPromise && !binding.resourceCloses.has(handle)) {
@@ -317,10 +322,12 @@ export class CodeSession {
     }
 
     private onExit(binding: HandleBinding): void {
+        // Before the guards, not after: a runtime that is retiring, already
+        // exited, superseded or disposed is exactly the case where its last
+        // measurement stops describing anything, and every one of those
+        // returns early below.
+        if (this.binding === binding) this.usage = null;
         if (binding.retiring || binding.exited || this.binding !== binding || this.disposed) return;
-        // The process that measured this is gone; its last figure is history,
-        // not the current size of anything.
-        this.usage = null;
         const op = this.operation;
         if (!op || op.binding !== binding) return;
         if (!op.settled) {
@@ -407,10 +414,11 @@ export class CodeSession {
                 } catch (error) { this.failPersistence(op, error); }
             },
             onContextUsage: usage => {
-                // Only the handle that currently owns this session may speak
-                // for it; a late report from a replaced runtime is not news
-                // about the session that is running now.
-                if (this.binding !== binding) return;
+                // Only the handle that currently owns this session, and is not
+                // on its way out, may speak for it. A binding can still be
+                // `this.binding` while retiring, and a report from a runtime
+                // being torn down is not news about the session.
+                if (this.binding !== binding || binding.retiring || binding.exited || this.disposed) return;
                 this.usage = usage;
             },
             onExit: () => this.onExit(binding),

--- a/src/code-mode/wire.ts
+++ b/src/code-mode/wire.ts
@@ -40,6 +40,30 @@ export interface CodeSessionInfo {
     lastUsedAt: number;
     /** Current index/snapshot attention, absent when not hydrated. */
     pendingPermissionCount?: number;
+    /**
+     * Latest reported context usage, absent when the runtime has not reported
+     * any. Like `pendingPermissionCount` this is attached at read time and
+     * never persisted: a number that was true for a process that has since
+     * exited is not a fact about the session now.
+     */
+    contextUsage?: CodeContextUsage;
+}
+
+/**
+ * What the native runtime said about the conversation's size.
+ *
+ * Every field except the total is nullable, because the runtime may report a
+ * breakdown without a window or a window without a breakdown, and an absent
+ * measurement must not be shown as zero.
+ */
+export interface CodeContextUsage {
+    totalTokens: number;
+    inputTokens: number | null;
+    cachedInputTokens: number | null;
+    outputTokens: number | null;
+    reasoningOutputTokens: number | null;
+    modelContextWindow: number | null;
+    updatedAt: number;
 }
 
 export interface CodePermissionRequest {

--- a/src/code-mode/wire.ts
+++ b/src/code-mode/wire.ts
@@ -57,11 +57,14 @@ export interface CodeSessionInfo {
  * measurement must not be shown as zero.
  */
 export interface CodeContextUsage {
+    /** Tokens resident in the context, from the runtime's last turn. */
     totalTokens: number;
     inputTokens: number | null;
     cachedInputTokens: number | null;
     outputTokens: number | null;
     reasoningOutputTokens: number | null;
+    /** Tokens billed across the conversation. Cost, not occupancy. */
+    processedTokens: number | null;
     modelContextWindow: number | null;
     updatedAt: number;
 }

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -683,6 +683,9 @@ is not a proportion, and a count with a window shows a percentage clamped at
 arithmetic. Every part of the breakdown is nullable and an unreported field
 shows as absent, never as zero. Thresholds change the ring colour at 75 and 90
 percent, and the accessible name carries the numbers the ring cannot.
+Usage is bound to the runtime that reported it: replacing a runtime without
+reusing it, or that runtime exiting, drops the figure rather than leaving a
+measurement of a process that is gone.
 
 The transcript renders sanitized Markdown, math and linear tables with stable
 virtual rows. Tool output stays escaped; local files open only after an explicit

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -674,18 +674,24 @@ the one row that is actually waiting its visibility; an unhydrated approval
 count remains unknown rather than being shown as zero.
 
 Context usage is reported by the runtime and shown in the composer footer as a
-ring beside the model. It is derived at read time and never persisted, like the
-pending approval count, because it describes a live native process. There are
-three states and they are distinct: nothing reported renders nothing, a count
-without a window shows the count alone since a proportion of an unknown total
-is not a proportion, and a count with a window shows a percentage clamped at
-100 so a conversation past its window reports the situation rather than the
-arithmetic. Every part of the breakdown is nullable and an unreported field
-shows as absent, never as zero. Thresholds change the ring colour at 75 and 90
-percent, and the accessible name carries the numbers the ring cannot.
-Usage is bound to the runtime that reported it: replacing a runtime without
-reusing it, or that runtime exiting, drops the figure rather than leaving a
-measurement of a process that is gone.
+ring beside the model. Occupancy is read from the runtime's last turn, which is
+what is resident in the context; the conversation-wide total is a spend
+accumulator that adds every turn including the prompt resent each time, so it
+passes the window many times over in ordinary use and is carried separately as
+processed tokens rather than driving the gauge. Usage is derived at read time
+and never persisted, like the pending approval count, because it describes a
+live native process. There are three states and they are distinct: nothing
+reported renders nothing, a count without a window shows the count alone since
+a proportion of an unknown total is not a proportion, and a count with a window
+shows a percentage. A count past the window caps the ring, which cannot draw
+past full, but says so rather than reading as a genuinely full context. Every
+part of the breakdown is nullable and an unreported field shows as absent,
+never as zero. Thresholds change the ring colour at 75 and 90 percent, and the
+accessible name carries the numbers the ring cannot.
+Usage is bound to the runtime that reported it and is dropped whenever that
+runtime is retired or exits, including disposal, an idle reap and a model
+change, rather than leaving a measurement of a process that is gone or a
+proportion of a window that no longer applies.
 
 Because it is attached at read time, usage travels on snapshots and listings
 and not on stored session events, which are built from the persisted record.

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -673,6 +673,17 @@ accessibility tree but are visually hidden, because a label on every row costs
 the one row that is actually waiting its visibility; an unhydrated approval
 count remains unknown rather than being shown as zero.
 
+Context usage is reported by the runtime and shown in the composer footer as a
+ring beside the model. It is derived at read time and never persisted, like the
+pending approval count, because it describes a live native process. There are
+three states and they are distinct: nothing reported renders nothing, a count
+without a window shows the count alone since a proportion of an unknown total
+is not a proportion, and a count with a window shows a percentage clamped at
+100 so a conversation past its window reports the situation rather than the
+arithmetic. Every part of the breakdown is nullable and an unreported field
+shows as absent, never as zero. Thresholds change the ring colour at 75 and 90
+percent, and the accessible name carries the numbers the ring cannot.
+
 The transcript renders sanitized Markdown, math and linear tables with stable
 virtual rows. Tool output stays escaped; local files open only after an explicit
 click. Endpoint/session changes reset measured heights and scroll ownership.

--- a/structure/frontend.md
+++ b/structure/frontend.md
@@ -687,6 +687,15 @@ Usage is bound to the runtime that reported it: replacing a runtime without
 reusing it, or that runtime exiting, drops the figure rather than leaving a
 measurement of a process that is gone.
 
+Because it is attached at read time, usage travels on snapshots and listings
+and not on stored session events, which are built from the persisted record.
+A session event therefore carries no usage, and the client keeps the figure it
+already has rather than blanking the meter on every unrelated status change.
+The number is refreshed by a snapshot, a session switch or an explicit refresh,
+so between those it can lag the runtime; it is old rather than invented, and
+the alternative would be a session frame per token notification against the
+turn's byte budget.
+
 The transcript renders sanitized Markdown, math and linear tables with stable
 virtual rows. Tool output stays escaped; local files open only after an explicit
 click. Endpoint/session changes reset measured heights and scroll ownership.

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -73,12 +73,12 @@ cli-jaw/
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
 │   │   ├── host.ts ← per-backend lazy composition and storage (70L)
 │   │   ├── manager.ts ← session index, admission and resource capacity (329L)
-│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (648L)
+│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (656L)
 │   │   ├── normalize.ts ← redacted materialized transcript and coalescing (534L)
 │   │   ├── store.ts ← SQLite ownership, replay, snapshots and byte budgets (794L)
 │   │   ├── provider.ts ← native handle and turn-context contracts (59L)
 │   │   ├── types.ts ← internal session and store contracts (12L)
-│   │   ├── wire.ts ← public request/event DTOs (210L)
+│   │   ├── wire.ts ← public request/event DTOs (213L)
 │   │   └── providers/        ← direct native adapters and capabilities
 │   │       ├── catalog.ts ← model/capability descriptions (129L)
 │   │       ├── live-models.ts ← last-known opencodex catalog, refreshed in background (93L)
@@ -178,7 +178,7 @@ cli-jaw/
 │   │   ├── cli-helpers.ts    ← Claude-like CLI 판별 helper (9L)
 │   │   ├── codex-app-client.ts ← Codex App stdio server client (1563L)
 │   │   ├── codex-host-pool.ts ← Codex App shared host generation + lane lease/FIFO/reaper/shutdown owner (494L)
-│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (573L)
+│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (593L)
 │   │   ├── error-classifier.ts ← stderr/result 기반 에러 분류 헬퍼 + shouldAnnounceStallTruncation (부분 출력 워치독 종료를 독자에게 알릴지 판정) (160L)
 │   │   ├── stall-notice.ts   ← 워치독 중단 통지 문구 + 접미사 전용 제거 (사람에겐 보이고 모델 컨텍스트엔 안 들어가도록 db 조회 경계가 사용) (21L) ✨
 │   │   ├── grok-trace-backfill.ts ← Grok trace backfill helper (167L) ✨

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -73,7 +73,7 @@ cli-jaw/
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
 │   │   ├── host.ts ← per-backend lazy composition and storage (70L)
 │   │   ├── manager.ts ← session index, admission and resource capacity (329L)
-│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (641L)
+│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (648L)
 │   │   ├── normalize.ts ← redacted materialized transcript and coalescing (534L)
 │   │   ├── store.ts ← SQLite ownership, replay, snapshots and byte budgets (794L)
 │   │   ├── provider.ts ← native handle and turn-context contracts (59L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -72,17 +72,17 @@ cli-jaw/
 │   │   └── skill-cache.ts    ← 활성 스킬 슬래시 커맨드 캐시 (registerSkillLoader, getSkillCommandsCache, invalidateSkillCommandsCache) (44L)
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
 │   │   ├── host.ts ← per-backend lazy composition and storage (70L)
-│   │   ├── manager.ts ← session index, admission and resource capacity (322L)
-│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (623L)
+│   │   ├── manager.ts ← session index, admission and resource capacity (329L)
+│   │   ├── session.ts ← captured turn ownership, cancellation and accepted-buffer drain (641L)
 │   │   ├── normalize.ts ← redacted materialized transcript and coalescing (534L)
 │   │   ├── store.ts ← SQLite ownership, replay, snapshots and byte budgets (794L)
-│   │   ├── provider.ts ← native handle and turn-context contracts (53L)
+│   │   ├── provider.ts ← native handle and turn-context contracts (59L)
 │   │   ├── types.ts ← internal session and store contracts (12L)
-│   │   ├── wire.ts ← public request/event DTOs (186L)
+│   │   ├── wire.ts ← public request/event DTOs (210L)
 │   │   └── providers/        ← direct native adapters and capabilities
 │   │       ├── catalog.ts ← model/capability descriptions (129L)
 │   │       ├── live-models.ts ← last-known opencodex catalog, refreshed in background (93L)
-│   │       ├── codex-app.ts ← Codex app-server adapter (320L)
+│   │       ├── codex-app.ts ← Codex app-server adapter (326L)
 │   │       ├── claude.ts ← Claude native adapter (93L)
 │   │       ├── acp.ts ← shared ACP resource ownership (134L)
 │   │       ├── cursor.ts ← Cursor native adapter (21L)
@@ -178,7 +178,7 @@ cli-jaw/
 │   │   ├── cli-helpers.ts    ← Claude-like CLI 판별 helper (9L)
 │   │   ├── codex-app-client.ts ← Codex App stdio server client (1563L)
 │   │   ├── codex-host-pool.ts ← Codex App shared host generation + lane lease/FIFO/reaper/shutdown owner (494L)
-│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (534L)
+│   │   ├── codex-app-events.ts ← Codex App turn/tool/message event adapter + phase 판정 + applyCodexAppTextEvent (573L)
 │   │   ├── error-classifier.ts ← stderr/result 기반 에러 분류 헬퍼 + shouldAnnounceStallTruncation (부분 출력 워치독 종료를 독자에게 알릴지 판정) (160L)
 │   │   ├── stall-notice.ts   ← 워치독 중단 통지 문구 + 접미사 전용 제거 (사람에겐 보이고 모델 컨텍스트엔 안 들어가도록 db 조회 경계가 사용) (21L) ✨
 │   │   ├── grok-trace-backfill.ts ← Grok trace backfill helper (167L) ✨
@@ -533,7 +533,7 @@ cli-jaw/
 │       ├── checkpoint/       ← checkpoint store + types (2 files, 59L) ✨
 │       ├── permissions/      ← permission policy + types (2 files, 80L) ✨
 │       └── context-map/      ← context map builder (1 file, 71L) ✨
-├── public/                   ← Web UI (Vite 8 + ES Modules, 605 files source/assets, ~102746L; generated `public/dist` and `public/public/dist` excluded)
+├── public/                   ← Web UI (Vite 8 + ES Modules, 607 files source/assets, ~103033L; generated `public/dist` and `public/public/dist` excluded)
 │   ├── settings/ ← standalone instance settings entry
 │   │   └── index.html ← Classic settings iframe HTML (13L)
 │   ├── index.html            ← 뼈대 + header project/git status anchor (695L)

--- a/tests/unit/code-context-usage.test.ts
+++ b/tests/unit/code-context-usage.test.ts
@@ -1,8 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import type { CodeContextUsage } from '../../src/code-mode/wire.ts';
-import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalTokens,
-    formatTokens } from '../../public/manager/src/code/context-usage.ts';
+import { contextUsageLabel, contextUsageLevel, contextUsageView, formatExactTokens,
+    formatOptionalTokens, formatTokens } from '../../public/manager/src/code/context-usage.ts';
 
 function usage(patch: Partial<CodeContextUsage> = {}): CodeContextUsage {
     return { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 200, outputTokens: 200,
@@ -52,6 +52,27 @@ test('counts stay short, and an unreported part stays absent', () => {
     assert.equal(formatTokens(1_250_000), '1.3M');
     assert.equal(formatOptionalTokens(null), '—', 'a field the runtime did not report is not zero');
     assert.equal(formatOptionalTokens(0), '0');
+});
+
+test('each unit is chosen after its own rounding, so no boundary produces a wrong one', () => {
+    // 999.5 rounds to 1000, which is not the bare small number that branch is
+    // for; 999,999 in thousands rounds to 1000, which would be a four-digit
+    // "k" where the answer is "1.0M".
+    assert.equal(formatTokens(999.5), '1.0k');
+    assert.equal(formatTokens(999_999), '1.0M');
+    assert.equal(formatTokens(999_499), '999k');
+    assert.equal(formatTokens(9_949), '9.9k');
+    assert.equal(formatTokens(10_000), '10k');
+    assert.equal(formatTokens(2_258_818), '2.3M');
+});
+
+test('the detail carries the count the trigger had to round away', () => {
+    // A reader cannot get from "12k" back to the number the percentage was
+    // computed from, and near a threshold that difference is the whole point.
+    assert.equal(formatExactTokens(12_400), '12,400');
+    assert.equal(formatExactTokens(134_904), '134,904');
+    assert.equal(formatExactTokens(null), '—');
+    assert.equal(formatExactTokens(Number.NaN), '—');
 });
 
 test('the accessible name says what the ring cannot', () => {

--- a/tests/unit/code-context-usage.test.ts
+++ b/tests/unit/code-context-usage.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { CodeContextUsage } from '../../src/code-mode/wire.ts';
+import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalTokens,
+    formatTokens } from '../../public/manager/src/code/context-usage.ts';
+
+function usage(patch: Partial<CodeContextUsage> = {}): CodeContextUsage {
+    return { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 200, outputTokens: 200,
+        reasoningOutputTokens: 0, modelContextWindow: 10000, updatedAt: 1, ...patch };
+}
+
+test('a reported window gives a proportion, and no window gives only a count', () => {
+    assert.deepEqual(contextUsageView(usage()), { state: 'measured', usedTokens: 1000, maxTokens: 10000, percent: 10 });
+    // A proportion of an unknown total is not a proportion, so the count stands
+    // alone rather than being turned into a percentage of something guessed.
+    assert.deepEqual(contextUsageView(usage({ modelContextWindow: null })), { state: 'counted', usedTokens: 1000 });
+    assert.deepEqual(contextUsageView(usage({ modelContextWindow: 0 })), { state: 'counted', usedTokens: 1000 });
+});
+
+test('nothing reported renders nothing, rather than a zero that reads as measured', () => {
+    assert.deepEqual(contextUsageView(undefined), { state: 'hidden' });
+    assert.deepEqual(contextUsageView(usage({ totalTokens: Number.NaN })), { state: 'hidden' });
+    assert.deepEqual(contextUsageView(usage({ totalTokens: -1 })), { state: 'hidden' });
+    // Zero used tokens IS a measurement, and differs from no measurement.
+    assert.deepEqual(contextUsageView(usage({ totalTokens: 0 })), { state: 'measured', usedTokens: 0, maxTokens: 10000, percent: 0 });
+});
+
+test('a conversation past the reported window clamps instead of reporting arithmetic', () => {
+    // Reachable after a model change or a compaction that has not landed:
+    // "118%" would describe the division, not the situation.
+    const over = contextUsageView(usage({ totalTokens: 11800 }));
+    assert.deepEqual(over, { state: 'measured', usedTokens: 11800, maxTokens: 10000, percent: 100 });
+});
+
+test('thresholds are named where attention starts', () => {
+    assert.equal(contextUsageLevel(74), 'normal');
+    assert.equal(contextUsageLevel(75), 'high');
+    assert.equal(contextUsageLevel(89), 'high');
+    assert.equal(contextUsageLevel(90), 'critical');
+    assert.equal(contextUsageLevel(100), 'critical');
+});
+
+test('counts stay short, and an unreported part stays absent', () => {
+    assert.equal(formatTokens(0), '0');
+    assert.equal(formatTokens(999), '999');
+    assert.equal(formatTokens(1000), '1.0k');
+    assert.equal(formatTokens(12400), '12k');
+    assert.equal(formatTokens(1_250_000), '1.3M');
+    assert.equal(formatOptionalTokens(null), '—', 'a field the runtime did not report is not zero');
+    assert.equal(formatOptionalTokens(0), '0');
+});
+
+test('the accessible name says what the ring cannot', () => {
+    assert.match(contextUsageLabel(contextUsageView(usage())), /10% used, 1\.0k of 10k tokens/);
+    assert.match(contextUsageLabel(contextUsageView(usage({ modelContextWindow: null }))), /window unknown/);
+    assert.equal(contextUsageLabel(contextUsageView(undefined)), '');
+});
+

--- a/tests/unit/code-context-usage.test.ts
+++ b/tests/unit/code-context-usage.test.ts
@@ -6,11 +6,11 @@ import { contextUsageLabel, contextUsageLevel, contextUsageView, formatOptionalT
 
 function usage(patch: Partial<CodeContextUsage> = {}): CodeContextUsage {
     return { totalTokens: 1000, inputTokens: 800, cachedInputTokens: 200, outputTokens: 200,
-        reasoningOutputTokens: 0, modelContextWindow: 10000, updatedAt: 1, ...patch };
+        reasoningOutputTokens: 0, processedTokens: 4000, modelContextWindow: 10000, updatedAt: 1, ...patch };
 }
 
 test('a reported window gives a proportion, and no window gives only a count', () => {
-    assert.deepEqual(contextUsageView(usage()), { state: 'measured', usedTokens: 1000, maxTokens: 10000, percent: 10 });
+    assert.deepEqual(contextUsageView(usage()), { state: 'measured', usedTokens: 1000, maxTokens: 10000, percent: 10, over: false });
     // A proportion of an unknown total is not a proportion, so the count stands
     // alone rather than being turned into a percentage of something guessed.
     assert.deepEqual(contextUsageView(usage({ modelContextWindow: null })), { state: 'counted', usedTokens: 1000 });
@@ -22,14 +22,18 @@ test('nothing reported renders nothing, rather than a zero that reads as measure
     assert.deepEqual(contextUsageView(usage({ totalTokens: Number.NaN })), { state: 'hidden' });
     assert.deepEqual(contextUsageView(usage({ totalTokens: -1 })), { state: 'hidden' });
     // Zero used tokens IS a measurement, and differs from no measurement.
-    assert.deepEqual(contextUsageView(usage({ totalTokens: 0 })), { state: 'measured', usedTokens: 0, maxTokens: 10000, percent: 0 });
+    assert.deepEqual(contextUsageView(usage({ totalTokens: 0 })), { state: 'measured', usedTokens: 0, maxTokens: 10000, percent: 0, over: false });
 });
 
-test('a conversation past the reported window clamps instead of reporting arithmetic', () => {
-    // Reachable after a model change or a compaction that has not landed:
-    // "118%" would describe the division, not the situation.
+test('past the window the ring caps but the label does not pretend it is full', () => {
+    // Reachable when a model change moves the window under a conversation that
+    // is already large. The ring cannot draw past full, but silently capping
+    // would make a wrong number look exactly like a genuinely full context --
+    // which is how a lifetime-spend figure would have hidden here.
     const over = contextUsageView(usage({ totalTokens: 11800 }));
-    assert.deepEqual(over, { state: 'measured', usedTokens: 11800, maxTokens: 10000, percent: 100 });
+    assert.deepEqual(over, { state: 'measured', usedTokens: 11800, maxTokens: 10000, percent: 100, over: true });
+    assert.match(contextUsageLabel(over), /over the window, 12k of 10k tokens/);
+    assert.doesNotMatch(contextUsageLabel(over), /100% used/, 'a self-contradictory label is worse than none');
 });
 
 test('thresholds are named where attention starts', () => {
@@ -55,4 +59,3 @@ test('the accessible name says what the ring cannot', () => {
     assert.match(contextUsageLabel(contextUsageView(usage({ modelContextWindow: null }))), /window unknown/);
     assert.equal(contextUsageLabel(contextUsageView(undefined)), '');
 });
-

--- a/tests/unit/code-native-session.test.ts
+++ b/tests/unit/code-native-session.test.ts
@@ -1615,3 +1615,24 @@ test('context usage answers for the live runtime only, and never outlives it', a
     assert.equal(f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage, undefined);
 });
 
+test('retiring a runtime retires its context figure, not just an explicit exit', async t => {
+    const f = fixture(t);
+    const row = f.create('codex-app');
+    f.manager.prompt(row.sessionId, prompt);
+    const options = await f.providers['codex-app'].opened();
+    const handle = f.providers['codex-app'].handles[0]!;
+    await handle.sent.promise;
+    options.onContextUsage({ totalTokens: 400_000, inputTokens: null, cachedInputTokens: null,
+        outputTokens: null, reasoningOutputTokens: null, processedTokens: null,
+        modelContextWindow: 1_000_000, updatedAt: 7 });
+    assert.equal(f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage?.totalTokens, 400_000);
+    handle.outcome.resolve(done);
+    await f.terminal(row.sessionId, 1);
+    // Disposal never reaches onExit's clear, because it retires the binding
+    // first. Leaving the figure would report 400k against a window belonging to
+    // a model that is no longer selected, for a runtime that is gone.
+    await f.manager.deleteSession?.(row.sessionId).catch(() => {});
+    const service = (f.manager as unknown as { sessions: Map<string, { dispose(): Promise<void> }> }).sessions.get(row.sessionId);
+    await service?.dispose();
+    assert.equal(f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage, undefined);
+});

--- a/tests/unit/code-native-session.test.ts
+++ b/tests/unit/code-native-session.test.ts
@@ -1591,3 +1591,27 @@ test('RT01: session dispose caches its promise before a drain subscriber dispose
     assert.equal(f.store.readTurn(row.sessionId, prompt.clientTurnKey)?.status, 'cancelled');
     assert.equal(handle.closes, 1);
 });
+
+test('context usage answers for the live runtime only, and never outlives it', async t => {
+    const f = fixture(t);
+    const row = f.create('codex-app');
+    f.manager.prompt(row.sessionId, prompt);
+    const options = await f.providers['codex-app'].opened();
+    const handle = f.providers['codex-app'].handles[0]!;
+    await handle.sent.promise;
+    assert.equal(f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage, undefined,
+        'nothing reported means nothing to say, not zero');
+    options.onContextUsage({ totalTokens: 345, inputTokens: 300, cachedInputTokens: 100,
+        outputTokens: 40, reasoningOutputTokens: 5, modelContextWindow: 272000, updatedAt: 7 });
+    const listed = f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage;
+    assert.equal(listed?.totalTokens, 345);
+    assert.equal(listed?.modelContextWindow, 272000);
+    assert.equal(f.manager.snapshot(row.sessionId).session.contextUsage?.totalTokens, 345);
+    handle.outcome.resolve(done);
+    await f.terminal(row.sessionId, 1);
+    // The process that measured this is gone. Its last figure is history, not
+    // the current size of anything, so it is not reported as if it still held.
+    options.onExit(null);
+    assert.equal(f.manager.list().find(entry => entry.sessionId === row.sessionId)?.contextUsage, undefined);
+});
+

--- a/tests/unit/code-native-ui-state.test.ts
+++ b/tests/unit/code-native-ui-state.test.ts
@@ -111,3 +111,22 @@ test('overflow bounds buffered data and requires authoritative recovery', () => 
     assert.equal(state.cursor, 0);
     assert.ok(state.error);
 });
+
+test('a session event does not blank context usage it was never able to carry', () => {
+    // Usage is attached at read time, so it travels on snapshots and listings
+    // and never on a stored session event. Replacing the record wholesale would
+    // clear the meter on every unrelated status change.
+    const usage = { totalTokens: 345, inputTokens: 300, cachedInputTokens: 100,
+        outputTokens: 40, reasoningOutputTokens: 5, modelContextWindow: 272000, updatedAt: 7 };
+    let state = reduceCodeSession(emptyCodeSession('s'), { type: 'snapshot',
+        snapshot: { ...snapshot(), session: { ...session, contextUsage: usage } } });
+    assert.equal(state.session?.contextUsage?.totalTokens, 345);
+    state = reduceCodeSession(state, { type: 'event', event: { topic: 'code', event: 'code_session',
+        sessionId: 's', sequence: 4, epoch: 1, session: { ...session, sequence: 4, status: 'idle' } } });
+    assert.equal(state.session?.status, 'idle', 'the event still applies');
+    assert.equal(state.session?.contextUsage?.totalTokens, 345, 'the last known figure stands');
+    // A newer read replaces it outright, including a read that reports none --
+    // a runtime that has exited has nothing to say about its context.
+    state = reduceCodeSession(state, { type: 'snapshot', snapshot: snapshot([item()], 5) });
+    assert.equal(state.session?.contextUsage, undefined);
+});

--- a/tests/unit/codex-app-events.test.ts
+++ b/tests/unit/codex-app-events.test.ts
@@ -410,3 +410,46 @@ test('codex-app lane normalizer rejects stale turn deltas without context mutati
         assert.equal(ctx.tokens, null, method);
     }
 });
+
+test('token usage reports the conversation total and the window, and keeps unreported fields absent', () => {
+    const ctx = createCtx();
+    ctx.sessionId = 'thread-a';
+    const result = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
+        threadId: 'thread-a', turnId: 'turn-a',
+        tokenUsage: {
+            last: { inputTokens: 3, outputTokens: 4, cachedInputTokens: 1 },
+            total: { inputTokens: 300, outputTokens: 40, cachedInputTokens: 100, reasoningOutputTokens: 5, totalTokens: 345 },
+            modelContextWindow: 272000,
+        },
+    }, ctx, 'thread-a', 'turn-a');
+    // The last turn still feeds cost accounting, unchanged.
+    assert.deepEqual(result?.tokens, { input_tokens: 3, output_tokens: 4, cached_input_tokens: 1 });
+    // The conversation total is what a context window is measured against, and
+    // it is a different number from the last turn.
+    assert.deepEqual(result?.contextUsage, {
+        totalTokens: 345, inputTokens: 300, cachedInputTokens: 100,
+        outputTokens: 40, reasoningOutputTokens: 5, modelContextWindow: 272000,
+    });
+});
+
+test('a runtime that reports no window, or no total at all, does not get a fabricated one', () => {
+    const ctx = createCtx();
+    ctx.sessionId = 'thread-a';
+    const noWindow = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
+        threadId: 'thread-a', turnId: 'turn-a',
+        tokenUsage: { last: { inputTokens: 1, outputTokens: 1 }, total: { totalTokens: 10 } },
+    }, ctx, 'thread-a', 'turn-a');
+    // Every unreported part stays null: absent is not zero.
+    assert.deepEqual(noWindow?.contextUsage, {
+        totalTokens: 10, inputTokens: null, cachedInputTokens: null,
+        outputTokens: null, reasoningOutputTokens: null, modelContextWindow: null,
+    });
+    const noTotal = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
+        threadId: 'thread-a', turnId: 'turn-a',
+        tokenUsage: { last: { inputTokens: 1, outputTokens: 1 } },
+    }, createCtx2(), 'thread-a', 'turn-a');
+    assert.equal(noTotal?.contextUsage, undefined, 'no total means nothing to say about the context');
+});
+
+function createCtx2() { const c = createCtx(); c.sessionId = 'thread-a'; return c; }
+

--- a/tests/unit/codex-app-events.test.ts
+++ b/tests/unit/codex-app-events.test.ts
@@ -411,25 +411,31 @@ test('codex-app lane normalizer rejects stale turn deltas without context mutati
     }
 });
 
-test('token usage reports the conversation total and the window, and keeps unreported fields absent', () => {
+test('the context gauge reads what is resident, not what has been billed', () => {
     const ctx = createCtx();
     ctx.sessionId = 'thread-a';
     const result = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
         threadId: 'thread-a', turnId: 'turn-a',
         tokenUsage: {
-            last: { inputTokens: 3, outputTokens: 4, cachedInputTokens: 1 },
-            total: { inputTokens: 300, outputTokens: 40, cachedInputTokens: 100, reasoningOutputTokens: 5, totalTokens: 345 },
-            modelContextWindow: 272000,
+            // Shape and magnitudes taken from a real 258,400-token session:
+            // `total` had reached 2,258,818 -- 8.7x the window -- while the
+            // live context sat at 134,904, because `total` adds every turn's
+            // usage including the prompt resent each time.
+            last: { inputTokens: 130372, outputTokens: 4532, cachedInputTokens: 128384, reasoningOutputTokens: 1551, totalTokens: 134904 },
+            total: { inputTokens: 2244365, outputTokens: 14453, cachedInputTokens: 2114176, reasoningOutputTokens: 6388, totalTokens: 2258818 },
+            modelContextWindow: 258400,
         },
     }, ctx, 'thread-a', 'turn-a');
     // The last turn still feeds cost accounting, unchanged.
-    assert.deepEqual(result?.tokens, { input_tokens: 3, output_tokens: 4, cached_input_tokens: 1 });
-    // The conversation total is what a context window is measured against, and
-    // it is a different number from the last turn.
+    assert.deepEqual(result?.tokens, { input_tokens: 130372, output_tokens: 4532, cached_input_tokens: 128384 });
+    // Occupancy comes from `last`; `total` is carried as spend, so a long
+    // conversation cannot pin the gauge to a permanent full.
     assert.deepEqual(result?.contextUsage, {
-        totalTokens: 345, inputTokens: 300, cachedInputTokens: 100,
-        outputTokens: 40, reasoningOutputTokens: 5, modelContextWindow: 272000,
+        totalTokens: 134904, inputTokens: 130372, cachedInputTokens: 128384,
+        outputTokens: 4532, reasoningOutputTokens: 1551,
+        processedTokens: 2258818, modelContextWindow: 258400,
     });
+    assert.ok((result?.contextUsage?.totalTokens ?? 0) < 258400, 'a real session stays inside its window');
 });
 
 test('a runtime that reports no window, or no total at all, does not get a fabricated one', () => {
@@ -437,19 +443,19 @@ test('a runtime that reports no window, or no total at all, does not get a fabri
     ctx.sessionId = 'thread-a';
     const noWindow = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
         threadId: 'thread-a', turnId: 'turn-a',
-        tokenUsage: { last: { inputTokens: 1, outputTokens: 1 }, total: { totalTokens: 10 } },
+        tokenUsage: { last: { totalTokens: 10 }, total: { totalTokens: 99 } },
     }, ctx, 'thread-a', 'turn-a');
     // Every unreported part stays null: absent is not zero.
     assert.deepEqual(noWindow?.contextUsage, {
         totalTokens: 10, inputTokens: null, cachedInputTokens: null,
-        outputTokens: null, reasoningOutputTokens: null, modelContextWindow: null,
+        outputTokens: null, reasoningOutputTokens: null,
+        processedTokens: 99, modelContextWindow: null,
     });
     const noTotal = extractFromCodexAppLaneEvent('thread/tokenUsage/updated', {
         threadId: 'thread-a', turnId: 'turn-a',
-        tokenUsage: { last: { inputTokens: 1, outputTokens: 1 } },
+        tokenUsage: { total: { totalTokens: 500 } },
     }, createCtx2(), 'thread-a', 'turn-a');
-    assert.equal(noTotal?.contextUsage, undefined, 'no total means nothing to say about the context');
+    assert.equal(noTotal?.contextUsage, undefined, 'spend alone says nothing about occupancy');
 });
 
 function createCtx2() { const c = createCtx(); c.sessionId = 'thread-a'; return c; }
-


### PR DESCRIPTION
Stacked on #641. Review that first; this PR's diff is only the context-usage work.

## Problem

The Code composer said nothing about how large a conversation had grown, and an earlier audit concluded it could not: [codex-app-events.ts](src/agent/codex-app-events.ts) reads only `tokenUsage.last`, so there was no running total and no window to measure it against.

That conclusion was wrong. The notification carries three things:

```ts
ThreadTokenUsage    = { last, total, modelContextWindow? }
TokenUsageBreakdown = { inputTokens, cachedInputTokens, outputTokens,
                        reasoningOutputTokens, totalTokens, cacheWriteInputTokens? }
```

cli-jaw was reading one of them, and three of the six fields inside it. The window had been arriving the whole time.

## What changed

The reader takes `total` and `modelContextWindow` as well. Existing last-turn tokens are untouched — that feeds cost accounting, and the running total is what a context window is measured against, so they stay separate.

Usage is attached at read time and never persisted, following the `pendingPermissionCount` precedent rather than adding a column. It describes a live native process, and a number that outlived that process would be a claim about a session that no longer holds. Only the handle that currently owns a session may report for it, so a late report from a replaced runtime is ignored.

## Three states, because they are three different claims

| runtime reported | shown |
|---|---|
| nothing | nothing — a zero would read as measured |
| a count, no window | `3.4k` alone; a proportion of an unknown total is not a proportion |
| a count and a window | a ring at `12%`, clamped at 100 |

The clamp matters after a model change or a compaction that has not landed: `118%` would be reporting the division rather than the situation. Every breakdown field is nullable and an unreported one shows as an em dash — the old `|| 0` could not tell "zero tokens" from "the runtime did not say", and this can.

The ring turns warn at 75% and error at 90%. The accessible name carries the numbers the ring cannot: `Context: 12% used, 3.4k of 28k tokens`.

## Cleanup

`.code-context-meter` and `.code-context-bar` were dead CSS from an earlier attempt that placed a meter in the session header, along with a comment still advertising it. Both are removed.

## Validation

- `tsc --noEmit` clean on both the root and frontend projects
- 617 tests pass across the Code and codex-app-events suites, 0 fail
- `check-doc-drift.sh` 4/4, `verify-counts.sh` 580/580, `check:private-boundary` OK

New tests cover the reader taking total and window while leaving last-turn tokens alone, unreported fields staying null, the three view states, the over-window clamp, threshold boundaries, and formatting.
