### PR TITLE
fix(steer): stop a steered Slack turn from posting "no response" and losing its answer

### DIFF
--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -935,10 +935,21 @@ export async function steerAgent(
     }
     insertMessage.run('user', newPrompt, source, '', settings["workingDir"] || null, chatSessionId);
     broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
-    broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey, requestId: meta?.requestId }));
+    broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey,
+        sessionId: chatSessionId, target: meta?.target, chatId: meta?.chatId, requestId: meta?.requestId,
+        remoteKey: meta?.remoteKey, replyViaTarget: meta?.replyViaTarget, mode: 'kill-steer' }));
     const { orchestrate, orchestrateContinue, orchestrateReset, isContinueIntent, isResetIntent } = await import('../orchestrator/pipeline.js');
     const origin = source || 'web';
-    const steerMeta = stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId, _skipInsert: true, _steerContext: steerContext || undefined });
+    // The follow-up run answers the SAME conversation the killed turn came from,
+    // but nothing downstream can infer that: a remote caller's reply is addressed
+    // by `target`, and dropping it here left the answer with nowhere to go. The
+    // dispatch waiter is already gone (ingress returns early for a steered
+    // submission), so an unaddressed terminal is silently discarded and the
+    // channel just goes quiet after a steer.
+    const steerMeta = stripUndefined({ origin, scope: scopeKey, chatSessionId, requestId: meta?.requestId,
+        target: meta?.target, chatId: meta?.chatId, remoteKey: meta?.remoteKey,
+        replyViaTarget: meta?.replyViaTarget, _fromSteer: true,
+        _skipInsert: true, _steerContext: steerContext || undefined });
     const task = isResetIntent(newPrompt)
         ? orchestrateReset(steerMeta)
         : isContinueIntent(newPrompt)
@@ -946,7 +957,9 @@ export async function steerAgent(
             : orchestrate(newPrompt, steerMeta);
     task.catch(async (err: Error) => {
         console.error('[steer:orchestrate]', err.message);
-        broadcast('orchestrate_done', stripUndefined({ text: `[error] ${err.message}`, error: true, origin, requestId: meta?.requestId }));
+        broadcast('orchestrate_done', stripUndefined({ text: `[error] ${err.message}`, error: true, origin,
+            target: meta?.target, chatId: meta?.chatId, replyViaTarget: meta?.replyViaTarget,
+            fromSteer: true, requestId: meta?.requestId }));
         settleOnce(meta?.requestId, 'failed', { error: err.message });
     });
     // The follow-up was started as a new run (kill-path or idle race). The caller

--- a/src/orchestrator/collect.ts
+++ b/src/orchestrator/collect.ts
@@ -49,6 +49,10 @@ export function orchestrateAndCollectData(
         let collected = '';
         let ownTerminalDiagnostic = '';
         let nativeSeen = false;
+        // Set when a LATER request steers this scope. The steer kills this run
+        // mid-flight, so its terminal carries no text — but that is a handover,
+        // not a failure, and must not surface as the "no response" placeholder.
+        let superseded = false;
         let settled = false;
         let runtimeActive = true;
         let nativeRunId: string | undefined;
@@ -113,6 +117,16 @@ export function orchestrateAndCollectData(
                     ownTerminalDiagnostic = ownTerminalDiagnostic || data['text'];
                 }
             }
+            // A steer aimed at THIS conversation retires this turn: the process is
+            // killed and the follow-up run owns the answer. Identity is checked so
+            // an unrelated scope's steer cannot retire this one, and the requestId
+            // must differ — a steer carrying our own id is not a supersession.
+            if (type === 'steer_started'
+                && data['scope'] === binding.scope
+                && (data['sessionId'] === undefined || data['sessionId'] === binding.chatSessionId)
+                && (!requestId || data['requestId'] !== requestId)) {
+                superseded = true;
+            }
             if (type === 'orchestrate_done') {
                 // Filter by requestId (strongest), then origin, then chatId
                 if (meta?.["requestId"] && data?.["requestId"] && data["requestId"] !== meta["requestId"]) return;
@@ -123,9 +137,11 @@ export function orchestrateAndCollectData(
                 runtimeActive = false;
                 removeBroadcastListener(handler);
                 const terminalText = typeof data['text'] === 'string' && data['text'].trim() ? data['text'] : '';
+                const fallback = superseded ? '' : t('tg.noResponse', {}, locale);
                 resolve({ text: native
-                    ? terminalText || ownTerminalDiagnostic || t('tg.noResponse', {}, locale)
-                    : data["text"] || collected || t('tg.noResponse', {}, locale), data });
+                    ? terminalText || ownTerminalDiagnostic || fallback
+                    : data["text"] || collected || fallback,
+                    data: superseded ? { ...data, superseded: true } : data });
             }
         };
         addBroadcastListener(handler);

--- a/src/orchestrator/pipeline.ts
+++ b/src/orchestrator/pipeline.ts
@@ -298,6 +298,10 @@ export async function orchestrate(
     // forwarder must fire for THESE turns only, or an ordinary reply, which the
     // dispatch path already posts, would go out twice.
     const fromQueue = meta["_fromQueue"] === true;
+    // Set by the kill-steer path. Like a queued turn, a steered follow-up has no
+    // live dispatch waiter (ingress returns early for a steered submission), so
+    // its terminal needs the standing forwarder to deliver it.
+    const fromSteer = meta["_fromSteer"] === true;
     const scope: string = meta['scope'];
     const chatSessionId: string = meta['chatSessionId'];
 
@@ -704,6 +708,7 @@ export async function orchestrate(
         requestId,
         replyViaTarget,
         ...(fromQueue ? { fromQueue: true } : {}),
+        ...(fromSteer ? { fromSteer: true } : {}),
         ...(nativeOutcome ? { scope, sessionId: chatSessionId }
             : settings["multiSession"]?.enabled === true ? { scope, sessionId: meta["chatSessionId"] || getActiveChatSession() } : {}),
         ...(typeof result['agyPlannerOnly'] === 'boolean' ? { agyPlannerOnly: result['agyPlannerOnly'] } : {}),

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -445,14 +445,19 @@ function installSlackTargetReplyForwarder(): void {
     targetReplyForwarderInstalled = true;
     addBroadcastListener((type, data) => {
         if (type !== 'orchestrate_done' || data["origin"] !== 'slack' || !data["text"]) return;
-        // Queued turns only. An ordinary turn is posted by the dispatch path
-        // that is still standing there awaiting it; answering that here too
-        // would post every reply twice.
+        // Queued and steered turns only. An ordinary turn is posted by the
+        // dispatch path that is still standing there awaiting it; answering that
+        // here too would post every reply twice.
         //
         // Errors included: after a restart there is no waiter to show them, so
         // dropping them here means the user's message vanishes without even a
         // failure notice.
-        if (data["fromQueue"] !== true) return;
+        //
+        // A steered turn is the same shape of orphan as a queued one: ingress
+        // returns early unless the disposition is 'new_run', so a mid-run steer
+        // leaves NO waiter for the follow-up answer. Without this the thread went
+        // silent after every steer while the answer completed server-side.
+        if (data["fromQueue"] !== true && data["fromSteer"] !== true) return;
         const target = data["target"] as RemoteTarget | undefined;
         if (!target || target.channel !== 'slack' || !target.targetId) return;
         // A live requester is already listening for this exact result; posting
@@ -584,6 +589,15 @@ async function slackOrchestrate(
                     }),
                 );
                 const text = collected.text;
+                // A turn retired by a steer has no answer of its own: the
+                // follow-up run owns it and the standing forwarder delivers it.
+                // Posting anything here — placeholder or empty body — is the
+                // "응답 없음" the user saw immediately after steering.
+                if (collected.data?.['superseded'] === true && !text.trim()) {
+                    log.info(`[slack:out:superseded] ${target.targetId}: retired by steer`);
+                    ackOutcome = 'success';
+                    return;
+                }
                 // Scoped for shutdown cancellation (#417): the body send and the
                 // image relay below share one abortable scope, released when the
                 // turn settles either way.

--- a/tests/unit/steer-superseded-delivery.test.ts
+++ b/tests/unit/steer-superseded-delivery.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { broadcast } from '../../src/core/bus.ts';
+
+// Regression for the Slack steer incident (suji, 2026-09-09): steering a running
+// turn posted the literal "응답 없음" placeholder into the thread, and the
+// follow-up run's real answer was never delivered at all.
+//
+// Both halves are reproduced here against the real collector:
+//   1. the killed turn must not resolve to the placeholder, and
+//   2. the follow-up terminal must be marked so the standing forwarder delivers it.
+
+let lastMeta: Record<string, unknown> = {};
+// The locale table is not loaded in this harness, so `t()` yields the raw key.
+// Asserting on the key keeps the test about WHICH string is chosen, not its wording.
+const NO_RESPONSE = 'tg.noResponse';
+
+test.mock.module('../../src/orchestrator/pipeline.ts', {
+    namedExports: {
+        isContinueIntent: () => false,
+        isResetIntent: () => false,
+        orchestrateContinue: () => undefined,
+        orchestrateReset: () => undefined,
+        orchestrate: (_prompt: string, meta: Record<string, unknown>) => {
+            lastMeta = meta;
+        },
+    },
+});
+
+test('a turn retired by a steer resolves empty, never the no-response placeholder', async () => {
+    const { orchestrateAndCollectData } = await import('../../src/orchestrator/collect.ts');
+    const pending = orchestrateAndCollectData('원본 질문', {
+        origin: 'slack', requestId: 'req-original', scope: 'default', chatSessionId: 'default',
+    });
+    // A LATER request steers this scope: the running process is killed, so its
+    // terminal carries no text.
+    broadcast('steer_started', { origin: 'slack', scope: 'default', sessionId: 'default', requestId: 'req-steer' });
+    broadcast('orchestrate_done', { ...lastMeta, text: '' });
+
+    const result = await pending;
+    assert.equal(result.text, '', 'a superseded turn must produce no user-visible text');
+    assert.notEqual(result.text, NO_RESPONSE);
+    assert.equal(result.data['superseded'], true, 'the send path needs this to stay silent');
+});
+
+test('an ordinary empty terminal still reports no response', async () => {
+    const { orchestrateAndCollectData } = await import('../../src/orchestrator/collect.ts');
+    const pending = orchestrateAndCollectData('원본 질문', {
+        origin: 'slack', requestId: 'req-plain', scope: 'default', chatSessionId: 'default',
+    });
+    broadcast('orchestrate_done', { ...lastMeta, text: '' });
+
+    const result = await pending;
+    assert.equal(result.text, NO_RESPONSE, 'a genuinely empty turn keeps its existing diagnostic');
+    assert.equal(result.data['superseded'], undefined);
+});
+
+test("another scope's steer does not retire this turn", async () => {
+    const { orchestrateAndCollectData } = await import('../../src/orchestrator/collect.ts');
+    const pending = orchestrateAndCollectData('원본 질문', {
+        origin: 'slack', requestId: 'req-scoped', scope: 'default', chatSessionId: 'default',
+    });
+    broadcast('steer_started', { origin: 'slack', scope: 'other-scope', sessionId: 'other', requestId: 'req-elsewhere' });
+    broadcast('orchestrate_done', { ...lastMeta, text: '' });
+
+    const result = await pending;
+    assert.equal(result.text, NO_RESPONSE);
+    assert.equal(result.data['superseded'], undefined);
+});


### PR DESCRIPTION
## Problem

Steering a running turn in Slack posted the literal `응답 없음` ("no response") placeholder into the thread, and the follow-up run's real answer never arrived. The thread then looked dead even though the agent had finished the work.

Observed live on suji (`cli: cursor`, `perCli.cursor.transport: print`, `midRunPolicy: steer`). A print-transport run exposes neither `steerTurnInBand` nor `replaceTurn`, so every steer there takes the kill path:

```
[slack:in]  아니 15일이 다음주 화요일인데 월요일로 대답했잖아
[slack:in]  ㅎㅇ                                  <- steers the running turn
[jaw:kill]  reason=steer scope=jaw:slack:channel:C0BRBKVRWCV:... cli=cursor
[jaw:main]  exited code=143, text=0 chars         <- killed turn
[slack:out] 응답 없음                              <- posted to the thread
[jaw:main]  exited code=0, text=12 chars          <- real answer, never sent
```

Two independent defects produce that pair.

**The killed turn resolved to the placeholder.** Its collector was still waiting when the steer killed the process, so the terminal carried no text and `collect.ts` fell through to its `t('tg.noResponse')` default. That default exists for a turn that genuinely produced nothing, not for one deliberately retired mid-flight.

**The follow-up answer had no route back.** The kill path built its orchestrate meta from `origin`/`scope`/`chatSessionId`/`requestId` only, dropping `target`, `chatId`, `remoteKey` and `replyViaTarget` — so the follow-up terminal was unaddressed. Nothing else could recover it: `ingress.ts` returns early unless the disposition is `new_run`, so a steered submission leaves no dispatch waiter, and the standing target-reply forwarder delivered `fromQueue` turns exclusively.

## Change

The collector watches `steer_started` for its own scope. When a *different* request retires the turn it resolves empty and marks the payload `superseded`; the Slack dispatch path stays silent on that marker rather than posting an empty body. Identity is checked on both scope and session, and a steer carrying the turn's own request id is not a supersession, so an unrelated conversation cannot retire this one. An ordinary empty terminal keeps its existing diagnostic.

The kill path now carries the owning conversation through to the follow-up run and tags it `fromSteer`. The Slack target-reply forwarder treats that as the same kind of orphan it already handles for queued turns, so the answer lands in the thread it came from.

## Behaviour

| | before | after |
|---|---|---|
| steered turn | posts `응답 없음` | posts nothing |
| follow-up answer | never delivered | delivered to the originating thread |
| genuinely empty turn | posts `응답 없음` | unchanged |

## Validation

- `npm run typecheck` — clean.
- The five existing steer suites (`cursor-acp-steer`, `native-steer-handler`, `codex-app-steer`, `queue-steer-main-wait`, `retired-busy-steer`) — 48/48 passing.
- New `tests/unit/steer-superseded-delivery.test.ts` drives the real collector through supersession, an ordinary empty terminal, and a steer belonging to another scope.
- Full `npm test` compared against an `origin/dev` baseline worktree: **no new failures**. Head shows 23 failures, baseline 22; the delta is two load-sensitive timing tests that pass in isolation, plus one file that fails identically on the untouched baseline (`browser-web-ai-headed-policy`, ENOENT on `skills_ref/web-ai/SKILL.md` — the submodule is not initialised in either worktree). All are environmental and in files this PR does not touch.
