### PR TITLE
fix(manager): stop the design watcher from holding a process open on Linux

### DIFF
--- a/src/manager/design/watcher.ts
+++ b/src/manager/design/watcher.ts
@@ -26,13 +26,21 @@ export function startDesignWatcher(): boolean {
     const root = dashboardPath('design');
     if (!existsSync(root)) return false;
     try {
-        watcher = watch(root, { recursive: true }, () => {
+        // persistent:false, not unref(), is what actually releases the loop here.
+        // Linux has no native recursive watch, so node builds one in JS
+        // (lib/fs.js: `if (options.recursive && !isMacOS && !isWindows)`), and that
+        // implementation's unref() only walks #files for StatWatcher entries — the
+        // per-directory FSWatchers in #watchers are never unref'ed, and a new one is
+        // added for every directory that appears after the start. A short-lived
+        // process therefore never exited on Linux while a page directory was created
+        // under the design root. persistent is forwarded to every inner watcher and
+        // to the native macOS/Windows path, so it holds on all three.
+        watcher = watch(root, { recursive: true, persistent: false }, () => {
             if (debounceTimer) clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => { version += 1; }, DEBOUNCE_MS);
             debounceTimer.unref?.();
         });
         watcher.on('error', () => stopDesignWatcher());
-        // Never keep a process alive just for the watcher (tests, CLI).
         watcher.unref?.();
         return true;
     } catch {

--- a/tests/unit/manager-design-routes.test.ts
+++ b/tests/unit/manager-design-routes.test.ts
@@ -7,11 +7,14 @@
  * - 409 conflict surfaces for stale baseRevision
  * - preview responds with HTML + locked CSP (script-src 'none')
  */
-import test from 'node:test';
+import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { stopDesignWatcher } from '../../src/manager/design/watcher.js';
 
 process.env['CLI_JAW_DASHBOARD_HOME'] = mkdtempSync(join(tmpdir(), 'jaw-design-routes-'));
 
@@ -132,3 +135,31 @@ test('snapshots list after export-before gate and restore requires header', asyn
     const restoreNoHeader = await request('POST', `/pages/${page.id}/snapshots/123-before/restore`);
     assert.equal(restoreNoHeader.code, 403);
 });
+test('the design watcher never holds a short-lived process open', () => {
+    // #661 follow-up: with forceExit gone, this file hung its child on CI for the full
+    // 180s stall bound. Linux has no native recursive fs.watch, and the JS stand-in's
+    // unref() never touches the per-directory handles it adds as directories appear —
+    // one is added for every page this suite creates. Only { persistent: false } stops
+    // that, so prove a child that starts the watcher and then creates a directory under
+    // it still exits on its own. On macOS this passes either way; CI is Linux.
+    const home = mkdtempSync(join(tmpdir(), 'jaw-design-watch-exit-'));
+    const watcherModule = pathToFileURL(join(import.meta.dirname, '..', '..', 'src', 'manager', 'design', 'watcher.ts')).href;
+    const script = [
+        `const { mkdirSync } = await import('node:fs');`,
+        `const { join } = await import('node:path');`,
+        `const root = join(process.env.CLI_JAW_DASHBOARD_HOME, 'design');`,
+        `mkdirSync(root, { recursive: true });`,
+        `const { startDesignWatcher } = await import(${JSON.stringify(watcherModule)});`,
+        `if (!startDesignWatcher()) { console.error('watcher did not start'); process.exit(2); }`,
+        `mkdirSync(join(root, 'page-created-after-start'), { recursive: true });`,
+        `await new Promise(resolve => setTimeout(resolve, 500));`,
+    ].join('\n');
+    const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', script], {
+        cwd: join(import.meta.dirname, '..', '..'), encoding: 'utf8', timeout: 30_000,
+        env: { ...process.env, CLI_JAW_DASHBOARD_HOME: home },
+    });
+    assert.equal(result.signal, null, `the child had to be killed, so the watcher held it open:\n${result.stderr ?? ''}`);
+    assert.equal(result.status, 0, result.stderr ?? '');
+});
+
+after(() => { stopDesignWatcher(); });


### PR DESCRIPTION
## What broke

Removing `forceExit` from the test driver (#661, merged as 2be76dd23) exposed a hang it had been hiding. On `ubuntu-latest`, `tests/unit/manager-design-routes.test.ts` passes all five of its tests and then its child never exits — the driver's new watchdog reported it precisely:

```
[tests/run] no progress for 180000ms (JAW_TEST_FILE_STALL_MS); aborting:
  .../tests/unit/manager-design-routes.test.ts — last test:pass 180818ms ago after 25 event(s)
```

The same file finishes in 98ms on macOS.

## Why

`startDesignWatcher()` called `fs.watch(root, { recursive: true })` and then `watcher.unref()`, with a comment promising it would "never keep a process alive just for the watcher (tests, CLI)". That promise only holds on macOS and Windows.

Linux has no native recursive watch, so node routes it through a JS implementation:

```js
// lib/fs.js
if (options.recursive && !isMacOS && !isWindows) {
  const nonNativeWatcher = require('internal/fs/recursive_watch');
```

and that implementation's `unref()` walks the wrong map:

```js
// lib/internal/fs/recursive_watch.js
unref() {
  this.#files.forEach((file) => {
    if (file instanceof StatWatcher) {
      file.unref();
    }
  });
}
```

`#files` holds `Stats`; the live per-directory handles live in `#watchers` and are never touched. `StatWatcher` is imported and never constructed there, so the call is a no-op. Worse, a fresh ref'ed handle is added for every directory that appears after the start — and this suite creates one per `POST /pages`. Node fixed it on `main` only ([nodejs/node#65486](https://github.com/nodejs/node/pull/65486), see also [#53350](https://github.com/nodejs/node/issues/53350)); v22 and v24 both ship the no-op, and CI runs Node 22.

## The change

`{ recursive: true, persistent: false }`. `persistent` is forwarded to every inner watcher (`watch(file, { persistent: this.#options.persistent })`) and to the native macOS/Windows path, so it expresses "do not hold the loop open" on all three platforms, at construction time rather than after. The watcher still works in the manager server, which stays alive for its listening socket.

`tests/unit/manager-design-routes.test.ts` also stops the watcher it starts, and gains a case that spawns a child which starts the watcher, creates a directory under it after the start, and asserts the child exits on its own. That case fails against the old code on Linux and passes either way on macOS, so CI is where it earns its keep.

## Validation

- `npm run typecheck` clean, `npm run gate:all` 23/23.
- Full `root,unit` scope locally: 13008 tests, 12988 pass, 0 fail.
- The Linux behaviour is only reachable in CI; this PR's own `test 2/4` shard is the proof.
