### PR TITLE
feat(slack): let a named bot trigger a turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,3 +459,5 @@ crates, bundles and installer payloads absent.
 - Optional pinned local services use `scripts/service-artifact.mjs` with an externally anchored manifest digest and an immutable package tree. Activation and registration remain explicit; keep the prior registration for rollback. See `docs/pinned-service-artifacts.md`.
 
 Slack file CLI uses an explicit conversation and completion-only upload receipts (`sent: boolean|unknown`, no auto retry or caption fallback); cancellation preserves known/unknown delivery. Sync commands/API/Slack docs.
+
+Slack `trustedBotTriggers` lets one named bot start a turn here: a fully validated rule plus a self-mention opens exactly the `bot_message` subtype, `allowBots` and `mention_via_app_mention` refusals, and nothing else. One malformed rule voids the whole list, and `isSlackMention` stays narrow because it also decides thread ownership. See `structure/infra.md` §`src/slack/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,5 @@ data. Do not restore `native/claude-e`, `claude-exec`, or `@bitkyc08/ai-e`.
 - Optional pinned local services use `scripts/service-artifact.mjs` with an externally anchored manifest digest and an immutable package tree. Activation and registration remain explicit; keep the prior registration for rollback. See `docs/pinned-service-artifacts.md`.
 
 Slack file CLI uses an explicit conversation and completion-only upload receipts (`sent: boolean|unknown`, no auto retry or caption fallback); cancellation preserves known/unknown delivery. Sync commands/API/Slack docs.
+
+Slack `trustedBotTriggers` lets one named bot start a turn here: a fully validated rule plus a self-mention opens exactly the `bot_message` subtype, `allowBots` and `mention_via_app_mention` refusals, and nothing else. One malformed rule voids the whole list, and `isSlackMention` stays narrow because it also decides thread ownership. See `structure/infra.md` §`src/slack/`.

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -311,6 +311,9 @@ function createDefaultSettings() {
             channelIds: [] as string[],
             forwardAll: true,
             allowBots: false,
+            // Named other bots that may start a turn here. Empty means none, and
+            // the inbound gate validates every rule before trusting any of them.
+            trustedBotTriggers: [] as { channelId: string; botId: string; userId: string; textMarker: string }[],
             // Slack bots typically live in shared team channels, where
             // answering every message is antisocial. DMs bypass this gate.
             mentionOnly: true,

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -1,6 +1,6 @@
 import { verifiedSlackWorkspace } from './verified-workspace.js';
 import { slackCredentialKey, type SlackToolSource } from './tool-context.js';
-import { isSlackMention } from './events.js';
+import { isSlackMention, matchesTrustedBotTrigger } from './events.js';
 // ─── Slack Bot ───────────────────────────────────────
 // Slack transport implementation for the cli-jaw messaging runtime.
 // Mirrors src/discord/bot.ts structurally: init/shutdown lifecycle, an inbound
@@ -409,6 +409,8 @@ function gateConfig() {
         allowBots: Boolean(sc.allowBots),
         mentionOnly: sc.mentionOnly !== false,
         channelIds: readSlackAllowlist(sc.channelIds),
+        // Validated inside the gate, not here: this module does not own the shape.
+        trustedBotTriggers: sc.trustedBotTriggers,
         // Thread continuation defaults ON (threadRequireMention=false):
         // once mentioned, a thread keeps flowing without re-mention.
         threadRequireMention: sc.threadRequireMention === true,
@@ -1098,7 +1100,9 @@ async function runSlackMessageEvent(
         ...(event.ts ? { ackTs: event.ts } : {}),
         ...(event.user ? { recipientUserId: event.user } : {}),
         isDirect: event.channel_type === 'im',
-        isMention: isSlackMention(event, selfUserId),
+        // A trusted bot trigger is addressed to this instance as surely as a
+        // human mention, and `isSlackMention` deliberately stays narrow.
+        isMention: isSlackMention(event, selfUserId) || matchesTrustedBotTrigger(event, gateConfig()),
     });
 }
 
@@ -1369,7 +1373,7 @@ export async function handleSlackEnvelope(envelope: SlackEnvelope, approvalTrans
     const prefetchOwner = preResolvedScope
         ? getSessionOwnershipGeneration(preResolvedScope)
         : undefined;
-    if (isSlackMention(event, selfUserId) && event.channel) {
+    if ((isSlackMention(event, selfUserId) || matchesTrustedBotTrigger(event, gateConfig())) && event.channel) {
         // A top-level mention starts a thread the bot will parent, so the whole
         // thread belongs to it. A mention INSIDE an existing thread is an
         // invitation into someone else's conversation, and only that (#400).

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -51,6 +51,12 @@ export type SlackGateConfig = {
     /** true = threads also require a mention (multi-bot escape hatch). */
     threadRequireMention: boolean;
     /**
+     * Operator-declared allowances for other bots, straight from settings.json.
+     * Deliberately `unknown`: nothing validates that file on read, so the shape
+     * is proven here rather than assumed by every caller.
+     */
+    trustedBotTriggers?: unknown;
+    /**
      * How the bot is in this thread, injected so this module stays IO-free.
      * `owned` = the bot's own message parents the thread; `joined` = it was
      * pulled into a conversation already in progress; null = not in it.
@@ -84,6 +90,75 @@ export function isSlackMention(event: SlackMessageEvent, selfUserId: string | nu
 
 export function mentionsUser(text: string, userId: string): boolean {
     return new RegExp(`<@${userId}(?:\\|[^>]*)?>`).test(text);
+}
+
+/** One other bot, in one conversation, saying one agreed word. */
+export type TrustedBotTrigger = {
+    channelId: string;
+    botId: string;
+    userId: string;
+    textMarker: string;
+};
+
+const TRUSTED_TRIGGER_KEYS = ['channelId', 'botId', 'userId', 'textMarker'] as const;
+const TRUSTED_TRIGGER_PATTERNS: Record<(typeof TRUSTED_TRIGGER_KEYS)[number], RegExp> = {
+    channelId: /^[CG][A-Z0-9]{2,}$/,
+    botId: /^B[A-Z0-9]{2,}$/,
+    userId: /^[UW][A-Z0-9]{2,}$/,
+    textMarker: /^[A-Z][A-Z0-9_]{2,63}$/,
+};
+const TRUSTED_TRIGGER_MAX = 16;
+
+/**
+ * Read the allowance list, or read nothing at all.
+ *
+ * One malformed rule refuses the whole list. A typo in an inbound-authorization
+ * setting has to fail closed: the alternative is a list that half-applies, where
+ * the operator sees their rule in the file and cannot tell which half is live.
+ */
+export function readTrustedBotTriggers(value: unknown): TrustedBotTrigger[] {
+    if (!Array.isArray(value) || value.length === 0 || value.length > TRUSTED_TRIGGER_MAX) return [];
+    const rules: TrustedBotTrigger[] = [];
+    for (const raw of value) {
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return [];
+        const row = raw as Record<string, unknown>;
+        if (Object.keys(row).length !== TRUSTED_TRIGGER_KEYS.length) return [];
+        for (const key of TRUSTED_TRIGGER_KEYS) {
+            const field = row[key];
+            if (typeof field !== 'string' || !TRUSTED_TRIGGER_PATTERNS[key].test(field)) return [];
+        }
+        rules.push({
+            channelId: row['channelId'] as string,
+            botId: row['botId'] as string,
+            userId: row['userId'] as string,
+            textMarker: row['textMarker'] as string,
+        });
+    }
+    return rules;
+}
+
+/**
+ * Does this event carry an allowance to start a turn even though a bot sent it?
+ *
+ * Everything a rule names must line up at once: the text mentions this instance,
+ * the payload carries a live bot identity that agrees with itself, and some rule
+ * matches its channel, bot id, sender id and marker word. Nothing here widens
+ * who may be answered — it only lets a named trigger past the bot refusals.
+ */
+export function matchesTrustedBotTrigger(event: SlackMessageEvent, config: SlackGateConfig): boolean {
+    const rules = readTrustedBotTriggers(config.trustedBotTriggers);
+    if (rules.length === 0 || !config.selfUserId) return false;
+    if (!mentionsUser(event.text || '', config.selfUserId)) return false;
+    const botId = event.bot_id || event.bot_profile?.id;
+    const userId = event.user || event.bot_profile?.user_id;
+    if (!botId || !userId || userId === config.selfUserId || event.bot_profile?.deleted === true) return false;
+    // A payload that disagrees with itself names no one, so it matches no rule.
+    if ((event.bot_id && event.bot_profile?.id && event.bot_id !== event.bot_profile.id)
+        || (event.user && event.bot_profile?.user_id && event.user !== event.bot_profile.user_id)) return false;
+    // Whole words only: REELBRAIN_MEDIA_V1X must never satisfy REELBRAIN_MEDIA_V1.
+    const words = new Set((event.text || '').split(/\s+/));
+    return rules.some(rule => rule.channelId === event.channel
+        && rule.botId === botId && rule.userId === userId && words.has(rule.textMarker));
 }
 
 /**
@@ -180,7 +255,11 @@ export function shouldProcessSlackEvent(
     config: SlackGateConfig,
     envelopeType: string,
 ): SlackGateDecision {
-    if (event.subtype && IGNORED_SUBTYPES.has(event.subtype)) {
+    // Computed once: three refusals below ask the same question, and re-deriving
+    // it would let the answer drift between them.
+    const trustedTrigger = matchesTrustedBotTrigger(event, config);
+    if (event.subtype && IGNORED_SUBTYPES.has(event.subtype)
+        && !(event.subtype === 'bot_message' && trustedTrigger)) {
         return { process: false, reason: `subtype_${event.subtype}` };
     }
     // Self-echo: our own posts arrive back as message events. Without this the
@@ -191,7 +270,7 @@ export function shouldProcessSlackEvent(
     // `bot_id` alone is not the whole bot signal: a granular-permission app can
     // send `bot_profile` without it, and that payload used to walk straight past
     // allowBots:false into an agent run (audit 002 §R2-6).
-    if ((event.bot_id || event.bot_profile) && !config.allowBots) {
+    if ((event.bot_id || event.bot_profile) && !config.allowBots && !trustedTrigger) {
         return { process: false, reason: 'bot_message' };
     }
     if (!event.channel) {
@@ -209,7 +288,10 @@ export function shouldProcessSlackEvent(
     // "❌ duplicate". The app_mention copy is the canonical path; DMs never
     // produce app_mention envelopes, so they are unaffected.
     // MPIM message events must stand alone; do not wait for an app_mention twin.
-    if (!dm && event.channel_type !== 'mpim' && event.type !== 'app_mention' && config.selfUserId
+    // A trusted trigger keeps its message envelope: the app_mention twin is not
+    // guaranteed for a bot post, and the duplicate claim in slack/bot.ts already
+    // collapses the pair by (team, channel, ts) when both do arrive.
+    if (!trustedTrigger && !dm && event.channel_type !== 'mpim' && event.type !== 'app_mention' && config.selfUserId
         && mentionsUser(event.text || '', config.selfUserId)) {
         return { process: false, reason: 'mention_via_app_mention' };
     }

--- a/structure/AGENTS.md
+++ b/structure/AGENTS.md
@@ -116,3 +116,5 @@ Native quota readers follow the OpenCodex source contract: Codex window duration
 
 
 Slack file CLI uses an explicit conversation and completion-only upload receipts (`sent: boolean|unknown`, no auto retry or caption fallback); cancellation preserves known/unknown delivery. Sync commands/API/Slack docs.
+
+Slack `trustedBotTriggers` lets one named bot start a turn here: a fully validated rule plus a self-mention opens exactly the `bot_message` subtype, `allowBots` and `mention_via_app_mention` refusals, and nothing else. One malformed rule voids the whole list, and `isSlackMention` stays narrow because it also decides thread ownership. See `structure/infra.md` §`src/slack/`.

--- a/structure/infra.md
+++ b/structure/infra.md
@@ -1241,6 +1241,14 @@ Channel narrowing helpers and slash-command registration.
 
 top-level 채널은 현재 event ts 직전의 `conversations.history`를 세션 소유 세대당 한 번 프롬프트 preamble에 주입한다. thread는 `conversations.replies` cursor를 최대 10페이지 따라가며 parent + 최신 50 replies만 보존한다. 합성 top-level reply 주소는 채널 session identity를 공유하되 `midRunPolicy: followup`으로 진행 중인 다른 사용자의 turn을 steer/kill하지 않는다.
 
+### trusted bot triggers (`events.ts`)
+
+`slack.trustedBotTriggers`는 다른 봇 하나가 이 인스턴스의 턴을 시작할 수 있게 하는 운영자 선언 목록이다. 규칙은 `{channelId, botId, userId, textMarker}` 네 키뿐이며 각각 `^[CG][A-Z0-9]{2,}$`, `^B[A-Z0-9]{2,}$`, `^[UW][A-Z0-9]{2,}$`, `^[A-Z][A-Z0-9_]{2,63}$`를 만족해야 한다. 목록은 최대 16개이고 **하나라도 어긋나면 전체가 무효**다 — 인바운드 권한 설정의 오타는 절반만 살아 있는 상태보다 닫히는 쪽이 낫다.
+
+매칭은 이벤트가 자기 자신을 멘션하고, `bot_id`/`bot_profile.id`와 `user`/`bot_profile.user_id`가 서로 모순되지 않으며, 삭제된 프로필이 아니고, 어떤 규칙이 채널·봇·발신자·마커 단어와 정확히 맞을 때만 성립한다. 마커는 공백 단위 단어 비교라 `REELBRAIN_MEDIA_V1X`가 `REELBRAIN_MEDIA_V1`을 만족시키지 않는다.
+
+일치는 정확히 세 거부만 연다: `bot_message` subtype 무시, `allowBots:false` 거부, 그리고 `mention_via_app_mention` 중복 제거. self-echo, 채널 누락, 대화 허용목록, `mentionOnly`, empty-event 검사는 그대로다. 중복 제거를 열어도 실행은 한 번인데, `bot.ts`가 dispatch 전에 `slackEventKey(teamId, channel, ts)`를 선점하므로 같은 글의 `app_mention`/`message` 두 봉투가 하나로 접힌다. `isSlackMention()` 자체는 넓히지 않는다 — 그 함수는 thread 참여 소유권도 정하기 때문에, 넓히면 #400이 고친 과잉 응답이 되돌아온다.
+
 ### mention-watch.ts (345L)
 
 `scanSlackMentions()`는 봇이 가입한 명시적 채널에서 특정 사용자가 태그된 새 메시지를 찾는다. 봇 토큰으로 쓸 수 없는 user-token 전용 `search.messages` 대신 `conversations.history`를 newest에서 과거 방향으로 읽는다. 커서는 처리가 끝난 메시지까지만 전진하고, 끝내지 못한 backward walk는 `resume_before`에서 이어간다. 채널 시작점을 tick마다 회전해 hot channel의 독점을 막고, 429가 오면 wrapper 재시도 없이 그 tick을 멈춘다. 한 tick의 채널 상한은 60이며 초과분은 `overflowChannels`로 반환한다.

--- a/tests/unit/slack-trusted-bot-trigger.test.ts
+++ b/tests/unit/slack-trusted-bot-trigger.test.ts
@@ -1,0 +1,147 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    shouldProcessSlackEvent,
+    matchesTrustedBotTrigger,
+    readTrustedBotTriggers,
+    type SlackGateConfig,
+    type SlackMessageEvent,
+} from '../../src/slack/events.ts';
+import { slackEventKey } from '../../src/slack/ingress.ts';
+import { mergeSettingsPatch } from '../../src/core/settings-merge.ts';
+
+const SELF = 'U0SELF00001';
+const RULE = { channelId: 'C0TRIGGER1', botId: 'B0TRIGGER1', userId: 'U0TRIGGER1', textMarker: 'REELBRAIN_MEDIA_V1' };
+
+function config(overrides: Partial<SlackGateConfig> = {}): SlackGateConfig {
+    return {
+        selfUserId: SELF,
+        allowBots: false,
+        mentionOnly: true,
+        channelIds: [],
+        threadRequireMention: false,
+        trustedBotTriggers: [RULE],
+        threadParticipation: () => null,
+        ...overrides,
+    };
+}
+
+function botPost(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
+    return {
+        type: 'message',
+        subtype: 'bot_message',
+        channel: RULE.channelId,
+        bot_id: RULE.botId,
+        user: RULE.userId,
+        ts: '1789000000.000100',
+        text: `<@${SELF}> REELBRAIN_MEDIA_V1 ready`,
+        ...overrides,
+    };
+}
+
+test('a configured trigger admits the bot post it names', () => {
+    assert.deepEqual(shouldProcessSlackEvent(botPost(), config(), 'events_api'), { process: true });
+});
+
+test('the same post is refused without a configured rule', () => {
+    const decision = shouldProcessSlackEvent(botPost(), config({ trustedBotTriggers: [] }), 'events_api');
+    assert.deepEqual(decision, { process: false, reason: 'subtype_bot_message' });
+});
+
+for (const [label, event] of [
+    ['another channel', botPost({ channel: 'C0ELSEWHERE' })],
+    ['another bot', botPost({ bot_id: 'B0OTHERBOT' })],
+    ['another sender', botPost({ user: 'U0OTHERUSR' })],
+    ['no marker', botPost({ text: `<@${SELF}> ready` })],
+    ['marker inside a longer token', botPost({ text: `<@${SELF}> REELBRAIN_MEDIA_V1X` })],
+    ['no mention of this instance', botPost({ text: 'REELBRAIN_MEDIA_V1 ready' })],
+    ['a deleted bot profile', botPost({ bot_profile: { id: RULE.botId, user_id: RULE.userId, deleted: true } })],
+    ['a bot id that contradicts its profile', botPost({ bot_profile: { id: 'B0OTHERBOT', user_id: RULE.userId } })],
+    ['a sender that contradicts its profile', botPost({ bot_profile: { id: RULE.botId, user_id: 'U0OTHERUSR' } })],
+] as const) test(`a trigger stays refused for ${label}`, () => {
+    assert.equal(matchesTrustedBotTrigger(event, config()), false);
+    assert.equal(shouldProcessSlackEvent(event, config(), 'events_api').process, false);
+});
+
+for (const [label, rules] of [
+    ['a missing field', [{ channelId: RULE.channelId, botId: RULE.botId, userId: RULE.userId }]],
+    ['an extra field', [{ ...RULE, note: 'why' }]],
+    ['a lowercase marker', [{ ...RULE, textMarker: 'reelbrain_media_v1' }]],
+    ['a user id shaped like a channel', [{ ...RULE, userId: RULE.channelId }]],
+    ['one bad rule beside a good one', [RULE, { ...RULE, botId: 'nope' }]],
+    ['more rules than the cap', Array.from({ length: 17 }, () => RULE)],
+    ['a rule that is not an object', ['REELBRAIN_MEDIA_V1']],
+] as const) test(`the whole list is refused for ${label}`, () => {
+    assert.deepEqual(readTrustedBotTriggers(rules), []);
+    assert.equal(matchesTrustedBotTrigger(botPost(), config({ trustedBotTriggers: rules })), false);
+});
+
+test('a rule naming this instance cannot make it answer itself', () => {
+    const selfRule = { ...RULE, userId: SELF };
+    const selfConfig = config({ trustedBotTriggers: [selfRule] });
+    const echo = botPost({ user: SELF, bot_id: RULE.botId });
+    assert.equal(matchesTrustedBotTrigger(echo, selfConfig), false);
+    assert.equal(shouldProcessSlackEvent(echo, selfConfig, 'events_api').process, false);
+    // Without the bot subtype the self-echo gate is the one that answers, and it
+    // runs before any bot handling, so no rule can reopen it.
+    assert.deepEqual(
+        shouldProcessSlackEvent(botPost({ user: SELF, subtype: undefined }), selfConfig, 'events_api'),
+        { process: false, reason: 'self_message' },
+    );
+});
+
+test('a trigger cannot reach a conversation outside the allowlist', () => {
+    const decision = shouldProcessSlackEvent(botPost(), config({ channelIds: ['C0ALLOWED1'] }), 'events_api');
+    assert.deepEqual(decision, { process: false, reason: 'channel_not_allowed' });
+});
+
+test('a human writing the marker in the same channel takes none of the bot skips', () => {
+    // The rule names a bot identity Slack attests. Copying the words is not
+    // holding the token, so this must read as an ordinary channel mention.
+    const impostor: SlackMessageEvent = {
+        type: 'message',
+        channel: RULE.channelId,
+        user: 'U0HUMAN001',
+        ts: '1789000000.000200',
+        text: `<@${SELF}> REELBRAIN_MEDIA_V1 ready`,
+    };
+    assert.equal(matchesTrustedBotTrigger(impostor, config()), false);
+    assert.deepEqual(
+        shouldProcessSlackEvent(impostor, config(), 'events_api'),
+        { process: false, reason: 'mention_via_app_mention' },
+    );
+    // The same words from a bot that is not the named one stay refused too.
+    const otherBot = botPost({ bot_id: 'B0OTHERBOT', user: 'U0OTHERUSR' });
+    assert.deepEqual(
+        shouldProcessSlackEvent(otherBot, config(), 'events_api'),
+        { process: false, reason: 'subtype_bot_message' },
+    );
+});
+
+test('an ordinary channel mention still defers to its app_mention twin', () => {
+    const human = { type: 'message', channel: 'C0PUBLIC01', user: 'U0HUMAN001', ts: '1.1', text: `<@${SELF}> hi` };
+    const decision = shouldProcessSlackEvent(human, config(), 'events_api');
+    assert.deepEqual(decision, { process: false, reason: 'mention_via_app_mention' });
+});
+
+test('both envelopes of one trigger post are admitted but share a duplicate key', () => {
+    const message = botPost();
+    const mention = botPost({ type: 'app_mention', subtype: undefined });
+    assert.equal(shouldProcessSlackEvent(message, config(), 'events_api').process, true);
+    assert.equal(shouldProcessSlackEvent(mention, config(), 'events_api').process, true);
+    // slack/bot.ts claims this key before dispatch, so only one of them runs.
+    assert.equal(
+        slackEventKey('T1', message.channel!, message.ts!),
+        slackEventKey('T1', mention.channel!, mention.ts!),
+    );
+});
+
+test('a settings write beside the rules leaves them intact', () => {
+    const merged = mergeSettingsPatch(
+        { slack: { allowBots: false, trustedBotTriggers: [RULE], channelIds: [] } },
+        { slack: { allowBots: true } },
+    );
+    assert.deepEqual(merged['slack'].trustedBotTriggers, [RULE]);
+    assert.equal(merged['slack'].allowBots, true);
+});


### PR DESCRIPTION
A second bot posts a message that mentions this instance to start its daily work, and that message never reaches an agent run. Three refusals in `shouldProcessSlackEvent` drop it: the `bot_message` subtype is ignored, `bot_id`/`bot_profile` is refused while `allowBots` is false, and a non-`app_mention` channel message that mentions self is dropped as `mention_via_app_mention`. There is no way to allow one specific trigger short of setting `allowBots: true`, which opens the instance to every bot in every allowed conversation.

`slack.trustedBotTriggers` names the exception instead. A rule is `{channelId, botId, userId, textMarker}` and admits a post only when all of it lines up: the text mentions this instance, the payload carries a live bot identity that agrees with itself (`bot_id` against `bot_profile.id`, `user` against `bot_profile.user_id`, not deleted, not this instance), and some rule matches the channel, bot, sender and marker as a whitespace-delimited word. A match opens exactly the three refusals above; self-echo, missing channel, the conversation allowlist, `mentionOnly` and the empty-event check all still apply.

Before: a bot post mentioning the app is refused as `subtype_bot_message`. After, with a matching rule: it is processed, and every near miss — another channel, another bot, another sender, a marker that is only a substring of a longer token — stays refused.

The list validates as a whole and one malformed rule voids all of it. A typo in an inbound-authorization setting should fail closed rather than half-apply, where the operator sees their rule in the file and cannot tell which half is live. The list is capped at 16 rules.

`isSlackMention` is deliberately not broadened. It also decides thread ownership through `markThreadParticipated`, so treating every channel message that mentions the app as a mention would re-open the over-answering that #400 fixed. The trusted match is computed separately and OR-ed in at the two call sites that need it, and a regression test pins that an ordinary user mention still defers to its `app_mention` twin.

Opening the mention dedup does not double-run a turn: `src/slack/bot.ts` claims `slackEventKey(teamId, channel, ts)` before dispatch, and that key ignores the envelope type, so the `app_mention` and `message` copies of one post collapse to a single run. A test asserts both envelopes are admitted by the gate and share one key.

Validation: 23 new cases in `tests/unit/slack-trusted-bot-trigger.test.ts` plus the existing Slack inbound and settings suites (111 passing), typecheck, atomic build, `verify-dist-assets`, `docs:check`, and all 23 repository gates. Two independent reviews ran on `xai/grok-4.6`: one confirmed the settings merge and load paths preserve an operator-written rule list, the other reviewed the gate for spoofable fields.

A live post from the trigger bot is the only end-to-end proof and is not ours to send; it remains an open live check.
