### PR TITLE
feat(slack): warn when a trusted trigger list is unusable

### DIFF
--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -1,6 +1,6 @@
 import { verifiedSlackWorkspace } from './verified-workspace.js';
 import { slackCredentialKey, type SlackToolSource } from './tool-context.js';
-import { isSlackMention, matchesTrustedBotTrigger } from './events.js';
+import { isSlackMention, matchesTrustedBotTrigger, readTrustedBotTriggers } from './events.js';
 // ─── Slack Bot ───────────────────────────────────────
 // Slack transport implementation for the cli-jaw messaging runtime.
 // Mirrors src/discord/bot.ts structurally: init/shutdown lifecycle, an inbound
@@ -1565,6 +1565,18 @@ async function runSlackInit(ctx?: TransportInitContext): Promise<TransportStartO
         // indistinguishable (#478).
         const emit = gap.level === 'warn' ? log.warn : log.info;
         emit(`[slack:scopes] ${gap.text}`);
+    }
+    // A trusted-trigger list that fails validation is refused whole and in
+    // silence, which reads exactly like a bot that never posted. Say it once at
+    // boot so a typo is a visible mistake instead of a trigger that vanished.
+    const declaredTriggers = Array.isArray(sc.trustedBotTriggers) ? sc.trustedBotTriggers.length : 0;
+    if (declaredTriggers > 0) {
+        const usable = readTrustedBotTriggers(sc.trustedBotTriggers).length;
+        if (usable === 0) {
+            log.warn(`[slack:triggers] ${declaredTriggers} trusted bot trigger(s) configured but the list is invalid, so none of them can start a turn — every rule needs exactly channelId (C/G), botId (B), userId (U/W) and an uppercase textMarker`);
+        } else {
+            log.info(`[slack:triggers] ${usable} trusted bot trigger(s) active`);
+        }
     }
     if (auth.data?.team_id && !sc.teamId) sc.teamId = auth.data.team_id;
     // The team id namespaces every ingress dedup key, and `slackEventKey`

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -349,7 +349,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (41 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1825L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1837L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (442L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (222L)
 │   │   ├── blocks.ts         ← Block Kit validation and per-table message splitting (143L)

--- a/tests/unit/slack-trusted-bot-trigger.test.ts
+++ b/tests/unit/slack-trusted-bot-trigger.test.ts
@@ -145,3 +145,13 @@ test('a settings write beside the rules leaves them intact', () => {
     assert.deepEqual(merged['slack'].trustedBotTriggers, [RULE]);
     assert.equal(merged['slack'].allowBots, true);
 });
+
+test('an invalid list is distinguishable from an absent one', () => {
+    // The boot warning in slack/bot.ts is built on exactly this difference:
+    // rules were declared, and none of them survived validation.
+    const declared = [{ ...RULE, botId: 'not-a-bot-id' }];
+    assert.equal(Array.isArray(declared) && declared.length > 0, true);
+    assert.deepEqual(readTrustedBotTriggers(declared), []);
+    assert.deepEqual(readTrustedBotTriggers(undefined), []);
+    assert.equal(readTrustedBotTriggers([RULE]).length, 1);
+});


### PR DESCRIPTION
A trusted-trigger list that fails validation is refused as a whole and in silence. From the outside that is indistinguishable from a trigger bot that never posted, and the likely cause — one mistyped id — is exactly the case an operator cannot see.

Slack init now says it once, next to the existing scope report: an invalid list warns with the rule shape it expects, and a usable list logs how many rules are active. Nothing about admission changes.

```
[slack:triggers] 1 trusted bot trigger(s) configured but the list is invalid, so none of them can start a turn — every rule needs exactly channelId (C/G), botId (B), userId (U/W) and an uppercase textMarker
```

Validation: 69 tests across the trusted-trigger and Slack inbound suites, typecheck, atomic build, `verify-dist-assets`, and all 23 gates.
