### PR TITLE
fix(code): give read-time session meta a single owner

### DIFF
--- a/public/manager/src/code/code-controller-runtime.ts
+++ b/public/manager/src/code/code-controller-runtime.ts
@@ -1,6 +1,6 @@
 import type {
-    CodeCreateSessionRequest, CodeModelCatalog, CodePatchSessionRequest, CodePermissionRequest,
-    CodeSessionInfo, CodeWireEvent,
+    CodeContextUsage, CodeCreateSessionRequest, CodeModelCatalog, CodePatchSessionRequest,
+    CodePermissionRequest, CodeSessionInfo, CodeWireEvent,
 } from '../../../../src/code-mode/wire';
 import type { CodeControllerModel, CodeControllerOptions, CodeSessionFilter, CodeTransportState } from './code-controller-types';
 import { CodeClientError, codeBaseOrigin, createCodeSessionClient, type CodeGitInfo } from './code-session-client';
@@ -22,12 +22,34 @@ const newer = (incoming: CodeSessionInfo, current?: CodeSessionInfo | null) => !
     || incoming.epoch > current.epoch || (incoming.epoch === current.epoch && (incoming.sequence > current.sequence
         || (incoming.sequence === current.sequence && incoming.revision >= current.revision)));
 
+/**
+ * What a read that could actually observe the runtime said about attention.
+ *
+ * `contextUsage` and `pendingPermissionCount` are attached at read time and never
+ * persisted, so only the two server reads that overlay them — list and snapshot —
+ * can speak for them. A stored `code_session` frame and the create/patch/cancel/
+ * attach responses carry neither field, and `newer()` ranks only epoch, sequence
+ * and revision, so without a separate owner a payload that simply cannot carry a
+ * field would outrank one that measured it.
+ *
+ * Absence is recorded, not skipped: once the runtime is reaped the owning read
+ * stops reporting usage, and the meter has to hide in that same turn.
+ */
+interface CodeSessionAttention {
+    epoch: number;
+    sequence: number;
+    revision: number;
+    pendingPermissionCount?: number;
+    contextUsage?: CodeContextUsage;
+}
+
 /** Code's async owner; React only subscribes and supplies the single SSE transport. */
 export class CodeController {
     private client;
     private book: CodeDraftBook;
     private details = new Map<string, CodeSessionState>();
     private summaries = new Map<string, CodeSessionInfo>();
+    private attention = new Map<string, CodeSessionAttention>();
     private rows: string[] = [];
     private catalog: CodeModelCatalog | null = null;
     private catalogError: string | null = null;
@@ -100,6 +122,7 @@ export class CodeController {
             this.book.listeners.delete(this.changed);
             this.details.clear();
             this.summaries.clear();
+            this.attention.clear();
             this.rows = [];
             this.gitGeneration++;
             this.pickerGeneration++;
@@ -133,13 +156,41 @@ export class CodeController {
         const summary = this.summaries.get(id);
         return summary && newer(summary, detail) ? summary : detail ?? summary ?? null;
     }
-    private accept(session: CodeSessionInfo): void {
+    /**
+     * Record what an owning read saw. Call this BEFORE accept() on the same object:
+     * accept() copies rather than mutates, but the ordering keeps the rule obvious.
+     */
+    private observe(session: CodeSessionInfo): void {
+        const known = this.attention.get(session.sessionId);
+        if (known && !newer(session, { ...session, epoch: known.epoch, sequence: known.sequence, revision: known.revision })) return;
+        this.attention.set(session.sessionId, {
+            epoch: session.epoch, sequence: session.sequence, revision: session.revision,
+            ...(session.pendingPermissionCount === undefined ? {} : { pendingPermissionCount: session.pendingPermissionCount }),
+            ...(session.contextUsage === undefined ? {} : { contextUsage: session.contextUsage }),
+        });
+    }
+    /** Publish `base` with attention resolved from its owner, absence included. */
+    private resolve(id: string, base: CodeSessionInfo): CodeSessionInfo {
+        const seen = this.attention.get(id);
+        const { contextUsage: _usage, pendingPermissionCount: _count, ...rest } = base;
+        return {
+            ...rest,
+            ...(seen?.pendingPermissionCount === undefined ? {} : { pendingPermissionCount: seen.pendingPermissionCount }),
+            ...(seen?.contextUsage === undefined ? {} : { contextUsage: seen.contextUsage }),
+        };
+    }
+    private accept(incoming: CodeSessionInfo): void {
         if (!this.active) return;
-        if (!newer(session, this.info(session.sessionId))) return;
+        if (!newer(incoming, this.info(incoming.sessionId))) return;
+        // The ranked record carries identity and lifecycle only. Attached fields are
+        // dropped by copy, never by mutation: readIndex hands the same row to
+        // observe(), and update() hands over details.session, which the reducer may
+        // still be holding (code-session-state.ts snapshot replace).
+        const { contextUsage: _usage, pendingPermissionCount: _count, ...session } = incoming;
         this.summaries.set(session.sessionId, session);
         if (this.summaries.size > MAX_INDEX + MAX_DETAILS) {
             const victim = [...this.summaries.keys()].find(id => id !== this.book.selectedId && !this.details.has(id) && !this.rows.includes(id));
-            if (victim) this.summaries.delete(victim);
+            if (victim) { this.summaries.delete(victim); this.attention.delete(victim); }
         }
         const draft = this.book.sessions.get(session.sessionId);
         if (draft?.stopTarget && (session.turnId !== draft.stopTarget.turnId || session.epoch !== draft.stopTarget.epoch
@@ -189,7 +240,13 @@ export class CodeController {
         const canonical = this.info(id);
         const draft = this.draft(id);
         const detail = id ? this.details.get(id) : undefined;
-        const session = canonical && detail?.synced ? { ...canonical, pendingPermissionCount: detail.permissions.length } : canonical;
+        // One place decides what either screen may show, so the meter and the
+        // sidebar cannot disagree about the same read.
+        const publish = (row: CodeSessionInfo, state?: CodeSessionState): CodeSessionInfo => {
+            const resolved = this.resolve(row.sessionId, row);
+            return state?.synced ? { ...resolved, pendingPermissionCount: state.permissions.length } : resolved;
+        };
+        const session = canonical ? publish(canonical, detail) : canonical;
         const operation = draft.operation;
         const persistenceWarning = this.book.storageWarning ?? this.book.recoveryWarning;
         const pending = ['creating', 'sending', 'stopping', 'resuming', 'patching'].includes(operation.kind) && !operation.error;
@@ -197,7 +254,7 @@ export class CodeController {
         return {
             catalog: this.catalog, sessions: this.rows.map(id => {
                 const row = this.info(id), detail = this.details.get(id);
-                return row && detail?.synced ? { ...row, pendingPermissionCount: detail.permissions.length } : row;
+                return row ? publish(row, detail) : row;
             }).filter((row): row is CodeSessionInfo => !!row),
             selectedId: id, session, items: withPendingUserItem(draft, detail?.items ?? []),
             permissions: detail?.permissions ?? [],
@@ -246,6 +303,8 @@ export class CodeController {
                 ...(this.filter.scope === 'cwd' ? { cwd: this.workingDir } : {}) }, this.abort.signal);
             if (!this.active || life !== this.lifetime || generation !== this.indexGeneration) return;
             for (const session of page.sessions) {
+                // A listing is one of the two reads that can see the live runtime.
+                this.observe(session);
                 this.accept(session);
                 const state = this.details.get(session.sessionId);
                 if (state?.hydrated && !state.hydrating && session.sequence > state.cursor) {
@@ -258,7 +317,7 @@ export class CodeController {
             this.moreSessions = page.hasMore && this.rows.length < MAX_INDEX;
             this.indexError = null;
             const retained = new Set([...this.rows, ...this.details.keys(), ...(this.book.selectedId ? [this.book.selectedId] : [])]);
-            for (const id of this.summaries.keys()) if (!retained.has(id)) this.summaries.delete(id);
+            for (const id of this.summaries.keys()) if (!retained.has(id)) { this.summaries.delete(id); this.attention.delete(id); }
         } catch (error) {
             if (this.active && life === this.lifetime && generation === this.indexGeneration) this.indexError = message(error);
         } finally {
@@ -292,6 +351,8 @@ export class CodeController {
                         const snapshot = await this.client.snapshot(id, read.signal);
                         if (!current()) return;
                         checkedStop = checkingStop;
+                        // The other owning read. Absence here is the idle reap.
+                        this.observe(snapshot.session);
                         this.update(id, reduceCodeSession(this.state(id), { type: 'snapshot', snapshot }));
                     }
                     state = this.state(id);
@@ -473,7 +534,11 @@ export class CodeController {
             this.accept(await this.client.patchSession(id, { ...input, expectedRevision: session.revision }));
             draft.operation = { kind: 'idle', error: null };
         } catch (error) {
-            if (error instanceof CodeClientError && error.session?.sessionId === id) this.accept(error.session);
+            if (error instanceof CodeClientError && error.session?.sessionId === id) {
+                // A revision conflict answers with the snapshot session, overlay included.
+                this.observe(error.session);
+                this.accept(error.session);
+            }
             failure = error instanceof CodeClientError ? error : new Error(message(error));
             draft.operation = { kind: 'idle', error: failure.message };
         }

--- a/tests/unit/code-native-controller.test.ts
+++ b/tests/unit/code-native-controller.test.ts
@@ -1,6 +1,6 @@
 import test, { type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
-import type { CodeItem, CodeModelCatalog, CodePermissionRequest, CodeSessionInfo, CodeSnapshot } from '../../src/code-mode/wire.ts';
+import type { CodeContextUsage, CodeItem, CodeModelCatalog, CodePermissionRequest, CodeSessionInfo, CodeSnapshot } from '../../src/code-mode/wire.ts';
 import { loadCodeDraftStorage } from '../../public/manager/src/code/code-controller-draft-storage.ts';
 import { CodeController } from '../../public/manager/src/code/code-controller-runtime.ts';
 
@@ -623,4 +623,59 @@ test('reloaded in-flight Stop stays captured and reconciles through reads withou
     assert.equal(restored.getModel().operation.kind, 'idle');
     assert.match(restored.getModel().operation.error!, /Press Stop to retry/);
     assert.equal(f.posts().length, 1);
+});
+
+// --- #702: one owner for read-time-attached session meta ---
+// contextUsage and pendingPermissionCount are attached at read time and never
+// persisted, so only list and snapshot can speak for them. Everything else —
+// stored code_session frames, and the create/patch/cancel/attach responses —
+// carries neither, and newer() cannot tell "absent because reaped" from
+// "absent because this payload could never carry it".
+const usage = (totalTokens: number, updatedAt = 9): CodeContextUsage => ({ totalTokens, inputTokens: null,
+    cachedInputTokens: null, outputTokens: null, reasoningOutputTokens: null, processedTokens: null,
+    modelContextWindow: 200_000, updatedAt });
+const meter = (controller: CodeController) => controller.getModel().session?.contextUsage?.totalTokens;
+const row = (controller: CodeController, id: string) => controller.getModel().sessions.find(entry => entry.sessionId === id);
+
+test('a session event alone never blanks the meter, and the owning read still hides it on the same turn it stops reporting', async t => {
+    const f = fixture(t);
+    f.snapshots.set('a', snap(session('a', { contextUsage: usage(345) })));
+    await f.controller.refresh(); await f.controller.selectSession('a');
+    assert.equal(meter(f.controller), 345);
+    // A stored frame cannot carry usage. It must not be read as "the runtime reports none".
+    f.controller.onEvent({ topic: 'code', event: 'code_session', sessionId: 'a', sequence: 4, epoch: 1,
+        session: session('a', { sequence: 4 }) });
+    assert.equal(meter(f.controller), 345, 'an SSE frame is not an observation of occupancy');
+    assert.equal(row(f.controller, 'a')?.contextUsage?.totalTokens, 345, 'the sidebar follows the same observation');
+    // Idle reap: the runtime is gone, so the owning reads stop attaching a figure.
+    f.snapshots.set('a', snap(session('a', { sequence: 5 })));
+    await f.controller.refresh();
+    assert.equal(meter(f.controller), undefined, 'the read that owns the figure withdrew it');
+    assert.equal(row(f.controller, 'a')?.contextUsage, undefined);
+});
+
+test('a metadata write that cannot observe the runtime does not blank a live meter', async t => {
+    const f = fixture(t);
+    f.snapshots.set('a', snap(session('a', { contextUsage: usage(345) })));
+    await f.controller.refresh(); await f.controller.selectSession('a');
+    assert.equal(meter(f.controller), 345);
+    // patch answers from the store, at a higher revision and with no overlay.
+    f.intercept(call => call.method === 'PATCH'
+        ? response({ ok: true, session: session('a', { title: 'renamed', revision: 9 }) }) : undefined);
+    await f.controller.rename('a', 'renamed');
+    assert.equal(f.controller.getModel().session?.title, 'renamed');
+    assert.equal(meter(f.controller), 345, 'a rename is not evidence that the runtime stopped reporting');
+});
+
+test('ranking a listing never strips the figure off the row the owner just read', async t => {
+    const f = fixture(t);
+    // The fixture serves the same session object for the listing and the snapshot,
+    // which is exactly the aliasing that an in-place strip would corrupt.
+    const live = snap(session('a', { contextUsage: usage(1234) }));
+    f.snapshots.set('a', live);
+    await f.controller.refresh();
+    assert.equal(live.session.contextUsage?.totalTokens, 1234, 'the caller object is left intact');
+    assert.equal(row(f.controller, 'a')?.contextUsage?.totalTokens, 1234);
+    await f.controller.selectSession('a');
+    assert.equal(meter(f.controller), 1234);
 });


### PR DESCRIPTION
## Problem

`contextUsage` and `pendingPermissionCount` are attached when the server reads a session and are never persisted (`src/code-mode/wire.ts:42-49`). Only `manager.list()` (`src/code-mode/manager.ts:134-137`) and `manager.snapshot()` (`:147-153`) overlay them. Stored `code_session` frames are built from `toCodeSessionInfo` (`src/code-mode/store.ts:210-223`) and carry neither, and neither do the create / patch / cancel / attach responses.

On the client every one of those sources funnels into `accept()`, and `newer()` ranks only epoch, sequence and revision — so a payload that could never carry a field never loses to one that measured it. Two concrete failures:

**Ghost occupancy.** The reducer deliberately keeps the last usage figure when a `code_session` frame cannot carry one (`code-session-state.ts:64-70`). That keep is a display-local fallback, but `update()` fed the reduced session straight back into `accept()`, promoting the client's own guess into the ranked record. After the runtime exited the meter kept showing the old figure until some later list read happened to correct it.

**Blank meter while alive.** A rename or a cancel answers from the store at a higher revision with no attached fields, so the summary was replaced and the meter blanked even though the runtime was still reporting. The badge survived the same write because `makeModel()` re-merged `pendingPermissionCount` and not `contextUsage` — which is exactly why the two screens disagreed.

## Change

Record what the owning reads saw in a separate `attention` map with its own watermark; keep the ranked summary to identity and lifecycle; resolve both fields from that one place when the model is published, for the selected session and for every sidebar row through the same helper.

Absence is recorded rather than skipped, so an idle reap hides the meter on the same turn the owner stops reporting, while an SSE frame — which is not an observation of occupancy — leaves it alone.

`accept()` drops the fields by copy, never by mutation: `readIndex` hands the same row object to `observe()`, and `update()` hands over `details.session`, which the reducer may still be holding.

No server file changes. The server already has exactly one overlay owner and it was correct.

## Verification

- 3 new controller tests in `tests/unit/code-native-controller.test.ts`, one per completion condition: an SSE frame does not blank the meter and the owning read still hides it on the reap turn; a metadata write that cannot observe the runtime does not blank a live meter; and ranking a listing does not strip the figure off the row the owner just read (the fixture serves one object for both the listing and the snapshot, which is the aliasing an in-place strip would corrupt).
- Existing assertions were checked against the change: `:243` stays `undefined`, `:304` stays `2` because `observe()` reattaches it, and `:305` stays `0` because the synced-detail precedence is unchanged.
- `bash structure/verify-counts.sh` → ALL PASS, 592 items. Neither changed file is line-tracked in `structure/str_func.md`, so this PR does not touch it.
- Local product suite **NOT RUN** by instruction: `npm test`, `npm run typecheck` and `npm run build` were not executed. CI on the head SHA is the only verification evidence.

Plan and two-round independent audit are recorded outside this repository.

Closes #702
