### PR TITLE
fix(security): guard the sensitive routes that skipped requireAuth (#684)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -393,7 +393,7 @@ registerGoalRoutes(app, requireAuth);
 registerTaskRoutes(app, requireAuth);
 registerBgtaskRoutes(app, requireAuth);
 registerEventsRoutes(app, requireAuth);
-registerInstanceRoutes(app);
+registerInstanceRoutes(app, requireAuth);
 registerChatSessionRoutes(app, requireAuth);
 registerMessageRoutes(app, requireAuth);
 const searchRegistry = new SearchProviderRegistry();
@@ -409,7 +409,7 @@ registerSearchRoutes(app, requireAuth, new SearchCoordinator(searchRegistry));
 // than imported by the wiki module so core keeps no dependency on manager config.
 setForbiddenWikiRoots([dashboardPath('notes')]);
 registerWikiRoutes(app, requireAuth, { forbiddenRoots: () => forbiddenWikiRoots() });
-registerSystemRoutes(app, { jawAuthToken: JAW_AUTH_TOKEN });
+registerSystemRoutes(app, requireAuth, { jawAuthToken: JAW_AUTH_TOKEN });
 registerAgentControlRoutes(app, requireAuth);
 registerCommandRoutes(app, requireAuth);
 registerGoalRunRoutes(app, requireAuth);

--- a/src/routes/i18n.ts
+++ b/src/routes/i18n.ts
@@ -5,8 +5,10 @@ import { join } from 'path';
 import { normalizeLocale } from '../core/i18n.js';
 import { settings } from '../core/config.js';
 
-export function registerI18nRoutes(app: Express, _requireAuth: AuthMiddleware, projectRoot: string): void {
-    app.get('/api/i18n/languages', (_, res) => {
+// The guard used to arrive here and be discarded (`_requireAuth`), so the locale
+// routes answered any caller (#684).
+export function registerI18nRoutes(app: Express, requireAuth: AuthMiddleware, projectRoot: string): void {
+    app.get('/api/i18n/languages', requireAuth, (_, res) => {
         const localeDir = join(projectRoot, 'public', 'locales');
         if (!fs.existsSync(localeDir)) {
             res.json({ languages: ['ko'], default: 'ko' });
@@ -18,7 +20,7 @@ export function registerI18nRoutes(app: Express, _requireAuth: AuthMiddleware, p
         res.json({ languages: langs, default: normalizeLocale(settings["locale"], 'ko') });
     });
 
-    app.get('/api/i18n/:lang', (req, res) => {
+    app.get('/api/i18n/:lang', requireAuth, (req, res) => {
         const raw = req.params.lang.replace(/[^a-z-]/gi, '');
         const lang = normalizeLocale(raw, '');
         if (!lang) {

--- a/src/routes/i18n.ts
+++ b/src/routes/i18n.ts
@@ -21,7 +21,10 @@ export function registerI18nRoutes(app: Express, requireAuth: AuthMiddleware, pr
     });
 
     app.get('/api/i18n/:lang', requireAuth, (req, res) => {
-        const raw = req.params.lang.replace(/[^a-z-]/gi, '');
+        // Bracket access with a String() coercion: once a middleware argument is
+        // present Express resolves a handler overload whose params carry an index
+        // signature, so req.params.lang is string | string[] | undefined here.
+        const raw = String(req.params['lang'] ?? '').replace(/[^a-z-]/gi, '');
         const lang = normalizeLocale(raw, '');
         if (!lang) {
             res.status(404).json({ error: 'locale not found' });

--- a/src/routes/instance.ts
+++ b/src/routes/instance.ts
@@ -4,14 +4,19 @@
 // toggle the `protected` flag on an existing marker.
 
 import type { Router } from 'express';
+import type { AuthMiddleware } from './types.js';
 import fs from 'fs';
 import { join } from 'path';
 import { JAW_HOME } from '../core/config.js';
 
 const LOCK_MARKER_FILENAME = '.dashboard-managed.json';
 
-export function registerInstanceRoutes(app: Router): void {
-    app.get('/api/instance/lock', (_req, res) => {
+// The lock routes read the dashboard marker and toggle `protected` on it, so
+// they take the same guard every sibling registrar takes (#684). Before this
+// they were registered with no middleware at all, which left a write endpoint
+// open to any network peer once remoteAccess bound a non-loopback address.
+export function registerInstanceRoutes(app: Router, requireAuth: AuthMiddleware): void {
+    app.get('/api/instance/lock', requireAuth, (_req, res) => {
         const markerPath = join(JAW_HOME, LOCK_MARKER_FILENAME);
         try {
             if (fs.existsSync(markerPath)) {
@@ -23,7 +28,7 @@ export function registerInstanceRoutes(app: Router): void {
         } catch { res.json({ ok: true, protected: false, marker: null }); }
     });
 
-    app.post('/api/instance/lock', (_req, res) => {
+    app.post('/api/instance/lock', requireAuth, (_req, res) => {
         const markerPath = join(JAW_HOME, LOCK_MARKER_FILENAME);
         try {
             if (fs.existsSync(markerPath)) {
@@ -37,7 +42,7 @@ export function registerInstanceRoutes(app: Router): void {
         } catch (err) { res.status(500).json({ ok: false, error: (err as Error).message }); }
     });
 
-    app.delete('/api/instance/lock', (_req, res) => {
+    app.delete('/api/instance/lock', requireAuth, (_req, res) => {
         const markerPath = join(JAW_HOME, LOCK_MARKER_FILENAME);
         try {
             if (fs.existsSync(markerPath)) {

--- a/src/routes/jaw-memory.ts
+++ b/src/routes/jaw-memory.ts
@@ -67,7 +67,7 @@ function saveCanonicalSoul(content: string): string {
 }
 
 export function registerJawMemoryRoutes(app: Express, requireAuth: AuthMiddleware): void {
-    app.get('/api/jaw-memory/search', async (req, res) => {
+    app.get('/api/jaw-memory/search', requireAuth, async (req, res) => {
         try {
             const q = String(req.query["q"] || '');
 
@@ -83,7 +83,7 @@ export function registerJawMemoryRoutes(app: Express, requireAuth: AuthMiddlewar
         catch (e: unknown) { res.status(500).json({ error: (e as Error).message }); }
     });
 
-    app.get('/api/jaw-memory/read', (req, res) => {
+    app.get('/api/jaw-memory/read', requireAuth, (req, res) => {
         try {
             const file = assertMemoryRelPath(String(req.query["file"] || ''), { allowExt: ['.md', '.txt', '.json'] });
             const mem = getMemoryStatus();
@@ -107,7 +107,7 @@ export function registerJawMemoryRoutes(app: Express, requireAuth: AuthMiddlewar
         } catch (e: unknown) { res.status(httpStatus(e, 500)).json({ error: (e as Error).message }); }
     });
 
-    app.get('/api/jaw-memory/context', (req, res) => {
+    app.get('/api/jaw-memory/context', requireAuth, (req, res) => {
         try {
             const file = assertMemoryRelPath(String(req.query["file"] || ''), { allowExt: ['.md', '.txt', '.json'] });
             const memDir = getAdvancedMemoryDir() || join(JAW_HOME, 'memory');
@@ -177,7 +177,7 @@ export function registerJawMemoryRoutes(app: Express, requireAuth: AuthMiddlewar
         } catch (e: unknown) { res.status(httpStatus(e, 500)).json({ error: (e as Error).message }); }
     });
 
-    app.get('/api/jaw-memory/list', (_, res) => {
+    app.get('/api/jaw-memory/list', requireAuth, (_, res) => {
         try {
             const mem = getMemoryStatus();
             const files = mem.routing.searchRead === 'advanced'
@@ -234,7 +234,7 @@ export function registerJawMemoryRoutes(app: Express, requireAuth: AuthMiddlewar
         }
     });
 
-    app.get('/api/jaw-memory/soul', async (_req, res) => {
+    app.get('/api/jaw-memory/soul', requireAuth, async (_req, res) => {
         try {
             const { readSoul } = await import('../memory/identity.js');
             res.json({ soul: readSoul() });

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -15,7 +15,7 @@ import { assertMemoryRelPath, assertFilename, safeResolveUnder } from '../securi
 import { migrateLegacyClaudeValue } from '../cli/claude-models.js';
 
 export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware): void {
-    app.get('/api/memory/status', (_req, res) => {
+    app.get('/api/memory/status', requireAuth, (_req, res) => {
         const base = getMemoryStatus();
         const lockPath = getMigrationLockPath();
         const migrationLocked = fs.existsSync(lockPath);
@@ -84,7 +84,7 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
         });
     });
 
-    app.get('/api/memory/files', (_req, res) => {
+    app.get('/api/memory/files', requireAuth, (_req, res) => {
         res.json(listMemoryFiles());
     });
 
@@ -140,7 +140,7 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
         }
     });
 
-    app.get('/api/memory-files/:filename', (req, res) => {
+    app.get('/api/memory-files/:filename', requireAuth, (req, res) => {
         try {
             const name = assertFilename(req.params.filename);
             const fp = safeResolveUnder(memoryModule.MEMORY_DIR, name);

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -142,7 +142,9 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
 
     app.get('/api/memory-files/:filename', requireAuth, (req, res) => {
         try {
-            const name = assertFilename(req.params.filename);
+            // Same index-signature widening as the DELETE sibling below, which
+            // already reads String(req.params["filename"]).
+            const name = assertFilename(String(req.params['filename'] ?? ''));
             const fp = safeResolveUnder(memoryModule.MEMORY_DIR, name);
             if (!fs.existsSync(fp)) {
                 res.status(404).json({ error: 'not found' });

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -458,7 +458,7 @@ export function registerSettingsRoutes(
         res.json(await getProjectGitSummary(settings["projectDirs"]));
     }));
 
-    app.get('/api/codex-context', (_, res) => {
+    app.get('/api/codex-context', requireAuth, (_, res) => {
         res.json(readCodexContextWindow());
     });
 
@@ -478,7 +478,7 @@ export function registerSettingsRoutes(
         res.json({ ok: true });
     });
 
-    app.get('/api/prompt-templates', (_, res) => {
+    app.get('/api/prompt-templates', requireAuth, (_, res) => {
         const dir = getTemplateDir();
         const files = fs.readdirSync(dir).filter((f: string) => f.endsWith('.md'));
         const templates = files.map((f: string) => ({
@@ -519,7 +519,7 @@ export function registerSettingsRoutes(
         res.json({ ok: true });
     });
 
-    app.get('/api/heartbeat-md', (_, res) => {
+    app.get('/api/heartbeat-md', requireAuth, (_, res) => {
         const content = fs.existsSync(HEARTBEAT_PATH) ? fs.readFileSync(HEARTBEAT_PATH, 'utf8') : '';
         res.json({ content });
     });
@@ -587,7 +587,7 @@ export function registerSettingsRoutes(
         }
     });
 
-    app.get('/api/mcp/registry', async (_, res) => {
+    app.get('/api/mcp/registry', requireAuth, async (_, res) => {
         try {
             const { fetchMcpRegistry, fetchMcpRegistryLocal } = await import('../../lib/mcp/mcp-registry.js');
             const localCandidates = [
@@ -606,14 +606,14 @@ export function registerSettingsRoutes(
         }
     });
 
-    app.get('/api/cli-registry', asyncHandler(async (_, res) => {
+    app.get('/api/cli-registry', requireAuth, asyncHandler(async (_, res) => {
         ok(res, await buildLiveCliRegistry());
     }));
     // `?force=1` skips the failure backoff. Retries are demand-driven with no
     // timer, so without this a user who fixed the underlying problem would keep
     // seeing the stale failure until the backoff expired, even after an
     // explicit refresh (#277).
-    app.get('/api/cli-status', (req, res) => {
+    app.get('/api/cli-status', requireAuth, (req, res) => {
         const force = req.query['force'] === '1' || req.query['force'] === 'true';
         const cached = force ? getCachedCliStatusForced() : getCachedCliStatus();
         // `lastStartFailure` is a sibling of the cached row, never a member of it:
@@ -682,7 +682,7 @@ export function registerSettingsRoutes(
         });
     }));
 
-    app.get('/api/quota', async (_, res) => {
+    app.get('/api/quota', requireAuth, async (_, res) => {
         const claudeCreds = readClaudeCreds();
         const codexTokens = readCodexTokens();
         const settleQuota = (read: () => Promise<unknown>) => Promise.resolve().then(read)

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -4,6 +4,7 @@
 // re-derived here, so it arrives as a factory dep.
 
 import type { Router } from 'express';
+import type { AuthMiddleware } from './types.js';
 import { fail, ok } from '../http/response.js';
 import { isLoopbackAddress } from '../http/loopback.js';
 import { APP_VERSION, settings } from '../core/config.js';
@@ -33,7 +34,12 @@ function getRuntimeSnapshot() {
     };
 }
 
-export function registerSystemRoutes(app: Router, deps: { jawAuthToken: string }): void {
+// `requireAuth` sits in the sibling registrars' position (#684). Only the three
+// probe routes below stay public: liveness, readiness and the secret-free Slack
+// manifest. `/api/auth/token` keeps its own stricter loopback check instead,
+// because `requireAuth` also admits LAN peers when lanBypass is on and that
+// would turn the token endpoint into a LAN token mint.
+export function registerSystemRoutes(app: Router, requireAuth: AuthMiddleware, deps: { jawAuthToken: string }): void {
     // LIVENESS. `ok` stays a constant on purpose (#471): it was added for
     // Docker HEALTHCHECK, and Docker restarts the container and the manager
     // drops the instance when it goes false. A CLI that cannot be resolved is
@@ -95,12 +101,12 @@ export function registerSystemRoutes(app: Router, deps: { jawAuthToken: string }
         }
     });
 
-    app.get('/api/session', (_, res) => ok(res, getSession(), getSession() as Record<string, unknown> | undefined));
+    app.get('/api/session', requireAuth, (_, res) => ok(res, getSession(), getSession() as Record<string, unknown> | undefined));
 
     // Memory composition probe: splits the JS
     // heap from native/mmap so RSS investigations can tell "V8 objects" apart
     // from "sqlite-mapped pages + native addons" without a debugger attach.
-    app.get('/api/debug/mem', (_req, res) => {
+    app.get('/api/debug/mem', requireAuth, (_req, res) => {
         const m = process.memoryUsage();
         const mb = (n: number) => Math.round(n / 1024 / 1024);
         res.json({
@@ -116,7 +122,7 @@ export function registerSystemRoutes(app: Router, deps: { jawAuthToken: string }
         });
     });
 
-    app.get('/api/runtime', (req, res) => {
+    app.get('/api/runtime', requireAuth, (req, res) => {
         if (req.query["logs"] === 'tail') {
             const lines = drainLogRing();
             res.json({ ok: true, lines });

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -426,9 +426,9 @@ cli-jaw/
 │   │   ├── skills.ts         ← skill list/enable/disable/reset 라우트 (90L)
 │   │   ├── jaw-memory.ts     ← jaw memory search/read/list/save/init/reflect/flush/soul/soul-activate/bootstrap 라우트 (362L)
 │   │   ├── jaw-ceo.ts        ← Jaw CEO channel/session support routes (321L) ✨
-│   │   ├── i18n.ts           ← locale bundle 라우트 (37L)
+│   │   ├── i18n.ts           ← locale bundle 라우트 (40L)
 │   │   ├── orchestrate.ts    ← IPABCD reset/state/workers/worker-runs/snapshot/queue cancel/queue steer async accept/dispatch/virtual dispatch/batch safe summary/worker result/state PUT 라우트 + Phase60 boss-token actor distinction + --attest body gate + single-use pendingAttestation null-clear (1293L)
-│   │   ├── memory.ts         ← memory status/KV/files/settings 라우트 (191L)
+│   │   ├── memory.ts         ← memory status/KV/files/settings 라우트 (193L)
 │   │   ├── settings.ts       ← settings/prompt/project pick/git summary/heartbeat-md/MCP/registry/status/quota/copilot + Pi profile register/model discovery 라우트 + CLI_KEYS 기반 quota parity/status-only metadata (738L)
 │   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (601L)
 │   │   ├── avatar.ts         ← Agent/User 아바타 이미지 업로드/서빙/삭제 + settings.json 메타 저장 + safeResolveUnder 경로 보호 (147L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -426,7 +426,7 @@ cli-jaw/
 │   │   ├── skills.ts         ← skill list/enable/disable/reset 라우트 (90L)
 │   │   ├── jaw-memory.ts     ← jaw memory search/read/list/save/init/reflect/flush/soul/soul-activate/bootstrap 라우트 (362L)
 │   │   ├── jaw-ceo.ts        ← Jaw CEO channel/session support routes (321L) ✨
-│   │   ├── i18n.ts           ← locale bundle 라우트 (35L)
+│   │   ├── i18n.ts           ← locale bundle 라우트 (37L)
 │   │   ├── orchestrate.ts    ← IPABCD reset/state/workers/worker-runs/snapshot/queue cancel/queue steer async accept/dispatch/virtual dispatch/batch safe summary/worker result/state PUT 라우트 + Phase60 boss-token actor distinction + --attest body gate + single-use pendingAttestation null-clear (1293L)
 │   │   ├── memory.ts         ← memory status/KV/files/settings 라우트 (191L)
 │   │   ├── settings.ts       ← settings/prompt/project pick/git summary/heartbeat-md/MCP/registry/status/quota/copilot + Pi profile register/model discovery 라우트 + CLI_KEYS 기반 quota parity/status-only metadata (738L)

--- a/tests/unit/remote-access-exposure.test.ts
+++ b/tests/unit/remote-access-exposure.test.ts
@@ -61,13 +61,244 @@ test('SEC-449e: env-provided channel tokens are stripped before the file is writ
     }
 });
 
-test('SEC-449f: conversation and memory reads are authenticated', () => {
-    const messages = read('src/routes/messages.ts');
-    const memory = read('src/routes/memory.ts');
-    assert.match(messages, /app\.get\('\/api\/messages', requireAuth/);
-    assert.match(messages, /app\.get\('\/api\/messages\/search', requireAuth/);
-    assert.match(memory, /app\.get\('\/api\/memory', requireAuth/);
-    assert.match(memory, /app\.get\('\/api\/memory-file', requireAuth/);
+// ─── #684: omission-detecting guard scan ─────────────────────────────────────
+//
+// The original SEC-449f named two routes and asserted the literal "', requireAuth"
+// sat next to each. That can only fail when someone deletes a guard from a route
+// the list already names. It cannot notice a NEW route that ships without one —
+// which is exactly how #684 happened, months after #449 closed the sibling paths.
+//
+// So this scans instead of matching. It parses the first argument of every
+// app.<verb>(...) registration in the covered modules and treats a route as
+// guarded only when that argument is exactly the identifier requireAuth. A
+// wrapper, a renamed local, or a comment that merely says requireAuth all read
+// as unguarded and fail the test.
+
+type ScannedRoute = { method: string; routePath: string | null; guard: string | null };
+
+// These modules attach the guard per route, so a missing one is invisible at the
+// server.ts level. Prefix-mounted modules (jaw-ceo, runtime-context, code-native)
+// are guarded once by app.use(..., requireAuth, ...); scanning them would report
+// every route as unguarded and say nothing.
+const COVERED_MODULES = [
+    'memory.ts', 'jaw-memory.ts', 'system.ts', 'instance.ts', 'i18n.ts', 'settings.ts',
+];
+
+// Exact paths, never prefixes: '/api/health' is a prefix of '/api/heartbeat-md'.
+const PUBLIC_ROUTES = new Set(['/api/health', '/api/ready', '/api/slack/manifest']);
+
+// /api/auth/token is neither public nor behind requireAuth, because requireAuth is
+// the WEAKER test for it: it also admits LAN peers when lanBypass is on, which
+// would turn the token endpoint into a LAN token mint. It carries a loopback-only
+// check instead, and SEC-449k proves that check still runs before the token.
+const SELF_GUARDED = new Map([['/api/auth/token', 'isLoopbackAddress']]);
+
+// A route that vanishes from the scan is as dangerous as one that loses its guard:
+// rewrite a registration into a shape the parser cannot read and SEC-449f goes
+// quiet instead of failing. This list is the coverage floor — every path here must
+// be SEEN, and seen as guarded.
+const REQUIRED_GUARDED: [string, string][] = [
+    ['memory.ts', '/api/memory'],
+    ['memory.ts', '/api/memory-file'],
+    ['memory.ts', '/api/memory-files'],
+    ['memory.ts', '/api/memory-files/:filename'],
+    ['memory.ts', '/api/memory/status'],
+    ['memory.ts', '/api/memory/files'],
+    ['jaw-memory.ts', '/api/jaw-memory/search'],
+    ['jaw-memory.ts', '/api/jaw-memory/read'],
+    ['jaw-memory.ts', '/api/jaw-memory/context'],
+    ['jaw-memory.ts', '/api/jaw-memory/list'],
+    ['jaw-memory.ts', '/api/jaw-memory/soul'],
+    ['system.ts', '/api/session'],
+    ['system.ts', '/api/runtime'],
+    ['system.ts', '/api/debug/mem'],
+    ['instance.ts', '/api/instance/lock'],
+    ['i18n.ts', '/api/i18n/languages'],
+    ['i18n.ts', '/api/i18n/:lang'],
+    ['settings.ts', '/api/settings'],
+    ['settings.ts', '/api/mcp'],
+    ['settings.ts', '/api/mcp/registry'],
+    ['settings.ts', '/api/prompt'],
+    ['settings.ts', '/api/prompt-templates'],
+    ['settings.ts', '/api/heartbeat-md'],
+    ['settings.ts', '/api/quota'],
+    ['settings.ts', '/api/cli-registry'],
+    ['settings.ts', '/api/cli-status'],
+    ['settings.ts', '/api/codex-context'],
+    // messages.ts is not scanned for omissions (another lane owns the file), but
+    // the routes #449 closed there must stay closed.
+    ['messages.ts', '/api/messages'],
+    ['messages.ts', '/api/messages/search'],
+];
+
+function skipTrivia(src: string, i: number): number {
+    for (;;) {
+        while (i < src.length && /\s/.test(src[i] as string)) i += 1;
+        if (src.startsWith('//', i)) {
+            const nl = src.indexOf('\n', i);
+            i = nl === -1 ? src.length : nl + 1;
+            continue;
+        }
+        if (src.startsWith('/*', i)) {
+            const end = src.indexOf('*/', i + 2);
+            i = end === -1 ? src.length : end + 2;
+            continue;
+        }
+        return i;
+    }
+}
+
+function readStringLiteral(src: string, i: number): { value: string; next: number } | null {
+    const quote = src[i];
+    if (quote !== "'" && quote !== '"' && quote !== '`') return null;
+    let out = '';
+    let j = i + 1;
+    while (j < src.length) {
+        const ch = src[j] as string;
+        if (ch === '\\') { out += src[j + 1] ?? ''; j += 2; continue; }
+        if (ch === quote) return { value: out, next: j + 1 };
+        out += ch;
+        j += 1;
+    }
+    return null;
+}
+
+// Reads one argument expression, stopping at the comma or paren that closes it at
+// depth zero. Quotes and nested brackets are tracked so a comma inside them does
+// not end the argument early.
+function readArgument(src: string, i: number): { text: string; next: number } {
+    let depth = 0;
+    const start = i;
+    while (i < src.length) {
+        const ch = src[i] as string;
+        if (ch === "'" || ch === '"' || ch === '`') {
+            const lit = readStringLiteral(src, i);
+            if (!lit) break;
+            i = lit.next;
+            continue;
+        }
+        if (ch === '(' || ch === '[' || ch === '{') { depth += 1; i += 1; continue; }
+        if (ch === ')' || ch === ']' || ch === '}') {
+            if (depth === 0) break;
+            depth -= 1;
+            i += 1;
+            continue;
+        }
+        if (ch === ',' && depth === 0) break;
+        i += 1;
+    }
+    return { text: src.slice(start, i).trim(), next: i };
+}
+
+function scanRoutes(src: string): ScannedRoute[] {
+    const calls = /\bapp\.(get|post|put|delete|patch|use)\s*\(/g;
+    const found: ScannedRoute[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = calls.exec(src)) !== null) {
+        const method = (match[1] as string).toUpperCase();
+        let i = skipTrivia(src, match.index + match[0].length);
+        const literal = readStringLiteral(src, i);
+        if (!literal) {
+            // A computed path cannot be checked here. Report it so it fails loudly
+            // instead of disappearing from the scan.
+            found.push({ method, routePath: null, guard: null });
+            continue;
+        }
+        i = skipTrivia(src, literal.next);
+        if (src[i] !== ',') continue; // app.use(router) with no path argument
+        i = skipTrivia(src, i + 1);
+        const arg = readArgument(src, i);
+        found.push({ method, routePath: literal.value, guard: arg.text || null });
+    }
+    return found;
+}
+
+const isGuarded = (route: ScannedRoute) => route.guard === 'requireAuth';
+const routesIn = (file: string) => scanRoutes(read('src/routes/' + file));
+
+test('SEC-449f: no sensitive route in the covered modules answers without a guard', () => {
+    const open: string[] = [];
+    for (const file of COVERED_MODULES) {
+        for (const route of routesIn(file)) {
+            if (isGuarded(route)) continue;
+            if (route.routePath === null) {
+                open.push(file + ': ' + route.method + ' with a computed path the scan cannot verify');
+                continue;
+            }
+            if (PUBLIC_ROUTES.has(route.routePath) || SELF_GUARDED.has(route.routePath)) continue;
+            open.push(file + ': ' + route.method + ' ' + route.routePath + ' (guard: ' + (route.guard ?? 'none') + ')');
+        }
+    }
+    assert.deepEqual(open, [],
+        'these routes are reachable without requireAuth — add the guard, or add the path to '
+        + 'PUBLIC_ROUTES with a reason:\n  ' + open.join('\n  '));
+});
+
+test('SEC-449h: every route #449 and #684 closed is still seen by the scan and still guarded', () => {
+    const broken: string[] = [];
+    const cache = new Map<string, ScannedRoute[]>();
+    for (const [file, routePath] of REQUIRED_GUARDED) {
+        if (!cache.has(file)) cache.set(file, routesIn(file));
+        const matches = (cache.get(file) as ScannedRoute[]).filter(r => r.routePath === routePath);
+        if (matches.length === 0) {
+            broken.push(file + ' ' + routePath + ': not found by the scan at all');
+            continue;
+        }
+        for (const route of matches) {
+            if (!isGuarded(route)) broken.push(file + ' ' + route.method + ' ' + routePath + ': guard is ' + (route.guard ?? 'none'));
+        }
+    }
+    assert.deepEqual(broken, [], 'guard coverage regressed:\n  ' + broken.join('\n  '));
+});
+
+test('SEC-449i: the scan actually detects an omission', () => {
+    // The assertions above are only worth their runtime if the scanner can fail.
+    // These fixtures are the forms a future edit would most plausibly take.
+    const fixture = [
+        "app.get('/api/guarded', requireAuth, (req, res) => res.json({}));",
+        "app.get('/api/plain-open', (req, res) => res.json({}));",
+        'app.get(',
+        "    '/api/multiline-open',",
+        '    async (req, res) => res.json({}),',
+        ');',
+        'app.post("/api/double-quoted-open", handler);',
+        "app.get('/api/comment-spoof-open', /* requireAuth */ handler);",
+        "app.put('/api/boolean-spoof-open', requireAuth && handler);",
+    ].join('\n');
+
+    const open = scanRoutes(fixture).filter(r => !isGuarded(r)).map(r => r.routePath);
+    assert.deepEqual(open.sort(), [
+        '/api/boolean-spoof-open',
+        '/api/comment-spoof-open',
+        '/api/double-quoted-open',
+        '/api/multiline-open',
+        '/api/plain-open',
+    ], 'the scanner must report every unguarded form, including the ones that only look guarded');
+    assert.equal(open.includes('/api/guarded'), false, 'a genuinely guarded route must not be reported');
+});
+
+test('SEC-449j: server.ts hands the guard to every registrar that needs it', () => {
+    // #684: these three took no middleware, or took it and dropped it, so their
+    // routes could never be guarded no matter what the module did.
+    const src = read('server.ts');
+    assert.match(src, /registerSystemRoutes\(app, requireAuth,/);
+    assert.match(src, /registerInstanceRoutes\(app, requireAuth\)/);
+    assert.match(src, /registerI18nRoutes\(app, requireAuth,/);
+    assert.doesNotMatch(read('src/routes/i18n.ts'), /_requireAuth/,
+        'i18n must apply the guard it receives, not discard it');
+});
+
+test('SEC-449k: the token route keeps its own loopback check', () => {
+    const src = read('src/routes/system.ts');
+    for (const [routePath, guardCall] of SELF_GUARDED) {
+        const start = src.indexOf("'" + routePath + "'");
+        assert.ok(start > -1, routePath + ' should still exist');
+        const route = src.slice(start);
+        const respondIdx = route.indexOf('deps.jawAuthToken');
+        assert.ok(respondIdx > -1, 'the route must still return the token somewhere');
+        assert.match(route.slice(0, respondIdx), new RegExp(guardCall),
+            routePath + ' is exempt from requireAuth only because ' + guardCall + ' runs first');
+    }
 });
 
 test('SEC-449g: health stays public — the guard must not break liveness checks', () => {

--- a/tests/unit/remote-access-exposure.test.ts
+++ b/tests/unit/remote-access-exposure.test.ts
@@ -284,8 +284,16 @@ test('SEC-449j: server.ts hands the guard to every registrar that needs it', () 
     assert.match(src, /registerSystemRoutes\(app, requireAuth,/);
     assert.match(src, /registerInstanceRoutes\(app, requireAuth\)/);
     assert.match(src, /registerI18nRoutes\(app, requireAuth,/);
-    assert.doesNotMatch(read('src/routes/i18n.ts'), /_requireAuth/,
-        'i18n must apply the guard it receives, not discard it');
+    // Signature-shaped, not a file-wide search: i18n's own comment mentions the
+    // discarded `_requireAuth` parameter this replaced, and prose should not
+    // decide whether the guard is wired.
+    assert.match(read('src/routes/i18n.ts'),
+        /export function registerI18nRoutes\([^)]*requireAuth: AuthMiddleware/,
+        'i18n must take the guard as a used parameter, not discard it as _requireAuth');
+    assert.match(read('src/routes/instance.ts'),
+        /export function registerInstanceRoutes\([^)]*requireAuth: AuthMiddleware/);
+    assert.match(read('src/routes/system.ts'),
+        /export function registerSystemRoutes\([^)]*requireAuth: AuthMiddleware/);
 });
 
 test('SEC-449k: the token route keeps its own loopback check', () => {


### PR DESCRIPTION
Closes #684

`requireAuth` is attached per route rather than as global middleware, so a route that omits it has no check at all. #449 closed `/api/settings`, `/api/mcp`, `/api/messages`, `/api/memory` and `/api/prompt`, but the sibling routes serving the same data kept answering unauthenticated callers.

With `remoteAccess` bound to `0.0.0.0` and `lanBypass` off, these returned memory files, prompt templates, provider quota and account state, the session row and the server log ring to any network peer. `/api/instance/lock` also **writes**: POST and DELETE toggled `protected` on the dashboard marker with no guard at all, because `registerInstanceRoutes` never accepted the middleware in the first place.

## What changed

Guarded with `requireAuth`:

| module | routes |
| --- | --- |
| `memory.ts` | `GET /api/memory/status`, `/api/memory/files`, `/api/memory-files/:filename` |
| `jaw-memory.ts` | `GET /api/jaw-memory/{search,read,context,list,soul}` |
| `system.ts` | `GET /api/session`, `/api/debug/mem`, `/api/runtime` |
| `instance.ts` | `GET`+`POST`+`DELETE /api/instance/lock` |
| `i18n.ts` | `GET /api/i18n/languages`, `/api/i18n/:lang` |
| `settings.ts` | `GET /api/codex-context`, `/api/prompt-templates`, `/api/heartbeat-md`, `/api/mcp/registry`, `/api/cli-registry`, `/api/cli-status`, `/api/quota` |

`registerSystemRoutes`, `registerInstanceRoutes` and `registerI18nRoutes` now take `AuthMiddleware` in the sibling position and `server.ts` passes it. i18n previously accepted the guard as `_requireAuth` and dropped it.

Still public, by design: `/api/health`, `/api/ready` and `/api/slack/manifest`, so probes and the settings-page copy button keep working.

`/api/auth/token` deliberately keeps its own `isLoopbackAddress` check instead of `requireAuth`. `requireAuth` is the weaker test there — it also admits LAN peers when `lanBypass` is on, which would turn the token endpoint into a LAN token mint. `SEC-449k` fails if that loopback check ever stops running before the token is returned.

The body of `requireAuth` is untouched: the loopback and LAN-bypass policy is byte-identical to `dev`, so the local UI, the CLI and cross-instance manager polling (`127.0.0.1` peers, no bearer) are unaffected.

## The test change is the point

`SEC-449f` used to assert that the literal `', requireAuth` appeared next to two named paths. That can only fail when a guard is deleted from a route the list already knows about — it cannot notice a new route that ships without one, which is exactly how this issue happened after #449, with the test green throughout.

It now parses. `scanRoutes()` reads the first argument of every `app.<verb>(...)` registration in the six per-route-guarded modules and counts a route as guarded only when that argument is exactly the identifier `requireAuth`; a wrapper, a renamed local, `requireAuth && handler` and `/* requireAuth */ handler` all read as unguarded.

- **SEC-449f** — any route outside the exact public allowlist that has no guard fails the test, and the message names it.
- **SEC-449h** — coverage floor. Every route #449 and #684 closed must still be *seen* by the parser and seen as guarded. Without it, rewriting a registration into a shape the parser cannot read would silently empty SEC-449f instead of failing it.
- **SEC-449i** — proves the scan can actually fail, over fixtures covering the plain, multiline, double-quoted, comment-spoofed and boolean-spoofed forms.
- **SEC-449j** — pins the `server.ts` wiring for the three registrars.
- **SEC-449k** — keeps the `/api/auth/token` exemption honest.

The allowlist is path-exact because `/api/health` is a prefix of `/api/heartbeat-md`. Prefix-mounted modules (`jaw-ceo`, `runtime-context`, `code-native`) are not scanned: they are guarded once at `app.use(..., requireAuth, ...)`, so every route inside them would read as unguarded and the scan would say nothing.

## Scope and what this does not close

The three-route public allowlist is enforced **for the six modules this PR owns**, not globally. These remain unguarded and are owned by other lanes: `GET /api/avatar`, `/api/avatar/:target/image`, `/api/commands`, `/api/employees`, `/api/messages/count`, `/api/skills`, `/api/skills/:id`, `GET /` and `GET /^\/\d+\/?$/` in `static.ts`, and `/api/browser/status`.

`tests/unit/slack-manifest-route.test.ts` still calls `registerSystemRoutes` with two arguments. It keeps passing — those tests only invoke the still-public `/api/slack/manifest`, and `tsconfig.json` excludes `tests/` from `tsc` — but the stub should gain a passthrough guard. Left alone here because that file belongs to another lane.

`structure/str_func.md` was regenerated with `bash structure/verify-counts.sh --fix`, not hand-edited.

## Verification

Local product suites were **NOT RUN** by instruction: `npm test`, `npm run typecheck` and `npm run build` were not executed. Evidence is the remote `ci-aggregate` for this head.

What was checked locally, without the suite: the scanner was exercised standalone against the live tree and against negative controls — removing `requireAuth` from `/api/quota` is reported as unguarded, and hiding a path behind a variable removes it from the scan, where the SEC-449h coverage list catches it.
