### PR TITLE
fix(runtime): route every spawn.ts kill through the process owner

### DIFF
--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -322,8 +322,12 @@ interface CopilotSpawnContext extends SpawnContext {
     thinkingBuf: string;
 }
 
-import { hasChildExited, killProcessTree, killProcessTreeIfAlive, ownProcess } from './spawn/process-kill.js';
+import { hasChildExited, ownProcess } from './spawn/process-kill.js';
 import { DUP_REGISTRATION_KILL_REASON, isLifecycleSteerReason } from './spawn/kill-reason.js';
+import {
+    armExitSettle, captureExitSettler, settleCapturedExit, settleExit, waitForExitSettled,
+    type ExitSettler,
+} from './spawn/exit-settle.js';
 import { releaseChildOutputAfterExit } from './spawn/exit-drain.js';
 import { clampPendingLine } from './spawn/line-buffer.js';
 import { appendBoundedFullText } from './events/fulltext-bound.js';
@@ -416,23 +420,20 @@ export function killAgentById(agentId: string): boolean {
     if (!proc) return false;
     try {
         if (cancelOwnedPiProcess(proc, 'user')) return true;
-        if (proc.pid) {
-            killProcessTree(proc.pid, 'SIGTERM');
-        } else {
-            proc.kill('SIGTERM');
-        }
-        setTimeout(() => {
-            try {
-                if (proc.pid) {
-                    killProcessTreeIfAlive(proc);
-                } else if (proc.exitCode === null && proc.signalCode === null) {
-                    proc.kill('SIGKILL');
-                }
-            } catch { /* already dead */ }
+        // Same owner as killActiveAgent. The hand-rolled version here escalated on a
+        // bare 3s timer with no liveness re-check, so a CLI that traps SIGTERM either
+        // survived or, worse, the delayed SIGKILL landed on a recycled PID. Worker
+        // stop (orchestrator/distribute.ts, orchestrator/pipeline.ts) reaches this
+        // path, which is why it had different lifetime rules from main stop.
+        ownProcess(proc).terminate('cancel');
+        // Stdio teardown stays on its own timer: it must happen even when the owner
+        // short-circuits because the child had already exited.
+        const teardown = setTimeout(() => {
             proc.stdin?.destroy();
             proc.stdout?.destroy();
             proc.stderr?.destroy();
-        }, 3_000);
+        }, DEFAULT_KILL_ESCALATION_MS);
+        teardown.unref?.();
         return true;
     } catch {
         return false;
@@ -543,12 +544,25 @@ function getActiveMainCli(scopeKey: string): string | null {
     return typeof cli === 'string' ? cli : null;
 }
 
-function getKillPolicy(_scopeKey: string, _reason: string): { signal: NodeJS.Signals; escalationMs: number } {
-    return { signal: 'SIGTERM', escalationMs: DEFAULT_KILL_ESCALATION_MS };
+/**
+ * Read this scope's `agentTimeout` block, global keys overlaid by per-CLI keys.
+ *
+ * `settings` is a live binding from core/config, so this reflects a settings edit made
+ * after the turn started — which is what a steer wants: it is deciding how long to wait
+ * right now, not how long the run was configured to take when it was spawned.
+ */
+function scopedAgentTimeoutCfg(scopeKey: string): Record<string, unknown> {
+    const cli = getActiveMainCli(scopeKey);
+    const raw = (settings as Record<string, unknown>)['agentTimeout'];
+    const global = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+    const perCli = cli && global[cli] && typeof global[cli] === 'object'
+        ? global[cli] as Record<string, unknown> : {};
+    return { ...global, ...perCli };
 }
 
-export function getSteerWaitMsForActiveAgent(_scopeKey = 'default'): number {
-    return DEFAULT_STEER_WAIT_MS;
+export function getSteerWaitMsForActiveAgent(scopeKey = 'default'): number {
+    const configured = scopedAgentTimeoutCfg(scopeKey)['steerWaitMs'];
+    return typeof configured === 'number' && configured > 0 ? configured : DEFAULT_STEER_WAIT_MS;
 }
 
 /** Get kill reason for a process (by PID), consuming it */
@@ -559,47 +573,10 @@ function consumeKillReason(pid: number | undefined): string | null {
     return reason;
 }
 
-// ─── Steer exit-settle barrier ─────────────────────
-// killActiveAgent removes the scope's activeMainProcesses entry synchronously,
-// so waitForProcessEnd() resolves immediately on a steer kill — long before the
-// exit handler has written the interrupted partial output to the messages table.
-// A follow-up spawn could then read history without the salvage row. The barrier
-// is armed at kill time (never at exit-handler entry — that is already too late)
-// and settled by the exit handler's completion, success or failure.
-const exitSettlers = new Map<string, { promise: Promise<void>; resolve: () => void }>();
-
-/** Arm the barrier. Idempotent: a repeated steer keeps the first arm. */
-export function armExitSettle(scopeKey: string): void {
-    if (exitSettlers.has(scopeKey)) return;
-    let resolve!: () => void;
-    const promise = new Promise<void>(r => { resolve = r; });
-    exitSettlers.set(scopeKey, { promise, resolve });
-}
-
-/** Settle the barrier; a no-op when no steer kill armed it. */
-export function settleExit(scopeKey: string): void {
-    const entry = exitSettlers.get(scopeKey);
-    if (!entry) return;
-    exitSettlers.delete(scopeKey);
-    entry.resolve();
-}
-
-/**
- * Await the armed exit handler's completion, bounded. A timeout releases the
- * waiter and drops the arm — a wedged exit handler must not hang the steer.
- */
-export function waitForExitSettled(scopeKey: string, timeoutMs = 5000): Promise<void> {
-    const entry = exitSettlers.get(scopeKey);
-    if (!entry) return Promise.resolve();
-    // The timer is NOT unref'd and is always cleared: an unref'd timer can vanish
-    // with a drained event loop (test runner), leaving the waiter pending forever.
-    let timer: NodeJS.Timeout;
-    const timeout = new Promise<void>(r => { timer = setTimeout(r, timeoutMs); });
-    return Promise.race([entry.promise, timeout]).then(() => {
-        clearTimeout(timer);
-        if (exitSettlers.get(scopeKey) === entry) exitSettlers.delete(scopeKey);
-    });
-}
+// The steer exit-settle barrier moved to ./spawn/exit-settle.js so it can be imported
+// without this module behind it. Re-exported here because every caller — the HTTP
+// route, the CLI slash handler and eleven test files — imports it from spawn.
+export { armExitSettle, settleExit, waitForExitSettled };
 
 /**
  * Fix A: 사용자 stop은 메모리 큐 + DB persisted_queue + frontend pending row를
@@ -661,19 +638,20 @@ export function killActiveAgent(scopeKeyOrReason = 'user', scopedReason?: string
         if (reason === 'api' || reason === 'user' || reason === 'steer' || reason === 'interrupt') activeMainProcesses.delete(scopeKey);
         return hadTimer || cancelledPendingMain || cancelledClaude;
     }
-    const policy = getKillPolicy(scopeKey, reason);
-    console.log(`[jaw:kill] reason=${reason} scope=${scopeKey} cli=${getActiveMainCli(scopeKey) || 'unknown'} signal=${policy.signal} escalationMs=${policy.escalationMs}`);
+    console.log(`[jaw:kill] reason=${reason} scope=${scopeKey} cli=${getActiveMainCli(scopeKey) || 'unknown'} signal=SIGTERM escalationMs=${DEFAULT_KILL_ESCALATION_MS}`);
     if (activeProcess.pid) killReasons.set(activeProcess.pid, reason);
     if (reason === 'steer' || reason === 'interrupt') armExitSettle(scopeKey);
     const proc = activeProcess;
-    // One owner runs the whole termination: tree walk with the policy signal,
-    // then escalation after policy.escalationMs that re-checks the ORIGINAL
-    // child. The previous escalation guarded on `!proc.killed`, which only
-    // records that a signal was delivered — a CLI that traps SIGTERM stays
-    // alive with killed set, and was therefore never escalated.
-    ownProcess(proc, {
-        policy: () => ({ initialSignal: policy.signal, graceMs: policy.escalationMs }),
-    }).terminate(reason === 'steer' ? 'steer' : 'cancel');
+    // One owner runs the whole termination: tree walk, then escalation after the
+    // grace that re-checks the ORIGINAL child. The previous escalation guarded on
+    // `!proc.killed`, which only records that a signal was delivered — a CLI that
+    // traps SIGTERM stays alive with killed set, and was therefore never escalated.
+    //
+    // No policy override: the owner is memoized on child identity and the FIRST call
+    // wins, so a policy passed here would be honoured for a main run and silently
+    // dropped for a worker that registerActiveProcess already owns. Taking the
+    // default keeps one rule for both.
+    ownProcess(proc).terminate(reason === 'steer' ? 'steer' : 'cancel');
     // Immediately sever stdio to stop late output from reaching broadcast handlers
     proc.stdout?.removeAllListeners('data');
     proc.stderr?.removeAllListeners('data');
@@ -683,7 +661,7 @@ export function killActiveAgent(scopeKeyOrReason = 'user', scopedReason?: string
         proc.stdin?.destroy();
         proc.stdout?.destroy();
         proc.stderr?.destroy();
-    }, policy.escalationMs);
+    }, DEFAULT_KILL_ESCALATION_MS);
     teardown.unref?.();
     // Fix C1: 사용자 stop/steer 시 해당 scope busy가 즉시 false가 되도록 참조를 동기 해제.
     // 실제 child 종료는 위 setTimeout SIGKILL이 백그라운드에서 마무리.
@@ -1739,7 +1717,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             if (claudeEmployeeTmpDir) cleanupEmployeeTmpDir(claudeEmployeeTmpDir, '', agentLabel);
         };
         const capturedRun = mainRun;
-        let capturedExit: (typeof exitSettlers extends Map<string, infer T> ? T : never) | undefined;
+        let capturedExit: ExitSettler | undefined;
         const ownedRun = () => isCurrentSessionOwner(persistenceOwner, scopeKey)
             && (!mainManaged || activeMainProcesses.get(scopeKey) === capturedRun);
         let attachedCancel: ((reason: string) => void) | undefined;
@@ -1762,7 +1740,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 activity: identity => opts.lifecycle?.onActivity?.('native-runtime', identity),
                 exited: code => opts.lifecycle?.onExit?.(code),
                 cancelling: reason => {
-                    if (reason === 'steer' || reason === 'interrupt') { armExitSettle(scopeKey); capturedExit ??= exitSettlers.get(scopeKey); }
+                    if (reason === 'steer' || reason === 'interrupt') { armExitSettle(scopeKey); capturedExit ??= captureExitSettler(scopeKey); }
                 },
                 exit: { cli, model: runtimeModel, effectiveProvider, agentLabel, mainManaged, origin, resumeKey, prompt, opts,
                     cfg: { ...cfg, effort }, ownerGeneration, persistenceOwner, forceNew, empSid, isResume, effortDefault: effort,
@@ -1789,7 +1767,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                         if (!mainManaged && activeProcesses.get(agentLabel) === child) activeProcesses.delete(agentLabel);
                         if (cleanupSafe) cleanupClaudeWorker();
                     } finally {
-                        if (capturedExit && exitSettlers.get(scopeKey) === capturedExit) { exitSettlers.delete(scopeKey); capturedExit.resolve(); }
+                        settleCapturedExit(scopeKey, capturedExit);
                         if (mainManaged && (queued || !activeMainProcesses.has(scopeKey))) void processQueue(scopeKey);
                     }
                 },
@@ -1827,7 +1805,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
         let failedStart: RuntimeProjection | null = null;
         let nativeStarted = false, runtimeEnded = false, finalizeFailed = false, finalized = false;
         let stopReason: string | null = null, queueRequested = false;
-        let capturedExit: (typeof exitSettlers extends Map<string, infer T> ? T : never) | undefined;
+        let capturedExit: ExitSettler | undefined;
         let selectedResult: SpawnPromiseResult | undefined;
         const ownsRun = () => !finalized && activeMainProcesses.get(scopeKey) === capturedRun
             && isCurrentSessionOwner(persistenceOwner, scopeKey);
@@ -1926,7 +1904,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             stopReason ??= reason;
             if (reason === 'steer' || reason === 'interrupt') {
                 armExitSettle(scopeKey);
-                capturedExit ??= exitSettlers.get(scopeKey);
+                capturedExit ??= captureExitSettler(scopeKey);
             }
             nativeRun.cancel(reason);
         };
@@ -2065,9 +2043,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                     // Projection/listener/cleanup failure must not leave our durable
                     // row running or rewrite a lifecycle that already selected a result.
                     if (ctx.runtimeOutcome) closeFailedTrace(ctx.runtimeOutcome);
-                    if (capturedExit && exitSettlers.get(scopeKey) === capturedExit) {
-                        exitSettlers.delete(scopeKey); capturedExit.resolve();
-                    }
+                    settleCapturedExit(scopeKey, capturedExit);
                     // Exceptional settlement can release the slot before lifecycle requests its normal wake.
                     if (queueRequested || !activeMainProcesses.has(scopeKey)) void processQueue(scopeKey);
                 }
@@ -2431,12 +2407,8 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
 
     // ─── Pi RPC branch ─────────────────────────────
     if (cli === 'pi') {
-        let piExit = exitSettlers.get(scopeKey);
-        const settlePiExit = () => {
-            if (!piExit || exitSettlers.get(scopeKey) !== piExit) return;
-            exitSettlers.delete(scopeKey);
-            piExit.resolve();
-        };
+        let piExit = captureExitSettler(scopeKey);
+        const settlePiExit = () => { settleCapturedExit(scopeKey, piExit); };
         const pi = normalizePiSettings(settings["pi"]);
         const profileId = cfg.provider || pi.defaultProfileId;
         const profile = pi.profiles.find((entry) => entry.id === profileId) || pi.profiles[0];
@@ -2568,13 +2540,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
                 if (cleanupDone) return Promise.resolve();
                 if (!lease) {
                     if (cancelOwnedPiProcess(child)) return Promise.resolve();
-                    if (child.pid) {
-                        const pid = child.pid;
-                        killProcessTree(pid, 'SIGTERM');
-                        setTimeout(() => {
-                            killProcessTreeIfAlive(child, pid);
-                        }, 5_000);
-                    } else child.kill('SIGTERM');
+                    ownProcess(child).terminate('cancel');
                     return Promise.resolve();
                 }
                 leaseCancel ??= lease.cancel();
@@ -2582,7 +2548,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             };
             const cancelHook = (reason: string) => {
                 if (cleanupDone) return;
-                if (reason === 'steer' || reason === 'interrupt') piExit = exitSettlers.get(scopeKey);
+                if (reason === 'steer' || reason === 'interrupt') piExit = captureExitSettler(scopeKey);
                 void requestCancel();
             };
             if (lease && mainRun) mainRun.cancelTurn = cancelHook;
@@ -3585,10 +3551,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             console.log(`[jaw:agy] output quiet for ${quietCompletionDelayMs}ms — completing print run`);
             killReasons.set(child.pid, AGY_COMPLETE_KILL_REASON);
             try {
-                killProcessTree(child.pid, 'SIGTERM');
-                setTimeout(() => {
-                    killProcessTreeIfAlive(child);
-                }, DEFAULT_KILL_ESCALATION_MS);
+                ownProcess(child).terminate('completion');
             } catch (e) {
                 console.warn('[jaw:agy] quiet completion kill failed:', (e as Error).message);
             }
@@ -3616,12 +3579,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             ctx.stderrBuf = ctx.stderrBuf ? `${ctx.stderrBuf}\n${agyWatchdogContext}` : agyWatchdogContext;
             pushTrace(ctx, agyWatchdogContext);
         }
-        if (child.pid) {
-            killProcessTree(child.pid, 'SIGTERM');
-            setTimeout(() => {
-                killProcessTreeIfAlive(child);
-            }, 5_000);
-        }
+        ownProcess(child).terminate('stall');
     }, watchdogConfig);
     ctx.stallWatchdog = stallWatchdog;
 
@@ -3737,7 +3695,7 @@ export function spawnAgent(prompt: string, opts: SpawnOpts = {}): SpawnResult {
             if (agyResumeDecision.ok && !agyGuardedStaleDetected && isAgyStaleSessionOutput(text)) {
                 agyGuardedStaleDetected = true;
                 console.log('[jaw:agy] stale guarded resume output detected — terminating for fresh retry');
-                if (child.pid) killProcessTree(child.pid, 'SIGTERM');
+                ownProcess(child).terminate('cancel');
                 return;
             }
             if (!ctx.sessionId) ctx.sessionId = extractAgyConversationId(ctx.fullText);

--- a/src/agent/spawn/exit-settle.ts
+++ b/src/agent/spawn/exit-settle.ts
@@ -1,0 +1,76 @@
+// ─── Steer exit-settle barrier ───
+//
+// `killActiveAgent` removes the scope's `activeMainProcesses` entry synchronously, so
+// `waitForProcessEnd()` resolves immediately on a steer kill — long before the exit
+// handler has written the interrupted partial output to the messages table. A follow-up
+// spawn could then read history without the salvage row. The barrier is armed at kill
+// time (never at exit-handler entry — that is already too late) and settled by the exit
+// handler's completion, success or failure (#523).
+//
+// Extracted from spawn.ts as a leaf so it can be imported without the server graph
+// behind it. That is what makes the drain regression in #697 possible: a child process
+// can import this module alone and observe whether the timeout keeps the loop alive.
+
+export type ExitSettler = { promise: Promise<void>; resolve: () => void };
+
+const exitSettlers = new Map<string, ExitSettler>();
+
+/** Arm the barrier. Idempotent: a repeated steer keeps the first arm. */
+export function armExitSettle(scopeKey: string): void {
+    if (exitSettlers.has(scopeKey)) return;
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => { resolve = r; });
+    exitSettlers.set(scopeKey, { promise, resolve });
+}
+
+/**
+ * Take a reference to the arm that is live right now.
+ *
+ * Runtimes that settle from a `finally` block must settle THEIR arm, not whatever is
+ * in the map when the block finally runs: a second steer can arm a new barrier for the
+ * same scope while the first turn is still unwinding, and resolving that one would
+ * release a waiter for output nobody has written yet.
+ */
+export function captureExitSettler(scopeKey: string): ExitSettler | undefined {
+    return exitSettlers.get(scopeKey);
+}
+
+/**
+ * Settle a captured arm, but only if the map still holds that exact entry.
+ *
+ * Returns whether it settled. A missing capture is a no-op, never a blind
+ * `settleExit` — an unarmed scope has no one waiting and a superseded arm belongs to
+ * a turn that is still running.
+ */
+export function settleCapturedExit(scopeKey: string, captured: ExitSettler | undefined): boolean {
+    if (!captured || exitSettlers.get(scopeKey) !== captured) return false;
+    exitSettlers.delete(scopeKey);
+    captured.resolve();
+    return true;
+}
+
+/** Settle the barrier; a no-op when no steer kill armed it. */
+export function settleExit(scopeKey: string): void {
+    const entry = exitSettlers.get(scopeKey);
+    if (!entry) return;
+    exitSettlers.delete(scopeKey);
+    entry.resolve();
+}
+
+/**
+ * Await the armed exit handler's completion, bounded. A timeout releases the waiter
+ * and drops the arm — a wedged exit handler must not hang the steer.
+ */
+export function waitForExitSettled(scopeKey: string, timeoutMs = 5000): Promise<void> {
+    const entry = exitSettlers.get(scopeKey);
+    if (!entry) return Promise.resolve();
+    // The timer is NOT unref'd and is always cleared: an unref'd timer can vanish
+    // with a drained event loop (test runner), leaving the waiter pending forever.
+    // Regression: tests/unit/spawn-exit-settle-drain.test.ts.
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<void>(r => { timer = setTimeout(r, timeoutMs); });
+    return Promise.race([entry.promise, timeout]).then(() => {
+        clearTimeout(timer);
+        if (exitSettlers.get(scopeKey) === entry) exitSettlers.delete(scopeKey);
+    });
+}

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -145,7 +145,7 @@ cli-jaw/
 │   │   ├── claude-runtime-run.ts ← native Claude main adaptation to shared host/lifecycle and fallback terminal ordering (293L)
 │   │   ├── prompt-context.ts ← history/operational/partial boundaries and bounded accepted Cursor redirects (201L)
 │   │   ├── steer-input-guard.ts ← transient scoped Stop fence through fallback enqueue (33L)
-│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4090L)
+│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4048L)
 │   │   ├── spawn/            ← spawn 서브모듈 (3 files)
 │   │   │   ├── queue.ts      ← QueueItem persistent DB queue + processQueue race fix + enqueue/dequeue + drainRecoveredQueue (부팅 시 복구 큐 기동, server.ts가 transport 준비 후 호출) + `_fromQueue` 표식 (대기자 없는 턴을 채널이 답할 수 있게) (694L)
 │   │   │   ├── resume.ts     ← session resume logic + stale resume detection (117L)

--- a/tests/unit/spawn-kill-policy.test.ts
+++ b/tests/unit/spawn-kill-policy.test.ts
@@ -11,10 +11,21 @@ const { armExitSettle, captureExitSettler, settleCapturedExit, waitForExitSettle
 const { killAgentById, activeProcesses } = await import('../../src/agent/spawn.ts');
 
 /** A child that catches SIGTERM and keeps running — the case `ChildProcess.killed` hides. */
-function spawnTermTrappingChild(): ChildProcess {
-    return spawn(process.execPath, ['-e',
-        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+async function spawnTermTrappingChild(): Promise<ChildProcess> {
+    const child = spawn(process.execPath, ['-e',
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000); process.stdout.write('READY');",
     ]);
+    // Waiting on the 'spawn' event is not enough: it fires before node has evaluated
+    // -e, so a SIGTERM sent immediately after would arrive while the default handler
+    // is still installed and the child would die on the first signal — proving nothing.
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('trap fixture never reported ready')), 10_000);
+        child.stdout!.on('data', (chunk: Buffer) => {
+            if (chunk.toString().includes('READY')) { clearTimeout(timer); resolve(); }
+        });
+        child.once('error', err => { clearTimeout(timer); reject(err); });
+    });
+    return child;
 }
 
 // ─── KP-001 ───
@@ -25,9 +36,8 @@ function spawnTermTrappingChild(): ChildProcess {
 // worker stop while main stop escalated correctly (#683).
 
 test('KP-001: killAgentById escalates a SIGTERM-trapping worker to SIGKILL', { timeout: 15_000 }, async () => {
-    const child = spawnTermTrappingChild();
-    await once(child, 'spawn');
-    const agentId = 'kp-001-trap';
+        const child = await spawnTermTrappingChild();
+        const agentId = 'kp-001-trap';
     activeProcesses.set(agentId, child);
     try {
         assert.equal(killAgentById(agentId), true, 'the worker kill port must accept a live child');

--- a/tests/unit/spawn-kill-policy.test.ts
+++ b/tests/unit/spawn-kill-policy.test.ts
@@ -1,0 +1,109 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+const { OwnedProcess } = await import('../../src/agent/spawn/process-kill.ts');
+const { armExitSettle, captureExitSettler, settleCapturedExit, waitForExitSettled } =
+    await import('../../src/agent/spawn/exit-settle.ts');
+const { killAgentById, activeProcesses } = await import('../../src/agent/spawn.ts');
+
+/** A child that catches SIGTERM and keeps running — the case `ChildProcess.killed` hides. */
+function spawnTermTrappingChild(): ChildProcess {
+    return spawn(process.execPath, ['-e',
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+    ]);
+}
+
+// ─── KP-001 ───
+//
+// Worker stop (`orchestrator/distribute.ts`, `orchestrator/pipeline.ts`) reaches
+// `killAgentById`, which used to escalate on a bare timer with no liveness re-check
+// and a different grace from main stop. A CLI that traps SIGTERM therefore survived
+// worker stop while main stop escalated correctly (#683).
+
+test('KP-001: killAgentById escalates a SIGTERM-trapping worker to SIGKILL', { timeout: 15_000 }, async () => {
+    const child = spawnTermTrappingChild();
+    await once(child, 'spawn');
+    const agentId = 'kp-001-trap';
+    activeProcesses.set(agentId, child);
+    try {
+        assert.equal(killAgentById(agentId), true, 'the worker kill port must accept a live child');
+        assert.equal(child.exitCode, null, 'SIGTERM alone must not have reaped a trapping child');
+        await once(child, 'exit');
+        assert.equal(child.signalCode, 'SIGKILL', 'the owner must escalate past a trapped SIGTERM');
+    } finally {
+        activeProcesses.delete(agentId);
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }
+});
+
+// ─── KP-002 ───
+//
+// The five rewritten kill sites deliberately pass no policy, because `ownProcess` is
+// memoized and a late policy is honoured for a main run but silently dropped for a
+// worker `registerActiveProcess` already owns. That only works if the DEFAULT policy
+// is the one each site wants, so pin it: the print stall watchdog keeps its 5s and
+// everything else takes the 2s DEFAULT_KILL_ESCALATION_MS.
+
+test('KP-002: the default policy preserves each site grace without an override', () => {
+    for (const [reason, expected] of [['stall', 5_000], ['cancel', 2_000], ['completion', 2_000], ['steer', 2_000]] as const) {
+        const signals: Array<{ pid: number; signal: string }> = [];
+        const timers: Array<{ delay: number; fn: () => void }> = [];
+        const child = { pid: 4242, exitCode: null, signalCode: null, once: () => child } as unknown as ChildProcess;
+        const owned = new OwnedProcess(child, {
+            terminateTree: (pid, signal = 'SIGTERM') => { signals.push({ pid, signal }); },
+            setTimer: ((fn: () => void, delay: number) => {
+                timers.push({ delay, fn });
+                return { unref() { return this; } } as unknown as NodeJS.Timeout;
+            }) as unknown as typeof setTimeout,
+        });
+        owned.terminate(reason);
+        assert.deepEqual(signals, [{ pid: 4242, signal: 'SIGTERM' }], `${reason} starts with SIGTERM`);
+        assert.equal(timers.length, 1, `${reason} schedules exactly one escalation`);
+        assert.equal(timers[0]!.delay, expected, `${reason} keeps its ${expected}ms grace`);
+        timers[0]!.fn();
+        assert.deepEqual(signals[1], { pid: 4242, signal: 'SIGKILL' }, `${reason} escalates`);
+    }
+});
+
+// ─── KP-003 ───
+//
+// The barrier moved to its own module so it could be imported without spawn behind
+// it (#697). The part that had to survive the move is identity: a runtime settles
+// from a `finally` block, and by then a second steer may have armed a NEW barrier
+// for the same scope. Resolving that one would release a waiter for output nobody
+// has written yet.
+
+test('KP-003: a captured arm never settles a successor arm for the same scope', async () => {
+    const scope = 'kp-003';
+    armExitSettle(scope);
+    const first = captureExitSettler(scope);
+    assert.ok(first, 'the first steer arms a barrier');
+
+    assert.equal(settleCapturedExit(scope, first), true, 'its own arm settles');
+    await waitForExitSettled(scope, 50);
+
+    armExitSettle(scope);
+    const second = captureExitSettler(scope);
+    assert.notEqual(second, first, 'a later steer arms a distinct barrier');
+    assert.equal(settleCapturedExit(scope, first), false, 'the stale capture must not settle it');
+
+    let released = false;
+    const waiter = waitForExitSettled(scope, 5_000).then(() => { released = true; });
+    await new Promise(r => setTimeout(r, 60));
+    assert.equal(released, false, 'the successor arm still holds its waiter');
+
+    assert.equal(settleCapturedExit(scope, second), true, 'the matching capture releases it');
+    await waiter;
+    assert.equal(released, true);
+});
+
+test('KP-004: settleCapturedExit is a no-op for an unarmed scope', () => {
+    // Never a blind settleExit: an unarmed scope has nobody waiting, and treating
+    // "I captured nothing" as "settle whatever is there" would resolve another
+    // turn's barrier.
+    assert.equal(settleCapturedExit('kp-004-never-armed', undefined), false);
+});


### PR DESCRIPTION
> Stacked on #705 (`codex/681-steer-reason-unify`). Base retargets to `dev` once #705 lands.

## Problem

`d113c0ffd` moved `killActiveAgent`, `killAllAgents` and the duplicate reaper onto
`OwnedProcess` and declared 44 direct `.kill()` calls unified. Five were not:

| site | before |
| --- | --- |
| `killAgentById` (`spawn.ts:414-441`) | `killProcessTree` + bare 3s `setTimeout` |
| Pi no-lease cancel (`:2568-2578`) | `killProcessTree` + 5s |
| AGY quiet completion (`:3593-3596`) | `killProcessTree` + 2s |
| print stall watchdog (`:3617-3628`) | `killProcessTree` + 5s |
| AGY stale resume (`:3745`) | `killProcessTree`, no escalation at all |

(The issue's line labels for three of these were swapped; the table above is what is
actually at those lines on `dev` `b5ea3c0ab`.)

This is not tidiness. The comment at `spawn.ts:670-677` states why the owner exists:
`ChildProcess.killed` records only that a signal was *delivered*, so a CLI that traps
SIGTERM stays alive with `killed === true` and is never escalated. All five paths kept
that defect. Worker stop reaches `killAgentById` from `orchestrator/distribute.ts:400`
and `orchestrator/pipeline.ts:784`, so worker children and main children ran under
different lifetime rules, and the steer timer/unref fixes (`1f6641ff3`, `8a5578b0a`,
`ef0cfd5e4`) that landed on `steerAgent` never propagated to either.

## Change

All five route through `ownProcess(child).terminate(reason)`.

**No site passes a policy override, deliberately.** `ownProcess` is memoized on child
identity and the *first* call wins (`spawn/process-kill.ts:189-195`), and
`registerActiveProcess` already owns every worker child with the default policy
(`spawn.ts:166`). A policy passed at the kill site would therefore be honoured for a
main run and silently dropped for a worker — the worst possible difference. The default
is what each site wants: `stall` keeps 5s, everything else takes
`DEFAULT_KILL_ESCALATION_MS`. `KP-002` pins that so it cannot drift.

### Disclosed behaviour changes

- `killAgentById` escalates after 2s instead of 3s; the Pi no-lease cancel after 2s
  instead of 5s. This is the alignment the issue asks for.
- AGY stale-resume gains a SIGKILL escalation it never had.
- Windows moves from `taskkill /T /F` to graceful-first, then the hard kill.
- The escalation timer is unref'd where the hand-rolled ones were not.
- The Pi no-lease branch drops its `child.kill('SIGTERM')` fallback for a pid-less
  child; such a child never started, and the owner completes it without signalling.

## Stub functions

`getKillPolicy` ignored both arguments and had exactly one caller. Deleted;
`killActiveAgent` uses the constant directly.

`getSteerWaitMsForActiveAgent` is exported and called from `src/routes/orchestrate.ts`
and `src/cli/handlers-runtime.ts`, both outside this change, so its signature is frozen.
Its body now uses `scopeKey`: resolve the scope's active CLI, read
`settings.agentTimeout` (global keys overlaid by per-CLI) for `steerWaitMs`, else the
previous constant. `settings` is a live binding, which is what a steer wants — it is
deciding how long to wait now, not how long the run was configured for when it spawned.

## Exit-settle seam

The barrier moves to `src/agent/spawn/exit-settle.ts` **with its map**. Six sites
(`:1743`, `:1766`, `:1793`, `:1929-1930`, `:2069-2070`, `:2435-2439`, `:2586`) capture an
arm and later settle it only if the map still holds that exact entry, so re-exporting
three functions would have silently dropped that guarantee. `captureExitSettler` and
`settleCapturedExit` make the identity contract explicit instead of reaching into a
private map from a `finally` block. `spawn.ts` re-exports the three public names, so
none of the fourteen importers change.

This also unblocks #697: a leaf module can be imported by a child process without the
server graph behind it, which is the only way to test the unref/drain failure mode.

## Not done here

Moving `killActiveAgent`/`killAllAgents`/the process registry into `src/agent/spawn/`
is proposed range item 2. No completion condition requires it and those functions close
over roughly fifteen module-level bindings, so the seam is opened where it pays and the
rest is left with the reason recorded rather than half-moved.

## Tests

`tests/unit/spawn-kill-policy.test.ts`:

- **KP-001** spawns a real child that traps SIGTERM, registers it as a worker, calls
  `killAgentById`, and asserts it dies by SIGKILL — the exact defect that survived the
  first unification.
- **KP-002** pins the default grace per reason through injected timers.
- **KP-003** proves a captured arm never settles a *successor* arm for the same scope.
- **KP-004** proves an empty capture is a no-op rather than a blind `settleExit`.

`structure/str_func.md` was regenerated with `bash structure/verify-counts.sh --fix`.

## Verification

Local test suite, typecheck and build: **NOT RUN** (this lane verifies on remote CI
only). Evidence is the `ci-aggregate` conclusion on this PR's final head SHA.

Closes #683
