### PR TITLE
refactor(slack): deliver every turn body through one helper

### DIFF
--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -656,32 +656,20 @@ function trackSlackReply(options: SlackReplyOptions): void {
                 const text = data['error'] === true && !requireBodyDelivery ? t('slack.progress.failure', {}, locale)
                     : requireBodyDelivery && !rawText.trim() ? '' : rawText;
                 display.phase('delivering');
-                const outbound = slackOutboundRegistry.start(signal);
-                try {
-                    const alreadyDelivered = text && (anchor ?? observedAnchor) !== undefined && wasSelfDelivered({ target, text, since: (anchor ?? observedAnchor)! });
-                    const sent: { ok: boolean; ts?: string } = text ? (alreadyDelivered ? { ok: true } : await sendSlackText(token, target, text, {
-                        signal: outbound.signal, ...(requireBodyDelivery ? { requireBodyDelivery: true } : {}),
-                        onPosted: async () => {
-                            // Same early-settle rule as the direct path: every chunk is
-                            // posted, so the ACK must not wait on readback verification.
-                            delivered = true;
-                            const early = bodyProgressOutcome(data, true, executionOutcome, !current());
-                            await settleAck(early === 'complete' ? 'success' : 'failure');
-                        },
-                    })) : { ok: false };
-                    delivered = sent.ok;
-                    confirmedDelivery = Boolean(alreadyDelivered) || (sent.ok && Boolean(sent.ts));
-                } finally { outbound.done(); }
-                const outcome = bodyProgressOutcome(data, delivered, executionOutcome, !current());
-                if (delivered && target.threadId) markThreadParticipated(target.targetId, target.threadId);
-                await settleAck(delivered && outcome === 'complete' ? 'success' : 'failure');
-                await display.finish(outcome, { bodyDelivered: confirmedDelivery });
-                if (text && current()) {
-                    const relay = slackOutboundRegistry.start(signal);
-                    try { await relaySlackImages(token, target, text, { signal: relay.signal }); }
-                    catch (error) { log.error('[slack:queue-relay]', logErrorText(error)); }
-                    finally { relay.done(); }
-                }
+                // Same rule as the direct path, and now literally the same code:
+                // the queued/steer turn differs only in where its text and anchor
+                // come from, and in keeping the image relay off the body's
+                // cancellation domain (#686).
+                await deliverSlackTurnBody({
+                    token, target, text, data, signal, display, settleAck, current,
+                    executionOutcome: () => executionOutcome,
+                    since: anchor ?? observedAnchor,
+                    skipSendIfEmpty: true,
+                    relayMode: 'isolated',
+                    relayWhenTextEmpty: false,
+                    report: (sentOk, confirmed) => { delivered = sentOk; confirmedDelivery = confirmed; },
+                    onRelayError: error => log.error('[slack:queue-relay]', logErrorText(error)),
+                });
             } catch (error) {
                 log.error('[slack:queue-send]', logErrorText(error));
                 await Promise.allSettled([
@@ -899,31 +887,20 @@ async function slackOrchestrate(
                 const text = collected.data.collectionFailure === 'error' ? t('slack.progress.failure', {}, locale)
                     : collected.data.collectionFailure === 'timeout' ? t('tg.timeout', {}, locale) : collected.text;
                 display.phase('delivering');
-                const outbound = slackOutboundRegistry.start(signal);
-                try {
-                    bodyAttempted = true;
-                    const alreadyDelivered = wasSelfDelivered({ target, text, since: turnStartedAt });
-                    const sendResult: { ok: boolean; ts?: string } = alreadyDelivered ? { ok: true } : await sendSlackText(token, target, text, {
-                        signal: outbound.signal,
-                        ...(requiresNativeBodyDelivery(collected.data) ? { requireBodyDelivery: true } : {}),
-                        onPosted: async () => {
-                            // Every chunk is posted, so the answer is visible. Settle
-                            // the ACK here: readback verification below can take
-                            // seconds per chunk and must not hold the reaction (#417).
-                            bodySucceeded = true;
-                            const early = bodyProgressOutcome(resultData, true, executionOutcome, !current());
-                            await settleAck(early === 'complete' ? 'success' : 'failure');
-                        },
-                    });
-                    bodySucceeded = sendResult.ok;
-                    bodyConfirmed = alreadyDelivered || (sendResult.ok && Boolean(sendResult.ts));
-                    const outcome = bodyProgressOutcome(resultData, bodySucceeded, executionOutcome, !current());
-                    if (bodySucceeded && target.threadId) markThreadParticipated(target.targetId, target.threadId);
-                    await settleAck(bodySucceeded && outcome === 'complete' ? 'success' : 'failure');
-                    await display.finish(outcome, { bodyDelivered: bodyConfirmed });
-                    if (current()) await relaySlackImages(token, target, text, { signal: outbound.signal });
-                    log.info(`[slack:out${alreadyDelivered ? ':skipped-self-delivered' : ''}] ${target.targetId}: ${redactOutboundText(text).slice(0, 80)}`);
-                } finally { outbound.done(); }
+                bodyAttempted = true;
+                await deliverSlackTurnBody({
+                    token, target, text, data: resultData, signal, display, settleAck, current,
+                    executionOutcome: () => executionOutcome,
+                    since: turnStartedAt,
+                    // The direct path posts even an empty body: sendSlackText owns
+                    // the empty_message rule, and the collector already replaced a
+                    // truly empty answer with its no-response placeholder.
+                    skipSendIfEmpty: false,
+                    relayMode: 'same-outbound',
+                    relayWhenTextEmpty: true,
+                    report: (delivered, confirmed) => { bodySucceeded = delivered; bodyConfirmed = confirmed; },
+                    onSent: alreadyDelivered => log.info(`[slack:out${alreadyDelivered ? ':skipped-self-delivered' : ''}] ${target.targetId}: ${redactOutboundText(text).slice(0, 80)}`),
+                });
             } catch (err: unknown) {
                 log.error('[slack:error]', logErrorText(err));
                 if (current()) executionOutcome ??= 'error';
@@ -978,6 +955,106 @@ async function slackOrchestrate(
         return;
     }
 
+}
+
+type SlackTurnBodyOutcome = { delivered: boolean; confirmed: boolean; outcome: SlackProgressOutcome };
+
+/**
+ * The one place a Slack turn's answer reaches the wire (#686).
+ *
+ * The direct dispatch path and the queued/steer tracker each carried their own
+ * copy of send -> early ACK -> progress finish -> image relay. Every delivery
+ * fix therefore had to land twice, and the ones that did not became bugs only
+ * the queued path kept (#655, #673).
+ *
+ * The two paths do genuinely disagree, so each disagreement is a PARAMETER
+ * rather than a branch inside the spine: the caller derives its own text from
+ * its own payload, brings its own delivery-ledger anchor, decides whether an
+ * empty body is posted at all, and chooses whether the image relay shares the
+ * body's cancellation domain. Collapsing those would silently change live
+ * behaviour, which is why this is an extraction and not a merge.
+ *
+ * Deliberately NOT folded in: the orphan forwarder. It has no ACK handle and no
+ * progress card, because it exists precisely for turns whose waiter is gone.
+ */
+async function deliverSlackTurnBody(options: {
+    token: string;
+    target: RemoteTarget;
+    /** Already derived by the caller: the two paths read different payloads. */
+    text: string;
+    data: Record<string, unknown>;
+    signal: AbortSignal;
+    display: SlackProgressLifecycle;
+    settleAck: (outcome: 'success' | 'failure') => Promise<void>;
+    /** Re-read, never cached: liveness can flip part-way through a send. */
+    current: () => boolean;
+    executionOutcome: () => 'error' | 'cancelled' | undefined;
+    /** Delivery-ledger anchor. Undefined skips the self-delivery check. */
+    since: number | undefined;
+    /** Queued: an empty body is never posted. Direct: sendSlackText decides. */
+    skipSendIfEmpty: boolean;
+    /** isolated: the relay gets its own registration and swallows its error.
+     *  same-outbound: the relay shares the body's registration and may throw. */
+    relayMode: 'isolated' | 'same-outbound';
+    /** NOT the same switch as skipSendIfEmpty: the queued path also skips the
+     *  IMAGE relay on an empty body, so one empty-text flag cannot serve both. */
+    relayWhenTextEmpty: boolean;
+    /** Mirrors the flags out as they change, so a caller's catch and finally see
+     *  the same partial state the inline blocks used to leave behind. */
+    report?: (delivered: boolean, confirmed: boolean) => void;
+    onSent?: (alreadyDelivered: boolean) => void;
+    onRelayError?: (error: unknown) => void;
+}): Promise<SlackTurnBodyOutcome> {
+    const { token, target, text, data, signal, display, settleAck, current, executionOutcome } = options;
+    const requireBodyDelivery = requiresNativeBodyDelivery(data);
+    let bodySucceeded = false;
+    let bodyConfirmed = false;
+    const report = () => options.report?.(bodySucceeded, bodyConfirmed);
+    const outbound = slackOutboundRegistry.start(signal);
+    let outboundClosed = false;
+    const closeOutbound = () => { if (!outboundClosed) { outboundClosed = true; outbound.done(); } };
+    try {
+        const skipped = options.skipSendIfEmpty && !text;
+        const since = options.since;
+        const alreadyDelivered = !skipped && since !== undefined
+            && wasSelfDelivered({ target, text, since });
+        const sent: { ok: boolean; ts?: string } = skipped ? { ok: false }
+            : alreadyDelivered ? { ok: true }
+            : await sendSlackText(token, target, text, {
+                signal: outbound.signal, ...(requireBodyDelivery ? { requireBodyDelivery: true } : {}),
+                onPosted: async () => {
+                    // Every chunk is posted, so the answer is visible. Settle the
+                    // ACK here: readback verification can take seconds per chunk
+                    // and must not hold the reaction on running (#417).
+                    bodySucceeded = true;
+                    report();
+                    const early = bodyProgressOutcome(data, true, executionOutcome(), !current());
+                    await settleAck(early === 'complete' ? 'success' : 'failure');
+                },
+            });
+        bodySucceeded = sent.ok;
+        bodyConfirmed = alreadyDelivered || (sent.ok && Boolean(sent.ts));
+        report();
+        // The queued path closes the body registration before settling, so a late
+        // image upload cannot keep the turn's outbound slot open.
+        if (options.relayMode === 'isolated') closeOutbound();
+        const outcome = bodyProgressOutcome(data, bodySucceeded, executionOutcome(), !current());
+        if (bodySucceeded && target.threadId) markThreadParticipated(target.targetId, target.threadId);
+        await settleAck(bodySucceeded && outcome === 'complete' ? 'success' : 'failure');
+        await display.finish(outcome, { bodyDelivered: bodyConfirmed });
+        if (current() && (options.relayWhenTextEmpty || Boolean(text))) {
+            if (options.relayMode === 'isolated') {
+                const relay = slackOutboundRegistry.start(signal);
+                try { await relaySlackImages(token, target, text, { signal: relay.signal }); }
+                catch (error) { options.onRelayError?.(error); }
+                finally { relay.done(); }
+            } else {
+                await relaySlackImages(token, target, text, { signal: outbound.signal });
+            }
+        }
+        if (!skipped) options.onSent?.(alreadyDelivered);
+        return { delivered: bodySucceeded, confirmed: bodyConfirmed, outcome };
+    } finally { closeOutbound(); }
 }
 
 function buildSlackFileFailureWarning(failed: readonly FailedSlackFile[], allFailed = false): string | null {

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -887,7 +887,6 @@ async function slackOrchestrate(
                 const text = collected.data.collectionFailure === 'error' ? t('slack.progress.failure', {}, locale)
                     : collected.data.collectionFailure === 'timeout' ? t('tg.timeout', {}, locale) : collected.text;
                 display.phase('delivering');
-                bodyAttempted = true;
                 await deliverSlackTurnBody({
                     token, target, text, data: resultData, signal, display, settleAck, current,
                     executionOutcome: () => executionOutcome,
@@ -898,6 +897,7 @@ async function slackOrchestrate(
                     skipSendIfEmpty: false,
                     relayMode: 'same-outbound',
                     relayWhenTextEmpty: true,
+                    onAttempt: () => { bodyAttempted = true; },
                     report: (delivered, confirmed) => { bodySucceeded = delivered; bodyConfirmed = confirmed; },
                     onSent: alreadyDelivered => log.info(`[slack:out${alreadyDelivered ? ':skipped-self-delivered' : ''}] ${target.targetId}: ${redactOutboundText(text).slice(0, 80)}`),
                 });
@@ -1002,6 +1002,9 @@ async function deliverSlackTurnBody(options: {
     /** Mirrors the flags out as they change, so a caller's catch and finally see
      *  the same partial state the inline blocks used to leave behind. */
     report?: (delivered: boolean, confirmed: boolean) => void;
+    /** Fires once the outbound registration exists, which is the moment the
+     *  original inline blocks considered the body attempted. */
+    onAttempt?: () => void;
     onSent?: (alreadyDelivered: boolean) => void;
     onRelayError?: (error: unknown) => void;
 }): Promise<SlackTurnBodyOutcome> {
@@ -1013,6 +1016,7 @@ async function deliverSlackTurnBody(options: {
     const outbound = slackOutboundRegistry.start(signal);
     let outboundClosed = false;
     const closeOutbound = () => { if (!outboundClosed) { outboundClosed = true; outbound.done(); } };
+    options.onAttempt?.();
     try {
         const skipped = options.skipSendIfEmpty && !text;
         const since = options.since;

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -349,7 +349,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
 │   ├── slack/                ← Slack 인터페이스 (41 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1837L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1918L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (442L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (222L)
 │   │   ├── blocks.ts         ← Block Kit validation and per-table message splitting (143L)

--- a/tests/unit/slack-delivery-helper.test.ts
+++ b/tests/unit/slack-delivery-helper.test.ts
@@ -1,0 +1,206 @@
+import '../setup/isolated-home.ts';
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { settings } from '../../src/core/config.ts';
+import { broadcast } from '../../src/core/bus.ts';
+
+// Drive the real Slack bot producers. Collection, gateway admission, ACK,
+// progress, identity and the outbound Slack transports are faked; no socket,
+// SDK client or live message request is started.
+const operations: string[] = [];
+let completion: Record<string, unknown> = {};
+let body = 'answer';
+let queued = false;
+let id = 0;
+let activeRequest = '';
+let sendCalls = 0;
+
+function assertSlackBodyOrder(events: string[], text: string, outcome = 'success') {
+    const ackLabel = `ack:${outcome}`;
+    const labels = [`post:slack:${text}`, ackLabel, 'progress:finish', 'images:slack'];
+    for (const label of labels) assert.equal(events.filter(value => value === label).length, 1, `${label}: ${JSON.stringify(events)}`);
+    assert.ok(events.indexOf(labels[0]!) < events.indexOf(ackLabel), 'body precedes reaction ACK');
+    assert.ok(events.indexOf(ackLabel) < events.indexOf('progress:finish'), 'ACK precedes bounded status cleanup');
+    assert.ok(events.indexOf('progress:finish') < events.indexOf('images:slack'), 'status settles before optional image relay');
+}
+
+function deliverySpine(events: string[], text: string) {
+    const labels = new Set([`post:slack:${text}`, 'ack:success', 'progress:finish', 'images:slack']);
+    return events.filter(value => labels.has(value));
+}
+
+type SlackSendOpts = {
+    requireBodyDelivery?: boolean;
+    onPosted?: (info: { ts?: string; messageTs: string[]; postedChunks: number; totalChunks: number }) => void | Promise<void>;
+};
+
+async function defaultSend(_token: string, _target: unknown, text: string, opts?: SlackSendOpts) {
+    sendCalls += 1;
+    operations.push(`post:slack:${text}`);
+    await opts?.onPosted?.({ ts: 'notice-ts', messageTs: ['notice-ts'], postedChunks: 1, totalChunks: 1 });
+    return { ok: true, ts: 'notice-ts' };
+}
+
+let sendSlackTextImpl: typeof defaultSend = defaultSend;
+
+mock.module('../../src/orchestrator/collect.ts', { namedExports: {
+    orchestrateAndCollect: async () => { throw new Error('Producer dropped native metadata'); },
+    orchestrateAndCollectData: async () => ({ text: body, data: completion }),
+} });
+mock.module('../../src/orchestrator/gateway.ts', { namedExports: {
+    submitMessage: () => ({
+        action: queued ? 'queued' : 'started',
+        disposition: queued ? 'queued' : 'new_run',
+        pending: 1,
+        requestId: activeRequest,
+        sessionContext: { scope: 'default', chatSessionId: 'default' },
+    }),
+} });
+const ack = await import('../../src/messaging/ack-reaction.ts');
+mock.module('../../src/messaging/ack-reaction.ts', { namedExports: { ...ack,
+    shouldAck: () => true,
+    createAckHandle: () => ({
+        to: async () => { operations.push('ack:running'); },
+        settle: async (outcome: string) => { operations.push(`ack:${outcome}`); },
+    }),
+} });
+const delivery = await import('../../src/messaging/turn-delivery.ts');
+mock.module('../../src/messaging/turn-delivery.ts', { namedExports: { ...delivery, wasSelfDelivered: () => false } });
+const slackSend = await import('../../src/slack/send-only-client.ts');
+mock.module('../../src/slack/send-only-client.ts', { namedExports: { ...slackSend,
+    getSlackSendClient: () => ({ token: 'fake' }),
+    sendSlackText: (_token: string, target: unknown, text: string, opts?: SlackSendOpts) => sendSlackTextImpl(_token, target, text, opts),
+} });
+const slackForwarder = await import('../../src/slack/forwarder.ts');
+mock.module('../../src/slack/forwarder.ts', { namedExports: { ...slackForwarder,
+    relaySlackImages: async () => { operations.push('images:slack'); },
+} });
+const identity = await import('../../src/slack/identity.ts');
+mock.module('../../src/slack/identity.ts', { namedExports: { ...identity,
+    resolveSenderIdentity: async () => ({ id: 'U1', name: 'User', kind: 'user' }),
+    buildSenderPrompt: (_identity: unknown, text: string) => text,
+    buildSenderDisplay: (_identity: unknown, text: string) => text,
+} });
+mock.module('../../src/slack/progress.ts', { namedExports: {
+    startSlackProgress: async () => {
+        let finished = false;
+        return {
+            update() {}, tool() {}, projectedTool() {}, phase() {},
+            finish: async (_outcome = 'complete', _options: { bodyDelivered?: boolean } = {}) => {
+                if (!finished) {
+                    finished = true;
+                    operations.push('progress:finish');
+                }
+            },
+            ready: async () => ({ mode: 'none', ts: null }),
+            abort() {},
+            terminalConfirmed: () => false,
+            ts: () => null,
+        };
+    },
+    statusFromToolEvent: () => null,
+} });
+const slackApi = await import('../../src/slack/api.ts');
+mock.module('../../src/slack/api.ts', { namedExports: { ...slackApi,
+    slackApi: async (_token: string, method: string) => {
+        if (method.startsWith('chat.')) operations.push(`slack-api:${method}`);
+        return { ok: true, data: { ts: 'notice-ts' } };
+    },
+} });
+mock.module('../../src/slack/notice-transport.ts', { namedExports: {
+    createSlackNoticeTransport: () => ({
+        delete: async () => { operations.push('notice:delete'); },
+        edit: async () => { operations.push('notice:edit'); },
+    }),
+} });
+
+const slack = await import('../../src/slack/bot.ts');
+const target = () => ({ channel: 'slack', targetKind: 'channel', peerKind: 'channel', targetId: 'C1' });
+
+async function drain() {
+    for (let n = 0; n < 20; n++) await new Promise(resolve => setImmediate(resolve));
+}
+
+async function run() {
+    activeRequest = `slack-delivery-${++id}`;
+    return slack.processSlackMessageEvent(
+        { user: 'U1', ts: String(id), channel: 'C1' } as never,
+        target() as never,
+        'prompt',
+        new AbortController().signal,
+    );
+}
+
+test.before(() => {
+    Object.assign(settings, {
+        multiSession: { enabled: false },
+        slack: {
+            enabled: true, botToken: 'fake', appToken: 'fake', channelIds: ['C1'],
+            conversationContext: false, progress: { enabled: true },
+        },
+    });
+});
+test.beforeEach(() => {
+    operations.length = 0;
+    completion = {};
+    body = 'answer';
+    queued = false;
+    sendCalls = 0;
+    sendSlackTextImpl = defaultSend;
+});
+
+test('the direct path and the queued tracker deliver through the same helper', async () => {
+    await run();
+    await drain();
+    const direct = [...operations];
+    assertSlackBodyOrder(direct, 'answer');
+
+    queued = true;
+    const pending = run();
+    await pending;
+    operations.length = 0;
+    broadcast('orchestrate_done', {
+        origin: 'slack', requestId: activeRequest, text: 'answer',
+        fromQueue: true, target: target(),
+    });
+    await drain();
+    const tracked = [...operations];
+    assertSlackBodyOrder(tracked, 'answer');
+    assert.deepEqual(deliverySpine(direct, 'answer'), deliverySpine(tracked, 'answer'));
+});
+
+test('a steer-superseded turn posts no placeholder', async () => {
+    body = '';
+    completion = { superseded: true };
+    await run();
+    await drain();
+    assert.equal(sendCalls, 0, `superseded turn must not call sendSlackText: ${JSON.stringify(operations)}`);
+    assert.equal(operations.filter(value => value.startsWith('post:slack:')).length, 0, JSON.stringify(operations));
+    assert.equal(operations.filter(value => value === 'ack:success').length, 1, JSON.stringify(operations));
+});
+
+test('the ACK settles when the body is posted, before readback verification finishes', { timeout: 3_000 }, async () => {
+    const posted = Promise.withResolvers<void>();
+    const verify = Promise.withResolvers<void>();
+    sendSlackTextImpl = async (_token, _target, text, opts) => {
+        sendCalls += 1;
+        operations.push(`post:slack:${text}`);
+        await opts?.onPosted?.({ ts: 'x', messageTs: ['x'], postedChunks: 1, totalChunks: 1 });
+        posted.resolve();
+        await verify.promise;
+        operations.push('send:resolved');
+        return { ok: true, ts: 'x' };
+    };
+    const pending = run();
+    await posted.promise;
+    operations.push('send:released');
+    verify.resolve();
+    await pending;
+    await drain();
+    assert.ok(operations.includes('ack:success'), JSON.stringify(operations));
+    assert.ok(
+        operations.indexOf('ack:success') < operations.indexOf('send:released'),
+        `ACK must settle before send resolves: ${JSON.stringify(operations)}`,
+    );
+    assert.ok(operations.indexOf('ack:success') < operations.indexOf('send:resolved'));
+});


### PR DESCRIPTION
Slack's answer delivery lived in two places. The direct dispatch path (`slackOrchestrate` → `runReply`) and the queued/steer tracker (`trackSlackReply` → `queueHandler`) each carried their own copy of the same four steps: send the body, settle the ACK, finish the progress card, relay images. The comment in the queued copy said outright that it repeated the direct path's rule.

That is why the recent Slack fixes came in pairs, and why the ones that did not become bugs only the queued path kept — #655 posted a "no response" placeholder over a steered turn's real answer, and #673 lands in the same seam.

## What changed

`deliverSlackTurnBody` now owns that spine and both call sites route through it.

The two paths do genuinely disagree, so every disagreement is a **parameter** rather than a branch inside the helper. Collapsing them would have silently changed live behaviour:

| Divergence | Direct | Queued |
| --- | --- | --- |
| text source | `collectionFailure` / `collected.text`, plus the timeout string | `data.error` / `data.text`, native-empty coerced to `''` |
| empty body | still calls `sendSlackText`, which owns `empty_message` | never posts at all (`skipSendIfEmpty`) |
| image relay on empty body | relays | skips (`relayWhenTextEmpty`) |
| self-delivery anchor | `turnStartedAt` from `nextDeliverySeq()` | `anchor ?? observedAnchor`, which may be absent |
| relay cancellation | shares the body's outbound registration | its own registration, errors swallowed into `[slack:queue-relay]` |

`current()` is passed as a callback, not a boolean, because liveness can flip part-way through a send.

Left at the call sites on purpose: the superseded silent return (#655), the collector's text derivation, the direct path's pre-body diagnostic send, its always-`finally` teardown, and the queued path's `claimTerminal` / `slackReplyDelivery.deliver` / lane wrapper — that ledger claim is what stops the orphan forwarder double-posting.

The orphan forwarder is **not** folded in. It has no ACK handle and no progress card, because it exists precisely for turns whose waiter is gone.

## Tests

`tests/unit/slack-delivery-helper.test.ts` adds three behavioural tests against the real `src/slack/bot.ts`:

1. the direct path and the queued tracker produce the same post → ACK → progress finish → image relay spine
2. a steer-superseded turn posts nothing and still settles its ACK as success (#655)
3. the ACK settles from `onPosted`, before readback verification resolves (#417)

They are behavioural rather than source greps, so they fail if the paths ever diverge again.

`tests/unit/native-delivery-producers.test.ts` is the existing characterization oracle for both paths and is untouched; it staying green is the evidence that this extraction preserved behaviour.

## Review notes

- `tests/unit/ack-call-site-wiring.test.ts` pins literal source text by searching forward from the `runReply` marker. The helper is defined after `slackOrchestrate` and keeps the names `token`/`target`/`text`/`bodySucceeded`, so `await settleAck(bodySucceeded` and `await relaySlackImages(token, target, text` still resolve in that order. The pin's intent — ACK settles before the uncancellable relay — is exactly what the helper preserves.
- `structure/str_func.md` was regenerated with `bash structure/verify-counts.sh --fix`, not hand-edited.
- Local `npm test`, `npm run typecheck` and `npm run build` were **NOT RUN** for this branch by instruction; CI on this head is the verification evidence.

Closes #686

