### PR TITLE
fix(code): stop reading a spent turn key as an accepted send

### DIFF
--- a/public/manager/src/code/code-controller-runtime.ts
+++ b/public/manager/src/code/code-controller-runtime.ts
@@ -1,6 +1,6 @@
 import type {
     CodeContextUsage, CodeCreateSessionRequest, CodeModelCatalog, CodePatchSessionRequest,
-    CodePermissionRequest, CodeSessionInfo, CodeWireEvent,
+    CodePermissionRequest, CodePromptReceipt, CodeSessionInfo, CodeWireEvent,
 } from '../../../../src/code-mode/wire';
 import type { CodeControllerModel, CodeControllerOptions, CodeSessionFilter, CodeTransportState } from './code-controller-types';
 import { CodeClientError, codeBaseOrigin, createCodeSessionClient, type CodeGitInfo } from './code-session-client';
@@ -21,6 +21,35 @@ const rejected = (error: unknown) => error instanceof CodeClientError && error.s
 const newer = (incoming: CodeSessionInfo, current?: CodeSessionInfo | null) => !current
     || incoming.epoch > current.epoch || (incoming.epoch === current.epoch && (incoming.sequence > current.sequence
         || (incoming.sequence === current.sequence && incoming.revision >= current.revision)));
+
+/**
+ * A receipt status that means the send is spent without having produced work.
+ *
+ * The server consumes a `clientTurnKey` once. After a restart seals an
+ * interrupted turn, the same key returns only a duplicate receipt — HTTP 200,
+ * `ok:true`, and the stored status — and starts nothing. Answering a retry with
+ * that receipt as if it were an admission is what left the composer idle on a
+ * session that had failed.
+ *
+ * `completed` is deliberately absent: that turn ran, and its output is in the
+ * transcript, so closing the send is the honest outcome.
+ */
+const spent = (status: CodePromptReceipt['status']): boolean => status === 'failed' || status === 'cancelled';
+
+/**
+ * Did the transcript already settle the turn this send belongs to?
+ *
+ * The HTTP receipt is only visible when the client actually posts. After a
+ * reload the draft is restored with its original key and the first refresh sees
+ * the orphaned turn's own `user_message` still in history, so the guard has to
+ * read the transcript rather than the response.
+ */
+function deadSend(state: CodeSessionState | undefined, key: string): boolean {
+    const sent = state?.items.find(item => item.kind === 'user_message' && item.clientTurnKey === key);
+    if (!sent) return false;
+    return state!.items.some(item => item.turnId === sent.turnId
+        && (item.kind === 'turn_failed' || item.kind === 'turn_cancelled'));
+}
 
 /**
  * What a read that could actually observe the runtime said about attention.
@@ -225,7 +254,8 @@ export class CodeController {
         if (state.session) this.accept(state.session);
         const draft = this.book.sessions.get(id);
         if (draft?.retry && state.items.some(item => item.kind === 'user_message' && item.clientTurnKey === draft.retry!.key)) {
-            acknowledgeCodeSend(draft, draft.retry.key);
+            if (deadSend(state, draft.retry.key)) this.requireNewKey(draft);
+            else acknowledgeCodeSend(draft, draft.retry.key);
         }
         if (draft && state.synced) {
             const current = new Set(state.permissions.map(p => p.permissionId));
@@ -234,6 +264,19 @@ export class CodeController {
             }
         }
         this.notify();
+    }
+    /**
+     * Keep the message, retire the key.
+     *
+     * The server will answer that spent key with the same duplicate receipt
+     * forever, so retrying it is not a retry. Rotating gives Retry something that
+     * can actually be admitted, and it also stops the settled turn's own
+     * `user_message` from matching, so this fires once rather than on every read.
+     */
+    private requireNewKey(draft: CodeDraft): void {
+        if (!draft.retry) return;
+        draft.retry = { ...draft.retry, key: crypto.randomUUID() };
+        draft.operation = { kind: 'unknown-send', error: 'The original attempt ended on the server without running. The message was not resent; Retry will submit it as a new message.' };
     }
     private makeModel(): CodeControllerModel {
         const id = this.book.selectedId;
@@ -396,7 +439,8 @@ export class CodeController {
         const draft = this.book.sessions.get(event.sessionId);
         if (event.item?.kind === 'user_message' && event.item.clientTurnKey && draft?.retry?.key === event.item.clientTurnKey) {
             draft.requiredSequence = Math.max(draft.requiredSequence, event.sequence);
-            acknowledgeCodeSend(draft, event.item.clientTurnKey);
+            if (deadSend(this.details.get(event.sessionId), event.item.clientTurnKey)) this.requireNewKey(draft);
+            else acknowledgeCodeSend(draft, event.item.clientTurnKey);
         }
         const previous = this.details.get(event.sessionId);
         if (!previous) { this.notify(); return; }
@@ -603,7 +647,10 @@ export class CodeController {
             draft.requiredSequence = Math.max(draft.requiredSequence, receipt.sequence);
             const state = this.details.get(id);
             if (state) this.details.set(id, reduceCodeSession(state, { type: 'stale' }));
-            acknowledgeCodeSend(draft, attempt.key);
+            // A duplicate receipt for a spent key is a report about a turn that is
+            // already over, not an admission of this one.
+            if (spent(receipt.status)) this.requireNewKey(draft);
+            else acknowledgeCodeSend(draft, attempt.key);
         } catch (error) {
             // The committed user event may already have acknowledged a lost HTTP response.
             if (draft.retry?.key === attempt.key) {

--- a/tests/unit/code-native-controller.test.ts
+++ b/tests/unit/code-native-controller.test.ts
@@ -679,3 +679,79 @@ test('ranking a listing never strips the figure off the row the owner just read'
     await f.controller.selectSession('a');
     assert.equal(meter(f.controller), 1234);
 });
+
+// --- #703: a spent clientTurnKey is a report, not an admission ---
+// The server consumes a key once. After a restart seals the turn, the same key
+// returns HTTP 200 with the stored status and starts nothing, and the orphaned
+// turn's own user_message stays in history.
+
+test('a duplicate receipt for a spent key does not close the send, and Retry then carries a key the server can admit', async t => {
+    const f = fixture(t); await f.controller.refresh(); await f.controller.selectSession('a');
+    const pending = deferred<Response>();
+    f.intercept(call => call.path.endsWith('/prompt') ? pending.promise : undefined);
+    f.controller.setInput('original message');
+    const sending = f.controller.send();
+    pending.reject(new TypeError('connection dropped'));
+    await sending;
+    const first = String(f.posts()[0]!.body['clientTurnKey']);
+    assert.equal(f.controller.getModel().operation.kind, 'unknown-send');
+    f.intercept(call => call.path.endsWith('/prompt')
+        ? response({ ok: true, turnId: 't', clientTurnKey: call.body['clientTurnKey'], sequence: 3, status: 'failed' }) : undefined);
+    await f.controller.retrySameSend();
+    assert.equal(f.controller.getModel().operation.kind, 'unknown-send', 'a failed duplicate is not an admission');
+    assert.match(f.controller.getModel().operation.error!, /not resent/);
+    assert.equal(f.controller.getModel().retryText, 'original message', 'the message is kept');
+    f.intercept(call => call.path.endsWith('/prompt')
+        ? response({ ok: true, turnId: 'second', clientTurnKey: call.body['clientTurnKey'], sequence: 4, status: 'accepted' }) : undefined);
+    await f.controller.retrySameSend();
+    assert.notEqual(f.posts()[2]!.body['clientTurnKey'], first, 'the spent key is retired');
+    assert.equal(f.posts()[2]!.body['text'], 'original message');
+    assert.equal(f.controller.getModel().operation.kind, 'idle');
+});
+
+test('an orphaned turn does not acknowledge itself through its own transcript', async t => {
+    const f = fixture(t); await f.controller.refresh(); await f.controller.selectSession('a');
+    const pending = deferred<Response>();
+    f.intercept(call => call.path.endsWith('/prompt') ? pending.promise : undefined);
+    f.controller.setInput('original message');
+    const sending = f.controller.send();
+    const key = String(f.posts()[0]!.body['clientTurnKey']);
+    pending.reject(new TypeError('old page disposed'));
+    await sending;
+    assert.equal(f.controller.getModel().operation.kind, 'unknown-send');
+    // recoverInterrupted() seals the turn: the user message stays in history and a
+    // turn_failed lands beside it. Matching the key alone would read that as success.
+    const sent: CodeItem = { itemId: 't:user', firstSequence: 4, turnId: 't', kind: 'user_message', status: 'done',
+        text: 'original message', clientTurnKey: key, createdAt: 1, updatedAt: 1 };
+    const terminal: CodeItem = { itemId: 't:terminal', firstSequence: 5, turnId: 't', kind: 'turn_failed', status: 'done',
+        createdAt: 1, updatedAt: 1 };
+    f.snapshots.set('a', snap(session('a', { sequence: 5, status: 'failed', error: { code: 'orphaned_turn',
+        message: 'Code turn interrupted by server restart', at: 1, recoverable: true } }), [sent, terminal]));
+    f.intercept(() => undefined);
+    await f.controller.refresh();
+    assert.equal(f.controller.getModel().operation.kind, 'unknown-send', 'the settled turn is not an acknowledgement');
+    assert.match(f.controller.getModel().operation.error!, /not resent/);
+    assert.equal(f.controller.getModel().retryText, 'original message');
+    assert.equal(f.posts().length, 1, 'nothing was resent automatically');
+});
+
+test('a user message whose turn actually ran still acknowledges the send', async t => {
+    const f = fixture(t); await f.controller.refresh(); await f.controller.selectSession('a');
+    const pending = deferred<Response>();
+    f.intercept(call => call.path.endsWith('/prompt') ? pending.promise : undefined);
+    f.controller.setInput('original message');
+    const sending = f.controller.send();
+    const key = String(f.posts()[0]!.body['clientTurnKey']);
+    const sent: CodeItem = { itemId: 't:user', firstSequence: 4, turnId: 't', kind: 'user_message', status: 'done',
+        text: 'original message', clientTurnKey: key, createdAt: 1, updatedAt: 1 };
+    const finished: CodeItem = { itemId: 't:terminal', firstSequence: 5, turnId: 't', kind: 'turn_completed', status: 'done',
+        createdAt: 1, updatedAt: 1 };
+    f.snapshots.set('a', snap(session('a', { sequence: 5 }), [sent, finished]));
+    pending.reject(new TypeError('response lost'));
+    await sending;
+    f.intercept(() => undefined);
+    await f.controller.refresh();
+    assert.equal(f.controller.getModel().operation.kind, 'idle', 'a turn that ran is a real acknowledgement');
+    assert.equal(f.controller.getModel().retryText, null);
+    assert.equal(f.posts().length, 1);
+});


### PR DESCRIPTION
## Problem

The server consumes a `clientTurnKey` once. When a restart seals an interrupted turn, `recoverInterrupted()` settles it `failed` (`src/code-mode/store.ts:774-793`) and the same key afterwards returns only a duplicate receipt carrying the stored status, starting nothing (`:584-586`, `src/code-mode/manager.ts:229-231`). The route answers that with HTTP 200 `{ok:true, ...receipt}` (`src/routes/code-native.ts:162-170`).

The client read `clientTurnKey` and `sequence` off the receipt and nothing else, so Retry acknowledged the send, the composer went idle, and the session sat there `failed` with no new work. The server-side rule is already fixed by `tests/unit/code-native-session.test.ts:405-412`; only the UI disagreed.

Checking `receipt.status` in `submit()` is necessary but not sufficient. Two other paths acknowledge on a bare key match and both run before Retry is ever pressed: `update()` and the event handler close the send as soon as a `user_message` with that key appears. After a reload the draft is restored with its original key (`code-controller-drafts.ts:41-43`) and the orphaned turn's own `user_message` is still in history (`store.ts:605`), so the first `refresh()` acknowledged a turn that had already failed.

## Change

Guard the acknowledgement itself. A send is spent when the transcript holds its `user_message` and a `turn_failed` or `turn_cancelled` for that message's turn — both of which the snapshot already carries, since `finish()` writes the terminal item (`store.ts:722-725`) and `recoverInterrupted()` goes through it.

On that, keep the text and rotate the key. The server will answer the old key with the same duplicate forever, so retrying it is not a retry; rotating gives Retry something that can actually be admitted, and it also stops the settled turn from matching, so the guard fires once rather than on every read. `submit()` applies the same rule to a `failed` or `cancelled` receipt, covering the non-reload path.

`completed` is deliberately not spent: that turn ran and its output is in the transcript, so closing the send is the honest outcome. The existing assertion at `tests/unit/code-native-controller.test.ts:119-123` continues to hold.

## Verification

- 3 new controller tests: a failed duplicate leaves the operation in `unknown-send` and the next Retry posts a key the server has never seen; an orphaned turn does not acknowledge itself through its own transcript on refresh; and a turn that actually ran still acknowledges.
- The existing reload case at `:581-607` still reaches idle — its fixture plants a `user_message` with no terminal item, which is not spent.
- `bash structure/verify-counts.sh` reports one drift, the `public/` aggregate (`~103033L` documented vs `103261L` actual). `--fix` cannot regenerate that line — it reported `수정: 0` — and it is a tolerance-based total that every worktree currently touching `public/` will move, so it is left for a single regeneration after these land rather than hand-edited into six conflicting PRs. No workflow enforces it: the risk gate looks for `structure/n.sh`, which does not exist. This PR does not touch `structure/str_func.md`.
- Local product suite **NOT RUN** by instruction: `npm test`, `npm run typecheck` and `npm run build` were not executed. CI on the head SHA is the only verification evidence.

Closes #703
