### PR TITLE
test(runtime): pin the exit-settle drain and the steer supersession sink

### DIFF
--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -324,6 +324,7 @@ interface CopilotSpawnContext extends SpawnContext {
 
 import { hasChildExited, ownProcess } from './spawn/process-kill.js';
 import { DUP_REGISTRATION_KILL_REASON, isLifecycleSteerReason } from './spawn/kill-reason.js';
+import { buildSteerStartedEvent } from './spawn/steer-event.js';
 import {
     armExitSettle, captureExitSettler, settleCapturedExit, settleExit, waitForExitSettled,
     type ExitSettler,
@@ -815,10 +816,10 @@ export async function steerAgent(
                 attempted = true; // A partial recording failure must never retry this input.
                 insertMessage.run('user', newPrompt, source, '', workingDir, chatSessionId);
                 broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
-                broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey,
-                    sessionId: chatSessionId, target: capturedMeta.target, chatId: capturedMeta.chatId,
-                    requestId: capturedMeta.requestId, remoteKey: capturedMeta.remoteKey, replyViaTarget: capturedMeta.replyViaTarget,
-                    mode: 'cancel-reprompt', localDispatch: true }));
+                broadcast('steer_started', buildSteerStartedEvent({
+                    prompt: newPrompt, source, scopeKey, chatSessionId, meta: capturedMeta,
+                    mode: 'cancel-reprompt', extra: { localDispatch: true },
+                }));
                 settleOnce(capturedMeta.requestId, 'steered');
             });
         } finally { inputCancelled = inputGuard.isCancelled(); inputGuard.release(); }
@@ -854,7 +855,9 @@ export async function steerAgent(
         }
         insertMessage.run('user', newPrompt, source, '', settings["workingDir"] || null, chatSessionId);
         broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
-        broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey, sessionId: chatSessionId, target: meta?.target, chatId: meta?.chatId, requestId: meta?.requestId, remoteKey: meta?.remoteKey, replyViaTarget: meta?.replyViaTarget, mode: 'native-input' }));
+        broadcast('steer_started', buildSteerStartedEvent({
+            prompt: newPrompt, source, scopeKey, chatSessionId, meta, mode: 'native-input',
+        }));
         settleOnce(meta?.requestId, 'steered');
         return 'steered';
     }
@@ -895,9 +898,9 @@ export async function steerAgent(
     }
     insertMessage.run('user', newPrompt, source, '', settings["workingDir"] || null, chatSessionId);
     broadcast('new_message', { role: 'user', content: newPrompt, source, scope: scopeKey, sessionId: chatSessionId });
-    broadcast('steer_started', stripUndefined({ prompt: newPrompt, origin: source || 'web', scope: scopeKey,
-        sessionId: chatSessionId, target: meta?.target, chatId: meta?.chatId, requestId: meta?.requestId,
-        remoteKey: meta?.remoteKey, replyViaTarget: meta?.replyViaTarget, mode: 'kill-steer', ...slackRestart }));
+    broadcast('steer_started', buildSteerStartedEvent({
+        prompt: newPrompt, source, scopeKey, chatSessionId, meta, mode: 'kill-steer', extra: slackRestart,
+    }));
     const { orchestrate, orchestrateContinue, orchestrateReset, isContinueIntent, isResetIntent } = await import('../orchestrator/pipeline.js');
     const origin = source || 'web';
     // Union of both contracts: the #655 steer identity (target/chatId/remoteKey/

--- a/src/agent/spawn/steer-event.ts
+++ b/src/agent/spawn/steer-event.ts
@@ -1,0 +1,52 @@
+// ─── The identity a steer announces ───
+//
+// Three steer modes broadcast `steer_started`, and each one built the payload from its
+// own hand-written field list. Two consumers depend on those fields: the collector
+// retires a turn only when `scope`, `sessionId` and a DIFFERING `requestId` line up
+// (`orchestrator/collect.ts:129-133`), and the Slack reply-control observer switches on
+// `mode` (`slack/bot.ts:521`, `:557`). A mode that dropped one field silently stopped
+// retiring the turn it replaced, which is how a steered Slack turn posted the
+// "no response" placeholder into a user's thread (suji, 2026-09-09).
+//
+// A leaf module so a regression can assert against the payload production actually
+// sends without importing spawn.ts and the server graph behind it.
+
+export type SteerStartedMeta = {
+    target?: unknown;
+    chatId?: unknown;
+    requestId?: unknown;
+    remoteKey?: unknown;
+    replyViaTarget?: unknown;
+};
+
+/** Which steer replaced the turn. Slack's reply control reads this. */
+export type SteerMode = 'cancel-reprompt' | 'native-input' | 'kill-steer' | 'restart';
+
+export function buildSteerStartedEvent(input: {
+    prompt: string;
+    source?: string | undefined;
+    scopeKey: string;
+    chatSessionId: string;
+    meta?: SteerStartedMeta | undefined;
+    mode: SteerMode;
+    /** Mode-specific additions, e.g. the pre-kill Slack restart capture (#654). */
+    extra?: Record<string, unknown> | undefined;
+}): Record<string, unknown> {
+    const event: Record<string, unknown> = {
+        prompt: input.prompt,
+        origin: input.source || 'web',
+        scope: input.scopeKey,
+        sessionId: input.chatSessionId,
+        target: input.meta?.target,
+        chatId: input.meta?.chatId,
+        requestId: input.meta?.requestId,
+        remoteKey: input.meta?.remoteKey,
+        replyViaTarget: input.meta?.replyViaTarget,
+        mode: input.mode,
+        ...(input.extra ?? {}),
+    };
+    for (const key of Object.keys(event)) {
+        if (event[key] === undefined) delete event[key];
+    }
+    return event;
+}

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -145,7 +145,7 @@ cli-jaw/
 │   │   ├── claude-runtime-run.ts ← native Claude main adaptation to shared host/lifecycle and fallback terminal ordering (293L)
 │   │   ├── prompt-context.ts ← history/operational/partial boundaries and bounded accepted Cursor redirects (201L)
 │   │   ├── steer-input-guard.ts ← transient scoped Stop fence through fallback enqueue (33L)
-│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4059L)
+│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4062L)
 │   │   ├── spawn/            ← spawn 서브모듈 (3 files)
 │   │   │   ├── queue.ts      ← QueueItem persistent DB queue + processQueue race fix + enqueue/dequeue + drainRecoveredQueue (부팅 시 복구 큐 기동, server.ts가 transport 준비 후 호출) + `_fromQueue` 표식 (대기자 없는 턴을 채널이 답할 수 있게) (694L)
 │   │   │   ├── resume.ts     ← session resume logic + stale resume detection (117L)

--- a/tests/unit/spawn-exit-settle-drain.test.ts
+++ b/tests/unit/spawn-exit-settle-drain.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Regression for 1f6641ff30, which changed ten lines of spawn.ts and shipped with no
+// test. An unref'd timeout does not keep the event loop alive, so when the barrier was
+// armed and never settled, the loop drained, the timer never fired, and the race never
+// resolved — "Promise resolution is still pending". The comment left behind explains
+// the bug but cannot stop it being reintroduced.
+//
+// Fake timers cannot catch this. They fire unref'd timers happily; the failure is about
+// process LIFETIME, which only a real process exhibits. So the check is a child that
+// imports the barrier alone, waits on it, and prints a sentinel. With the timer
+// referenced the child prints and exits 0. With unref() restored it exits silently.
+//
+// Importing the leaf is what makes this affordable: before the barrier was extracted
+// it lived in spawn.ts, and a child would have had to load the whole server graph.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const moduleUrl = pathToFileURL(join(__dirname, '../../src/agent/spawn/exit-settle.ts')).href;
+
+function runChild(body: string) {
+    const started = Date.now();
+    const child = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '-e',
+        `import { armExitSettle, settleExit, waitForExitSettled } from '${moduleUrl}';\n${body}`,
+    ], { encoding: 'utf8', timeout: 30_000 });
+    return { ...child, elapsed: Date.now() - started };
+}
+
+test('ES-001: an armed, never-settled barrier still releases its waiter before the process exits',
+    { timeout: 40_000 }, () => {
+        const child = runChild([
+            "armExitSettle('drain');",
+            // Nothing else is scheduled. The timeout is the only handle holding this
+            // process open, which is exactly the condition 1f6641ff30 hit.
+            "await waitForExitSettled('drain', 400);",
+            "process.stdout.write('SETTLED');",
+        ].join('\n'));
+
+        assert.equal(child.status, 0, `child failed: ${child.stderr}`);
+        assert.match(child.stdout, /SETTLED/,
+            'the waiter must resolve; an unref\'d timeout would let the drained loop exit silently');
+        assert.ok(child.elapsed >= 350,
+            `the waiter must actually wait out its timeout (elapsed ${child.elapsed}ms)`);
+    });
+
+test('ES-002: settling early releases the waiter without burning the timeout',
+    { timeout: 40_000 }, () => {
+        // The negative control: without it, ES-001 would also pass if waitForExitSettled
+        // resolved immediately for the wrong reason.
+        const child = runChild([
+            "armExitSettle('drain');",
+            "const waiter = waitForExitSettled('drain', 30000);",
+            "settleExit('drain');",
+            "await waiter;",
+            "process.stdout.write('SETTLED');",
+        ].join('\n'));
+
+        assert.equal(child.status, 0, `child failed: ${child.stderr}`);
+        assert.match(child.stdout, /SETTLED/);
+        assert.ok(child.elapsed < 25_000,
+            'a settled barrier must not hold the process for the full timeout');
+    });
+
+test('ES-003: an unarmed scope resolves without arming a timer at all',
+    { timeout: 40_000 }, () => {
+        const child = runChild([
+            "await waitForExitSettled('never-armed', 30000);",
+            "process.stdout.write('SETTLED');",
+        ].join('\n'));
+
+        assert.equal(child.status, 0, `child failed: ${child.stderr}`);
+        assert.match(child.stdout, /SETTLED/);
+        assert.ok(child.elapsed < 25_000, 'no arm means no wait');
+    });

--- a/tests/unit/steer-superseded-sink.test.ts
+++ b/tests/unit/steer-superseded-sink.test.ts
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { broadcast } from '../../src/core/bus.ts';
+import { buildSteerStartedEvent } from '../../src/agent/spawn/steer-event.ts';
+
+// Second half of the Slack steer incident (suji, 2026-09-09): steering a running turn
+// posted the literal "no response" placeholder into the user's thread.
+//
+// tests/unit/steer-superseded-delivery.test.ts already covers the collector, but it
+// feeds it hand-written event literals. That is the gap #697 names: if a steer mode
+// stopped sending scope, or sent its own requestId, production would break while the
+// test stayed green. So this file drives the collector with the payload PRODUCTION
+// builds, and ends at a sink rather than at a field assertion.
+//
+// Scope boundary, stated plainly: the actual send decision lives in
+// src/slack/bot.ts:894-898, which this lane does not own. What is proved here is that
+// the collector hands a plain sink nothing worth sending. The assertion that bot.ts
+// honours that is the other half of #697.
+
+let lastMeta: Record<string, unknown> = {};
+
+// Mocked ONLY to stop a real agent launching. orchestrateAndCollectData calls
+// orchestrate, and the subject here is what the collector resolves, not what the
+// pipeline does. Nothing below asserts against this mock.
+test.mock.module('../../src/orchestrator/pipeline.ts', {
+    namedExports: {
+        isContinueIntent: () => false,
+        isResetIntent: () => false,
+        orchestrateContinue: () => undefined,
+        orchestrateReset: () => undefined,
+        orchestrate: (_prompt: string, meta: Record<string, unknown>) => { lastMeta = meta; },
+    },
+});
+
+/**
+ * The smallest honest sink: it sends whatever text it is handed, if there is any.
+ *
+ * Deliberately NOT a copy of the superseded rule in bot.ts. A stub that re-implemented
+ * that rule would pass no matter what the collector produced. By sending anything
+ * non-blank, it fails the moment the collector resolves to a placeholder again.
+ */
+function stubSink() {
+    const sent: string[] = [];
+    return { sent, send(text: unknown) { if (String(text ?? '').trim()) sent.push(String(text)); } };
+}
+
+const NO_RESPONSE = 'tg.noResponse';
+
+test('SS-001: a turn retired by a real kill-steer event hands the sink nothing', async () => {
+    const { orchestrateAndCollectData } = await import('../../src/orchestrator/collect.ts');
+    const sink = stubSink();
+    const pending = orchestrateAndCollectData('original question', {
+        origin: 'slack', requestId: 'req-original', scope: 'default', chatSessionId: 'default',
+    });
+
+    // Built by production, not by this test. A steer mode that drops scope or reuses
+    // the original requestId stops retiring the turn, and this is what notices.
+    broadcast('steer_started', buildSteerStartedEvent({
+        prompt: 'replacement question', source: 'slack', scopeKey: 'default',
+        chatSessionId: 'default', meta: { requestId: 'req-steer' }, mode: 'kill-steer',
+    }));
+    broadcast('orchestrate_done', { ...lastMeta, text: '' });
+
+    const result = await pending;
+    sink.send(result.text);
+
+    assert.deepEqual(sink.sent, [], 'a steered turn must put nothing in the user thread');
+    assert.notEqual(result.text, NO_RESPONSE);
+    assert.equal(result.data['superseded'], true, 'and must be marked so the send path stays silent');
+});
+
+test('SS-002: the same sink DOES receive a genuinely empty turn', async () => {
+    // Without this, SS-001 would pass against a sink that never sends anything.
+    const { orchestrateAndCollectData } = await import('../../src/orchestrator/collect.ts');
+    const sink = stubSink();
+    const pending = orchestrateAndCollectData('original question', {
+        origin: 'slack', requestId: 'req-plain', scope: 'default', chatSessionId: 'default',
+    });
+    broadcast('orchestrate_done', { ...lastMeta, text: '' });
+
+    const result = await pending;
+    sink.send(result.text);
+
+    assert.deepEqual(sink.sent, [NO_RESPONSE],
+        'an unsteered empty turn keeps its diagnostic - supersession is what suppresses it');
+});
+
+test('SS-003: every steer mode carries the fields the collector retires on', () => {
+    // The collector needs scope, a matching sessionId and a DIFFERING requestId
+    // (orchestrator/collect.ts:129-133). Slack reply control needs mode
+    // (slack/bot.ts:521, :557). All three modes must carry them, which is the whole
+    // reason the payload has one builder.
+    for (const mode of ['kill-steer', 'native-input', 'cancel-reprompt'] as const) {
+        const event = buildSteerStartedEvent({
+            prompt: 'p', source: 'slack', scopeKey: 'scope-a', chatSessionId: 'session-a',
+            meta: { requestId: 'req-steer', chatId: 'c1' }, mode,
+        });
+        assert.equal(event['scope'], 'scope-a', mode + ' must name the scope it retires');
+        assert.equal(event['sessionId'], 'session-a', mode + ' must name the session');
+        assert.equal(event['requestId'], 'req-steer', mode + ' must carry the NEW request id');
+        assert.equal(event['mode'], mode);
+        assert.equal(event['origin'], 'slack');
+    }
+});
+
+test('SS-004: absent optional identity is omitted, never sent as undefined', () => {
+    // The collector treats a MISSING sessionId as matching any session, but an explicit
+    // undefined serialises differently across the bus for remote consumers.
+    const event = buildSteerStartedEvent({
+        prompt: 'p', scopeKey: 'scope-a', chatSessionId: 'session-a', mode: 'kill-steer',
+    });
+    assert.equal('target' in event, false);
+    assert.equal('chatId' in event, false);
+    assert.equal('requestId' in event, false);
+    assert.equal(event['origin'], 'web', 'an unnamed source defaults to web, as before');
+});
+
+test('SS-005: a pre-kill Slack restart capture still overrides the base mode', () => {
+    // #654: the reply-control observer only treats restart as a real start
+    // (slack/bot.ts:521), so the extra capture must win over kill-steer.
+    const event = buildSteerStartedEvent({
+        prompt: 'p', source: 'slack', scopeKey: 'scope-a', chatSessionId: 'session-a',
+        meta: { requestId: 'req-steer', target: { channel: 'slack' } }, mode: 'kill-steer',
+        extra: { mode: 'restart', target: { channel: 'slack', id: 'C1' }, replyViaTarget: true },
+    });
+    assert.equal(event['mode'], 'restart');
+    assert.deepEqual(event['target'], { channel: 'slack', id: 'C1' });
+    assert.equal(event['replyViaTarget'], true);
+});


### PR DESCRIPTION
> Stacked on #709 → #708 → #705. Base retargets as each parent lands.
> **`Refs #697`, not `Closes`** — worktree W2 owns the Slack log/masking half.

## Problem

Two hot-path fixes landed with a comment where a test belonged.

**`1f6641ff30`** changed ten lines of `spawn.ts` and touched no test. An unref'd
timeout does not hold the event loop open, so an armed barrier that was never settled
left its waiter pending once the loop drained — `Promise resolution is still pending`.
The comment at `spawn.ts:595` explains the bug but cannot prevent its return.

**`254b700e35`** added a regression for the Slack steer placeholder, and its comment
even records the 2026-09-09 incident. But it mocks `pipeline.ts` and feeds the
collector hand-written event literals. The three steer modes each built the
`steer_started` payload from their own field list, so a mode that stopped sending
`scope`, or reused the original `requestId`, would stop retiring the turn it replaced
while the test stayed green.

## Change

### Exit-settle drain

`tests/unit/spawn-exit-settle-drain.test.ts` spawns a child that imports the barrier
**alone**, arms it, waits without settling, and prints a sentinel. With the timer
referenced the child prints and exits 0; with `unref()` restored the drained loop exits
silently and the assertion fails.

Fake timers cannot test this — they fire unref'd timers happily, and the failure mode
is about process *lifetime*. Two controls sit beside it so ES-001 cannot pass for the
wrong reason: settling early must not burn the timeout, and an unarmed scope must
resolve without waiting at all.

This is only affordable because #708 extracted the barrier into a leaf; before that a
child would have had to load the whole server graph to reach it.

### Steer supersession

The three `steer_started` broadcasts (`spawn.ts:818`, `:857`, `:898`) now share
`buildSteerStartedEvent` in `src/agent/spawn/steer-event.ts`. Two consumers depend on
that payload: the collector retires a turn only when `scope`, `sessionId` and a
*differing* `requestId` line up (`orchestrator/collect.ts:129-133`), and Slack reply
control switches on `mode` (`slack/bot.ts:521`, `:557`). Field-list duplication across
three modes is exactly how one of them drifts.

`tests/unit/steer-superseded-sink.test.ts` drives the real collector with the payload
**production builds**, and ends at a stub sink instead of a field assertion.

The sink deliberately does **not** re-implement the superseded rule. It sends any
non-blank text, so it fails the moment the collector resolves to a placeholder again. A
paired test proves the sink is live by letting a genuinely empty turn through — without
it, SS-001 would pass against a sink that never sends anything.

`pipeline.ts` is still mocked, and the comment says why: only to stop a real agent
launching. Nothing in the file asserts against that mock.

## What this does not prove

The actual send decision is at `src/slack/bot.ts:894-898`, which this lane does not own
and must not edit. `data.superseded` is produced by `src/orchestrator/collect.ts`, also
outside scope, and the kill-steer broadcast fires after `waitForExitSettled` — by which
point the first `orchestrate_done` has already settled the collector — so no real spawn
fixture can produce a superseded result end to end either.

So this closes the collector-to-sink half: production builds the event, the collector
retires the turn, and a plain sink receives nothing worth sending. The assertion that
`bot.ts` honours that contract is W2's half, and the issue stays open until both land.

Proposed range item 3 (a NOTEST checklist for hot-path fixes) is a contributing-docs
change rather than a source change, and those files are outside this lane. Recorded,
not done.

## Verification

Local test suite, typecheck and build: **NOT RUN** (this lane verifies on remote CI
only). Evidence is the `ci-aggregate` conclusion on this PR's final head SHA.

Refs #697
