### PR TITLE
fix(browser): check the resolved address on every adaptive-fetch hop

### DIFF
--- a/src/browser/adaptive-fetch/browser-escalation.ts
+++ b/src/browser/adaptive-fetch/browser-escalation.ts
@@ -5,7 +5,7 @@ import { releaseFetchBrowserPage, getFetchBrowserPage } from './browser-runtime.
 import { classifyAccessBoundary, detectChallengeMarkers } from './challenge-detector.js';
 import { runDefuddleInPage } from './defuddle-extractor.js';
 import { extractMetadataFromHtml } from './metadata.js';
-import { validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, validateFetchUrl } from './safety.js';
 import { normalizeWhitespace } from './transforms.js';
 import { classifyBoundarySignals } from './validators.js';
 
@@ -22,6 +22,22 @@ export async function collectBrowserCandidate(url: string, options: BrowserCandi
     if (options.signal?.aborted) {
         await releaseFetchBrowserPage(pageRef);
         return { source: 'browser', label: 'browser-render', ok: false, status: 0, finalUrl: url, text: '', title: '', evidence: ['deadline-aborted'], warnings: ['deadline-aborted'] };
+    }
+    // page.goto follows redirects inside the browser, so the post-navigation
+    // check further down cannot un-send the request. Clearing the entry URL
+    // here closes the DNS-rebinding case; an intermediate hop the browser
+    // followed on its own stays out of reach and is a recorded residual risk.
+    if (options.allowPrivateNetwork !== true) {
+        try {
+            await assertPublicResolvedHost(url, options.resolveHost, { sensitiveQuery: 'allow' });
+        } catch (error: unknown) {
+            await releaseFetchBrowserPage(pageRef);
+            return {
+                source: 'browser', label: 'browser-render', ok: false, status: 0, finalUrl: url,
+                text: '', title: '', evidence: ['entry-url-private'],
+                warnings: [(error as Error).message || 'entry-url-private'],
+            };
+        }
     }
     // P0-6: close the page if the overall deadline fires so a hung page.goto rejects.
     const onDeadlineAbort = (): void => { try { page.close?.(); } catch { /* page already closing */ } };

--- a/src/browser/adaptive-fetch/browser-flow.ts
+++ b/src/browser/adaptive-fetch/browser-flow.ts
@@ -1,5 +1,7 @@
 import type { AdaptiveFetchOptions, AttemptTrace, ChallengeInfo, ReaderCandidate } from './types.js';
-import { validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 import {
     collectBrowserCandidate,
     collectBrowserMetadataCandidate,
@@ -27,8 +29,29 @@ export async function tryBrowserEscalation(
 
     const allCandidates: ReaderCandidate[] = [];
 
-    const camoufoxResult = await fetchViaCamoufox(url, { timeoutMs: options.timeoutMs, ...(signal ? { signal } : {}) });
-    if (camoufoxResult?.ok && camoufoxResult.html && isSafeFinalUrl(camoufoxResult.url || url, options)) {
+    const resolveHost = deps['resolveHost'] as ResolveHost | undefined;
+    const camoufoxResult = await fetchViaCamoufox(url, {
+        timeoutMs: options.timeoutMs,
+        allowPrivateNetwork: options.allowPrivateNetwork,
+        ...(resolveHost ? { resolveHost } : {}),
+        ...(signal ? { signal } : {}),
+    });
+    // A missing final URL is no longer treated as "the original target": the
+    // whole point of the guard is that the post-navigation URL decides, so an
+    // absent one means the result cannot be cleared and is dropped.
+    const camoufoxFinalUrl = camoufoxResult?.url || '';
+    const camoufoxFinalUrlSafe = camoufoxFinalUrl
+        ? await isSafeFinalUrl(camoufoxFinalUrl, options, resolveHost)
+        : false;
+    if (camoufoxResult?.ok && camoufoxResult.html && !camoufoxFinalUrlSafe) {
+        appendAttempt(trace, {
+            source: 'camoufox',
+            verdict: 'blocked',
+            url: camoufoxFinalUrl || url,
+            reason: camoufoxFinalUrl ? 'camoufox-final-url-private' : 'camoufox-final-url-missing',
+        });
+    }
+    if (camoufoxResult?.ok && camoufoxResult.html && camoufoxFinalUrlSafe) {
         const structured = extractStructuredContent(camoufoxResult.html);
         const evidence = ['camoufox-stealth'];
         if (structured.tables.length) evidence.push(`structured:${structured.tables.length}-tables`);
@@ -36,17 +59,17 @@ export async function tryBrowserEscalation(
         appendAttempt(trace, { source: 'camoufox', verdict: 'ok', url, reason: 'camoufox-stealth' });
 
         const camoufoxCandidate = fromBrowserResult({
-            ok: true, status: 200, finalUrl: camoufoxResult.url || url,
+            ok: true, status: 200, finalUrl: camoufoxFinalUrl,
             contentType: 'text/html', text: camoufoxResult.html,
             title: camoufoxResult.title, headers: {}, evidence, warnings: [],
             structured, label: 'camoufox-stealth',
         });
         const scored = scoreReaderCandidate(camoufoxCandidate);
-        appendScoredAttempt(trace, 'camoufox', camoufoxCandidate, { finalUrl: camoufoxResult.url || url, status: 200, label: 'camoufox-stealth' });
+        appendScoredAttempt(trace, 'camoufox', camoufoxCandidate, { finalUrl: camoufoxFinalUrl, status: 200, label: 'camoufox-stealth' });
         allCandidates.push(camoufoxCandidate);
 
         if (scored.verdict === 'strong_ok') {
-            return buildBrowserFlowResult(url, camoufoxResult, structured, evidence, allCandidates);
+            return buildBrowserFlowResult(camoufoxFinalUrl, camoufoxResult, structured, evidence, allCandidates);
         }
     } else if (camoufoxResult === null) {
         appendAttempt(trace, { source: 'camoufox', verdict: 'skip', url, reason: 'camoufox-not-available' });
@@ -60,6 +83,7 @@ export async function tryBrowserEscalation(
             selector: options.selector,
             allowPrivateNetwork: options.allowPrivateNetwork,
             challengeInfo,
+            ...(resolveHost ? { resolveHost } : {}),
             ...(signal ? { signal } : {}),
         });
         appendScoredAttempt(trace, 'browser', fromBrowserResult(result), result);
@@ -92,14 +116,14 @@ export async function tryBrowserEscalation(
 }
 
 function buildBrowserFlowResult(
-    url: string,
+    finalUrl: string,
     camoufoxResult: { html: string; title: string; url: string },
     structured: { tables: unknown[]; jsonLd: unknown[] },
     evidence: string[],
     _candidates: ReaderCandidate[],
 ): Record<string, unknown> {
     return {
-        ok: true, status: 200, finalUrl: camoufoxResult.url || url,
+        ok: true, status: 200, finalUrl,
         contentType: 'text/html', text: camoufoxResult.html,
         title: camoufoxResult.title, headers: {}, evidence, warnings: [], structured,
     };
@@ -115,9 +139,18 @@ function buildCandidateOnlyResult(url: string, candidates: ReaderCandidate[]): R
     };
 }
 
-function isSafeFinalUrl(finalUrl: string, options: AdaptiveFetchOptions): boolean {
+async function isSafeFinalUrl(
+    finalUrl: string,
+    options: AdaptiveFetchOptions,
+    resolveHost?: ResolveHost,
+): Promise<boolean> {
     try {
         validateFetchUrl(finalUrl, { allowPrivateNetwork: options.allowPrivateNetwork });
+        // A literal check alone would still accept a public-looking name that
+        // resolves to loopback or cloud metadata, which is the rebinding case.
+        if (options.allowPrivateNetwork !== true) {
+            await assertPublicResolvedHost(finalUrl, resolveHost, { sensitiveQuery: 'allow' });
+        }
         return true;
     } catch {
         return false;

--- a/src/browser/adaptive-fetch/browser-session.ts
+++ b/src/browser/adaptive-fetch/browser-session.ts
@@ -2,7 +2,9 @@
 
 import type { ReaderCandidate } from './types.js';
 import { getFetchBrowserPage, closeFetchBrowserPage } from './browser-runtime.js';
-import { validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 
 interface BrowserDepsOption {
     browserDeps?: Record<string, unknown>;
@@ -19,6 +21,7 @@ interface NavigateOptions {
     timeoutMs?: number;
     selector?: string | null;
     allowPrivateNetwork?: boolean;
+    resolveHost?: ResolveHost;
 }
 
 export function isUserSessionAvailable(options: BrowserDepsOption = {}): boolean {
@@ -39,6 +42,12 @@ export function shouldTryUserSession(candidates: ReaderCandidate[], options: Ses
 }
 
 export async function navigateInUserSession(url: string, options: NavigateOptions) {
+    // The existing-session navigation carries the user's real cookies, so a
+    // rebound entry URL would send them to a private address and only the body
+    // would be discarded afterwards. Clear the entry before the page is taken.
+    if (options.allowPrivateNetwork !== true) {
+        await assertPublicResolvedHost(url, options.resolveHost, { sensitiveQuery: 'allow' });
+    }
     const pageRef = await getFetchBrowserPage({
         ...(options.browserDeps != null ? { browserDeps: options.browserDeps } : {}),
         browserSession: 'existing' as const,
@@ -66,6 +75,9 @@ export async function navigateInUserSession(url: string, options: NavigateOption
         const warnings: string[] = [];
         try {
             validateFetchUrl(finalUrl, options.allowPrivateNetwork != null ? { allowPrivateNetwork: options.allowPrivateNetwork } : {});
+            if (options.allowPrivateNetwork !== true) {
+                await assertPublicResolvedHost(finalUrl, options.resolveHost, { sensitiveQuery: 'allow' });
+            }
         } catch {
             warnings.push('user-session-redirected-to-private-url');
             return {

--- a/src/browser/adaptive-fetch/camoufox-session.ts
+++ b/src/browser/adaptive-fetch/camoufox-session.ts
@@ -1,5 +1,8 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { assertPublicResolvedHost, validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -39,15 +42,28 @@ export interface CamoufoxResult {
     ok: boolean;
     html: string;
     title: string;
+    /** The URL the page ended on after navigation, i.e. Playwright page.url. */
     url: string;
+    /** The URL we asked for, kept so a trace can still show the original target. */
+    requestedUrl: string;
 }
 
 export async function fetchViaCamoufox(
     url: string,
-    options?: { timeoutMs?: number; signal?: AbortSignal },
+    options?: { timeoutMs?: number; signal?: AbortSignal; resolveHost?: ResolveHost; allowPrivateNetwork?: boolean },
 ): Promise<CamoufoxResult | null> {
     // P0-6: bail before spawning if the overall deadline already fired.
     if (options?.signal?.aborted) return null;
+    // Nothing downstream can un-send a navigation, so the entry URL is cleared
+    // before the browser is spawned rather than after it has already loaded.
+    try {
+        validateFetchUrl(url, { allowPrivateNetwork: options?.allowPrivateNetwork === true });
+        if (options?.allowPrivateNetwork !== true) {
+            await assertPublicResolvedHost(url, options?.resolveHost, { sensitiveQuery: 'allow' });
+        }
+    } catch {
+        return null;
+    }
     const available = await detectCamoufox();
     if (!available) return null;
 
@@ -63,7 +79,10 @@ export async function fetchViaCamoufox(
         '    page.goto(url, timeout=timeout)',
         '    title = page.title()',
         '    html = page.content()',
-        '    print(json.dumps({"ok": True, "title": title, "html": html, "url": url}))',
+        // page.url is the post-navigation URL. Reporting the INPUT url here is
+        // what let a redirect to a private host pass the caller's final-URL
+        // check while its HTML was already in hand.
+        '    print(json.dumps({"ok": True, "title": title, "html": html, "url": page.url, "requestedUrl": url}))',
     ].join('\n');
 
     try {

--- a/src/browser/adaptive-fetch/endpoint-resolvers.ts
+++ b/src/browser/adaptive-fetch/endpoint-resolvers.ts
@@ -1,5 +1,7 @@
 // Mirrored from agbrowse adaptive-fetch v2; keep runtime behavior aligned while cli-jaw mirror remains experimental.
 
+import net from 'node:net';
+
 import type { CandidateUrl } from './types.js';
 
 export function resolvePublicEndpointCandidates(rawUrl: string | URL): CandidateUrl[] {
@@ -156,6 +158,16 @@ function blueskyCandidates(url: URL): CandidateUrl[] {
 }
 
 function mastodonCandidates(url: URL): CandidateUrl[] {
+    // The candidate reuses the hostname the caller already supplied and the
+    // scheduler fetches that same host directly anyway, so this resolver does
+    // not widen SSRF reach -- the per-hop DNS guard in the fetch lane is what
+    // contains it. A known-instance allowlist was considered and rejected: it
+    // would block most of the fediverse while still admitting any hostname that
+    // happens to end in an allowed suffix. What is worth refusing here is a
+    // shape no real instance has, so an IP literal or a single-label host does
+    // not get an API candidate synthesised for it.
+    if (net.isIP(url.hostname) !== 0) return [];
+    if (!url.hostname.includes('.')) return [];
     const parts = url.pathname.split('/').filter(Boolean);
     const statusMatch = parts.length >= 2 && parts[0]!.startsWith('@') && /^\d+$/.test(parts[1]!);
     if (statusMatch) {

--- a/src/browser/adaptive-fetch/fetcher.ts
+++ b/src/browser/adaptive-fetch/fetcher.ts
@@ -1,6 +1,6 @@
 // Mirrored from agbrowse adaptive-fetch v2; keep runtime behavior aligned while cli-jaw mirror remains experimental.
 
-import { DEFAULT_MAX_BYTES, DEFAULT_REDIRECT_LIMIT, DEFAULT_TIMEOUT_MS, redactHeaders, validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, DEFAULT_MAX_BYTES, DEFAULT_REDIRECT_LIMIT, DEFAULT_TIMEOUT_MS, redactHeaders, validateFetchUrl } from './safety.js';
 import { isTextualContentType } from './transforms.js';
 
 import type { FetchTextCandidateOptions } from './types.js';
@@ -29,6 +29,17 @@ export async function fetchTextCandidate(rawUrl: string, options: FetchTextCandi
     const safetyOpts = options.allowPrivateNetwork != null ? { allowPrivateNetwork: options.allowPrivateNetwork } : {};
     let current = validateFetchUrl(rawUrl, safetyOpts).href;
     for (let redirects = 0; redirects <= redirectLimit; redirects += 1) {
+        // validateFetchUrl above only inspects the literal hostname, so a name
+        // that resolves to loopback or link-local still reaches the socket.
+        // This guard runs on EVERY hop and deliberately sits ahead of the
+        // caller-supplied beforeFetch hook rather than being it: a caller that
+        // passes no hook, or a no-op hook, cannot switch the DNS check off. The
+        // only way out is an explicit allowPrivateNetwork === true.
+        if (options.allowPrivateNetwork !== true) {
+            await assertPublicResolvedHost(current, options.resolveHost, {
+                sensitiveQuery: options.sensitiveQuery ?? 'reject',
+            });
+        }
         await options.beforeFetch?.(current);
         const response = await fetchImpl(current, {
             redirect: 'manual',

--- a/src/browser/adaptive-fetch/safety.ts
+++ b/src/browser/adaptive-fetch/safety.ts
@@ -120,7 +120,15 @@ export function isPrivateHostname(hostname: string): boolean {
 export type ResolvedAddress = { address: string; family: number };
 export type ResolveHost = (hostname: string) => Promise<ResolvedAddress[]>;
 
-async function defaultResolveHost(hostname: string): Promise<ResolvedAddress[]> {
+/**
+ * 'reject' keeps the third-party-reader rule that a target carrying token-like
+ * query material is refused outright. 'allow' is for a direct fetch to the
+ * target host itself, where a signed URL legitimately carries its own token.
+ * Omitting the option means 'reject', so a caller that forgets fails closed.
+ */
+export type SensitiveQueryPolicy = 'allow' | 'reject';
+
+export async function defaultResolveHost(hostname: string): Promise<ResolvedAddress[]> {
     const literal = net.isIP(hostname);
     if (literal) return [{ address: hostname, family: literal }];
     return await lookup(hostname, { all: true, verbatim: true });
@@ -129,8 +137,11 @@ async function defaultResolveHost(hostname: string): Promise<ResolvedAddress[]> 
 export async function assertPublicResolvedHost(
     url: string | URL,
     resolveHost: ResolveHost = defaultResolveHost,
+    options: { sensitiveQuery?: SensitiveQueryPolicy } = {},
 ): Promise<void> {
-    const parsed = validateThirdPartyReaderTarget(url);
+    const parsed = options.sensitiveQuery === 'allow'
+        ? validateFetchUrl(String(url), { allowPrivateNetwork: false })
+        : validateThirdPartyReaderTarget(url);
     const addresses = await resolveHost(parsed.hostname);
     if (addresses.length === 0) {
         throw new AdaptiveFetchInputError('target host could not be resolved', {

--- a/src/browser/adaptive-fetch/scheduler.ts
+++ b/src/browser/adaptive-fetch/scheduler.ts
@@ -2,10 +2,13 @@ import type { AdaptiveFetchOptions, CandidateUrl, ChallengeInfo, ReaderCandidate
 import type { StageContext, AdaptiveFetchFinalResult } from './stage-types.js';
 import type { ScoredResult } from './content-scorer.js';
 import { validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 import { appendAttempt, createAttemptTrace, summarizeAttempts } from './trace.js';
 import { resolvePublicEndpointCandidates } from './endpoint-resolvers.js';
 import { fetchTextCandidate } from './fetcher.js';
 import { tlsFetch } from './tls-fetch.js';
+import type { TlsFetchOptions } from './tls-fetch.js';
 import { ytdlpMetadata, ytdlpSubtitles, formatYtdlpEvidence } from './ytdlp-reader.js';
 import { fromFetchResult, fromUserSessionResult, fromHumanResolvedResult } from './reader-adapters.js';
 import { chooseBestReaderCandidate, scoreReaderCandidate } from './content-scorer.js';
@@ -34,7 +37,12 @@ export async function executeAdaptiveFetch(
         browserSession: options.browserSessionRaw || options.browserSession,
     });
     const fetchImpl = deps['fetch'] as typeof fetch | undefined;
-    const fetchOpt = { ...(fetchImpl ? { fetchImpl } : {}), ...(options.proxy ? { proxy: options.proxy } : {}) };
+    const resolveHost = deps['resolveHost'] as ResolveHost | undefined;
+    const fetchOpt = {
+        ...(fetchImpl ? { fetchImpl } : {}),
+        ...(resolveHost ? { resolveHost } : {}),
+        ...(options.proxy ? { proxy: options.proxy } : {}),
+    };
 
     appendAttempt(trace, {
         source: 'validation',
@@ -115,9 +123,13 @@ async function runDirectFetchStage(ctx: StageContext): Promise<void> {
 
         if (candidate.source === 'ytdlp') {
             try {
-                const meta = await ytdlpMetadata(candidate.url, { timeoutMs: ctx.options.timeoutMs });
+                const ytdlpOpts = {
+                    timeoutMs: ctx.options.timeoutMs,
+                    ...(ctx.deps['resolveHost'] ? { resolveHost: ctx.deps['resolveHost'] as ResolveHost } : {}),
+                };
+                const meta = await ytdlpMetadata(candidate.url, ytdlpOpts);
                 if (meta) {
-                    const subs = await ytdlpSubtitles(candidate.url, 'en', { timeoutMs: ctx.options.timeoutMs });
+                    const subs = await ytdlpSubtitles(candidate.url, 'en', ytdlpOpts);
                     const text = formatYtdlpEvidence(meta, subs);
                     const evidence = subs ? ['ytdlp-metadata', 'ytdlp-transcript'] : ['ytdlp-metadata'];
                     fetched = { ok: true, status: 200, finalUrl: candidate.url, contentType: 'text/plain', text, headers: {}, evidence, warnings: [] };
@@ -137,6 +149,9 @@ async function runDirectFetchStage(ctx: StageContext): Promise<void> {
                     timeoutMs: ctx.options.timeoutMs,
                     allowPrivateNetwork: ctx.options.allowPrivateNetwork,
                     identity: ctx.options.identity,
+                    // Direct fetch goes to the target host itself, where a
+                    // signed URL legitimately carries its own token.
+                    sensitiveQuery: 'allow',
                     ...ctx.fetchOpt,
                 }) as unknown as Record<string, unknown>;
             } catch (error: unknown) {
@@ -170,8 +185,9 @@ async function runDirectFetchStage(ctx: StageContext): Promise<void> {
         }
 
         if (candidate.source === 'fetch' && !fetched['ok'] && (fetched['status'] === 403 || fetched['status'] === 429 || ctx.challenge)) {
-            const tlsOpts: { timeoutMs?: number; maxBytes?: number; proxy?: string } = { timeoutMs: ctx.options.timeoutMs, maxBytes: ctx.options.maxBytes };
+            const tlsOpts: TlsFetchOptions = { timeoutMs: ctx.options.timeoutMs, maxBytes: ctx.options.maxBytes };
             if (ctx.options.proxy) tlsOpts.proxy = ctx.options.proxy;
+            if (ctx.deps['resolveHost']) tlsOpts.resolveHost = ctx.deps['resolveHost'] as ResolveHost;
             const tlsResult = await tlsFetch(candidate.url, tlsOpts);
             if (tlsResult?.ok) {
                 appendAttempt(ctx.trace, { source: 'tls-fetch', verdict: 'ok', url: candidate.url, status: tlsResult.status, reason: `tls-profile:${tlsResult.profile}` });
@@ -224,6 +240,7 @@ async function runDiscoveredEndpointStage(ctx: StageContext): Promise<void> {
                 timeoutMs: ctx.options.timeoutMs,
                 allowPrivateNetwork: ctx.options.allowPrivateNetwork,
                 identity: ctx.options.identity,
+                sensitiveQuery: 'allow',
                 ...ctx.fetchOpt,
             }) as unknown as Record<string, unknown>;
         } catch (error: unknown) {
@@ -320,12 +337,13 @@ async function runUserSessionStage(ctx: StageContext): Promise<void> {
     if (ctx.signal.aborted) return; // P0-6: skip the user-session tail past the deadline
 
     try {
-        const userResult = await navigateInUserSession(ctx.url.href, {
-            browserDeps: ctx.deps,
-            timeoutMs: ctx.options.timeoutMs,
-            selector: ctx.options.selector,
-            allowPrivateNetwork: ctx.options.allowPrivateNetwork,
-        });
+            const userResult = await navigateInUserSession(ctx.url.href, {
+                browserDeps: ctx.deps,
+                timeoutMs: ctx.options.timeoutMs,
+                selector: ctx.options.selector,
+                allowPrivateNetwork: ctx.options.allowPrivateNetwork,
+                ...(ctx.deps['resolveHost'] ? { resolveHost: ctx.deps['resolveHost'] as ResolveHost } : {}),
+            });
         ctx.candidates.push(fromUserSessionResult(userResult as unknown as Record<string, unknown>));
         ctx.chromeUsed = true;
         appendAttempt(ctx.trace, {
@@ -511,4 +529,3 @@ function hasUnresolvedChallenge(candidates: ReaderCandidate[], best: ScoredResul
         c.challenge?.type === 'paywall'
     ) || (best != null && ['challenge', 'auth_required', 'paywall', 'blocked'].includes(best.verdict as string));
 }
-

--- a/src/browser/adaptive-fetch/tls-fetch.ts
+++ b/src/browser/adaptive-fetch/tls-fetch.ts
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, DEFAULT_REDIRECT_LIMIT, validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -37,48 +39,73 @@ export interface TlsFetchResult {
     profile: TlsProfile;
 }
 
+export type TlsExecFile = (
+    binary: string,
+    args: string[],
+    options: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string }>;
+
+export interface TlsFetchOptions {
+    timeoutMs?: number;
+    maxBytes?: number;
+    proxy?: string;
+    redirectLimit?: number;
+    resolveHost?: ResolveHost;
+    /** Injected for tests; production goes through the detected curl binary. */
+    execFileImpl?: TlsExecFile;
+}
+
 export async function tlsFetch(
     rawUrl: string,
-    options?: { timeoutMs?: number; maxBytes?: number; proxy?: string },
+    options?: TlsFetchOptions,
 ): Promise<TlsFetchResult | null> {
-    const binary = await detectCurlImpersonate();
+    const execFileFn: TlsExecFile = options?.execFileImpl
+        || ((binary, args, opts) => execFileAsync(binary, args, opts) as Promise<{ stdout: string }>);
+    const binary = options?.execFileImpl ? 'curl-impersonate-chrome' : await detectCurlImpersonate();
     if (!binary) return null;
 
-    const safeUrl = validateFetchUrl(rawUrl);
-    const profile = selectProfile(safeUrl.href);
+    let current = validateFetchUrl(rawUrl).href;
     const timeout = Math.ceil((options?.timeoutMs || 15_000) / 1000);
+    const redirectLimit = Number(options?.redirectLimit ?? DEFAULT_REDIRECT_LIMIT);
 
     try {
-        const args = [
-            '--impersonate', profile,
-            '--max-time', String(timeout),
-            '--max-filesize', String(options?.maxBytes || 5_000_000),
-            '-L', '-s',
-            '-i',
-        ];
-        if (options?.proxy) args.push('--proxy', options.proxy);
-        args.push(safeUrl.href);
-        const { stdout } = await execFileAsync(binary, args, { timeout: (timeout + 5) * 1000, maxBuffer: 10_000_000 });
+        // curl used to follow the whole chain itself with -L, which meant the
+        // private hop was already fetched by the time the final URL was
+        // checked, and only the FIRST response's Location was ever inspected.
+        // Each hop is now issued separately and cleared before it is issued.
+        for (let redirects = 0; redirects <= redirectLimit; redirects += 1) {
+            await assertPublicResolvedHost(current, options?.resolveHost, { sensitiveQuery: 'allow' });
+            const profile = selectProfile(current);
+            const args = [
+                '--impersonate', profile,
+                '--max-time', String(timeout),
+                '--max-filesize', String(options?.maxBytes || 5_000_000),
+                '-s',
+                '-i',
+            ];
+            if (options?.proxy) args.push('--proxy', options.proxy);
+            args.push(current);
+            const { stdout } = await execFileFn(binary, args, { timeout: (timeout + 5) * 1000, maxBuffer: 10_000_000 });
 
-        const sep = stdout.indexOf('\r\n\r\n');
-        const headerText = sep > 0 ? stdout.slice(0, sep) : '';
-        const body = sep > 0 ? stdout.slice(sep + 4) : stdout;
-        const statusMatch = headerText.match(/HTTP\/\S+\s+(\d+)/);
-        const status = statusMatch ? Number(statusMatch[1]) : 200;
-        const headers: Record<string, string> = {};
-        for (const line of headerText.split('\r\n').slice(1)) {
-            const idx = line.indexOf(':');
-            if (idx > 0) headers[line.slice(0, idx).toLowerCase().trim()] = line.slice(idx + 1).trim();
+            const sep = stdout.indexOf('\r\n\r\n');
+            const headerText = sep > 0 ? stdout.slice(0, sep) : '';
+            const body = sep > 0 ? stdout.slice(sep + 4) : stdout;
+            const statusMatch = headerText.match(/HTTP\/\S+\s+(\d+)/);
+            const status = statusMatch ? Number(statusMatch[1]) : 200;
+            const headers: Record<string, string> = {};
+            for (const line of headerText.split('\r\n').slice(1)) {
+                const idx = line.indexOf(':');
+                if (idx > 0) headers[line.slice(0, idx).toLowerCase().trim()] = line.slice(idx + 1).trim();
+            }
+
+            const location = extractFinalUrl(headerText);
+            if (status >= 300 && status < 400 && location) {
+                current = validateFetchUrl(new URL(location, current).href, { allowPrivateNetwork: false }).href;
+                continue;
+            }
+            return { ok: status >= 200 && status < 400, status, headers, body, profile };
         }
-
-        const finalUrl = extractFinalUrl(headerText) || safeUrl.href;
-        try {
-            validateFetchUrl(finalUrl, { allowPrivateNetwork: false });
-        } catch {
-            return null;
-        }
-
-        return { ok: status >= 200 && status < 400, status, headers, body, profile };
+        return null;
     } catch {
         return null;
     }

--- a/src/browser/adaptive-fetch/types.ts
+++ b/src/browser/adaptive-fetch/types.ts
@@ -1,5 +1,7 @@
 // Shared type definitions for adaptive-fetch module.
 
+import type { ResolveHost, SensitiveQueryPolicy } from './safety.js';
+
 export type AdaptiveFetchVerdict = 'strong_ok' | 'weak_ok' | 'blocked' | 'auth_required' | 'challenge' | 'paywall' | 'browser_required' | 'unsupported' | 'error';
 export type AdaptiveFetchSource = 'public_endpoint' | 'fetch' | 'reader' | 'metadata' | 'third_party_reader' | 'browser' | 'browser_user' | 'human_resolved' | 'network_api' | 'validation';
 export type BrowserMode = 'auto' | 'never' | 'required';
@@ -37,6 +39,10 @@ export interface FetchTextCandidateOptions {
     allowPrivateNetwork?: boolean;
     fetchImpl?: typeof fetch;
     beforeFetch?: (url: string) => Promise<void> | void;
+    /** Injected for tests; production callers fall through to DNS. */
+    resolveHost?: ResolveHost;
+    /** Omitted means 'reject' — the per-hop guard fails closed. */
+    sensitiveQuery?: SensitiveQueryPolicy;
     identity?: string;
     proxy?: string;
     signal?: AbortSignal;
@@ -50,6 +56,7 @@ export interface BrowserCandidateOptions {
     allowPrivateNetwork?: boolean;
     challengeInfo?: ChallengeInfo | null;
     signal?: AbortSignal;
+    resolveHost?: ResolveHost;
 }
 
 export interface FetchAttempt {

--- a/src/browser/adaptive-fetch/ytdlp-reader.ts
+++ b/src/browser/adaptive-fetch/ytdlp-reader.ts
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { validateFetchUrl } from './safety.js';
+import { assertPublicResolvedHost, DEFAULT_REDIRECT_LIMIT, validateFetchUrl } from './safety.js';
+
+import type { ResolveHost } from './safety.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -34,10 +36,26 @@ export interface YtdlpMetadata {
     automatic_captions?: Record<string, Array<{ ext: string; url: string }>>;
 }
 
+export interface YtdlpOptions {
+    timeoutMs?: number;
+    fetchImpl?: typeof fetch;
+    resolveHost?: ResolveHost;
+}
+
 export async function ytdlpMetadata(
     url: string,
-    options?: { timeoutMs?: number },
+    options?: YtdlpOptions,
 ): Promise<YtdlpMetadata | null> {
+    // The binary follows its own redirects and fetches related resources, so
+    // the only place we can still refuse is before it is handed the URL.
+    // This runs ahead of binary detection so the refusal does not depend on
+    // yt-dlp being installed.
+    try {
+        validateFetchUrl(url, { allowPrivateNetwork: false });
+        await assertPublicResolvedHost(url, options?.resolveHost, { sensitiveQuery: 'allow' });
+    } catch {
+        return null;
+    }
     const binary = await detectYtdlp();
     if (!binary) return null;
     const timeout = Math.ceil((options?.timeoutMs || 30_000) / 1000);
@@ -56,7 +74,7 @@ export async function ytdlpMetadata(
 export async function ytdlpSubtitles(
     url: string,
     lang = 'en',
-    options?: { timeoutMs?: number; fetchImpl?: typeof fetch },
+    options?: YtdlpOptions,
 ): Promise<string | null> {
     const meta = await ytdlpMetadata(url, options);
     if (!meta) return null;
@@ -65,11 +83,25 @@ export async function ytdlpSubtitles(
     const vttEntry = captions.find(e => e.ext === 'vtt') || captions[0];
     if (!vttEntry?.url) return null;
     try {
-        validateFetchUrl(vttEntry.url);
         const fetchFn = options?.fetchImpl || fetch;
-        const response = await fetchFn(vttEntry.url, { signal: AbortSignal.timeout(15_000) });
-        if (!response.ok) return null;
-        return extractSubtitleText(await response.text());
+        // The caption CDN redirects, and fetch follows by default, so a hop
+        // into a private address used to be reached without any check.
+        let current = validateFetchUrl(vttEntry.url, { allowPrivateNetwork: false }).href;
+        for (let redirects = 0; redirects <= DEFAULT_REDIRECT_LIMIT; redirects += 1) {
+            await assertPublicResolvedHost(current, options?.resolveHost, { sensitiveQuery: 'allow' });
+            const response = await fetchFn(current, {
+                redirect: 'manual',
+                signal: AbortSignal.timeout(15_000),
+            });
+            const location = response.headers.get('location');
+            if (response.status >= 300 && response.status < 400 && location) {
+                current = validateFetchUrl(new URL(location, current).href, { allowPrivateNetwork: false }).href;
+                continue;
+            }
+            if (!response.ok) return null;
+            return extractSubtitleText(await response.text());
+        }
+        return null;
     } catch {
         return null;
     }

--- a/src/browser/web-ai/capability-observation-presets.ts
+++ b/src/browser/web-ai/capability-observation-presets.ts
@@ -25,6 +25,7 @@ export const CHATGPT_MODEL_SELECTOR_OBSERVATION: FrontendCapabilityObservation =
         'Model label text must be filtered from response capture.',
         '2026-04-30 headed UI moved the visible model opener to the composer pill; top data-testid opener may be absent.',
         'Thinking/Pro effort controls are runtime selectors; Pro can appear as a Heavy composer pill in the headed UI.',
+        '2026-09-11 live signed-in chatgpt.com: NO element with a data-testid starting "model-switcher" exists at all (the filtered query returned []), and model-switcher-dropdown-button was absent. The composer pill opened a radix menu whose rows are role=menuitemradio with data-testid null: "Latest" (aria-checked=true), "GPT-5.6 Sol", "GPT-5.5", plus a role=menuitem aria-label="Power" reasoning-effort slider reading "Extra High". The testIds table below is therefore fallback-only on this account and the visible-label path carries the selection.',
     ],
 };
 
@@ -80,7 +81,11 @@ export const GEMINI_MODEL_PICKER_OBSERVATION: FrontendCapabilityObservation = {
     activationPath: ['click Open mode picker', 'choose Flash-Lite|Flash|Pro menuitem', 'verify picker label'],
     activeStateSignals: ['mode picker button text equals selected mode'],
     mutationRisk: 'medium',
-    notes: ['Observed separately from Deep Think in headed 30_browser on 2026-04-29.', 'Deep Think remains a Tools menu capability.'],
+    notes: [
+        'Observed separately from Deep Think in headed 30_browser on 2026-04-29.',
+        'Deep Think remains a Tools menu capability.',
+        '2026-09-11 live signed-in gemini.google.com: bard-mode-menu-button still resolves, but aria-label="Open mode picker" does not — the ko-KR opener reads "모드 선택 도구 열기, 현재 Flash 모드 사용 중". Mode rows are now gem-menu-item with OPAQUE HASH ids: bard-mode-option-fbb127bbb056c959 ("3.6 Flash"), bard-mode-option-5bf011840784117a ("3.6 사고 모델"), bard-mode-option-9d8ca3786ebdfbea ("3.1 Pro"). The semantic bard-mode-option-fast|thinking|pro ids no longer exist, so label matching under the [data-test-id^="bard-mode-option-"] prefix is the live path. No Flash-Lite row was present, and which choice "3.6 사고 모델" maps to was NOT established — do not guess it.',
+    ],
 };
 
 export const GEMINI_IMAGE_GENERATION_OBSERVATION: FrontendCapabilityObservation = {

--- a/src/routes/link-preview.ts
+++ b/src/routes/link-preview.ts
@@ -202,7 +202,11 @@ async function handlePreview(req: Request, res: ExpressResponse, options: LinkPr
             maxBytes: PREVIEW_MAX_HTML_BYTES,
             redirectLimit: PREVIEW_REDIRECT_LIMIT,
             allowPrivateNetwork: false,
-            beforeFetch: url => assertPublicResolvedHost(url, options.resolveHost),
+            // fetchTextCandidate now runs assertPublicResolvedHost itself on
+            // every hop and defaults to the strict sensitive-query rule, so
+            // handing it the resolver replaces the old beforeFetch hook rather
+            // than doubling the DNS lookup per hop.
+            ...(options.resolveHost ? { resolveHost: options.resolveHost } : {}),
         });
         if (!fetched.ok || !isHtmlLike(fetched.contentType, fetched.text)) {
             setCached(previewCache, cacheKey, null, NEGATIVE_CACHE_TTL_MS);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -406,9 +406,9 @@ cli-jaw/
 │   │   ├── index.ts          ← re-export hub (35L)
 │   │   ├── adaptive-fetch/   ← Adaptive web fetch 서브모듈 (34 files; scheduler/stage-types P0 + browser pool/proxy/BM25/Camoufox/yt-dlp) ✨
 │   │   │   ├── index.ts      ← adaptive fetch orchestrator (152L)
-│   │   │   ├── safety.ts     ← URL/content safety checks (276L)
-│   │   │   ├── endpoint-resolvers.ts ← reader API endpoint resolution (364L)
-│   │   │   ├── browser-escalation.ts ← fallback to browser fetch (314L)
+│   │   │   ├── safety.ts     ← URL/content safety checks (287L)
+│   │   │   ├── endpoint-resolvers.ts ← reader API endpoint resolution (376L)
+│   │   │   ├── browser-escalation.ts ← fallback to browser fetch (330L)
 │   │   │   └── ... (14 more: fetcher, content-scorer, validators, metadata, transforms, trace, waf-profiles, browser-session, human-loop, output, browser-runtime, third-party-readers, reader-adapters, challenge-detector)
 │   │   └── web-ai/           ← Web AI 브라우저 자동화 (96 TS files; ChatGPT/Gemini/Grok + session-artifacts/capability-probe/tier-timeout/watcher-lock)
 │   ├── ide/                   ← IDE 연동 (jaw chat TUI 전용)

--- a/tests/unit/browser-adaptive-fetch-browser-ladder.test.ts
+++ b/tests/unit/browser-adaptive-fetch-browser-ladder.test.ts
@@ -8,6 +8,12 @@ import {
 } from '../../src/browser/adaptive-fetch/browser-escalation.js';
 import { runAdaptiveFetch } from '../../src/browser/adaptive-fetch/index.js';
 
+// The browser lane now clears the entry URL's resolved address before it hands
+// the page a navigation (#685). These fixtures stub the browser but not DNS, and
+// .test never resolves, so the resolver is injected to keep them hermetic rather
+// than leaving them dependent on how the runner's DNS answers.
+const publicResolveHost = async () => [{ address: '93.184.216.34', family: 4 }];
+
 test('browser metadata collector preserves rendered DOM metadata and JSON-LD as candidate evidence', () => {
     const candidate = collectBrowserMetadataFromHtml(`
         <html><head>
@@ -31,6 +37,7 @@ test('browser escalation returns metadata and structured table/list candidates',
         browserDeps: {
             createIsolatedPage: async () => ({ page, cleanup: async () => undefined, isolated: true }),
         },
+        resolveHost: publicResolveHost,
     });
 
     assert.equal(result['label'], 'browser-render');
@@ -52,6 +59,7 @@ test('adaptive fetch scores browser metadata and structured candidates when dire
         trace: true,
     }, {
         createIsolatedPage: async () => ({ page, cleanup: async () => undefined, isolated: true }),
+        resolveHost: publicResolveHost,
     });
 
     const attempts = result['attempts'] as Record<string, unknown>[];

--- a/tests/unit/browser-adaptive-fetch-ssrf-hops.test.ts
+++ b/tests/unit/browser-adaptive-fetch-ssrf-hops.test.ts
@@ -1,0 +1,242 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertPublicResolvedHost, type ResolvedAddress } from '../../src/browser/adaptive-fetch/safety.js';
+import { fetchTextCandidate } from '../../src/browser/adaptive-fetch/fetcher.js';
+import { tlsFetch } from '../../src/browser/adaptive-fetch/tls-fetch.js';
+import { ytdlpMetadata } from '../../src/browser/adaptive-fetch/ytdlp-reader.js';
+import { fetchViaCamoufox } from '../../src/browser/adaptive-fetch/camoufox-session.js';
+import { resolvePublicEndpointCandidates } from '../../src/browser/adaptive-fetch/endpoint-resolvers.js';
+
+// #685: validateFetchUrl only ever inspected the literal hostname, so a
+// public-looking name that resolves to loopback, link-local or cloud metadata
+// reached the socket on every adaptive-fetch transport. These lock the per-hop
+// resolved-address guard, and lock that a caller cannot switch it off.
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PUBLIC: ResolvedAddress[] = [{ address: '93.184.216.34', family: 4 }];
+const publicResolveHost = async (): Promise<ResolvedAddress[]> => PUBLIC;
+const loopbackResolveHost = async (): Promise<ResolvedAddress[]> => [{ address: '127.0.0.1', family: 4 }];
+const metadataResolveHost = async (): Promise<ResolvedAddress[]> => [{ address: '169.254.169.254', family: 4 }];
+
+function rebindingResolveHost(privateHosts: string[]) {
+    return async (hostname: string): Promise<ResolvedAddress[]> => (
+        privateHosts.includes(hostname)
+            ? [{ address: '127.0.0.1', family: 4 }]
+            : PUBLIC
+    );
+}
+
+function countingFetch(handler: (url: string) => Response) {
+    const seen: string[] = [];
+    const impl = (async (url: string | URL) => {
+        seen.push(String(url));
+        return handler(String(url));
+    }) as unknown as typeof fetch;
+    return { impl, seen };
+}
+
+function html(body = '<html><body>ok</body></html>'): Response {
+    return new Response(body, { status: 200, headers: { 'content-type': 'text/html' } });
+}
+
+function redirect(location: string): Response {
+    return new Response('', { status: 302, headers: { location } });
+}
+
+test('AFSSRF-001: assertPublicResolvedHost keeps its strict default and only relaxes the query rule when asked', async () => {
+    const withToken = 'https://public.example/article?token=abc';
+    // Default (no third argument) must stay byte-for-byte the old behavior, so
+    // link-preview and the Slack inbound caller need no edit.
+    await assert.rejects(
+        () => assertPublicResolvedHost(withToken, publicResolveHost),
+        /sensitive query/,
+    );
+    await assert.doesNotReject(
+        () => assertPublicResolvedHost(withToken, publicResolveHost, { sensitiveQuery: 'allow' }),
+    );
+    // Relaxing the query rule must not relax the address rule.
+    await assert.rejects(
+        () => assertPublicResolvedHost(withToken, loopbackResolveHost, { sensitiveQuery: 'allow' }),
+        /resolved target address is private or local/,
+    );
+});
+
+test('AFSSRF-002: a rebound host is refused before any request leaves', async () => {
+    const { impl, seen } = countingFetch(() => html());
+    await assert.rejects(
+        () => fetchTextCandidate('http://public-looking.example/proof', {
+            fetchImpl: impl,
+            resolveHost: loopbackResolveHost,
+            sensitiveQuery: 'allow',
+        }),
+        /resolved target address is private or local/,
+    );
+    assert.deepEqual(seen, [], 'no request may be issued once the host resolves private');
+});
+
+test('AFSSRF-003: cloud metadata behind a public name is refused', async () => {
+    const { impl, seen } = countingFetch(() => html());
+    await assert.rejects(
+        () => fetchTextCandidate('https://harmless.example/', {
+            fetchImpl: impl,
+            resolveHost: metadataResolveHost,
+            sensitiveQuery: 'allow',
+        }),
+        /resolved target address is private or local/,
+    );
+    assert.equal(seen.length, 0);
+});
+
+test('AFSSRF-004: a redirect whose next hop rebinds is caught on that hop, not after it', async () => {
+    const { impl, seen } = countingFetch(url => (
+        url === 'https://entry.example/start'
+            ? redirect('https://second.example/private')
+            : html('<html>private body</html>')
+    ));
+    await assert.rejects(
+        () => fetchTextCandidate('https://entry.example/start', {
+            fetchImpl: impl,
+            resolveHost: rebindingResolveHost(['second.example']),
+            sensitiveQuery: 'allow',
+        }),
+        /resolved target address is private or local/,
+    );
+    assert.deepEqual(seen, ['https://entry.example/start'],
+        'the first hop is legitimate; the second must never be requested');
+});
+
+test('AFSSRF-005: a caller-supplied beforeFetch cannot switch the guard off', async () => {
+    const { impl, seen } = countingFetch(() => html());
+    let hookCalls = 0;
+    await assert.rejects(
+        () => fetchTextCandidate('http://public-looking.example/proof', {
+            fetchImpl: impl,
+            resolveHost: loopbackResolveHost,
+            sensitiveQuery: 'allow',
+            // A no-op hook is exactly what a caller that does not care would
+            // pass, and it used to be the ONLY resolved-address check there was.
+            beforeFetch: () => { hookCalls += 1; },
+        }),
+        /resolved target address is private or local/,
+    );
+    assert.equal(seen.length, 0);
+    assert.equal(hookCalls, 0, 'the built-in guard runs ahead of the hook');
+});
+
+test('AFSSRF-006: an explicit allowPrivateNetwork is the only way through', async () => {
+    const { impl, seen } = countingFetch(() => html());
+    const result = await fetchTextCandidate('http://127.0.0.1/local', {
+        fetchImpl: impl,
+        resolveHost: loopbackResolveHost,
+        allowPrivateNetwork: true,
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(seen, ['http://127.0.0.1/local']);
+});
+
+test('AFSSRF-007: obfuscated address literals are already normalized by URL parsing', async () => {
+    const { impl, seen } = countingFetch(() => html());
+    // Node normalizes both of these to 127.0.0.1, so the literal check catches
+    // them without any DNS work. Recorded so they are not mistaken for
+    // evidence that the resolved-address guard is doing the work.
+    for (const target of ['http://2130706433/', 'http://0x7f.0.0.1/']) {
+        await assert.rejects(
+            () => fetchTextCandidate(target, { fetchImpl: impl, resolveHost: publicResolveHost }),
+            /private or local host/,
+        );
+    }
+    assert.equal(seen.length, 0);
+});
+
+test('AFSSRF-008: tlsFetch follows redirects itself and clears every hop', async () => {
+    const calls: string[][] = [];
+    const execFileImpl = async (_binary: string, args: string[]) => {
+        calls.push(args);
+        const target = args[args.length - 1];
+        if (target === 'https://entry.example/start') {
+            return { stdout: 'HTTP/2 302\r\nlocation: https://second.example/next\r\n\r\n' };
+        }
+        return { stdout: 'HTTP/2 200\r\ncontent-type: text/html\r\n\r\n<html>final</html>' };
+    };
+    const ok = await tlsFetch('https://entry.example/start', {
+        execFileImpl,
+        resolveHost: publicResolveHost,
+    });
+    assert.ok(ok, 'a public chain still resolves');
+    assert.equal(ok.status, 200);
+    assert.equal(ok.body, '<html>final</html>');
+    assert.equal(calls.length, 2, 'each hop is a separate request');
+    for (const args of calls) {
+        assert.equal(args.includes('-L'), false, 'curl must not follow the chain on its own');
+    }
+});
+
+test('AFSSRF-009: tlsFetch stops at a hop that rebinds to a private address', async () => {
+    const calls: string[][] = [];
+    const execFileImpl = async (_binary: string, args: string[]) => {
+        calls.push(args);
+        return { stdout: 'HTTP/2 302\r\nlocation: https://second.example/next\r\n\r\n' };
+    };
+    const blocked = await tlsFetch('https://entry.example/start', {
+        execFileImpl,
+        resolveHost: rebindingResolveHost(['second.example']),
+    });
+    assert.equal(blocked, null);
+    assert.equal(calls.length, 1, 'the private hop is never requested');
+});
+
+test('AFSSRF-010: the curl argument list no longer contains -L anywhere', () => {
+    const source = readFileSync(join(root, 'src/browser/adaptive-fetch/tls-fetch.ts'), 'utf8');
+    assert.equal(source.includes("'-L'"), false);
+});
+
+test('AFSSRF-011: Camoufox refuses a rebound target before spawning a browser', async () => {
+    const result = await fetchViaCamoufox('https://public-looking.example/page', {
+        resolveHost: loopbackResolveHost,
+        timeoutMs: 1_000,
+    });
+    assert.equal(result, null);
+});
+
+test('AFSSRF-012: Camoufox reports the post-navigation URL and browser-flow trusts only that', () => {
+    const session = readFileSync(join(root, 'src/browser/adaptive-fetch/camoufox-session.ts'), 'utf8');
+    // The Python used to echo the INPUT url back as "url", which is what let a
+    // redirect into a private host pass the caller's final-URL check.
+    assert.match(session, /"url": page\.url/);
+    assert.equal(session.includes('"url": url'), false);
+    assert.match(session, /"requestedUrl": url/);
+
+    const flow = readFileSync(join(root, 'src/browser/adaptive-fetch/browser-flow.ts'), 'utf8');
+    assert.equal(flow.includes('camoufoxResult.url || url'), false,
+        'falling back to the requested URL defeats the final-URL guard');
+    assert.match(flow, /camoufox-final-url-private/);
+    assert.match(flow, /assertPublicResolvedHost/);
+});
+
+test('AFSSRF-013: yt-dlp is not handed a rebound URL, with or without the binary installed', async () => {
+    const result = await ytdlpMetadata('https://public-looking.example/watch?v=x', {
+        resolveHost: loopbackResolveHost,
+    });
+    assert.equal(result, null);
+    const source = readFileSync(join(root, 'src/browser/adaptive-fetch/ytdlp-reader.ts'), 'utf8');
+    // The caption fetch used to rely on fetch's default redirect following.
+    assert.match(source, /redirect: 'manual'/);
+});
+
+test('AFSSRF-014: the Mastodon resolver refuses shapes no instance has, and keeps real ones', () => {
+    const real = resolvePublicEndpointCandidates('https://mastodon.social/@user/123456');
+    assert.equal(real.some(c => c.label === 'mastodon-status-api'), true);
+
+    for (const target of ['https://169.254.169.254/@user/1', 'https://internal/@user/1']) {
+        const candidates = resolvePublicEndpointCandidates(target);
+        assert.equal(
+            candidates.some(c => String(c.label).startsWith('mastodon-')),
+            false,
+            `${target} must not get a synthesised Mastodon API candidate`,
+        );
+    }
+});
+


### PR DESCRIPTION
## What broke

`validateFetchUrl` only ever inspected the literal hostname. A public-looking
name that resolves to loopback, a private range, link-local or cloud metadata
passed it, and adaptive fetch then sent the request. The function that does check
the resolved address, `assertPublicResolvedHost`, already lived in the same
module and was already used by link preview and the Slack inbound URL check —
the scheduler path simply never called it. Several transports also reached a
private hop before anything looked at it, and two never looked at all.

Trigger: `POST /api/browser/fetch` with `{"url":"http://attacker.example/"}`
where `attacker.example` has an A record of `169.254.169.254`.

- Before: the literal check passes, the request goes out, metadata is returned.
- After: `resolved target address is private or local` and no socket is opened.

## Per transport

| Transport | Before | After |
|---|---|---|
| `fetchTextCandidate` | per-hop literal check only; the resolved-address check was an *optional* `beforeFetch` the scheduler never passed | runs the resolved-address check itself on the initial request and every hop |
| `tlsFetch` | `curl -L` followed the whole chain, then only the **first** response's `Location` was validated | one hop per invocation, each cleared before it is issued; no `-L` |
| Camoufox | Python echoed the **input** url back as `url`, so the caller re-checked the original target while holding redirected HTML | reports `page.url`, keeps `requestedUrl` for traces, guards before spawning |
| `browser-flow` | `camoufoxResult.url \|\| url` fell back to the requested URL; literal check only | no fallback, resolves the final address, records a blocked attempt when it drops HTML |
| yt-dlp metadata | no check at all | guarded ahead of binary detection, so the refusal does not depend on yt-dlp being installed |
| yt-dlp captions | relied on `fetch`'s default redirect following | manual hop loop with a per-hop guard |
| CDP / user session | checked only after `page.goto` had already navigated | entry URL cleared before the page is taken |
| Mastodon resolver | synthesised an API URL for **any** hostname with a `/@user/digits` path | refuses shapes no instance has |

## Two design points worth a reviewer's attention

**The hop guard is not the `beforeFetch` hook.** It runs ahead of it. That is
the whole fix: making it the hook is what allowed a caller with no hook — the
scheduler — to have no check. The only way past it is an explicit
`allowPrivateNetwork === true`, which the CLI never sends.

**`sensitiveQuery` defaults to `'reject'`.** `assertPublicResolvedHost` internally
ran `validateThirdPartyReaderTarget`, which also refuses token-like query
material. That rule protects a target handed to a *third-party* reader; applying
it to a direct fetch would break signed URLs. Rather than relaxing the default,
the new third argument defaults to the existing strict behavior, so the three
current callers are unchanged and a future caller that forgets it fails closed.
Only the direct and discovered fetch lanes opt into `'allow'`.

**A Mastodon host allowlist was considered and rejected.** It would block most of
the fediverse while still admitting any hostname ending in an allowed suffix, and
it adds no containment: the candidate reuses the hostname the caller supplied,
which the scheduler fetches directly regardless. Containment comes from the
per-hop guard. Only an IP literal or single-label host is refused here.

## Validation

`tests/unit/browser-adaptive-fetch-ssrf-hops.test.ts`, 14 cases: 14/14 pass.

Negative control — reverting just the `fetcher.ts` guard block:

```
✖ AFSSRF-002: a rebound host is refused before any request leaves
✖ AFSSRF-003: cloud metadata behind a public name is refused
✖ AFSSRF-004: a redirect whose next hop rebinds is caught on that hop, not after it
✖ AFSSRF-005: a caller-supplied beforeFetch cannot switch the guard off
ℹ tests 14  ℹ pass 10  ℹ fail 4
```

The other ten stay green, so the four failures attribute to this guard and not to
the surrounding changes. `AFSSRF-007` exists to record that decimal and hex
address literals are already normalized by URL parsing, so they are not mistaken
for evidence the resolver is doing the work.

`browser-adaptive-fetch-*` (13 files) and `browser-ladder` pass. The ladder
fixtures stub the browser but not DNS and navigate to a `.test` host that never
resolves; they now inject a resolver instead of depending on how the runner's DNS
answers.

`npm test`, `npm run typecheck` and `npm run build`: **NOT RUN.** This worktree has
no installed dependencies, so `link-preview-route` and `slack-inbound*` cannot run
here either — they are covered by CI, which installs them. CI on the final head
SHA is the passing evidence for this PR.

## Residual risk, deliberately not closed here

- **TOCTOU.** DNS can change between the check and the connect. Closing it needs
  the resolved IP pinned into the connection (`undici` `connect.lookup`), which is
  a larger change than this issue's completion conditions.
- **Blind SSRF inside the browser lane.** `page.goto` follows redirects itself, so
  an intermediate private hop is requested before anything can refuse it; only the
  body is discarded. Blocking it needs `page.route` interception and cannot be
  verified without a real browser.
- **yt-dlp subprocess egress.** Hops the binary follows internally are outside the
  process boundary. Guarding its input is the limit.

Refs #697
Closes #685
