### PR TITLE
fix(code): put structured permission requests in front of the user in ask mode

### DIFF
--- a/src/code-mode/providers/codex-app.ts
+++ b/src/code-mode/providers/codex-app.ts
@@ -29,6 +29,26 @@ const policy: Record<CodeOpenOptions['permissionMode'], Pick<CodexThreadOptions,
 const object = (value: unknown): Record<string, unknown> => value !== null && typeof value === 'object'
     && !Array.isArray(value) ? value as Record<string, unknown> : {};
 
+/**
+ * An empty granted profile is the native runtime's decline, not a no-op.
+ *
+ * codex-rs short-circuits an empty profile and records no grant
+ * (core/src/session/mod.rs:3118-3141), the TUI's Deny button emits exactly this
+ * payload (tui/src/bottom_pane/approval_overlay.rs:1968-2002), and analytics
+ * scores it Denied (analytics/src/reducer.rs:3095-3096). Verified against
+ * codex-rs 095da4b7e8b70b01afb5c6131ef926dcb8c0d85d.
+ */
+const PERMISSIONS_DENY = { permissions: {}, scope: 'turn' };
+const PERMISSION_REASON_MAX = 200;
+
+/** What the model asked for, in the words the person approving it needs. */
+function permissionLabel(requested: Record<string, unknown>, reason: unknown): string {
+    const asked = Object.keys(requested).map(key => key === 'fileSystem' ? 'file system' : key).join(' and ');
+    const why = typeof reason === 'string' && reason.trim()
+        ? `: ${reason.trim().slice(0, PERMISSION_REASON_MAX)}` : '';
+    return `Grant ${asked || 'additional'} access for this turn${why}`;
+}
+
 class CodeCodexSession implements CodeProviderSession {
     private readonly client: CodexAppClient;
     private readonly scope: string;
@@ -194,6 +214,9 @@ class CodeCodexSession implements CodeProviderSession {
 
     private async approval(method: string, params: Record<string, unknown>, _rpcId: number | string,
         signal: AbortSignal): Promise<Record<string, unknown> | undefined> {
+        // Each method answers in its own vocabulary. A command decline is not a
+        // valid PermissionsRequestApprovalResponse, so they cannot share a body.
+        if (method === 'item/permissions/requestApproval') return this.approvePermissions(params, signal);
         if (method !== 'item/commandExecution/requestApproval' && method !== 'item/fileChange/requestApproval') return undefined;
         const decline = { decision: 'decline' };
         const turn = this.active;
@@ -230,6 +253,62 @@ class CodeCodexSession implements CodeProviderSession {
                 requestType: 'approval', view: request.view })) request.cancel();
             const answer = await request.answer;
             return current() ? answer : decline;
+        } finally {
+            signal.removeEventListener('abort', abort);
+            request.cancel();
+            this.options.record(turn.context, { kind: 'request-settled', requestId: request.requestId });
+        }
+    }
+
+    /**
+     * Structured permission requests, which ask mode promised the user would see.
+     *
+     * These were previously unhandled here, so the client answered them with its
+     * own fallback and the request never reached the queue. That fallback is the
+     * canonical decline, so nothing was over-granted — but ask mode silently
+     * refused network and MCP requests while telling the user it would show them.
+     */
+    private async approvePermissions(params: Record<string, unknown>,
+        signal: AbortSignal): Promise<Record<string, unknown>> {
+        const requested = object(params['permissions']);
+        const turn = this.active;
+        // An empty ask cannot be granted into anything, so it declines before the queue.
+        if (!turn || this.options.permissionMode === 'read-only' || Object.keys(requested).length === 0) return PERMISSIONS_DENY;
+        const nativeTurn = this.client.getActiveTurnId(this.scope);
+        const requestedItem = params['itemId'];
+        // A permissions request names the tool item that asked, whose native type
+        // this protocol does not fix, so ownership is "this turn has seen it and it
+        // has not settled" rather than a command/file type literal.
+        const current = () => this.active === turn && this.alive && !this.exited && !this.closing && !turn.cancelled && !signal.aborted
+            && turn.context.isCurrent() && !!turn.nativeTurn && this.client.getActiveTurnId(this.scope) === turn.nativeTurn
+            && typeof requestedItem === 'string' && turn.items.has(requestedItem) && turn.items.get(requestedItem) !== 'completed';
+        if (!nativeTurn || turn.nativeTurn !== nativeTurn || !current()
+            || params['threadId'] !== this.nativeId || params['turnId'] !== nativeTurn) return PERMISSIONS_DENY;
+        // Core intersects a grant with what was requested, so echoing the request
+        // grants exactly what was asked and cannot widen it.
+        const grant = { permissions: requested, scope: 'turn' };
+        if (this.options.permissionMode === 'auto') return grant;
+        const accept = randomUUID(), reject = randomUUID();
+        const request = this.options.registry.open({ ...turn.context, requestType: 'approval',
+            view: { title: 'Approve additional permissions',
+                fields: [{ id: randomUUID(), label: permissionLabel(requested, params['reason']), multiSelect: false,
+                    allowFreeform: false, options: [{ id: accept, label: 'Allow once' }, { id: reject, label: 'Decline' }] }] },
+            cancelled: PERMISSIONS_DENY, isCurrent: current,
+            validate(value) {
+                const answer = object(value);
+                if (Object.keys(answer).length !== 1 || !Object.hasOwn(answer, 'optionId')
+                    || (answer['optionId'] !== accept && answer['optionId'] !== reject)) throw new Error('invalid_option');
+                return answer['optionId'] === accept ? grant : PERMISSIONS_DENY;
+            },
+        });
+        const abort = () => request.cancel();
+        signal.addEventListener('abort', abort, { once: true });
+        try {
+            if (!current()) request.cancel();
+            else if (!this.options.record(turn.context, { kind: 'request', requestId: request.requestId,
+                requestType: 'approval', view: request.view })) request.cancel();
+            const answer = await request.answer;
+            return current() ? answer : PERMISSIONS_DENY;
         } finally {
             signal.removeEventListener('abort', abort);
             request.cancel();

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -82,7 +82,7 @@ cli-jaw/
 │   │   └── providers/        ← direct native adapters and capabilities
 │   │       ├── catalog.ts ← model/capability descriptions (129L)
 │   │       ├── live-models.ts ← last-known opencodex catalog, refreshed in background (93L)
-│   │       ├── codex-app.ts ← Codex app-server adapter (326L)
+│   │       ├── codex-app.ts ← Codex app-server adapter (405L)
 │   │       ├── claude.ts ← Claude native adapter (93L)
 │   │       ├── acp.ts ← shared ACP resource ownership (134L)
 │   │       ├── cursor.ts ← Cursor native adapter (21L)

--- a/tests/unit/code-native-providers.test.ts
+++ b/tests/unit/code-native-providers.test.ts
@@ -308,10 +308,13 @@ for (const mismatch of [{ threadId: 'foreign' }, { turnId: 'previous' }, { itemI
     });
 }
 
-test('Codex read-only and structured permission grants never open approval handles', async t => {
+test('Codex read-only declines both plain approvals and structured permission requests explicitly', async t => {
     const f = await asking('read-only'); t.after(() => f.session.close());
     assert.deepEqual(await f.client.request(), { decision: 'decline' });
-    assert.equal(await f.client.request({ permissions: { network: true } }, 'item/permissions/requestApproval'), undefined);
+    // An empty granted profile is the runtime's decline, so read-only answers it
+    // here rather than leaving the client fallback to speak for an unhandled method.
+    assert.deepEqual(await f.client.request({ permissions: { network: true } }, 'item/permissions/requestApproval'),
+        { permissions: {}, scope: 'turn' });
     assert.equal(f.registry.list('code-session').length, 0);
     f.client.finish(); await f.turn;
 });
@@ -951,4 +954,76 @@ test('all four reject aborted startup and public audience before native construc
         await assert.rejects(provider.open(publicOwner.options), /invalid_owner/);
     }
     assert.equal(jawEffects, 0);
+});
+
+// --- #704: structured permission requests reach the queue in ask mode ---
+// { permissions: {}, scope: 'turn' } is the runtime's canonical decline, verified
+// against codex-rs 095da4b7e: core records no grant for an empty profile
+// (core/src/session/mod.rs:3118-3141) and the TUI Deny button emits exactly this
+// (tui/src/bottom_pane/approval_overlay.rs:1968-2002). So the old fallback was
+// fail-closed - but ask mode never showed the request it promised to show.
+const PERMISSIONS = 'item/permissions/requestApproval';
+const asked = { network: { enabled: true } };
+async function askingPermissions(mode: CodeOpenOptions['permissionMode'] = 'ask', type = 'mcpToolCall') {
+    const f = await codexFixture({ permissionMode: mode }, client => {
+        client.script = c => c.notification('item/started', { item: { id: 'native-tool', type } });
+    });
+    const turn = f.session.send('prompt');
+    return { ...f, turn };
+}
+
+test('ask surfaces a structured permission request and answers only what the user chose', async t => {
+    const f = await askingPermissions(); t.after(() => f.session.close());
+    const answer = f.client.request({ permissions: asked, reason: 'fetch the changelog' }, PERMISSIONS);
+    const pending = f.registry.list('code-session')[0]!;
+    assert.ok(pending, 'the request is queued with the same turn ownership as command and file approvals');
+    assert.equal(pending.view.title, 'Approve additional permissions');
+    assert.match(pending.view.fields[0]!.label, /network/);
+    assert.match(pending.view.fields[0]!.label, /fetch the changelog/);
+    const handles = pending.view.fields[0]!.options;
+    assert.deepEqual(handles.map(h => h.label), ['Allow once', 'Decline']);
+    f.registry.respond(pending.requestId, f.context(), { optionId: handles[0]!.id });
+    // Echoing the request grants exactly what was asked; core intersects it anyway.
+    assert.deepEqual(await answer, { permissions: asked, scope: 'turn' });
+    assert.equal(f.registry.list('code-session').length, 0);
+    f.client.finish(); await f.turn;
+});
+
+test('declining a structured permission request answers the runtime decline', async t => {
+    const f = await askingPermissions(); t.after(() => f.session.close());
+    const answer = f.client.request({ permissions: asked }, PERMISSIONS);
+    const pending = f.registry.list('code-session')[0]!;
+    const handles = pending.view.fields[0]!.options;
+    f.registry.respond(pending.requestId, f.context(), { optionId: handles[1]!.id });
+    assert.deepEqual(await answer, { permissions: {}, scope: 'turn' });
+    f.client.finish(); await f.turn;
+});
+
+test('auto grants the requested profile without a handle, and denies an empty ask', async t => {
+    const f = await askingPermissions('auto'); t.after(() => f.session.close());
+    assert.deepEqual(await f.client.request({ permissions: asked }, PERMISSIONS), { permissions: asked, scope: 'turn' });
+    assert.equal(f.registry.list('code-session').length, 0, 'auto keeps its labelled behaviour');
+    // Nothing was asked for, so there is nothing to grant.
+    assert.deepEqual(await f.client.request({ permissions: {} }, PERMISSIONS), { permissions: {}, scope: 'turn' });
+    assert.deepEqual(await f.client.request({}, PERMISSIONS), { permissions: {}, scope: 'turn' });
+    assert.equal(f.registry.list('code-session').length, 0);
+    f.client.finish(); await f.turn;
+});
+
+for (const mismatch of [{ threadId: 'foreign' }, { turnId: 'previous' }, { itemId: 'unknown' }, { threadId: undefined }]) {
+    test(`Codex denies an unverified permission request ${JSON.stringify(mismatch)}`, async t => {
+        const f = await askingPermissions('auto'); t.after(() => f.session.close());
+        assert.deepEqual(await f.client.request({ permissions: asked, ...mismatch }, PERMISSIONS),
+            { permissions: {}, scope: 'turn' });
+        assert.equal(f.registry.list('code-session').length, 0);
+        f.client.finish(); await f.turn;
+    });
+}
+
+test('a settled item can no longer carry a permission request', async t => {
+    const f = await askingPermissions(); t.after(() => f.session.close());
+    f.client.notification('item/completed', { item: { id: 'native-tool', type: 'mcpToolCall', status: 'completed' } });
+    assert.deepEqual(await f.client.request({ permissions: asked }, PERMISSIONS), { permissions: {}, scope: 'turn' });
+    assert.equal(f.registry.list('code-session').length, 0);
+    f.client.finish(); await f.turn;
 });


### PR DESCRIPTION
## The hypothesis in the issue is resolved

#704 left open whether `{ permissions: {}, scope: 'turn' }` reads to the native runtime as a denial or as an acknowledgement that lets the action through. It is a denial, established from source rather than inferred. All citations are from `codex-rs` at `095da4b7e8b70b01afb5c6131ef926dcb8c0d85d` (2026-09-08):

- `PermissionsRequestApprovalResponse { permissions, scope, strict_auto_review }` — `app-server-protocol/src/protocol/v2/permissions.rs:796-807`; both fields of `GrantedPermissionProfile` are optional, so `{}` is valid (`:503-513`).
- `scope` is exactly `"turn" | "session"`, default `"turn"` (`:787-793`).
- `RequestPermissionProfile::is_empty` is `network.is_none() && file_system.is_none()` — `protocol/src/request_permissions.rs:26-27`.
- Core short-circuits an empty profile and records no grant — `core/src/session/mod.rs:3118-3119`, `:3140-3141`.
- The TUI Deny shortcut emits exactly this payload; its assertion message "expected permission deny shortcut to emit an empty permission response" is at `tui/src/bottom_pane/approval_overlay.rs:2001`, inside the deny test at `:1968-2002`. (The neighbouring test at `:2005+` asserts `strict_auto_review` and is a *grant*.)
- Analytics scores an empty profile `Denied` — `analytics/src/reducer.rs:3095-3096`.

So cli-jaw was fail-closed, not permissive. `src/agent/codex-app-client.ts:1447` already sends the canonical decline and `structure/runtime-integration.md:296` already documents it as one.

## The defect that is real

The Code codex-app adapter handled only command and file approvals and returned `undefined` for this method, so the client fallback answered for it. Ask mode therefore refused every network and MCP permission request silently, while its own copy promises "Review native permission requests before allowing actions" (`public/manager/src/code/code-types.ts:9-12`). The user never got the choice the mode advertises.

## Change

`approval()` becomes a dispatcher. A command decline is not a valid `PermissionsRequestApprovalResponse`, so the two methods cannot share a body — folding the third method into the existing one would have answered a permissions RPC with `{decision:'decline'}`.

- **ask** opens the same Allow once / Decline handle as command and file, so the request appears in `CodePermissionQueue` under the same turn ownership and is cancelled by the same staleness paths. The label names what was asked for and why.
- **read-only** declines explicitly instead of falling through to the client.
- **auto** grants what was asked. This is the one judgment call here rather than a correction, and it is deliberate: auto is the labelled YOLO mode whose sandbox is already `danger-full-access`, `approvalPolicy: 'never'` is shared by auto and read-only so the adapter must branch on `permissionMode` itself, and leaving auto denying would make auto stricter than ask. Echoing the request cannot widen anything — core intersects a grant with what was requested (`core/src/session/mod.rs:3122-3128`), so `intersect(request, request) ⊆ request` — and an empty ask still declines.

Ownership is "this turn has seen the item and it has not settled" rather than a type literal, because a permissions request names the tool item that asked and this protocol does not fix that item's native type.

## Verification

- 9 new provider tests: ask queues the request and Allow returns the requested profile while Decline returns the empty deny; auto grants without a handle and denies an empty or missing ask; four ownership mismatches deny; and a settled item can no longer carry a request. The ask/auto tests start an `mcpToolCall` item rather than reusing the `commandExecution` fixture, since that is the case the loosened predicate exists for.
- The stale assertion that read-only returns `undefined` was updated to the explicit deny payload. `tests/unit/codex-app-code-policy.test.ts` is untouched and still valid, because `src/agent/codex-app-client.ts` is not modified.
- `bash structure/verify-counts.sh --fix` regenerated one line — this file's own count, `codex-app.ts` 326L → 405L. The `public/` aggregate (`~103033L` vs `103261L`) remains out of tolerance; `--fix` cannot regenerate that line, and it is a total that every worktree currently touching `public/` will move, so it is left for one regeneration after these land rather than hand-edited into six conflicting PRs.
- Local product suite **NOT RUN** by instruction: `npm test`, `npm run typecheck` and `npm run build` were not executed. CI on the head SHA is the only verification evidence.

Closes #704
