### PR TITLE
fix(web-ai): derive model aliases from the test-id generations instead of a fourth hand-written copy

### DIFF
--- a/bin/commands/browser-web-ai.ts
+++ b/bin/commands/browser-web-ai.ts
@@ -1,6 +1,9 @@
 import { parseArgs } from 'node:util';
 import { renderContextDryRunReport } from '../../src/browser/web-ai/context-pack/index.js';
 import type { ContextDryRunMode, ContextPackResult } from '../../src/browser/web-ai/context-pack/index.js';
+import { CHATGPT_MODEL_ALIAS_KEYS, normalizeChatGptModelChoice } from '../../src/browser/web-ai/chatgpt-model.js';
+import { GEMINI_DEEP_THINK_ALIAS_KEYS, GEMINI_MODEL_ALIAS_KEYS } from '../../src/browser/web-ai/gemini-model.js';
+import { GROK_MODEL_ALIAS_KEYS } from '../../src/browser/web-ai/grok-model.js';
 
 type BrowserApi = (method: string, path: string, body?: unknown) => Promise<unknown>;
 type QueryString = (params: Record<string, unknown>) => string;
@@ -38,9 +41,14 @@ Commands:
 
 Provider:
   --vendor <name>     chatgpt | gemini | grok (default: chatgpt)
-  --model <alias>     ChatGPT: instant, thinking, pro
-                      Gemini:  flash-lite, flash, pro, deepthink
-                      Grok:    auto, fast, expert, thinking, heavy
+  --model <alias>     ChatGPT: instant, thinking, pro. Generation spellings are
+                      accepted too and follow the model switcher, currently
+                      gpt-5.6, gpt-5.6-thinking, gpt-5.6-pro and the gpt-5.5 and
+                      gpt-5.3 equivalents.
+                      Gemini:  flash-lite, flash, pro, deepthink. A versioned
+                      label such as "3.1 Pro" is accepted.
+                      Grok:    auto, fast, expert, build, heavy, thinking,
+                      grok-4.6, grok-4.3
   --effort <alias>    ChatGPT reasoning effort. Requires --model because
                       ChatGPT may expose either legacy effort menus or the
                       simplified Intelligence picker.
@@ -205,24 +213,35 @@ function rejectFutureWebAiFlags(values: Record<string, unknown>): void {
     if (effort && !isSupportedWebAiEffort(vendor, values["model"], effort)) throw new Error(`unsupported ${webAiVendorLabel(vendor)} reasoning effort: ${effort}`);
 }
 
-function isSupportedWebAiModel(vendor: unknown, model: unknown): boolean {
+export function isSupportedWebAiModel(vendor: unknown, model: unknown): boolean {
     const key = String(model || '').trim().toLowerCase();
+    // Keep this ahead of the sets. Gemini's runtime normalizer accepts a
+    // version-prefixed label ("3.1 Pro") through normalizeGeminiModelLabel,
+    // which no alias key can enumerate, so dropping it would make the CLI
+    // refuse an input the runtime handles -- the exact drift this closes.
     if (String(vendor || 'chatgpt') === 'gemini' && /^(?:gemini\s+)?(?:\d+(?:\.\d+)?\s+)?(?:flash[-_\s]?lite|flash|pro)$/.test(key)) return true;
+    // The members come from the vendor modules rather than being retyped here.
+    // As three hand-copied lists they drifted in both directions: 'grok-4.6'
+    // worked in the runtime but died at this check, and no gpt-5-6 spelling
+    // reached the runtime at all.
     const byVendor: Record<string, Set<string>> = {
-        chatgpt: new Set(['instant', 'fast', 'gpt-5-3', 'gpt-5.3', 'thinking', 'think', 'gpt-5-5-thinking', 'gpt-5.5-thinking', 'pro', 'gpt-5-5-pro', 'gpt-5.5-pro']),
-        gemini: new Set(['fast', 'flash-lite', 'flash_lite', 'flash lite', 'gemini-fast', 'gemini-flash-lite', 'gemini-flash_lite', 'gemini flash lite', 'flash', 'gemini-flash', 'thinking', 'think', 'gemini-thinking', 'pro', 'gemini-pro', 'deepthink', 'deep-think', 'deep_think', 'deep think', 'gemini-deepthink', 'gemini-deep-think']),
-        grok: new Set(['auto', 'automatic', 'fast', 'quick', 'expert', 'thinking', 'think', 'grok-4.3', 'grok43', 'grok-43', 'beta', 'heavy']),
+        chatgpt: new Set(CHATGPT_MODEL_ALIAS_KEYS),
+        // Deep Think is a Tools capability rather than a model choice, so its
+        // spellings are not in the model alias table and stay listed here.
+        gemini: new Set([...GEMINI_MODEL_ALIAS_KEYS, ...GEMINI_DEEP_THINK_ALIAS_KEYS, 'deepthink', 'deep-think', 'deep_think', 'deep think']),
+        grok: new Set(GROK_MODEL_ALIAS_KEYS),
     };
     return Boolean(byVendor[String(vendor || 'chatgpt')]?.has(key));
 }
 
-function isSupportedWebAiEffort(vendor: unknown, model: unknown, effort: unknown): boolean {
+export function isSupportedWebAiEffort(vendor: unknown, model: unknown, effort: unknown): boolean {
     if (String(vendor || 'chatgpt') !== 'chatgpt') return false;
     const effortKey = String(effort || '').trim().toLowerCase();
     const normalizedEffort = ({ low: 'light', light: 'light', standard: 'standard', normal: 'standard', regular: 'standard', default: 'standard', high: 'extended', extended: 'extended', heavy: 'heavy' } as Record<string, string>)[effortKey];
     if (!normalizedEffort) return false;
-    const modelKey = String(model || '').trim().toLowerCase();
-    const normalizedModel = ({ think: 'thinking', thinking: 'thinking', 'gpt-5-5-thinking': 'thinking', 'gpt-5.5-thinking': 'thinking', pro: 'pro', 'gpt-5-5-pro': 'pro', 'gpt-5.5-pro': 'pro' } as Record<string, string>)[modelKey];
+    // A second copy of the model table lived here, so --effort died on any
+    // spelling the copy had not been updated with even once --model accepted it.
+    const normalizedModel = normalizeChatGptModelChoice(String(model || ''));
     if (normalizedModel === 'thinking') return ['light', 'standard', 'extended', 'heavy'].includes(normalizedEffort);
     if (normalizedModel === 'pro') return ['standard', 'extended'].includes(normalizedEffort);
     return false;

--- a/src/browser/web-ai/capability-observation-presets.ts
+++ b/src/browser/web-ai/capability-observation-presets.ts
@@ -1,4 +1,5 @@
 import type { FrontendCapabilityObservation } from './capability-types.js';
+import { chatGptModelSelectorTestIds } from './chatgpt-model.js';
 
 export const CHATGPT_MODEL_SELECTOR_OBSERVATION: FrontendCapabilityObservation = {
     status: 'implemented',
@@ -6,15 +7,11 @@ export const CHATGPT_MODEL_SELECTOR_OBSERVATION: FrontendCapabilityObservation =
     selectorCandidates: [
         '[data-testid="model-switcher-dropdown-button"]',
         'button.__composer-pill[aria-haspopup="menu"]',
-        '[data-testid="model-switcher-gpt-5-3"]',
-        '[data-testid="model-switcher-gpt-5-5-thinking"]',
-        '[data-testid="model-switcher-gpt-5-5-pro"]',
-        '[data-testid="model-switcher-gpt-5-5-thinking-thinking-effort"]',
-        '[data-testid="model-switcher-gpt-5-5-pro-thinking-effort"]',
-        '[data-testid="model-switcher-gpt-5-6-thinking"]',
-        '[data-testid="model-switcher-gpt-5-6-pro"]',
-        '[data-testid="model-switcher-gpt-5-6-thinking-thinking-effort"]',
-        '[data-testid="model-switcher-gpt-5-6-pro-thinking-effort"]',
+        // Derived from the runtime tables rather than appended by hand once per
+        // generation. The hand-maintained list had already fallen behind: it was
+        // missing the gpt-5-6 base id and the gpt-5-5 instant id that
+        // CHATGPT_MODEL_OPTIONS has been driving.
+        ...chatGptModelSelectorTestIds().map(testId => `[data-testid="${testId}"]`),
     ],
     textCandidates: ['Latest', 'Instant', 'Fast', 'Thinking', 'Thinking • Heavy', 'Pro', 'Heavy', 'Effort', 'Configure...'],
     activationPath: ['open model switcher or composer model pill', 'select menuitemradio or model-switcher effort menuitem', 'verify aria-checked=true or active pill text'],

--- a/src/browser/web-ai/chatgpt-model.ts
+++ b/src/browser/web-ai/chatgpt-model.ts
@@ -138,19 +138,84 @@ const CHATGPT_SIMPLIFIED_INTELLIGENCE_OPTIONS: Readonly<Record<ChatGptModelChoic
     },
 };
 
-const MODEL_ALIASES: Record<string, ChatGptModelChoice> = {
+/**
+ * Human-facing aliases that are not tied to any model generation. Seeded first
+ * so a derived slug can never take one of these names.
+ */
+const MODEL_ALIAS_SEEDS: Record<string, ChatGptModelChoice> = {
     instant: 'instant',
     fast: 'instant',
-    'gpt-5-3': 'instant',
-    'gpt-5.3': 'instant',
     thinking: 'thinking',
     think: 'thinking',
-    'gpt-5-5-thinking': 'thinking',
-    'gpt-5.5-thinking': 'thinking',
     pro: 'pro',
-    'gpt-5-5-pro': 'pro',
-    'gpt-5.5-pro': 'pro',
 };
+
+/** 'model-switcher-gpt-5-6-thinking-thinking-effort' -> 'gpt-5-6-thinking'. */
+function modelSlugFromTestId(testId: string): string {
+    return testId.replace(/^model-switcher-/, '').replace(/-thinking-effort$/, '');
+}
+
+/**
+ * 'gpt-5-6-thinking' -> 'gpt-5.6-thinking'. Only the version prefix is
+ * rewritten: collapsing the whole slug would drop the thinking/pro suffix and
+ * silently merge three distinct choices into one key.
+ */
+function dottedModelSlug(slug: string): string {
+    return slug.replace(/^gpt-(\d+)-(\d+)/, 'gpt-$1.$2');
+}
+
+/**
+ * Every model slug the DOM table knows about, newest generation first.
+ *
+ * CHATGPT_MODEL_OPTIONS is the one place a new generation gets added, so the
+ * accepted --model spellings are derived from it rather than written out a
+ * second time. They used to be two hand-maintained tables, and they drifted:
+ * the table above already listed gpt-5-6 while the alias list stopped at
+ * gpt-5-5-thinking, so a released client that could drive gpt-5-6 still
+ * rejected 'gpt-5.6' as an unsupported model.
+ */
+export function chatGptModelTestIdSlugs(): string[] {
+    const slugs: string[] = [];
+    for (const { testIds } of Object.values(CHATGPT_MODEL_OPTIONS)) {
+        for (const testId of testIds) {
+            const slug = modelSlugFromTestId(testId);
+            if (slug && !slugs.includes(slug)) slugs.push(slug);
+        }
+    }
+    return slugs;
+}
+
+/** Every model-switcher test-id the runtime will try, including effort triggers. */
+export function chatGptModelSelectorTestIds(): string[] {
+    const ids: string[] = [];
+    for (const { testIds } of Object.values(CHATGPT_MODEL_OPTIONS)) {
+        for (const testId of testIds) if (!ids.includes(testId)) ids.push(testId);
+    }
+    for (const { triggerTestIds } of Object.values(CHATGPT_MODEL_EFFORT_OPTIONS)) {
+        for (const testId of triggerTestIds) if (!ids.includes(testId)) ids.push(testId);
+    }
+    return ids;
+}
+
+function deriveModelAliases(): Record<string, ChatGptModelChoice> {
+    const aliases: Record<string, ChatGptModelChoice> = { ...MODEL_ALIAS_SEEDS };
+    for (const [choice, { testIds }] of Object.entries(CHATGPT_MODEL_OPTIONS) as [ChatGptModelChoice, { testIds: string[] }][]) {
+        for (const testId of testIds) {
+            const slug = modelSlugFromTestId(testId);
+            if (!slug) continue;
+            for (const key of [slug, dottedModelSlug(slug)]) {
+                // Exact keys, never prefix matching: 'gpt-5-5' and
+                // 'gpt-5-5-thinking' are different choices and must stay apart.
+                if (!(key in aliases)) aliases[key] = choice;
+            }
+        }
+    }
+    return aliases;
+}
+
+const MODEL_ALIASES: Record<string, ChatGptModelChoice> = deriveModelAliases();
+
+export const CHATGPT_MODEL_ALIAS_KEYS: readonly string[] = Object.freeze(Object.keys(MODEL_ALIASES));
 
 const EFFORT_ALIASES: Record<string, ChatGptEffortChoice> = {
     light: 'light',
@@ -765,6 +830,12 @@ export function modelChoiceFromText(text: string): ChatGptModelChoice | null {
     if (/\b(Medium|High|Extra High)\b|중간|높음|매우 높음/i.test(text)) return 'thinking';
     if (/\b(Thinking|Think)\b/i.test(text)) return 'thinking';
     if (/\b(Pro|Heavy)\b/i.test(text)) return 'pro';
+    // Observed live on 2026-09-11: the menu rows read 'Latest', 'GPT-5.6 Sol'
+    // and 'GPT-5.5' with no data-testid at all, and both fell through to null,
+    // which left the label fallback unable to identify the base tier. Every
+    // qualifier is matched above, so reaching here means an unqualified row.
+    if (/^\s*Latest\b/i.test(text)) return 'instant';
+    if (/^\s*(?:ChatGPT\s+)?GPT[-\s]?\d/i.test(text)) return 'instant';
     return null;
 }
 

--- a/src/browser/web-ai/gemini-model.ts
+++ b/src/browser/web-ai/gemini-model.ts
@@ -14,6 +14,12 @@ const GEMINI_MODE_MENU_BUTTONS = [
     'button[data-test-id="bard-mode-menu-button"]',
     'button[aria-label="Open mode picker"]',
     'button[aria-label*="mode picker" i]',
+    // Observed live on 2026-09-11: the English aria-label does not exist on a
+    // ko-KR account, where the opener reads
+    // "모드 선택 도구 열기, 현재 Flash 모드 사용 중". The test-id still resolved,
+    // but the English-only fallbacks were dead weight in that locale.
+    'button[aria-label*="모드 선택" i]',
+    'button[aria-label*="모드" i][aria-haspopup]',
 ] as const;
 
 const GEMINI_MODE_OPTION_SELECTOR = '[data-test-id^="bard-mode-option-"], [role="menuitem"], [role="option"]';
@@ -56,6 +62,24 @@ export function normalizeGeminiModelChoice(model: string | undefined): GeminiMod
     if (!key) return null;
     return GEMINI_MODEL_ALIASES[key] || normalizeGeminiModelLabel(key);
 }
+
+export const GEMINI_MODEL_ALIAS_KEYS: readonly string[] = Object.freeze(Object.keys(GEMINI_MODEL_ALIASES));
+
+export const GEMINI_DEEP_THINK_ALIAS_KEYS: readonly string[] = Object.freeze([...GEMINI_DEEP_THINK_ALIASES]);
+
+export function geminiModeLabels(choice: GeminiModelChoice): readonly string[] {
+    return GEMINI_MODE_OPTIONS[choice].labels;
+}
+
+/**
+ * The semantic ids kept as a first attempt. Observed live on 2026-09-11 the rows
+ * carry opaque hashes instead (bard-mode-option-fbb127bbb056c959 and friends),
+ * so the label match under the [data-test-id^="bard-mode-option-"] prefix is
+ * what actually resolves; these remain because an account may still serve them.
+ */
+export const GEMINI_MODE_OPTION_TEST_IDS: readonly string[] = Object.freeze(
+    (Object.values(GEMINI_MODE_OPTIONS) as { testId: string }[]).map(option => option.testId),
+);
 
 export function isGeminiDeepThinkChoice(model: string | undefined): boolean {
     const key = String(model || '').trim().toLowerCase();

--- a/src/browser/web-ai/grok-model.ts
+++ b/src/browser/web-ai/grok-model.ts
@@ -73,7 +73,7 @@ export function grokModelLabels(choice: GrokModelChoice): readonly string[] {
 /**
  * Recognises an open model menu from its labels with the version left generic.
  *
- * The four probes used to spell '^Grok 4\.\d' inline, so the day the web UI
+ * The four probes each spelled the major and minor inline, so the day the web UI
  * shipped a different major an open menu stopped reading as open. Deriving one
  * pattern from the labels means a new release needs no probe edit, and the 2026-09-11
  * observation that no Grok 4.x row existed at all is exactly that failure mode.

--- a/src/browser/web-ai/grok-model.ts
+++ b/src/browser/web-ai/grok-model.ts
@@ -1,7 +1,7 @@
 import type { Page } from 'playwright-core';
 import type { CapabilityProbeResult } from './capability-probe.js';
 
-export type GrokModelChoice = 'auto' | 'fast' | 'expert' | 'grok-4.3' | 'grok-4.6' | 'heavy';
+export type GrokModelChoice = 'auto' | 'fast' | 'expert' | 'build' | 'grok-4.3' | 'grok-4.6' | 'heavy';
 
 export interface GrokModelSelectionResult {
     requested: GrokModelChoice;
@@ -19,28 +19,80 @@ const GROK_MODEL_OPTIONS: Record<GrokModelChoice, { labels: string[] }> = {
     auto: { labels: ['Auto'] },
     fast: { labels: ['Fast'] },
     expert: { labels: ['Expert'] },
+    // Observed live on 2026-09-11: the menu read Auto / Fast / Expert / Build /
+    // Heavy, with no Grok 4.x row at all on that account. The version choices
+    // stay because they reappear per account, and Build was simply unreachable.
+    build: { labels: ['Build'] },
     'grok-4.3': { labels: ['Grok 4.3'] },
     'grok-4.6': { labels: ['Grok 4.6'] },
     heavy: { labels: ['Heavy'] },
 };
 
-const GROK_MODEL_ALIASES: Record<string, GrokModelChoice> = {
-    auto: 'auto',
+/** Aliases that are not derivable from a menu label. */
+const GROK_MODEL_ALIAS_SEEDS: Record<string, GrokModelChoice> = {
     automatic: 'auto',
-    fast: 'fast',
     quick: 'fast',
-    expert: 'expert',
     thinking: 'expert',
     think: 'expert',
-    'grok-4.3': 'grok-4.3',
-    'grok43': 'grok-4.3',
-    'grok-43': 'grok-4.3',
     beta: 'grok-4.3',
-    'grok-4.6': 'grok-4.6',
-    'grok46': 'grok-4.6',
-    'grok-46': 'grok-4.6',
-    heavy: 'heavy',
 };
+
+/**
+ * Aliases come from the labels rather than a parallel hand-written table, which
+ * is what let 'grok-4.6' exist here while the CLI still rejected it. 'Grok 4.6'
+ * yields grok-4.6, grok46 and grok-46 on its own, so a new release only needs a
+ * label.
+ */
+function deriveGrokModelAliases(): Record<string, GrokModelChoice> {
+    const aliases: Record<string, GrokModelChoice> = {};
+    for (const [choice, { labels }] of Object.entries(GROK_MODEL_OPTIONS) as [GrokModelChoice, { labels: string[] }][]) {
+        const keys = new Set<string>([choice]);
+        for (const label of labels) {
+            const lower = label.toLowerCase();
+            keys.add(lower);
+            keys.add(lower.replace(/\s+/g, '-'));
+            keys.add(lower.replace(/[\s.]+/g, ''));
+            keys.add(lower.replace(/\s+/g, '-').replace(/\./g, ''));
+        }
+        for (const key of keys) if (key && !(key in aliases)) aliases[key] = choice;
+    }
+    for (const [key, choice] of Object.entries(GROK_MODEL_ALIAS_SEEDS)) {
+        if (!(key in aliases)) aliases[key] = choice;
+    }
+    return aliases;
+}
+
+const GROK_MODEL_ALIASES: Record<string, GrokModelChoice> = deriveGrokModelAliases();
+
+export const GROK_MODEL_ALIAS_KEYS: readonly string[] = Object.freeze(Object.keys(GROK_MODEL_ALIASES));
+
+export function grokModelLabels(choice: GrokModelChoice): readonly string[] {
+    return GROK_MODEL_OPTIONS[choice].labels;
+}
+
+/**
+ * Recognises an open model menu from its labels with the version left generic.
+ *
+ * The four probes used to spell '^Grok 4\.\d' inline, so the day the web UI
+ * shipped a different major an open menu stopped reading as open. Deriving one
+ * pattern from the labels means a new release needs no probe edit, and the 2026-09-11
+ * observation that no Grok 4.x row existed at all is exactly that failure mode.
+ */
+export function grokModelMenuLabelPattern(): RegExp {
+    const alternatives = new Set<string>();
+    for (const { labels } of Object.values(GROK_MODEL_OPTIONS)) {
+        for (const label of labels) {
+            const versionless = label.replace(/\s*\d+(?:\.\d+)?\s*$/, '').trim();
+            const base = escapeRegExp(versionless || label);
+            alternatives.add(versionless && versionless !== label
+                ? `^${base}\\s+\\d+(?:\\.\\d+)?`
+                : `^${base}\\b`);
+        }
+    }
+    return new RegExp([...alternatives].join('|'), 'i');
+}
+
+const GROK_MENU_LABEL_PATTERN = grokModelMenuLabelPattern();
 
 export function normalizeGrokModelChoice(model: string | undefined): GrokModelChoice | null {
     const key = String(model || '').trim().toLowerCase();
@@ -80,7 +132,7 @@ export async function selectGrokModel(page: Page, model: string | undefined): Pr
 }
 
 async function openGrokModelMenu(page: Page, usedFallbacks: string[]): Promise<void> {
-    if (await page.locator('[role="menuitem"]').filter({ hasText: /^Auto\b|^Fast\b|^Expert\b|^Grok 4\.\d|^Heavy\b/i }).first().isVisible().catch(() => false)) return;
+    if (await page.locator('[role="menuitem"]').filter({ hasText: GROK_MENU_LABEL_PATTERN }).first().isVisible().catch(() => false)) return;
     const deadline = Date.now() + 5_000;
     while (Date.now() < deadline) {
         for (const selector of GROK_MODEL_MENU_BUTTONS) {
@@ -88,12 +140,12 @@ async function openGrokModelMenu(page: Page, usedFallbacks: string[]): Promise<v
             if (!(await loc.isVisible().catch(() => false))) continue;
             await loc.click({ timeout: 5_000 });
             await page.waitForTimeout(350).catch(() => undefined);
-            if (await page.locator('[role="menuitem"]').filter({ hasText: /^Auto\b|^Fast\b|^Expert\b|^Grok 4\.\d|^Heavy\b/i }).first().isVisible().catch(() => false)) return;
+            if (await page.locator('[role="menuitem"]').filter({ hasText: GROK_MENU_LABEL_PATTERN }).first().isVisible().catch(() => false)) return;
         }
         await page.waitForTimeout(150).catch(() => undefined);
     }
     usedFallbacks.push('model-menu-text-button');
-    const textButton = page.locator('button').filter({ hasText: /^Auto$|^Fast$|^Expert$|^Grok 4\.\d|^Heavy$/i }).first();
+    const textButton = page.locator('button').filter({ hasText: GROK_MENU_LABEL_PATTERN }).first();
     if (await textButton.isVisible().catch(() => false)) {
         await textButton.click({ timeout: 5_000 });
         await page.waitForTimeout(350).catch(() => undefined);
@@ -132,7 +184,7 @@ async function readGrokModel(page: Page): Promise<GrokModelChoice | null> {
 async function closeGrokModelMenu(page: Page): Promise<void> {
     for (let i = 0; i < 3; i += 1) {
         const menuVisible = await page.locator('[role="menuitem"]')
-            .filter({ hasText: /^Auto\b|^Fast\b|^Expert\b|^Grok 4\.\d|^Heavy\b/i }).first().isVisible().catch(() => false);
+            .filter({ hasText: GROK_MENU_LABEL_PATTERN }).first().isVisible().catch(() => false);
         if (!menuVisible) return;
         await page.keyboard.press('Escape').catch(() => undefined);
         await page.waitForTimeout(250).catch(() => undefined);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -623,7 +623,7 @@ cli-jaw/
 │       ├── service.ts        ← 크로스 플랫폼 서비스 관리 (systemd/launchd/docker, 289L)
 │       ├── orchestrate.ts    ← IPABCD 상태 제어 CLI (jaw orchestrate [I|P|A|B|C|D|reset]) + Phase60 --attest evidence arg + x-jaw-boss-token header attach (185L)
 │       ├── browser.ts        ← 브라우저 CLI (primitive + tab/debug + web-ai delegator, 876L)
-│       ├── browser-web-ai.ts ← `jaw browser web-ai` ChatGPT/Gemini/Grok 자동화 helper (452L)
+│       ├── browser-web-ai.ts ← `jaw browser web-ai` ChatGPT/Gemini/Grok 자동화 helper (471L)
 │       ├── dashboard.ts      ← `jaw dashboard serve` + dashboard memory delegation (290L)
 │       ├── dashboard-memory.ts ← `jaw dashboard memory` L2 federation CLI helper (210L)
 │       ├── dashboard-chat.ts ← `jaw dashboard chat search` L2 federation CLI helper (110L)

--- a/tests/unit/browser-web-ai-composer.test.ts
+++ b/tests/unit/browser-web-ai-composer.test.ts
@@ -571,7 +571,10 @@ test('BWCOMP-008: ChatGPT reasoning effort is exposed through CLI and typed inpu
     assert.match(cliSrc, /'reasoning-effort': \{ type: 'string' \}/);
     assert.match(cliSrc, /reasoningEffort: values\.effort \|\| values\['reasoning-effort'\]/);
     assert.match(cliSrc, /reasoning effort requires --model/);
-    assert.match(cliSrc, /modelKey = String\(model \|\| ''\)/);
+    // This used to pin the local modelKey lowercasing, which existed only to feed
+    // a second copy of the model table. The effort gate now normalizes through
+    // the runtime, so the assertion follows that instead of the deleted line.
+    assert.match(cliSrc, /normalizedModel = normalizeChatGptModelChoice\(String\(model \|\| ''\)\)/);
     assert.match(typesSrc, /reasoningEffort\?: string/);
 });
 

--- a/tests/unit/browser-web-ai-grok-live-policy.test.ts
+++ b/tests/unit/browser-web-ai-grok-live-policy.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isGrokUrl } from '../../src/browser/web-ai/grok-live.ts';
-import { normalizeGrokModelChoice } from '../../src/browser/web-ai/grok-model.ts';
+import { grokModelMenuLabelPattern, normalizeGrokModelChoice } from '../../src/browser/web-ai/grok-model.ts';
 
 const root = process.cwd();
 const grokLiveSrc = readFileSync(join(root, 'src/browser/web-ai/grok-live.ts'), 'utf8');
@@ -42,7 +42,9 @@ test('BWAG-004: Grok supports opt-in copy markdown fallback', () => {
 
 test('BWAG-005: Grok supports observed model picker choices', () => {
     assert.match(grokModelSrc, /button\[aria-label="Model select"\]/);
-    for (const label of ['auto', 'fast', 'expert', 'grok-4.3', 'heavy']) {
+    // grok-4.6 shipped with the runtime but was never required here, and 'build'
+    // was observed live on 2026-09-11 in a menu that had no Grok 4.x row at all.
+    for (const label of ['auto', 'fast', 'expert', 'build', 'grok-4.3', 'grok-4.6', 'heavy']) {
         assert.match(grokModelSrc, new RegExp(label.replace('.', '\\.')));
     }
     assert.match(grokLiveSrc, /selectGrokModel/);
@@ -92,11 +94,16 @@ test('BWAG-010: whitespace collapse is general, and unknown input stays null', (
 });
 
 test('BWAG-011: the menu-open probe accepts any Grok 4.x, not one pinned release', () => {
-    // A version pinned into the probe regex means the day the web UI ships a different
-    // Grok 4.x, an open menu stops being recognized as open.
-    const probes = grokModelSrc.match(/\^Grok 4\\\.[^|/]*/g) || [];
-    assert.ok(probes.length >= 3, `expected the version probes to be present, found ${probes.length}`);
-    for (const probe of probes) {
-        assert.ok(probe.includes('\\d'), `probe is pinned to one release: ${probe}`);
+    // This used to count '^Grok 4\.' occurrences in the source, which meant the
+    // four probes had to stay written out inline. They are now derived from the
+    // labels, so the behavior is asserted instead: the probe recognises an open
+    // menu for a version it has never been told about, and no major or minor is
+    // baked into it.
+    const pattern = grokModelMenuLabelPattern();
+    for (const label of ['Auto', 'Fast', 'Expert', 'Build', 'Heavy', 'Grok 4.3', 'Grok 4.6', 'Grok 4.7', 'Grok 5.0']) {
+        assert.ok(pattern.test(label), `${label} should read as an open model menu`);
     }
+    assert.equal(pattern.test('Settings'), false);
+    assert.equal(/Grok 4\\./.test(String(pattern)), false, 'the probe must not pin a major or minor version');
+    assert.equal(grokModelSrc.includes('^Grok 4\\.\\d'), false, 'no inline pinned probe should remain');
 });

--- a/tests/unit/browser-web-ai-grok-live-policy.test.ts
+++ b/tests/unit/browser-web-ai-grok-live-policy.test.ts
@@ -105,5 +105,11 @@ test('BWAG-011: the menu-open probe accepts any Grok 4.x, not one pinned release
     }
     assert.equal(pattern.test('Settings'), false);
     assert.equal(/Grok 4\\./.test(String(pattern)), false, 'the probe must not pin a major or minor version');
-    assert.equal(grokModelSrc.includes('^Grok 4\\.\\d'), false, 'no inline pinned probe should remain');
+    // Check the code rather than the prose: an earlier version of this asserted
+    // the pinned spelling was absent from the whole file and tripped on the
+    // comment that explains why it was removed.
+    const inlineHasText = grokModelSrc.match(/hasText:\s*\/[^/]*\//g) || [];
+    assert.equal(inlineHasText.length, 0, `menu probes should use the derived pattern, found ${inlineHasText.join(', ')}`);
+    const derivedUses = grokModelSrc.match(/hasText:\s*GROK_MENU_LABEL_PATTERN/g) || [];
+    assert.ok(derivedUses.length >= 4, `expected every probe to use the derived pattern, found ${derivedUses.length}`);
 });

--- a/tests/unit/browser-web-ai-model-alias-parity.test.ts
+++ b/tests/unit/browser-web-ai-model-alias-parity.test.ts
@@ -1,0 +1,167 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    CHATGPT_MODEL_ALIAS_KEYS,
+    CHATGPT_MODEL_OPTIONS,
+    chatGptModelSelectorTestIds,
+    chatGptModelTestIdSlugs,
+    modelChoiceFromText,
+    normalizeChatGptModelChoice,
+} from '../../src/browser/web-ai/chatgpt-model.js';
+import { CHATGPT_MODEL_SELECTOR_OBSERVATION } from '../../src/browser/web-ai/capability-observation-presets.js';
+import {
+    GROK_MODEL_ALIAS_KEYS,
+    grokModelLabels,
+    grokModelMenuLabelPattern,
+    normalizeGrokModelChoice,
+} from '../../src/browser/web-ai/grok-model.js';
+import {
+    GEMINI_MODE_OPTION_TEST_IDS,
+    GEMINI_MODEL_ALIAS_KEYS,
+    geminiModeLabels,
+    normalizeGeminiModelChoice,
+} from '../../src/browser/web-ai/gemini-model.js';
+
+// #692: the accepted --model spellings, the DOM test-id generations, the
+// observation preset and the CLI's allow-list were four hand-maintained copies
+// of the same fact. They drifted: the test-id table already drove gpt-5-6 while
+// nothing downstream accepted 'gpt-5.6', and grok-4.6 worked in the runtime but
+// died at the CLI. These lock the derivation so a new generation cannot be
+// half-added again.
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const cliSrc = readFileSync(join(root, 'bin/commands/browser-web-ai.ts'), 'utf8');
+
+test('BWMAP-001: every model slug the DOM table drives is an accepted --model spelling', () => {
+    const slugs = chatGptModelTestIdSlugs();
+    assert.ok(slugs.length >= 7, `expected the generation table to yield slugs, got ${slugs.length}`);
+    for (const slug of slugs) {
+        const dotted = slug.replace(/^gpt-(\d+)-(\d+)/, 'gpt-$1.$2');
+        assert.ok(
+            normalizeChatGptModelChoice(slug),
+            `CHATGPT_MODEL_OPTIONS drives ${slug} but no alias accepts it`,
+        );
+        assert.ok(
+            normalizeChatGptModelChoice(dotted),
+            `CHATGPT_MODEL_OPTIONS drives ${slug} but the dotted spelling ${dotted} is rejected`,
+        );
+    }
+});
+
+test('BWMAP-002: the slug a test-id yields maps to the choice that test-id belongs to', () => {
+    for (const [choice, { testIds }] of Object.entries(CHATGPT_MODEL_OPTIONS)) {
+        for (const testId of testIds) {
+            const slug = testId.replace(/^model-switcher-/, '').replace(/-thinking-effort$/, '');
+            assert.equal(normalizeChatGptModelChoice(slug), choice, `${slug} should resolve to ${choice}`);
+        }
+    }
+});
+
+test('BWMAP-003: the spellings that already worked keep working', () => {
+    const legacy: Record<string, string> = {
+        instant: 'instant', fast: 'instant', 'gpt-5-3': 'instant', 'gpt-5.3': 'instant',
+        thinking: 'thinking', think: 'thinking', 'gpt-5-5-thinking': 'thinking', 'gpt-5.5-thinking': 'thinking',
+        pro: 'pro', 'gpt-5-5-pro': 'pro', 'gpt-5.5-pro': 'pro',
+    };
+    for (const [input, expected] of Object.entries(legacy)) {
+        assert.equal(normalizeChatGptModelChoice(input), expected, `${input} regressed`);
+    }
+});
+
+test('BWMAP-004: the generation spellings the issue reported now resolve', () => {
+    assert.equal(normalizeChatGptModelChoice('gpt-5.6'), 'instant');
+    assert.equal(normalizeChatGptModelChoice('gpt-5-6'), 'instant');
+    assert.equal(normalizeChatGptModelChoice('gpt-5-6-thinking'), 'thinking');
+    assert.equal(normalizeChatGptModelChoice('gpt-5.6-thinking'), 'thinking');
+    assert.equal(normalizeChatGptModelChoice('gpt-5-6-pro'), 'pro');
+    assert.equal(normalizeChatGptModelChoice('gpt-5.6-pro'), 'pro');
+    // Unknown input must still be refused rather than guessed at.
+    assert.equal(normalizeChatGptModelChoice('gpt-9000-ultra'), null);
+});
+
+test('BWMAP-005: a generation cannot reach the DOM table without reaching the observation preset', () => {
+    const candidates = CHATGPT_MODEL_SELECTOR_OBSERVATION.selectorCandidates;
+    for (const testId of chatGptModelSelectorTestIds()) {
+        assert.ok(
+            candidates.includes(`[data-testid="${testId}"]`),
+            `${testId} is driven by the runtime but absent from the observation preset`,
+        );
+    }
+});
+
+test('BWMAP-006: the live 2026-09-11 ChatGPT menu labels resolve through the label fallback', () => {
+    // Observed rows carried no data-testid at all, so the label path is the only
+    // one left; both of these used to return null.
+    assert.equal(modelChoiceFromText('Latest'), 'instant');
+    assert.equal(modelChoiceFromText('GPT-5.6 Sol'), 'instant');
+    assert.equal(modelChoiceFromText('GPT-5.5'), 'instant');
+    // A qualifier still wins over the bare-generation rule.
+    assert.equal(modelChoiceFromText('GPT-5.6 Thinking'), 'thinking');
+    assert.equal(modelChoiceFromText('GPT-5.6 Pro'), 'pro');
+});
+
+test('BWMAP-007: every Grok choice survives an id to label to id round trip', () => {
+    for (const choice of ['auto', 'fast', 'expert', 'build', 'grok-4.3', 'grok-4.6', 'heavy'] as const) {
+        const labels = grokModelLabels(choice);
+        assert.ok(labels.length > 0, `${choice} has no label`);
+        for (const label of labels) {
+            assert.equal(normalizeGrokModelChoice(label), choice, `visible label ${label} must map back to ${choice}`);
+        }
+    }
+});
+
+test('BWMAP-008: the Grok menu probe recognises a version it has never seen', () => {
+    const pattern = grokModelMenuLabelPattern();
+    // Observed live on 2026-09-11: Auto/Fast/Expert/Build/Heavy with no Grok 4.x
+    // row at all. A probe pinned to one minor stops recognising an open menu.
+    for (const label of ['Auto', 'Fast', 'Expert', 'Build', 'Heavy', 'Grok 4.3', 'Grok 4.6', 'Grok 4.7', 'Grok 5.0', 'Grok 11']) {
+        assert.ok(pattern.test(label), `${label} should read as an open model menu`);
+    }
+    assert.equal(pattern.test('Settings'), false);
+    assert.equal(/Grok 4\\\./.test(String(pattern)), false, 'the probe must not pin a minor version');
+});
+
+test('BWMAP-009: every Gemini choice survives an id to label to id round trip', () => {
+    for (const choice of ['flash-lite', 'flash', 'pro'] as const) {
+        for (const label of geminiModeLabels(choice)) {
+            assert.equal(normalizeGeminiModelChoice(label), choice, `visible label ${label} must map back to ${choice}`);
+        }
+        // A version-prefixed label is what the live menu actually renders.
+        for (const label of geminiModeLabels(choice)) {
+            assert.equal(normalizeGeminiModelChoice(`3.6 ${label}`), choice, `versioned label 3.6 ${label} must map back to ${choice}`);
+        }
+    }
+    assert.equal(GEMINI_MODE_OPTION_TEST_IDS.length, 3);
+});
+
+test('BWMAP-010: the CLI derives its allow-list instead of keeping a fourth copy', () => {
+    // A literal list here is what made --model grok-4.6 fail while the runtime
+    // accepted it, so the derivation itself is the thing under test.
+    assert.match(cliSrc, /chatgpt: new Set\(CHATGPT_MODEL_ALIAS_KEYS\)/);
+    assert.match(cliSrc, /grok: new Set\(GROK_MODEL_ALIAS_KEYS\)/);
+    assert.match(cliSrc, /gemini: new Set\(\[\.\.\.GEMINI_MODEL_ALIAS_KEYS/);
+    assert.match(cliSrc, /deepthink/);
+    // Gemini's runtime normalizer accepts a versioned label that no key list can
+    // enumerate, so this regex has to survive the derivation.
+    assert.match(cliSrc, /flash\[-_\\s\]\?lite\|flash\|pro/);
+    // The effort check kept its own model table and so refused any spelling that
+    // copy had not been updated with.
+    assert.match(cliSrc, /normalizedModel = normalizeChatGptModelChoice/);
+    assert.equal(cliSrc.includes("'gpt-5-5-thinking': 'thinking'"), false, 'the duplicated effort model map should be gone');
+});
+
+test('BWMAP-011: the runtime alias keys cover both spellings of every generation', () => {
+    for (const key of CHATGPT_MODEL_ALIAS_KEYS) {
+        assert.ok(normalizeChatGptModelChoice(key), `${key} is listed but does not normalize`);
+    }
+    for (const key of GROK_MODEL_ALIAS_KEYS) {
+        assert.ok(normalizeGrokModelChoice(key), `${key} is listed but does not normalize`);
+    }
+    for (const key of GEMINI_MODEL_ALIAS_KEYS) {
+        assert.ok(normalizeGeminiModelChoice(key), `${key} is listed but does not normalize`);
+    }
+});
+


### PR DESCRIPTION
## What broke

`--model gpt-5.6` failed. The selector table had already moved on — `CHATGPT_MODEL_OPTIONS`
lists `model-switcher-gpt-5-6` as its newest generation — but three other places
repeated the same fact by hand and had not been updated with it:

| Place | Newest generation it knew |
|---|---|
| `CHATGPT_MODEL_OPTIONS.testIds` | gpt-5-6 |
| `MODEL_ALIASES` | gpt-5-5-thinking / gpt-5-5-pro (no base, no 5-6) |
| `CHATGPT_MODEL_SELECTOR_OBSERVATION` | missing the gpt-5-6 base and gpt-5-5 instant ids |
| CLI `byVendor` sets | gpt-5-5-thinking / gpt-5-5-pro |

- Before: `--model gpt-5.6` → `unsupported ChatGPT model selection` at the CLI; through
  the API → `provider.model-mismatch`. `gpt-5-5` with no suffix failed the same way.
- After: `gpt-5.6`, `gpt-5-6`, `gpt-5-6-thinking`, `gpt-5.6-pro` and the `gpt-5-5`
  equivalents all resolve, and adding the next generation to `CHATGPT_MODEL_OPTIONS`
  carries the rest automatically.

Grok drifted the other way: `grok-4.6` worked in the runtime and was rejected by the CLI.

## Verified against the live UIs, not assumed

Aside drove the real signed-in browser for all three vendors read-only on 2026-09-11.
Two recorded selector generations no longer exist, which changed what this PR does:

- **chatgpt.com** exposes **no** `data-testid` starting `model-switcher` at all. The menu is
  radix `menuitemradio` rows reading `Latest`, `GPT-5.6 Sol`, `GPT-5.5`, with an
  `aria-label="Power"` effort slider. `Latest` and `GPT-5.6 Sol` both returned `null` from
  `modelChoiceFromText`, so with the test-ids gone nothing could identify the base tier.
  Both are handled now. **Rewriting the selector layer for the new DOM is deliberately out
  of scope** — it is not in the issue's completion conditions and needs per-path live
  verification. The finding is recorded in the observation notes instead.
- **gemini.google.com** still resolves `bard-mode-menu-button`, but the rows now carry
  opaque hashes (`bard-mode-option-fbb127bbb056c959`) rather than `-fast`/`-thinking`/`-pro`,
  and `aria-label="Open mode picker"` does not exist under ko-KR. The label match under the
  `[data-test-id^="bard-mode-option-"]` prefix already carried this; the localized opener is
  added. Which choice the `3.6 사고 모델` row maps to was **not** established, so it is
  recorded as unknown rather than guessed.
- **grok.com** showed `Auto / Fast / Expert / Build / Heavy` and **no Grok 4.x row at all**.
  So `^Grok 4\.\d`, spelled inline in four probes, matched nothing, and `Build` had no
  choice to select it with.

## Validation

`tests/unit/browser-web-ai-model-alias-parity.test.ts`, 11 cases: 11/11 pass.

Negative control — restoring the hand-written alias table:

```
✖ BWMAP-001: every model slug the DOM table drives is an accepted --model spelling
✖ BWMAP-002: the slug a test-id yields maps to the choice that test-id belongs to
✖ BWMAP-004: the generation spellings the issue reported now resolve
ℹ tests 11  ℹ pass 8  ℹ fail 3
```

The other eight stay green, including BWMAP-005, which covers the observation preset
independently. A generation that reaches the DOM table without reaching the accepted
spellings now fails CI.

47/47 across `composer`, `cli-contract` and `gemini-live-policy`; 75/75 across the ten
web-ai model and capability files that run without installed dependencies.

Two existing source-regex assertions had to move to behavior, which is the point rather
than collateral. `BWAG-011` counted `^Grok 4\.` occurrences in the source, so it required
the four probes to stay written out inline — it would have failed the refactor that
implements what it was testing. `BWCOMP-008` pinned a local lowercasing line whose only
purpose was feeding the duplicated effort table.

`npm test`, `npm run typecheck` and `npm run build`: **NOT RUN.** This worktree has no
installed dependencies, so `chatgpt-contract` (`better-sqlite3`) and `grok-live-policy`
(`fast-glob`) cannot run here; both are pre-existing to this change and are covered by CI.
CI on the final head SHA is the passing evidence.

## Not changed

The semantic Gemini test-ids stay as a first attempt even though the live account serves
hashes, since another account may still serve them and `GEM-LIVE-003` locks them.
`grok-4.3` and `grok-4.6` stay for the same reason. `validateFreshnessGate` remains a
schema helper with no runtime caller — turning it into a real gate is a separate change,
and this PR records the 2026-09-11 retrieval in the observation notes instead.

Refs #697
Closes #692
