### PR TITLE
fix(code): stop describing a re-keyed send as possibly already accepted

### DIFF
--- a/public/manager/src/code/CodeWorkbench.tsx
+++ b/public/manager/src/code/CodeWorkbench.tsx
@@ -66,12 +66,19 @@ export function CodeWorkbench({ controller: c, endpointKey, onOpenLocalFile }: P
             <p>Your draft and choices are kept. Press Send when you are ready to create another session.</p>
             <button type="button" onClick={c.startAnotherSession}>Start another session</button>
         </section>}
-        {unknownSend && <section className="code-recovery-strip" aria-label="Unconfirmed send">
-            <strong>Send outcome not confirmed</strong>
-            <p>Retry uses the original request. It may submit it if the server has not already accepted it.</p>
+        {unknownSend && <section className="code-recovery-strip"
+            aria-label={c.resendRequired ? 'Send not started' : 'Unconfirmed send'}>
+            <strong>{c.resendRequired ? 'Send did not start' : 'Send outcome not confirmed'}</strong>
+            {/* Once the server has spent the key, acceptance is no longer unknown,
+                so this must stop offering the weaker, hedged explanation. */}
+            <p>{c.resendRequired
+                ? 'The original attempt ended on the server without running. Retry sends this as a new message.'
+                : 'Retry uses the original request. It may submit it if the server has not already accepted it.'}</p>
             <pre className="code-retry-preview" aria-label="Original prompt">{c.retryText}</pre>
             <button type="button" disabled={!c.canRetrySameSend || retrying === sessionKey} onClick={() => void retry()}>
-                {retrying === sessionKey ? 'Retrying original send…' : 'Retry same send'}</button>
+                {retrying === sessionKey
+                    ? (c.resendRequired ? 'Sending as a new message…' : 'Retrying original send…')
+                    : (c.resendRequired ? 'Send as a new message' : 'Retry same send')}</button>
         </section>}
         {archived ? <section className="code-recovery-strip"><span>Archived · Read-only history</span>
             <button type="button" disabled={!c.synced || c.pending} onClick={() => { const id = c.selectedId; if (id) perform(() => c.archive(id, false)); }}>Restore session</button>

--- a/public/manager/src/code/code-controller-draft-storage.ts
+++ b/public/manager/src/code/code-controller-draft-storage.ts
@@ -20,7 +20,7 @@ export interface StoredCodeDraft {
     selection: DraftSelection;
     selectionEdit: number;
     creating: boolean;
-    retry: { text: string; key: string; edit: number } | null;
+    retry: { text: string; key: string; edit: number; resend?: boolean } | null;
     stop: { turnId: string; epoch: number } | null;
 }
 export interface StoredCodeEndpoint {
@@ -49,7 +49,10 @@ function parseDraft(value: unknown): StoredCodeDraft | null {
     return {
         input: value['input'], edit: value['edit'], selectionEdit: value['selectionEdit'], creating: value['creating'],
         selection: { provider: selection['provider'] as DraftSelection['provider'], cwd: selection['cwd'], model: selection['model'], effort: selection['effort'], permissionMode: selection['permissionMode'] as DraftSelection['permissionMode'] },
-        retry: retry === null ? null : { text: retry['text'] as string, key: retry['key'] as string, edit: retry['edit'] as number },
+        // `resend` is optional on purpose: a draft stored before this field existed
+        // must still parse, or recovery is wiped instead of downgraded.
+        retry: retry === null ? null : { text: retry['text'] as string, key: retry['key'] as string, edit: retry['edit'] as number,
+            ...(retry['resend'] === true ? { resend: true } : {}) },
         stop: stop === null ? null : { turnId: stop['turnId'] as string, epoch: stop['epoch'] as number },
     };
 }
@@ -116,7 +119,8 @@ function pack(draft: CodeDraft): StoredCodeDraft | null {
     const { provider, cwd, model, effort, permissionMode } = draft.selection;
     return parseDraft({ input: draft.input, edit: draft.edit, selection: { provider, cwd, model, effort, permissionMode }, selectionEdit: draft.selectionEdit,
         creating: draft.createUnknown || draft.operation.kind === 'creating',
-        retry: draft.retry ? { text: draft.retry.text, key: draft.retry.key, edit: draft.retry.edit } : null,
+        retry: draft.retry ? { text: draft.retry.text, key: draft.retry.key, edit: draft.retry.edit,
+            ...(draft.retry.resend ? { resend: true } : {}) } : null,
         stop: draft.stopTarget ? { turnId: draft.stopTarget.turnId, epoch: draft.stopTarget.epoch } : null });
 }
 export function saveCodeDraftStorage(storage: Storage, endpoint: string, book: CodeDraftBook): string | null {

--- a/public/manager/src/code/code-controller-drafts.ts
+++ b/public/manager/src/code/code-controller-drafts.ts
@@ -8,7 +8,12 @@ export interface CodeDraft {
     selection: CodeCreateSessionRequest;
     selectionEdit: number;
     operation: CodeControllerModel['operation'];
-    retry: { text: string; key: string; edit: number } | null;
+    /**
+     * `resend` marks an attempt whose key the server already spent. Acceptance is
+     * then known — it failed — so the surfaces that describe an unconfirmed send
+     * must stop hedging.
+     */
+    retry: { text: string; key: string; edit: number; resend?: boolean } | null;
     createUnknown: boolean;
     requiredSequence: number;
     stopTarget: { turnId: string; epoch: number; outcome: 'pending' | 'unknown' | 'retryable' | 'accepted' } | null;
@@ -40,7 +45,9 @@ function restoreDraft(saved: StoredCodeDraft): CodeDraft {
     draft.createUnknown = saved.creating;
     draft.retry = saved.retry;
     if (saved.creating) draft.operation = { kind: 'creating', error: 'Creation was interrupted by reload. The original session may exist; no request has been retried.' };
-    if (saved.retry) draft.operation = { kind: 'unknown-send', error: 'The original message has not been reconciled after reload. It will not be sent automatically.' };
+    if (saved.retry) draft.operation = { kind: 'unknown-send', error: saved.retry.resend
+        ? 'The original attempt ended on the server without running. The message was not resent; Retry will submit it as a new message.'
+        : 'The original message has not been reconciled after reload. It will not be sent automatically.' };
     if (saved.stop) {
         draft.stopTarget = { ...saved.stop, outcome: 'unknown' };
         draft.operation = { kind: 'stopping', error: 'Checking the captured Stop after reload. No cancellation has been resent.' };

--- a/public/manager/src/code/code-controller-runtime.ts
+++ b/public/manager/src/code/code-controller-runtime.ts
@@ -275,7 +275,7 @@ export class CodeController {
      */
     private requireNewKey(draft: CodeDraft): void {
         if (!draft.retry) return;
-        draft.retry = { ...draft.retry, key: crypto.randomUUID() };
+        draft.retry = { ...draft.retry, key: crypto.randomUUID(), resend: true };
         draft.operation = { kind: 'unknown-send', error: 'The original attempt ended on the server without running. The message was not resent; Retry will submit it as a new message.' };
     }
     private makeModel(): CodeControllerModel {
@@ -307,6 +307,7 @@ export class CodeController {
             error: [operation.error ?? detail?.error ?? this.indexError ?? this.catalogError ?? this.gitError ?? session?.error?.message, persistenceWarning].filter(Boolean).join(' ') || null,
             operation: { ...operation, error: operation.error && persistenceWarning ? `${operation.error} ${persistenceWarning}` : operation.error }, retryText: draft.retry?.text ?? null,
             canRetrySameSend: !!id && operation.kind === 'unknown-send' && !!draft.retry && synced && session?.archivedAt === null,
+            resendRequired: !!draft.retry?.resend,
             permissionOperations: { ...draft.permissionOperations }, hasMoreSessions: this.moreSessions,
             hasOlderHistory: detail?.hasOlder ?? false, filter: this.filter,
             creationUnknown: id === null && draft.createUnknown, startAnotherSession: this.startAnotherSession,

--- a/public/manager/src/code/code-controller-types.ts
+++ b/public/manager/src/code/code-controller-types.ts
@@ -27,6 +27,8 @@ export interface CodeControllerModel {
     operation: { kind: CodeOperationKind; error: string | null };
     retryText: string | null;
     canRetrySameSend: boolean;
+    /** The previous key is spent: Retry sends a new message rather than reusing it. */
+    resendRequired?: boolean;
     permissionOperations: Record<string, { pending: boolean; error: string | null }>;
     hasMoreSessions: boolean;
     hasOlderHistory: boolean;

--- a/public/manager/src/code/pending-user-item.ts
+++ b/public/manager/src/code/pending-user-item.ts
@@ -19,6 +19,11 @@ export const PENDING_USER_ITEM_ID = 'pending:user';
 export function pendingUserItem(draft: CodeDraft, items: CodeItem[], now = Date.now()): CodeItem | null {
     const retry = draft.retry;
     if (!retry) return null;
+    // The server already spent the previous key, so nothing is in flight. This row
+    // renders as "Sending"; showing it here would restate the very confusion the
+    // re-key exists to remove. The failed attempt stays in history and the recovery
+    // strip still previews the text.
+    if (retry.resend) return null;
     // The authoritative item is here: show that one instead.
     if (items.some(item => item.kind === 'user_message' && item.clientTurnKey === retry.key)) return null;
     const unknown = draft.operation.kind === 'unknown-send';

--- a/tests/unit/code-native-controller.test.ts
+++ b/tests/unit/code-native-controller.test.ts
@@ -755,3 +755,32 @@ test('a user message whose turn actually ran still acknowledges the send', async
     assert.equal(f.controller.getModel().retryText, null);
     assert.equal(f.posts().length, 1);
 });
+
+// --- after a re-key, nothing is in flight and the UI must stop saying otherwise ---
+
+test('a re-keyed send stops claiming it might already be accepted, and shows the text once', async t => {
+    const f = fixture(t); await f.controller.refresh(); await f.controller.selectSession('a');
+    const pending = deferred<Response>();
+    f.intercept(call => call.path.endsWith('/prompt') ? pending.promise : undefined);
+    f.controller.setInput('original message');
+    const sending = f.controller.send();
+    const key = String(f.posts()[0]!.body['clientTurnKey']);
+    pending.reject(new TypeError('connection dropped'));
+    await sending;
+    // Before the server speaks, acceptance really is unknown and the old copy holds.
+    assert.equal(f.controller.getModel().resendRequired, false);
+    // The orphaned turn is in history, so the transcript already carries the text.
+    const sent: CodeItem = { itemId: 't:user', firstSequence: 4, turnId: 't', kind: 'user_message', status: 'done',
+        text: 'original message', clientTurnKey: key, createdAt: 1, updatedAt: 1 };
+    const terminal: CodeItem = { itemId: 't:terminal', firstSequence: 5, turnId: 't', kind: 'turn_failed', status: 'done',
+        createdAt: 1, updatedAt: 1 };
+    f.snapshots.set('a', snap(session('a', { sequence: 5, status: 'failed' }), [sent, terminal]));
+    f.intercept(() => undefined);
+    await f.controller.refresh();
+    assert.equal(f.controller.getModel().operation.kind, 'unknown-send');
+    assert.equal(f.controller.getModel().resendRequired, true, 'the key is spent, so acceptance is known');
+    const copies = f.controller.getModel().items.filter(item => item.kind === 'user_message' && item.text === 'original message');
+    assert.equal(copies.length, 1, 'no second copy claiming to be in flight');
+    assert.equal(copies[0]!.itemId, 't:user', 'the surviving copy is the real failed attempt');
+    assert.equal(f.controller.getModel().retryText, 'original message', 'the strip still previews the text');
+});


### PR DESCRIPTION
Follow-up to #711. Not tied to an issue: this is a regression that the #703 fix itself introduced, found while closing out the W5 lane.

## Problem

#703 made the client rotate the `clientTurnKey` when the server reports a spent one. That is correct — the key is consumed and the turn it belonged to failed. But two surfaces still describe the state from *before* the rotation.

**The recovery strip contradicts the line above it.** `requireNewKey()` writes "The original attempt ended on the server without running. The message was not resent" (`code-controller-runtime.ts:279`), and `CodeWorkbench.tsx:69-74` then unconditionally prints "Send outcome not confirmed / Retry uses the original request. It may submit it if the server has not already accepted it." Both halves of that sentence are false after a rotation: Retry no longer reuses the original request, and the server explicitly reported non-acceptance.

**The transcript grows a second copy.** The rotated key no longer matches the stored `user_message`, so `pending-user-item.ts` emits a pending row alongside the real failed one. That row is not subtle — `CodeTranscript.tsx:69`/`:105` label it **Sending** and `code.css:489` gives it dashed, faded styling. It asserts a send in flight when nothing is in flight, which is the exact confusion #703 existed to remove.

## Change

Carry one fact from the place that knows it to the two places that describe it. The draft's retry attempt gains a `resend` marker, set where the key is rotated and persisted across reload; the pending bubble is not emitted for it, and the strip says the attempt ended without running and that Retry will send a new message.

**The old copy stays the default.** A send lost to a dropped HTTP response is still genuinely unknown — Retry does reuse that key and the server may well have accepted it — so only the spent-key case gets the stronger wording. Heading, body, `aria-label` and button text all branch together, so the strip cannot half-update.

`resend` is optional in the stored shape, so a draft written before this field parses rather than returning null and wiping recovery (`code-controller-draft-storage.ts:46-47`, `:107`), and `pack` writes it only when true so the existing storage assertion is unaffected.

Checked and deliberately **not** changed: `phase: 'unknown'` on the pending row is inert. `CodeTranscript.tsx:104` is the only reader of `phase` and it applies only to assistant commentary, so user rows never take that branch.

## Verification

- 1 new controller test: before the server speaks, `resendRequired` is false and the old copy holds; after a spent-key duplicate with the orphaned turn in history, the operation stays `unknown-send`, `resendRequired` is true, the transcript holds exactly one copy of the text and it is the real failed attempt, and the strip still previews the text.
- The test uses the orphan fixture that has the original `user_message` in `items`, not the empty-items path, so "exactly one copy" is a meaningful assertion.
- `tests/unit/code-transcript-summary.test.ts` covers `pendingUserItem` directly and is **not** edited — it is outside the W5 write list, and every draft it builds has no `resend`, so the added early return cannot affect it.
- `bash structure/verify-counts.sh`: no per-file entry changed. The `public/` aggregate remains out of tolerance as described in #714; `--fix` cannot regenerate that line and it needs one pass after the parallel lanes land.
- Local product suite **NOT RUN** by instruction: `npm test`, `npm run typecheck` and `npm run build` were not executed. CI on the head SHA is the only verification evidence.
