### PR TITLE
test: cross Slack, agent lifecycle and code-mode at the integration level

### DIFF
--- a/tests/fixtures/print-agent-stub.mjs
+++ b/tests/fixtures/print-agent-stub.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Print-mode agent stand-in, installed on a server child's PATH under a real
+ * CLI name (claude).
+ *
+ * Seam: spawnAgent resolves the binary by NAME off PATH (src/core/cli-detect.ts
+ * detectCliBinary, src/agent/spawn.ts preflight). There is no settings field for
+ * an absolute agent path and no CLAUDE_BIN env, so PATH is the whole mechanism.
+ * Two consequences this file must respect:
+ *   - isSpawnableCliFile rejects a text file with no shebang and no exec bit
+ *     (src/core/cli-detect.ts), hence the shebang above and mode 0o755;
+ *   - the Claude print argv carries NO prompt (src/agent/args.ts); the prompt
+ *     arrives on stdin and the stream is ended, so this must drain stdin before
+ *     it can decide anything.
+ *
+ * Mode comes from the LAST STUB_MODI:<mode>:<token> directive in the prompt:
+ *   echo   answer with one assistant message and exit (default)
+ *   empty  emit only the result line — the empty-terminal shape
+ *   hold   stay alive until released or killed — makes a live pid, a steer and
+ *          a scoped kill observable
+ *
+ * LAST, not first, and one directive rather than several independent markers:
+ * the prompt carries the conversation history, so an earlier turn's directive is
+ * still in the text. Matching the first occurrence made every turn replay turn
+ * one's mode, which is a bug that reads as a product failure.
+ *
+ * Every wait is capped well under the tests/run.mts 180s per-file stall
+ * watchdog, so a missed release fails one case with a message instead of
+ * silently stalling the integration job.
+ */
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOLD_CAP_MS = 60_000;
+const dir = process.env['JAW_STUB_DIR'] ?? '';
+const recordPath = dir ? join(dir, process.pid + '.json') : '';
+
+function record(extra) {
+    if (!recordPath) return;
+    try {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(recordPath, JSON.stringify({ pid: process.pid, argv: process.argv.slice(2), ...extra }, null, 2));
+    } catch { /* the test asserts on the record; a write failure shows up there */ }
+}
+
+function note(line) {
+    if (!dir) return;
+    try { appendFileSync(join(dir, 'stub.log'), process.pid + ' ' + line + '\n'); } catch { /* best effort */ }
+}
+
+async function readPrompt() {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    return Buffer.concat(chunks).toString('utf8');
+}
+
+function directive(prompt) {
+    const hits = [...prompt.matchAll(/STUB_MODI:(echo|empty|hold):([A-Za-z0-9-]+)/g)];
+    const last = hits.at(-1);
+    return last ? { mode: last[1], token: last[2] } : { mode: 'echo', token: 'default' };
+}
+
+const prompt = await readPrompt();
+record({ prompt, startedAt: new Date().toISOString() });
+note('started');
+
+const { mode, token: echo } = directive(prompt);
+const empty = mode === 'empty';
+const hold = mode === 'hold' ? echo : null;
+
+function emit(obj) { process.stdout.write(JSON.stringify(obj) + '\n'); }
+
+function finish() {
+    if (!empty) emit({ type: 'assistant', message: { id: 'stub-1', content: [{ type: 'text', text: 'stub reply ' + echo }] } });
+    emit({ type: 'result', total_cost_usd: 0, num_turns: 1, duration_ms: 1 });
+    process.exit(0);
+}
+
+if (hold === null) {
+    finish();
+} else {
+    // A kill from the product must look like a normal terminated agent: record
+    // that the signal arrived so the test can tell a real SIGTERM apart from a
+    // process that merely vanished, then leave.
+    for (const signal of ['SIGTERM', 'SIGINT']) {
+        process.on(signal, () => {
+            record({ prompt, terminatedAt: new Date().toISOString(), signal });
+            note('terminated by ' + signal);
+            process.exit(0);
+        });
+    }
+    const release = dir ? join(dir, 'release-' + hold) : '';
+    const started = Date.now();
+    const tick = setInterval(() => {
+        if (release && existsSync(release)) { clearInterval(tick); note('released'); finish(); return; }
+        if (Date.now() - started >= HOLD_CAP_MS) {
+            clearInterval(tick);
+            note('hold cap reached');
+            process.stderr.write('print-agent-stub: hold ' + hold + ' was never released within ' + HOLD_CAP_MS + 'ms\n');
+            finish();
+        }
+    }, 50);
+}

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -1,0 +1,51 @@
+# tests/helpers
+
+Machinery that tests drive, not tests themselves. Nothing here is collected by
+`tests/run.mts`: the driver only picks up `*.test.ts` under a declared scope
+(`tests/run.mts` `list()`, `tests/setup/shard.ts` `SCOPES`), and this directory is
+not a scope. Files here are imported or spawned by a test that is.
+
+## What lives here
+
+| File | Shape | Driven by |
+| --- | --- | --- |
+| `code-native-qa-server.mjs` | Supervises a built Manager with mocked Code providers, plus a `/__qa` control surface | `tests/browser/code-native-workbench.test.ts`, `tests/browser/retired-runtime-settings.test.ts` |
+| `hosted-manager-qa.mjs` | Hosted Manager + Playwright QA driver | the `workflow_dispatch`-only Hosted Manager QA job |
+
+Both need a build and a browser, which is why they sit outside the PR-admission
+path. A helper that an `integration` test depends on must not: that job runs on
+every code PR and feeds `ci-aggregate`.
+
+## Rules for a new helper
+
+**Fail closed, or do not guard at all.** The pattern to copy is
+`tests/integration/api-smoke.test.ts`: a missing dependency is a skip on a
+developer box and an `assert.fail` under `CI`, because the integration job owns
+that dependency and a silent skip there turns a broken startup into a green run.
+A helper that returns a `'skipped'` sentinel pushes that decision onto every
+caller, and the callers have historically got it wrong.
+
+**Surface the child's output.** A helper that spawns a process captures stdout
+and stderr and attaches them to the error it throws. A boot failure with no
+output reads as an environment quirk, which is how one gets skipped instead of
+fixed.
+
+**Bound every wait below the driver's watchdog.** `tests/run.mts` fails a file
+that goes quiet for `JAW_TEST_FILE_STALL_MS` (default 180s). Any hold, poll or
+retry a helper owns needs a cap well under that, so a missed release fails one
+case with a usable message instead of stalling the job and being attributed to
+the runner.
+
+**Name the seam in a comment.** Several product paths have exactly one test
+seam and no second one — a constructor argument that production never passes, a
+global that is resolved at call time, a binary resolved off `PATH`. When a
+helper depends on one, say which line of the product makes it work, so the next
+person who changes that line finds out here rather than in a red CI run.
+
+## Scope note
+
+Helpers are test infrastructure. They may import product modules read-only to
+reuse a contract (path resolution, wire types) but must not require a change to
+`src/`, `server.ts` or `bin/` to function. If a crossing cannot be tested
+without a new product seam, that is a finding to report, not something to work
+around here.

--- a/tests/helpers/code-fake-providers.mts
+++ b/tests/helpers/code-fake-providers.mts
@@ -1,0 +1,140 @@
+/**
+ * Injectable Code providers for native HTTP/store tests.
+ *
+ * A FRESH factory instance must be used per host. Sharing a counts object
+ * across hosts would carry the first process's open/send into the recovered
+ * host and make the "native send is zero after recovery" assertion meaningless.
+ */
+import type {
+    CodeOpenOptions,
+    CodeProvider,
+    CodeProviderSession,
+    CodeProviders,
+} from '../../src/code-mode/provider.ts';
+import type { CodeProviderCatalog, CodeProviderId } from '../../src/code-mode/wire.ts';
+import type { RuntimeTurnOutcome } from '../../src/shared/runtime-contract.ts';
+
+const PROVIDER_IDS: readonly CodeProviderId[] = ['codex-app', 'claude', 'cursor', 'grok'];
+const MODEL = 'default';
+
+export interface FakeCodeProviderCounts {
+    opens: number;
+    sends: number;
+}
+
+export interface FakeCodeProviders {
+    providers: CodeProviders;
+    counts: FakeCodeProviderCounts;
+    /** Completes every held send. Tests that cancel/kill do not need this. */
+    release(): void;
+}
+
+function catalog(id: CodeProviderId): CodeProviderCatalog {
+    return {
+        id,
+        label: id,
+        available: true,
+        reason: null,
+        models: [MODEL],
+        defaultModel: MODEL,
+        defaultEffort: null,
+        modelSource: 'registry',
+        capabilities: {
+            resume: true,
+            interrupt: true,
+            permissions: true,
+            setModelMidSession: false,
+            efforts: ['low', 'high'],
+            permissionModes: ['ask', 'auto', 'read-only'],
+        },
+    };
+}
+
+type HoldResolver = (outcome: RuntimeTurnOutcome) => void;
+
+class FakeHandle implements CodeProviderSession {
+    readonly nativeSessionId: string;
+    alive = true;
+    closed = false;
+    private settled = false;
+    private hold: HoldResolver | null = null;
+    constructor(
+        private readonly options: CodeOpenOptions,
+        private readonly counts: FakeCodeProviderCounts,
+        private readonly holds: Set<FakeHandle>,
+        nativeSessionId: string,
+    ) {
+        this.nativeSessionId = nativeSessionId;
+    }
+
+    private finish(outcome: RuntimeTurnOutcome): void {
+        if (this.settled) return;
+        this.settled = true;
+        const resolve = this.hold;
+        this.hold = null;
+        this.holds.delete(this);
+        resolve?.(outcome);
+    }
+
+    release(): void {
+        this.finish({ status: 'done', finalText: 'held assistant text', partialText: 'held assistant text' });
+    }
+
+    async send(text: string): Promise<RuntimeTurnOutcome> {
+        this.counts.sends += 1;
+        const context = this.options.getTurnContext();
+        const observer = this.options.transcript(context);
+        if (text.includes('HOLD')) {
+            // Emit before returning a pending promise so the 50ms coalesce window
+            // can commit an assistant_message that sealAccepted can drain.
+            observer.text('message', 'answer', 'held assistant text', 'replace', 'commentary');
+            return await new Promise<RuntimeTurnOutcome>(resolve => {
+                this.hold = resolve;
+                this.holds.add(this);
+            });
+        }
+        observer.text('message', 'answer', 'completed assistant text', 'replace', 'final');
+        return { status: 'done', finalText: 'completed assistant text', partialText: '' };
+    }
+
+    cancel(): Promise<void> {
+        // Must not await a caller-owned gate: that hangs past the 180s stall watchdog.
+        this.finish({ status: 'stopped', finalText: null, partialText: 'held assistant text' });
+        return Promise.resolve();
+    }
+
+    close(): Promise<void> {
+        this.finish({ status: 'stopped', finalText: null, partialText: 'held assistant text' });
+        this.alive = false;
+        this.closed = true;
+        return Promise.resolve();
+    }
+}
+
+export function createFakeCodeProviders(): FakeCodeProviders {
+    const counts: FakeCodeProviderCounts = { opens: 0, sends: 0 };
+    const holds = new Set<FakeHandle>();
+    let nextNative = 0;
+    const providers = Object.fromEntries(PROVIDER_IDS.map(id => {
+        const provider: CodeProvider = {
+            id,
+            describe: () => catalog(id),
+            async open(options: CodeOpenOptions): Promise<CodeProviderSession> {
+                counts.opens += 1;
+                const handle = new FakeHandle(options, counts, holds, `fake-native-${id}-${++nextNative}`);
+                options.onResource(handle);
+                return handle;
+            },
+        };
+        return [id, provider];
+    })) as CodeProviders;
+    return {
+        providers,
+        counts,
+        release() {
+            for (const handle of [...holds]) handle.release();
+        },
+    };
+}
+
+export const FAKE_CODE_MODEL = MODEL;

--- a/tests/helpers/code-host-child.mts
+++ b/tests/helpers/code-host-child.mts
@@ -1,0 +1,69 @@
+/**
+ * Child Code host for crash-recovery tests.
+ *
+ * hostPort is the createCodeHost `port` OPTION (src/code-mode/host.ts): it
+ * only names `code-worker-<port>.sqlite`. The HTTP listener is a separate
+ * listen(0) port. Do not install a SIGTERM handler that disposes the host —
+ * the parent SIGKILLs this process mid-turn so the sqlite row stays
+ * `streaming` and the next owner's recover() can convert it to an orphan.
+ * A clean dispose() would settle the turn and the orphan would never happen
+ * (src/code-mode/session.ts dispose, src/code-mode/store.ts recoverInterrupted).
+ */
+import express, { type RequestHandler } from 'express';
+import { createCodeHost } from '../../src/code-mode/host.ts';
+import { createWorkerApiJsonParser } from '../../src/routes/code-body-parser.ts';
+import { registerNativeCodeRoutes } from '../../src/routes/code-native.ts';
+import { createFakeCodeProviders } from './code-fake-providers.mts';
+
+interface ChildConfig {
+    home: string;
+    hostPort: number;
+}
+
+function readConfig(): ChildConfig {
+    const fromArgv = process.argv[2];
+    const raw = fromArgv && fromArgv.startsWith('{')
+        ? fromArgv
+        : process.env['CODE_HOST_CHILD_CONFIG'];
+    if (!raw) throw new Error('code-host-child requires JSON config via argv or CODE_HOST_CHILD_CONFIG');
+    const parsed = JSON.parse(raw) as Partial<ChildConfig>;
+    if (typeof parsed.home !== 'string' || !parsed.home) throw new Error('code-host-child home is required');
+    if (!Number.isInteger(parsed.hostPort) || parsed.hostPort < 1 || parsed.hostPort > 65535) {
+        throw new Error('code-host-child hostPort must be a TCP port integer');
+    }
+    return { home: parsed.home, hostPort: parsed.hostPort };
+}
+
+const config = readConfig();
+const fake = createFakeCodeProviders();
+const host = createCodeHost({
+    home: config.home,
+    role: 'worker',
+    port: config.hostPort,
+    providers: fake.providers,
+    idleReapMs: 3_600_000,
+});
+
+const passThroughAuth: RequestHandler = (_req, _res, next) => next();
+const app = express();
+app.use(createWorkerApiJsonParser());
+registerNativeCodeRoutes(app, passThroughAuth, () => host.get(), '/api/code');
+
+/**
+ * Die the way a crashed owner dies: no dispose, no close, no chance to settle
+ * the live turn. The parent could send SIGKILL instead, but a signal has to
+ * find the right process and the pipes have to reach EOF before the parent can
+ * exit, and getting either wrong shows up as a stalled test file rather than as
+ * a leaked child. Ending the process from inside is the same crash with none of
+ * that ambiguity.
+ */
+app.post('/__crash', (_req, res) => {
+    res.json({ ok: true });
+    res.on('finish', () => setImmediate(() => process.exit(1)));
+});
+
+const server = app.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('code-host-child failed to bind HTTP');
+    process.stdout.write(JSON.stringify({ httpPort: address.port }) + '\n');
+});

--- a/tests/helpers/jaw-server.mts
+++ b/tests/helpers/jaw-server.mts
@@ -1,0 +1,189 @@
+/**
+ * Isolated product-server harness for integration crossings.
+ *
+ * The CI integration job owns one server on TEST_PORT, but that process runs
+ * with the runner's real home and an empty messaging.enabledChannels
+ * (src/core/config.ts), so it can answer read-only API smoke calls and nothing
+ * else. Any crossing that needs Slack running, a chosen agent runtime, or a
+ * fake binary on PATH has to own its server. compact-api-managed.test.ts and
+ * multi-instance.test.ts each hand-rolled that, and both skip when
+ * node_modules/.bin/tsx is missing — a skip that is silent under CI.
+ *
+ * This harness fixes both halves: one spawn path, and a dependency check that
+ * fails the run under CI instead of skipping (the api-smoke.test.ts rule).
+ */
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { resolveTsxSpawn } from '../../src/core/tsx-spawn.ts';
+
+export const PROJECT_ROOT = resolve(import.meta.dirname, '..', '..');
+const CLI_ENTRY = join(PROJECT_ROOT, 'bin', 'cli-jaw.ts');
+
+export function findFreePort(): Promise<number> {
+    return new Promise((ok, no) => {
+        const probe = createServer();
+        probe.once('error', no);
+        probe.listen(0, '127.0.0.1', () => {
+            const address = probe.address();
+            if (address === null || typeof address === 'string') { probe.close(); no(new Error('no port')); return; }
+            const port = address.port;
+            probe.close(() => ok(port));
+        });
+    });
+}
+
+/**
+ * tsx is a devDependency, so a checkout without node_modules cannot run this
+ * family at all. Locally that is a skip; under CI it is a broken job, because
+ * the integration job runs npm ci before the suite. Returning a sentinel and
+ * letting each caller decide is what produced the green skips #689 is about.
+ */
+export function requireHarness(t: { skip(reason: string): void }): boolean {
+    let usable = false;
+    try {
+        const spec = resolveTsxSpawn(PROJECT_ROOT, CLI_ENTRY, null);
+        usable = spec.command !== 'tsx';
+    } catch { usable = false; }
+    if (usable) return true;
+    if (process.env['CI']) {
+        assert.fail('tsx entry not resolvable under CI — the integration job runs npm ci, so this is a broken job, not a missing local tool');
+    }
+    t.skip('tsx is not installed; run npm ci to exercise the isolated-server crossings');
+    return false;
+}
+
+export type JawServer = {
+    child: ChildProcess;
+    port: number;
+    home: string;
+    base: string;
+    /** Everything the child wrote, for failure messages. */
+    output(): string;
+};
+
+export type StartOptions = {
+    home: string;
+    port: number;
+    settings: Record<string, unknown>;
+    env?: Record<string, string>;
+};
+
+/**
+ * Schema bookkeeping a settings fixture cannot omit.
+ *
+ * A document with no settingsSchemaVersion is treated as pre-v4, and the v3
+ * gateway migration REPLACES messaging.enabledChannels with the legacy scalar
+ * channel — which defaults to telegram (src/core/config.ts). A fixture that
+ * writes {messaging:{enabledChannels:['slack']}} and nothing else therefore
+ * boots a Telegram install and the Slack transport never starts.
+ *
+ * Declaring v4 in turn obliges the document to carry a valid multiSession block
+ * and the multiSessionDefaultMigration key (assertCurrentSchemaSessionShape);
+ * null is an accepted value for the latter, but the key must exist. Keeping
+ * this in one place means a schema bump is one edit, not one per test.
+ */
+export function withSettingsSchema(settings: Record<string, unknown>): Record<string, unknown> {
+    const multiSession = (settings['multiSession'] ?? {}) as Record<string, unknown>;
+    return {
+        settingsSchemaVersion: 4,
+        multiSessionDefaultMigration: null,
+        ...settings,
+        multiSession: { enabled: true, maxConcurrent: 4, ...multiSession },
+    };
+}
+
+export function startJawServer(options: StartOptions): JawServer {
+    mkdirSync(options.home, { recursive: true, mode: 0o700 });
+    writeFileSync(join(options.home, 'settings.json'), JSON.stringify(withSettingsSchema(options.settings), null, 2));
+    const spec = resolveTsxSpawn(PROJECT_ROOT, CLI_ENTRY, null);
+    const child = spawn(
+        spec.command,
+        [...spec.args, '--home', options.home, 'serve', '--port', String(options.port), '--no-open'],
+        {
+            cwd: PROJECT_ROOT,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, NO_COLOR: '1', ...(options.env ?? {}) },
+        },
+    );
+    // Captured, not discarded. graceful-shutdown collected stderr and threw it
+    // away, which is exactly why a failed boot there reads as an environment
+    // fact rather than a stack trace.
+    let log = '';
+    const keep = (chunk: Buffer) => { log += chunk.toString(); if (log.length > 64_000) log = log.slice(-64_000); };
+    child.stdout?.on('data', keep);
+    child.stderr?.on('data', keep);
+    return {
+        child,
+        port: options.port,
+        home: options.home,
+        base: 'http://127.0.0.1:' + options.port,
+        output: () => log,
+    };
+}
+
+/**
+ * 500ms, not a tight loop: the server rate-limits an unauthenticated loopback
+ * caller by path class (src/core/rate-limit.ts), and a readiness probe that
+ * trips that limiter reports "not ready" for a server that is perfectly fine.
+ */
+async function poll(server: JawServer, what: string, probe: () => Promise<boolean>, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (server.child.exitCode !== null) {
+            throw new Error('server exited with ' + server.child.exitCode + ' while waiting for ' + what + '\n' + server.output());
+        }
+        try { if (await probe()) return; } catch { /* not up yet */ }
+        await new Promise(r => setTimeout(r, 500));
+    }
+    throw new Error('timed out after ' + timeoutMs + 'ms waiting for ' + what + '\n' + server.output());
+}
+
+export async function waitForServer(server: JawServer, timeoutMs = 45_000): Promise<void> {
+    await poll(server, 'GET /api/session', async () => {
+        const res = await fetch(server.base + '/api/session', { signal: AbortSignal.timeout(2000) });
+        return res.ok;
+    }, timeoutMs);
+}
+
+/**
+ * /api/session answering 200 does NOT mean an inbound channel is live: routes
+ * are registered before listen, and initEnabledMessagingRuntimes() runs inside
+ * the listen callback (server.ts). Channel health is the observable that moves
+ * when a transport actually starts (src/messaging/channel-health.ts).
+ *
+ * "running" still only means init returned started — a transport whose socket
+ * has not reached connected is reported as running. Callers that inject inbound
+ * traffic must also retry until the product acknowledges it.
+ */
+export async function waitForInboundChannel(server: JawServer, channel: string, timeoutMs = 45_000): Promise<void> {
+    await poll(server, 'channel ' + channel + ' in /api/health activeInboundChannels', async () => {
+        const res = await fetch(server.base + '/api/health', { signal: AbortSignal.timeout(2000) });
+        if (!res.ok) return false;
+        const body = await res.json() as { channels?: { activeInboundChannels?: unknown } };
+        const running = body.channels?.activeInboundChannels;
+        return Array.isArray(running) && running.includes(channel);
+    }, timeoutMs);
+}
+
+export async function stopJawServer(server: JawServer): Promise<void> {
+    const child = server.child;
+    if (child.exitCode === null && !child.killed) {
+        child.kill('SIGTERM');
+        await new Promise<void>(done => {
+            const hard = setTimeout(() => { if (child.exitCode === null) child.kill('SIGKILL'); done(); }, 2500);
+            child.once('exit', () => { clearTimeout(hard); done(); });
+        });
+    }
+    rmSync(server.home, { recursive: true, force: true });
+}
+
+export async function api(server: JawServer, path: string, init?: RequestInit): Promise<Response> {
+    return fetch(server.base + path, {
+        ...init,
+        headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+        signal: AbortSignal.timeout(15_000),
+    });
+}

--- a/tests/helpers/jaw-server.mts
+++ b/tests/helpers/jaw-server.mts
@@ -15,7 +15,7 @@
 import assert from 'node:assert/strict';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createServer } from 'node:net';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { resolveTsxSpawn } from '../../src/core/tsx-spawn.ts';
 
@@ -81,17 +81,24 @@ export type StartOptions = {
  * boots a Telegram install and the Slack transport never starts.
  *
  * Declaring v4 in turn obliges the document to carry a valid multiSession block
- * and the multiSessionDefaultMigration key (assertCurrentSchemaSessionShape);
- * null is an accepted value for the latter, but the key must exist. Keeping
- * this in one place means a schema bump is one edit, not one per test.
+ * and the multiSessionDefaultMigration key (assertCurrentSchemaSessionShape),
+ * AND a valid messaging gateway block (assertCurrentSchemaMessagingShape). Miss
+ * any of them and loadSettings throws, latches persistence, and serves LEGACY
+ * defaults instead — multiSession off, one lane — while the server still boots
+ * and answers every request. That failure is invisible unless something looks
+ * for it, which is what assertSettingsAccepted below is for.
+ *
+ * Keeping this in one place means a schema bump is one edit, not one per test.
  */
 export function withSettingsSchema(settings: Record<string, unknown>): Record<string, unknown> {
     const multiSession = (settings['multiSession'] ?? {}) as Record<string, unknown>;
+    const messaging = (settings['messaging'] ?? {}) as Record<string, unknown>;
     return {
         settingsSchemaVersion: 4,
         multiSessionDefaultMigration: null,
         ...settings,
         multiSession: { enabled: true, maxConcurrent: 4, ...multiSession },
+        messaging: { enabledChannels: [], homeChannel: 'telegram', ...messaging },
     };
 }
 
@@ -146,6 +153,25 @@ export async function waitForServer(server: JawServer, timeoutMs = 45_000): Prom
         const res = await fetch(server.base + '/api/session', { signal: AbortSignal.timeout(2000) });
         return res.ok;
     }, timeoutMs);
+    assertSettingsAccepted(server);
+}
+
+/**
+ * A rejected settings document does not stop the boot. loadSettings copies the
+ * file to settings.json.corrupt-<ts>.bak, latches persistence and carries on
+ * with legacy defaults, so a fixture that gets its schema wrong yields a server
+ * that runs with settings nobody asked for — one lane instead of four, an
+ * inbound channel that never starts — and every assertion downstream measures
+ * the wrong thing. The backup file is the cheapest honest signal that happened.
+ */
+export function assertSettingsAccepted(server: JawServer): void {
+    const rejected = readdirSync(server.home).filter(name => name.includes('settings.json.corrupt-'));
+    if (rejected.length === 0) return;
+    throw new Error(
+        'the server rejected the fixture settings and fell back to defaults (' + rejected.join(', ') + ').\n'
+        + 'A v4 document must carry multiSession, multiSessionDefaultMigration and messaging; see withSettingsSchema.\n'
+        + server.output(),
+    );
 }
 
 /**

--- a/tests/helpers/slack-api-preload.mjs
+++ b/tests/helpers/slack-api-preload.mjs
@@ -1,0 +1,40 @@
+/**
+ * Redirects a server child's Slack traffic at a local fixture.
+ *
+ * Seam: src/slack/api.ts hardcodes SLACK_API_BASE and resolves a BARE fetch at
+ * call time (options.fetchImpl || fetch), and initSlack constructs
+ * SlackSocketClient without fetchImpl or socketFactory. So inside a spawned
+ * server there is exactly one interception point — globalThis.fetch — and no
+ * product change is needed to use it. Registered with
+ * NODE_OPTIONS=--import <this file>, which bin/commands/serve.ts forwards to the
+ * real server process because it spreads ...process.env.
+ *
+ * Two rewrites:
+ *   1. the Slack Web API base -> JAW_TEST_SLACK_API_BASE (must end in '/', or
+ *      'auth.test' concatenates into '.../apiauth.test');
+ *   2. https on loopback -> http. src/slack/slack-file.ts REJECTS any
+ *      upload_url whose protocol is not https:, so the fixture hands back an
+ *      https loopback URL to satisfy that validation and the request is
+ *      downgraded here. No TLS, no certificate, no product edit.
+ *
+ * Everything else is delegated untouched, so the server's own HTTP still works.
+ */
+const SLACK_BASE = 'https://slack.com/api/';
+const fixture = process.env['JAW_TEST_SLACK_API_BASE'] ?? '';
+const inner = globalThis.fetch;
+
+function rewrite(url) {
+    if (fixture && url.startsWith(SLACK_BASE)) return fixture + url.slice(SLACK_BASE.length);
+    if (url.startsWith('https://127.0.0.1:')) return 'http://' + url.slice('https://'.length);
+    return url;
+}
+
+globalThis.fetch = function patchedFetch(input, init) {
+    if (typeof input === 'string') return inner(rewrite(input), init);
+    if (input instanceof URL) return inner(rewrite(input.toString()), init);
+    if (input && typeof input === 'object' && typeof input.url === 'string') {
+        const target = rewrite(input.url);
+        if (target !== input.url) return inner(new Request(target, input), init);
+    }
+    return inner(input, init);
+};

--- a/tests/helpers/slack-fixture.mts
+++ b/tests/helpers/slack-fixture.mts
@@ -1,0 +1,173 @@
+/**
+ * A scripted Slack in the test process: Web API over HTTP plus Socket Mode over
+ * a real websocket.
+ *
+ * Why a websocket at all: Slack inbound is Socket Mode only — there is no events
+ * HTTP route — so a crossing that starts at a real envelope has to speak it.
+ * apps.connections.open hands the client its socket URL (src/slack/socket.ts),
+ * so returning a loopback ws:// URL is enough and the product's own global
+ * WebSocket connects here. Nothing about the client is stubbed.
+ *
+ * The default response for an unscripted method is ok:true, so an identity or
+ * auto-join probe can never hang a boot on a method this fixture forgot.
+ */
+import { createServer, type Server } from 'node:http';
+import { WebSocketServer, type WebSocket } from 'ws';
+
+export type SlackCall = { method: string; body: Record<string, unknown>; at: number };
+
+export type SlackFixture = {
+    apiBase: string;
+    httpPort: number;
+    wsPort: number;
+    calls: SlackCall[];
+    callsOf(method: string): SlackCall[];
+    waitForCall(method: string, predicate?: (call: SlackCall) => boolean, timeoutMs?: number): Promise<SlackCall>;
+    emitUntilAcked(envelope: Record<string, unknown>, timeoutMs?: number): Promise<void>;
+    acked: Set<string>;
+    close(): Promise<void>;
+};
+
+const BOT_USER = 'UBOT';
+const TEAM = 'T1';
+
+export async function startSlackFixture(): Promise<SlackFixture> {
+    const calls: SlackCall[] = [];
+    const acked = new Set<string>();
+    const sockets = new Set<WebSocket>();
+    // Per-fixture, not module state: two fixtures in one file would otherwise
+    // hand each other's port to files.getUploadURLExternal.
+    let ownPort = 0;
+
+    const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await new Promise<void>(ok => wss.once('listening', ok));
+    const wsPort = (wss.address() as { port: number }).port;
+
+    wss.on('connection', socket => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+        socket.on('message', raw => {
+            try {
+                const frame = JSON.parse(String(raw)) as { envelope_id?: string };
+                if (typeof frame.envelope_id === 'string') acked.add(frame.envelope_id);
+            } catch { /* the product only ever sends JSON acks */ }
+        });
+        // hello is the ONLY frame that moves the client to 'connected'
+        // (src/slack/socket.ts). Everything received before that is dropped
+        // un-acked, so a fixture that skips hello makes every emitted envelope
+        // disappear. Sent on every accept, reconnects included.
+        socket.send(JSON.stringify({ type: 'hello' }));
+    });
+
+    let http: Server | undefined;
+    const httpPort = await new Promise<number>((ok, no) => {
+        http = createServer((req, res) => {
+            const chunks: Buffer[] = [];
+            req.on('data', c => chunks.push(c as Buffer));
+            req.on('end', () => {
+                const path = (req.url ?? '').split('?')[0] ?? '';
+                const raw = Buffer.concat(chunks).toString('utf8');
+                // A file upload is multipart to the upload URL, not a Web API
+                // call; record it by path and answer with the plain-text OK the
+                // real upload endpoint returns.
+                if (path.startsWith('/upload/')) {
+                    calls.push({ method: 'upload', body: { path, bytes: raw.length }, at: Date.now() });
+                    res.writeHead(200, { 'Content-Type': 'text/plain' });
+                    res.end('OK - file_uploaded');
+                    return;
+                }
+                const method = path.replace(/^\/api\//, '');
+                let body: Record<string, unknown> = {};
+                if (raw) {
+                    try { body = JSON.parse(raw) as Record<string, unknown>; }
+                    catch { body = Object.fromEntries(new URLSearchParams(raw)); }
+                }
+                calls.push({ method, body, at: Date.now() });
+                res.writeHead(200, { 'Content-Type': 'application/json', 'x-oauth-scopes': SCOPES });
+                res.end(JSON.stringify(reply(method, body, ownPort, wsPort)));
+            });
+        });
+        http.on('error', no);
+        http.listen(0, '127.0.0.1', () => ok((http!.address() as { port: number }).port));
+    });
+    ownPort = httpPort;
+
+    async function waitForCall(method: string, predicate?: (call: SlackCall) => boolean, timeoutMs = 30_000): Promise<SlackCall> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const hit = calls.find(c => c.method === method && (predicate === undefined || predicate(c)));
+            if (hit) return hit;
+            await new Promise(r => setTimeout(r, 60));
+        }
+        const seen = [...new Set(calls.map(c => c.method))].join(', ') || 'none';
+        throw new Error('no ' + method + ' call within ' + timeoutMs + 'ms; methods seen: ' + seen);
+    }
+
+    /**
+     * Slack redelivers an envelope that was not acked, and the client drops
+     * frames received before it is connected, so retrying the same envelope_id
+     * is both the product's contract and the only way to close the race between
+     * "transport running" and "socket connected". A redelivery that arrives
+     * after the work is done is acked and dropped by the client's own duplicate
+     * guard, so this cannot double-spawn.
+     */
+    async function emitUntilAcked(envelope: Record<string, unknown>, timeoutMs = 30_000): Promise<void> {
+        const id = String(envelope['envelope_id']);
+        const deadline = Date.now() + timeoutMs;
+        let nextSend = 0;
+        while (Date.now() < deadline) {
+            if (acked.has(id)) return;
+            // Redelivery is spaced like Slack's own, not tight. The client's
+            // duplicate guard is only consulted once the frame reaches
+            // handleFrame, and the work it guards is async, so hammering the
+            // same envelope races the guard instead of testing it.
+            if (Date.now() >= nextSend) {
+                for (const socket of sockets) {
+                    if (socket.readyState === 1) socket.send(JSON.stringify(envelope));
+                }
+                nextSend = Date.now() + 3_000;
+            }
+            await new Promise(r => setTimeout(r, 100));
+        }
+        throw new Error('envelope ' + id + ' was never acked within ' + timeoutMs + 'ms (sockets: ' + sockets.size + ')');
+    }
+
+    return {
+        apiBase: 'http://127.0.0.1:' + httpPort + '/api/',
+        httpPort,
+        wsPort,
+        calls,
+        callsOf: (method: string) => calls.filter(c => c.method === method),
+        waitForCall,
+        emitUntilAcked,
+        acked,
+        async close() {
+            for (const socket of sockets) { try { socket.close(); } catch { /* closing */ } }
+            await new Promise<void>(ok => wss.close(() => ok()));
+            await new Promise<void>(ok => http?.close(() => ok()));
+        },
+    };
+}
+
+const SCOPES = 'app_mentions:read,channels:history,chat:write,files:write,reactions:write,users:read';
+
+function reply(method: string, body: Record<string, unknown>, httpPort: number, wsPort: number): Record<string, unknown> {
+    switch (method) {
+        case 'auth.test':
+            return { ok: true, user_id: BOT_USER, bot_id: 'B1', team_id: TEAM, team: 'fixture', url: 'https://fixture.slack.com/' };
+        case 'apps.connections.open':
+            return { ok: true, url: 'ws://127.0.0.1:' + wsPort + '/' };
+        case 'chat.postMessage':
+            return { ok: true, channel: body['channel'] ?? 'C1', ts: (Date.now() / 1000).toFixed(6), message: { text: body['text'] ?? '' } };
+        case 'users.info':
+            return { ok: true, user: { id: body['user'] ?? 'U1', name: 'fixture-user', real_name: 'Fixture User', profile: { display_name: 'fixture' } } };
+        case 'files.getUploadURLExternal':
+            // https on purpose: src/slack/slack-file.ts rejects a non-https
+            // upload_url, and the preload downgrades this to the local listener.
+            return { ok: true, upload_url: 'https://127.0.0.1:' + httpPort + '/upload/u1', file_id: 'F1' };
+        case 'files.completeUploadExternal':
+            return { ok: true, files: [{ id: 'F1', title: 'fixture' }] };
+        default:
+            return { ok: true };
+    }
+}

--- a/tests/integration/agent-lifecycle-real-child.test.ts
+++ b/tests/integration/agent-lifecycle-real-child.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Agent lifecycle against REAL child processes (#688).
+ *
+ * tests/integration/multi-session-concurrency.test.ts stays as it is: it proves
+ * the lane bookkeeping in-process. What it cannot prove, and says so in its own
+ * comments, is the part that has an operating system in it. Its fakeChild is an
+ * EventEmitter with an injected terminateTree, so killProcessTree never runs
+ * (src/agent/spawn/process-kill.ts short-circuits a pid-less child), no signal
+ * is ever delivered, and a restart is never attempted.
+ *
+ * This file drives the same contract over HTTP against a booted server with two
+ * live children: stop one scope, and the other keeps running; then start the
+ * stopped scope again.
+ *
+ * Observation is the stub's own pid record, not an HTTP snapshot: spawn.ts
+ * deletes the map entry before the operating system has reaped anything, so
+ * /api/runtime can report a scope as free while its process is still alive.
+ * A pid is the fact; the map is an opinion.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    PROJECT_ROOT, api, findFreePort, requireHarness, startJawServer,
+    stopJawServer, waitForServer, type JawServer,
+} from '../helpers/jaw-server.mts';
+
+type StubRecord = { pid: number; prompt: string; terminatedAt?: string; signal?: string };
+
+function records(dir: string): StubRecord[] {
+    return readdirSync(dir)
+        .filter(name => name.endsWith('.json'))
+        .map(name => JSON.parse(readFileSync(join(dir, name), 'utf8')) as StubRecord);
+}
+
+function recordFor(dir: string, token: string): StubRecord | undefined {
+    return records(dir).find(entry => entry.prompt.includes('STUB_MODI:hold:' + token)
+        || entry.prompt.includes('STUB_MODI:echo:' + token));
+}
+
+function alive(pid: number): boolean {
+    try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function until(what: string, probe: () => boolean, timeoutMs = 60_000, detail?: () => string): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (probe()) return;
+        await new Promise(r => setTimeout(r, 100));
+    }
+    throw new Error('timed out after ' + timeoutMs + 'ms waiting for ' + what + (detail ? '\n' + detail() : ''));
+}
+
+test('AGENT-INT: a scoped stop kills one live child and leaves the other running', { timeout: 170_000 }, async t => {
+    if (!requireHarness(t)) return;
+
+    const home = mkdtempSync(join(tmpdir(), 'jaw-agent-int-'));
+    const workspace = mkdtempSync(join(tmpdir(), 'jaw-agent-ws-'));
+    const stubDir = mkdtempSync(join(tmpdir(), 'jaw-agent-stub-'));
+    const binDir = join(stubDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    symlinkSync(join(PROJECT_ROOT, 'tests', 'fixtures', 'print-agent-stub.mjs'), join(binDir, 'claude'));
+
+    const port = await findFreePort();
+    const server: JawServer = startJawServer({
+        home, port,
+        settings: {
+            cli: 'claude',
+            permissions: 'auto',
+            workingDir: workspace,
+            // Two scopes have to be able to run at once, or the second prompt
+            // queues behind the first and there is never a pair of live pids.
+            multiSession: { enabled: true, maxConcurrent: 4, midRunPolicy: 'steer' },
+        },
+        env: {
+            PATH: binDir + ':' + (process.env['PATH'] ?? ''),
+            HOME: home,
+            JAW_STUB_DIR: stubDir,
+        },
+    });
+
+    t.after(async () => { await stopJawServer(server); });
+    await waitForServer(server);
+
+    // Read the body ONCE. An assertion message that awaits res.text() is
+    // evaluated even when the assertion passes, which consumes the stream and
+    // turns the next res.json() into "Body is unusable".
+    async function call(path: string, body: unknown): Promise<{ status: number; text: string; json: Record<string, any> }> {
+        const res = await api(server, path, { method: 'POST', body: JSON.stringify(body) });
+        const text = await res.text();
+        let parsed: Record<string, any> = {};
+        try { parsed = JSON.parse(text) as Record<string, any>; } catch { /* reported through text */ }
+        return { status: res.status, text, json: parsed };
+    }
+
+    const created = await call('/api/chat-sessions', { label: 'lane-b' });
+    assert.equal(created.status, 200, 'could not create a second chat session: ' + created.text);
+    const sessionB = created.json['data']?.id as string | undefined;
+    assert.ok(sessionB, 'no session id in ' + created.text);
+
+    // BOTH sends name their session. Creating a session also makes it active, so
+    // an unqualified send follows the new one and the two prompts end up in a
+    // single scope — where the second is queued behind the first and there is
+    // never a second live child to prove anything about.
+    const listed = await api(server, '/api/chat-sessions');
+    const listedBody = await listed.json() as { data?: { sessions?: { id: string }[] } };
+    const sessionA = listedBody.data?.sessions?.map(s => s.id).find(id => id !== sessionB);
+    assert.ok(sessionA, 'no first session in ' + JSON.stringify(listedBody));
+    assert.notEqual(sessionA, sessionB);
+
+    const send = (prompt: string, sessionId?: string) =>
+        call('/api/message', { prompt, ...(sessionId ? { sessionId } : {}) });
+
+    await t.test('AGENT-INT-001 stopping one scope leaves the other alive', async () => {
+        const a = await send('lane a please wait STUB_MODI:hold:laneA', sessionA);
+        assert.equal(a.status, 200, 'lane A send failed: ' + a.text);
+        assert.notEqual(a.json['action'], 'queued', 'lane A was queued: ' + a.text);
+        const b = await send('lane b please wait STUB_MODI:hold:laneB', sessionB);
+        assert.equal(b.status, 200, 'lane B send failed: ' + b.text);
+        assert.notEqual(b.json['action'], 'queued', 'lane B queued behind lane A instead of running beside it: ' + b.text);
+
+        await until('both held children to report a pid',
+            () => recordFor(stubDir, 'laneA') !== undefined && recordFor(stubDir, 'laneB') !== undefined,
+            60_000, () => 'created session: ' + created.text
+                + '\nsend A: ' + a.text
+                + '\nsend B: ' + b.text
+                + '\nrecords: ' + JSON.stringify(records(stubDir).map(r => ({ pid: r.pid, prompt: r.prompt.slice(-120) })))
+                + '\nserver: ' + server.output().slice(-1500));
+
+        const pidA = recordFor(stubDir, 'laneA')!.pid;
+        const pidB = recordFor(stubDir, 'laneB')!.pid;
+        assert.notEqual(pidA, pidB, 'the two lanes must be different processes');
+        assert.ok(alive(pidA) && alive(pidB), 'both children should be running before the stop');
+
+        const stopped = await call('/api/stop', { sessionId: sessionA });
+        assert.equal(stopped.status, 200, 'stop failed: ' + stopped.text);
+
+        // Polled, not read once: the kill is SIGTERM with SIGKILL escalating
+        // after a couple of seconds, so the pid can legitimately still be alive
+        // the instant the HTTP call returns.
+        await until('lane A to die', () => !alive(pidA), 30_000,
+            () => 'lane A record: ' + JSON.stringify(recordFor(stubDir, 'laneA')));
+        // B is checked across that whole window, which is the stronger claim:
+        // a kill that took the wrong scope with it would have shown up by now.
+        assert.ok(alive(pidB), 'lane B was killed by a stop aimed at the default scope');
+
+        const killed = recordFor(stubDir, 'laneA');
+        assert.equal(killed?.signal, 'SIGTERM', 'lane A should have received a real signal, not merely vanished');
+    });
+
+    await t.test('AGENT-INT-002 the stopped scope can start a new child', async () => {
+        const before = recordFor(stubDir, 'laneA')!.pid;
+        const pidB = recordFor(stubDir, 'laneB')!.pid;
+        // Different text on purpose: the gateway drops an identical
+        // (scope, origin, text, chat, thread) inside a 5s window as a duplicate,
+        // and a restart that was silently deduped looks exactly like a restart
+        // that silently failed.
+        const again = await send('lane a restarted STUB_MODI:echo:laneA2', sessionA);
+        assert.equal(again.status, 200, 'restart send failed: ' + again.text);
+
+        await until('a fresh lane A child', () => recordFor(stubDir, 'laneA2') !== undefined, 60_000,
+            () => server.output().slice(-2000));
+        assert.notEqual(recordFor(stubDir, 'laneA2')!.pid, before, 'the restart reused the killed pid');
+        assert.equal(recordFor(stubDir, 'laneB')!.pid, pidB, 'lane B was restarted by someone else');
+    });
+});

--- a/tests/integration/api-smoke.test.ts
+++ b/tests/integration/api-smoke.test.ts
@@ -108,4 +108,26 @@ test('API Smoke Tests', async (t) => {
         });
         assert.ok([400, 401, 403].includes(res.status), `expected rejection, got ${res.status}`);
     });
+
+    // The Code surface had no integration coverage at all: the unit tests mount
+    // the routes over a fake service, and the workbench test needs a browser and
+    // a built Manager, so neither runs on the PR admission path. These two are
+    // the cheapest real HTTP calls that prove the router is mounted and the host
+    // answers on a server the CI job actually started.
+    await t.test('SMOKE-013: GET /api/code/models → 200 + provider catalog', async () => {
+        const res = await fetch(`${BASE}/api/code/models`);
+        assert.equal(res.status, 200);
+        const data = await res.json();
+        assert.equal(data.ok, true);
+        assert.ok(data.providers, 'no provider catalog in the response');
+        assert.equal(typeof data.defaultProvider, 'string');
+    });
+
+    await t.test('SMOKE-014: GET /api/code/sessions → 200 + paged list', async () => {
+        const res = await fetch(`${BASE}/api/code/sessions?scope=all&limit=1`);
+        assert.equal(res.status, 200);
+        const data = await res.json();
+        assert.equal(data.ok, true);
+        assert.ok(Array.isArray(data.sessions), 'sessions should be an array');
+    });
 });

--- a/tests/integration/code-native-api.test.ts
+++ b/tests/integration/code-native-api.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Real HTTP against real native Code routes over a real store.
+ *
+ * Routes are mounted ONCE. The service getter is a closure over a mutable
+ * `let host` because registerNativeCodeRoutes does app.use(prefix, router)
+ * per call and stacking routers would mix owners (src/routes/code-native.ts).
+ */
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import express, { type RequestHandler } from 'express';
+import type { Server } from 'node:http';
+import { createCodeHost } from '../../src/code-mode/host.ts';
+import { createWorkerApiJsonParser } from '../../src/routes/code-body-parser.ts';
+import { registerNativeCodeRoutes } from '../../src/routes/code-native.ts';
+import { createFakeCodeProviders, FAKE_CODE_MODEL } from '../helpers/code-fake-providers.mts';
+
+const PROJECT_ROOT = resolve(import.meta.dirname, '../..');
+const CHILD_ENTRY = join(PROJECT_ROOT, 'tests/helpers/code-host-child.mts');
+
+type Json = Record<string, unknown>;
+type Host = ReturnType<typeof createCodeHost>;
+
+const passThroughAuth: RequestHandler = (_req, _res, next) => next();
+
+function sqlitePath(home: string, hostPort: number): string {
+    return join(home, 'code-worker-' + hostPort + '.sqlite');
+}
+
+async function request(url: string, method = 'GET', body?: unknown, timeoutMs = 15_000): Promise<{ status: number; json: Json }> {
+    const response = await fetch(url, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { status: response.status, json: await response.json() as Json };
+}
+
+async function pollSnapshot(url: string, predicate: (body: Json) => boolean, timeoutMs = 8_000): Promise<Json> {
+    const deadline = Date.now() + timeoutMs;
+    let last: Json | undefined;
+    while (Date.now() < deadline) {
+        const response = await request(url);
+        assert.equal(response.status, 200);
+        last = response.json;
+        if (predicate(last)) return last;
+        await delay(40);
+    }
+    throw new Error('timed out waiting for snapshot: ' + JSON.stringify(last));
+}
+
+async function waitForStreaming(url: string): Promise<Json> {
+    return pollSnapshot(url, body => (body['session'] as Json | undefined)?.['status'] === 'streaming');
+}
+
+function createBody(cwd: string) {
+    return {
+        provider: 'codex-app' as const,
+        cwd,
+        model: FAKE_CODE_MODEL,
+        effort: null,
+        permissionMode: 'ask' as const,
+    };
+}
+
+async function spawnChild(home: string, hostPort: number): Promise<{ child: ChildProcess; httpPort: number; output(): string; kill(): Promise<void> }> {
+    // --import tsx, NOT the tsx CLI. The CLI runs the entry in a grandchild, and
+    // killing the wrapper leaves that grandchild alive holding the write end of
+    // these pipes: the reads never reach EOF, this process cannot exit, and the
+    // driver reports it 180s later as a stalled file rather than a leaked child.
+    // The loader form keeps everything in the process we actually kill.
+    const child = spawn(process.execPath, ['--import', 'tsx', CHILD_ENTRY, JSON.stringify({ home, hostPort })], {
+        cwd: PROJECT_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, NO_COLOR: '1' },
+    });
+    let log = '';
+    const keep = (chunk: Buffer) => {
+        log += chunk.toString();
+        if (log.length > 64_000) log = log.slice(-64_000);
+    };
+    child.stdout?.on('data', keep);
+    child.stderr?.on('data', keep);
+    const kill = async (): Promise<void> => {
+        if (child.exitCode === null) {
+            child.kill('SIGKILL');
+            await once(child, 'exit');
+        }
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+    };
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+        if (child.exitCode !== null) throw new Error('code-host-child exited ' + String(child.exitCode) + '\n' + log);
+        const line = log.split('\n').find(entry => entry.trim().startsWith('{'));
+        if (line) {
+            const parsed = JSON.parse(line) as { httpPort?: number };
+            assert.equal(typeof parsed.httpPort, 'number');
+            return { child, httpPort: parsed.httpPort as number, output: () => log, kill };
+        }
+        await delay(40);
+    }
+    await kill();
+    throw new Error('timed out waiting for code-host-child httpPort\n' + log);
+}
+
+describe('code native HTTP', { concurrency: false }, () => {
+    let host: Host | undefined;
+    let server: Server;
+    let base = '';
+    const homes: string[] = [];
+
+    before(async () => {
+        const app = express();
+        app.use(createWorkerApiJsonParser());
+        registerNativeCodeRoutes(app, passThroughAuth, () => {
+            if (!host) throw new Error('Code host is not assigned');
+            return host.get();
+        }, '/api/code');
+        server = app.listen(0, '127.0.0.1');
+        await once(server, 'listening');
+        const address = server.address();
+        assert.ok(address && typeof address === 'object');
+        base = 'http://127.0.0.1:' + String(address.port);
+    });
+
+    after(async () => {
+        await new Promise<void>(done => {
+            // Close live keep-alive sockets first; server.close() only stops new
+            // connections and would otherwise wait on the open ones.
+            server.closeAllConnections?.();
+            server.close(() => done());
+        });
+        await host?.dispose().catch(() => undefined);
+        for (const home of homes) rmSync(home, { recursive: true, force: true });
+    });
+
+    function tempHome(): string {
+        const home = mkdtempSync(join(tmpdir(), 'code-native-api-'));
+        homes.push(home);
+        return home;
+    }
+
+    async function assignHost(home: string, hostPort: number, providers = createFakeCodeProviders().providers): Promise<Host> {
+        const previous = host;
+        host = createCodeHost({
+            home,
+            role: 'worker',
+            port: hostPort,
+            providers,
+            idleReapMs: 3_600_000,
+        });
+        await previous?.dispose().catch(() => undefined);
+        return host;
+    }
+
+    let recovered: {
+        sessionId: string;
+        turnId: string;
+        prompt: { text: string; clientTurnKey: string };
+    } | undefined;
+
+    test('CODE-INT-001 create', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        const hostPort = 19_088;
+        const db = sqlitePath(home, hostPort);
+        await assignHost(home, hostPort);
+        assert.equal(existsSync(db), false);
+        const created = await request(base + '/api/code/sessions', 'POST', createBody(cwd));
+        assert.equal(created.status, 201);
+        assert.equal((created.json['session'] as Json)['cwd'], cwd);
+        assert.ok(existsSync(db));
+    });
+
+    test('CODE-INT-002 prompt + duplicate', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        await assignHost(home, 19_088);
+        const created = await request(base + '/api/code/sessions', 'POST', createBody(cwd));
+        const sessionId = (created.json['session'] as Json)['sessionId'] as string;
+        const prompt = { text: 'hello world', clientTurnKey: 'k1' };
+        const first = await request(base + '/api/code/sessions/' + sessionId + '/prompt', 'POST', prompt);
+        assert.equal(first.status, 202);
+        assert.equal(first.json['status'], 'accepted');
+        const second = await request(base + '/api/code/sessions/' + sessionId + '/prompt', 'POST', prompt);
+        assert.equal(second.status, 200);
+        assert.equal(second.json['turnId'], first.json['turnId']);
+    });
+
+    test('CODE-INT-003 snapshot', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        await assignHost(home, 19_088);
+        const created = await request(base + '/api/code/sessions', 'POST', createBody(cwd));
+        const sessionId = (created.json['session'] as Json)['sessionId'] as string;
+        const prompt = { text: 'persist this user message', clientTurnKey: 'k-snapshot' };
+        const admitted = await request(base + '/api/code/sessions/' + sessionId + '/prompt', 'POST', prompt);
+        assert.equal(admitted.status, 202);
+        const early = await request(base + '/api/code/sessions/' + sessionId);
+        const earlyItems = early.json['items'] as Array<Json>;
+        assert.ok(earlyItems.some(item => item['kind'] === 'user_message' && item['text'] === prompt.text));
+        const snapshot = await pollSnapshot(base + '/api/code/sessions/' + sessionId, body => {
+            const items = body['items'] as Array<Json>;
+            return items.some(item => item['kind'] === 'assistant_message');
+        });
+        const items = snapshot['items'] as Array<Json>;
+        assert.ok(items.some(item => item['kind'] === 'user_message' && item['text'] === prompt.text));
+        assert.ok(items.some(item => item['kind'] === 'assistant_message'));
+    });
+
+    test('CODE-INT-004 cancel', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        await assignHost(home, 19_088);
+        const created = await request(base + '/api/code/sessions', 'POST', createBody(cwd));
+        const sessionId = (created.json['session'] as Json)['sessionId'] as string;
+        const admitted = await request(base + '/api/code/sessions/' + sessionId + '/prompt', 'POST', {
+            text: 'please HOLD this turn', clientTurnKey: 'k-hold',
+        });
+        assert.equal(admitted.status, 202);
+        const live = await waitForStreaming(base + '/api/code/sessions/' + sessionId);
+        const started = Date.now();
+        const cancelled = await request(base + '/api/code/sessions/' + sessionId + '/cancel', 'POST', {
+            turnId: admitted.json['turnId'],
+            epoch: (live['session'] as Json)['epoch'],
+        }, 2_000);
+        assert.ok(Date.now() - started < 2_000);
+        assert.equal(cancelled.status, 200);
+        assert.equal(cancelled.json['ok'], true);
+        const after = await request(base + '/api/code/sessions/' + sessionId);
+        // Cancel returns after op.work, so the snapshot has already left streaming.
+        assert.notEqual((after.json['session'] as Json)['status'], 'streaming');
+    });
+
+    test('CODE-INT-005 negative contract', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        await assignHost(home, 19_088);
+        const relative = await request(base + '/api/code/sessions', 'POST', { ...createBody(cwd), cwd: 'relative' });
+        assert.equal(relative.status, 400);
+        assert.equal(relative.json['error'], 'absolute_cwd_required');
+        const unknown = await request(base + '/api/code/sessions', 'POST', { ...createBody(cwd), extra: true });
+        assert.equal(unknown.status, 400);
+        assert.equal(unknown.json['error'], 'unknown_field');
+        const retired = await request(base + '/api/code/sessions/stored');
+        assert.equal(retired.status, 410);
+        assert.equal(retired.json['error'], 'code_endpoint_retired');
+    });
+
+    test('CODE-INT-006 restart hydration', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        const hostPort = 19_101;
+        const child = await spawnChild(home, hostPort);
+        try {
+            const childBase = 'http://127.0.0.1:' + String(child.httpPort);
+            const created = await request(childBase + '/api/code/sessions', 'POST', createBody(cwd));
+            assert.equal(created.status, 201);
+            const sessionId = (created.json['session'] as Json)['sessionId'] as string;
+            const prompt = { text: 'HOLD across crash', clientTurnKey: 'k-crash' };
+            const admitted = await request(childBase + '/api/code/sessions/' + sessionId + '/prompt', 'POST', prompt);
+            assert.equal(admitted.status, 202);
+            await waitForStreaming(childBase + '/api/code/sessions/' + sessionId);
+            // Crash the owner mid-turn: no dispose, so the row stays 'streaming'
+            // and the next owner's recover() is what has to seal it.
+            await request(childBase + '/__crash', 'POST', {}, 5_000).catch(() => undefined);
+            await Promise.race([
+                once(child.child, 'exit'),
+                delay(10_000).then(() => { throw new Error('code-host-child did not exit after /__crash\n' + child.output()); }),
+            ]);
+            await child.kill();
+            const fake = createFakeCodeProviders();
+            await assignHost(home, hostPort, fake.providers);
+            const recoveredSnap = await request(base + '/api/code/sessions/' + sessionId);
+            const session = recoveredSnap.json['session'] as Json;
+            const error = session['error'] as Json | null;
+            assert.equal(error?.['code'], 'orphaned_turn');
+            assert.equal(session['status'], 'failed');
+            assert.equal(fake.counts.opens, 0);
+            assert.equal(fake.counts.sends, 0);
+            recovered = {
+                sessionId,
+                turnId: admitted.json['turnId'] as string,
+                prompt,
+            };
+        } finally {
+            await child.kill();
+        }
+    });
+
+    test('CODE-INT-008 consumed key after restart', async () => {
+        assert.ok(recovered, 'CODE-INT-006 must recover a session before CODE-INT-008');
+        const duplicate = await request(base + '/api/code/sessions/' + recovered.sessionId + '/prompt', 'POST', recovered.prompt);
+        assert.equal(duplicate.status, 200);
+        assert.notEqual(duplicate.json['status'], 'accepted');
+        assert.notEqual(duplicate.json['status'], 'running');
+        assert.equal(duplicate.json['status'], 'failed');
+        assert.equal(duplicate.json['turnId'], recovered.turnId);
+        const snapshot = await request(base + '/api/code/sessions/' + recovered.sessionId);
+        const items = snapshot.json['items'] as Array<Json>;
+        assert.equal(items.filter(item => item['kind'] === 'turn_started').length, 1);
+    });
+
+    test('CODE-INT-007 interrupt transcript survives', async () => {
+        const home = tempHome();
+        const cwd = realpathSync(mkdtempSync(join(home, 'workspace-')));
+        const hostPort = 19_088;
+        await assignHost(home, hostPort);
+        const created = await request(base + '/api/code/sessions', 'POST', createBody(cwd));
+        const sessionId = (created.json['session'] as Json)['sessionId'] as string;
+        const admitted = await request(base + '/api/code/sessions/' + sessionId + '/prompt', 'POST', {
+            text: 'HOLD so sealAccepted can drain', clientTurnKey: 'k-seal',
+        });
+        const live = await waitForStreaming(base + '/api/code/sessions/' + sessionId);
+        await pollSnapshot(base + '/api/code/sessions/' + sessionId, body => {
+            const items = body['items'] as Array<Json>;
+            return items.some(item => item['kind'] === 'assistant_message'
+                && typeof item['text'] === 'string'
+                && (item['text'] as string).includes('held assistant text'));
+        });
+        const cancelled = await request(base + '/api/code/sessions/' + sessionId + '/cancel', 'POST', {
+            turnId: admitted.json['turnId'],
+            epoch: (live['session'] as Json)['epoch'],
+        });
+        assert.equal(cancelled.status, 200);
+        await assignHost(home, hostPort);
+        const snapshot = await request(base + '/api/code/sessions/' + sessionId);
+        const items = snapshot.json['items'] as Array<Json>;
+        assert.ok(items.some(item => item['kind'] === 'assistant_message'
+            && typeof item['text'] === 'string'
+            && (item['text'] as string).includes('held assistant text')));
+    });
+});

--- a/tests/integration/slack-inbound-turn.test.ts
+++ b/tests/integration/slack-inbound-turn.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Slack crossing: socket envelope -> gate -> ingress -> real spawned child ->
+ * outbound reply, through a booted product server (#688).
+ *
+ * Everything below the envelope is the product. The only substitutions are the
+ * two things a test cannot be allowed to reach: Slack itself (a scripted
+ * fixture, injected through the server child's global fetch, which is the sole
+ * seam initSlack leaves open) and the agent binary (a print-mode stub on PATH,
+ * which is how spawnAgent resolves a runtime).
+ *
+ * The existing Slack coverage is 88 unit files that mock.module the API, the
+ * socket, or the orchestrator pipeline; none of them run initSlack inside a
+ * server or reach spawnAgent. That gap is what let a steered turn post "no
+ * response" into a user's thread (#655) and what #697 says
+ * steer-superseded-delivery still does not close.
+ *
+ * One server for all four cases on purpose: a boot costs seconds under tsx and
+ * the driver fails a file that goes quiet for 180s, so four boots would spend
+ * the budget on process startup rather than on the crossing.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { startSlackFixture } from '../helpers/slack-fixture.mts';
+import {
+    PROJECT_ROOT, api, findFreePort, requireHarness, startJawServer,
+    stopJawServer, waitForInboundChannel, waitForServer, type JawServer,
+} from '../helpers/jaw-server.mts';
+
+/** Every localized form of the empty-terminal placeholder (collect.ts t('tg.noResponse')). */
+const PLACEHOLDERS = new Set(['en', 'ko', 'ja', 'zh'].map(code => {
+    const table = JSON.parse(readFileSync(join(PROJECT_ROOT, 'public', 'locales', code + '.json'), 'utf8')) as Record<string, string>;
+    return table['tg.noResponse'] ?? '';
+}).filter(Boolean));
+
+function envelope(id: string, text: string, ts: string, channel = 'C1'): Record<string, unknown> {
+    // The full Socket Mode shape, and event.ts is mandatory: without it the ACK
+    // reaction is skipped (ackTs in src/slack/bot.ts) and ingress dedupe is
+    // skipped too, so a retry would spawn a second agent.
+    return {
+        envelope_id: id,
+        type: 'events_api',
+        accepts_response_payload: false,
+        payload: {
+            team_id: 'T1',
+            event: {
+                type: 'app_mention', channel, channel_type: 'channel',
+                user: 'U1', text, ts, event_ts: ts,
+            },
+        },
+    };
+}
+
+function stubRecords(dir: string): Record<string, unknown>[] {
+    return readdirSync(dir)
+        .filter(name => name.endsWith('.json'))
+        .map(name => JSON.parse(readFileSync(join(dir, name), 'utf8')) as Record<string, unknown>);
+}
+
+/**
+ * A timeout here is the failure mode that is hardest to diagnose from CI, so
+ * the detail callback is not optional decoration: it is the difference between
+ * "the crossing stalled" and knowing which side stalled.
+ */
+async function waitFor(what: string, probe: () => boolean, timeoutMs = 30_000, detail?: () => string): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (probe()) return;
+        await new Promise(r => setTimeout(r, 80));
+    }
+    throw new Error('timed out after ' + timeoutMs + 'ms waiting for ' + what + (detail ? '\n' + detail() : ''));
+}
+
+function postedTexts(
+    fixture: { callsOf(m: string): { body: Record<string, unknown> }[] },
+    channel?: string,
+): string[] {
+    return fixture.callsOf('chat.postMessage')
+        .filter(c => channel === undefined || c.body['channel'] === channel)
+        .map(c => String(c.body['text'] ?? ''));
+}
+
+test('SLACK-INT: a mention crosses from socket envelope to posted reply', { timeout: 170_000 }, async t => {
+    if (!requireHarness(t)) return;
+
+    const fixture = await startSlackFixture();
+    const home = mkdtempSync(join(tmpdir(), 'jaw-slack-int-'));
+    const workspace = mkdtempSync(join(tmpdir(), 'jaw-slack-ws-'));
+    const stubDir = mkdtempSync(join(tmpdir(), 'jaw-slack-stub-'));
+    const binDir = join(stubDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    // spawnAgent resolves a runtime by BINARY NAME off PATH, so the stub has to
+    // be called 'claude'. HOME is redirected to the temp home as well, because
+    // cli-detect promotes a real ~/.claude/local/bin/claude above anything on
+    // PATH; every case still asserts a stub record, so a real binary winning
+    // would fail loudly rather than quietly answering for it.
+    symlinkSync(join(PROJECT_ROOT, 'tests', 'fixtures', 'print-agent-stub.mjs'), join(binDir, 'claude'));
+
+    const port = await findFreePort();
+    const server: JawServer = startJawServer({
+        home, port,
+        settings: {
+            cli: 'claude',
+            permissions: 'auto',
+            workingDir: workspace,
+            messaging: { enabledChannels: ['slack'], homeChannel: 'slack' },
+            slack: {
+                enabled: true, botToken: 'xoxb-test', appToken: 'xapp-test', teamId: 'T1',
+                channelIds: [], mentionOnly: true, conversationContext: false,
+                autoJoin: { enabled: false },
+                // ACK reactions are OFF by default (SLACK_ACK_DEFAULTS), and
+                // resolveAckConfig only enables them for enabled === true. Without
+                // this the reaction assertions below would assert nothing.
+                ack: { enabled: true, scope: 'all' },
+            },
+        },
+        env: {
+            PATH: binDir + ':' + (process.env['PATH'] ?? ''),
+            HOME: home,
+            JAW_STUB_DIR: stubDir,
+            JAW_TEST_SLACK_API_BASE: fixture.apiBase,
+            CLI_JAW_SLACK_ALLOW_SHARED_TOKEN: '1',
+            NODE_OPTIONS: '--import ' + join(PROJECT_ROOT, 'tests', 'helpers', 'slack-api-preload.mjs'),
+        },
+    });
+
+    t.after(async () => { await stopJawServer(server); await fixture.close(); });
+
+    await waitForServer(server);
+    await waitForInboundChannel(server, 'slack');
+    // Proof the preload landed: these two calls only exist if the product's
+    // Slack client reached the fixture instead of slack.com.
+    await fixture.waitForCall('auth.test');
+    await fixture.waitForCall('apps.connections.open');
+
+    await t.test('SLACK-INT-001 app_mention acks, spawns a real child and posts the answer', async () => {
+        await fixture.emitUntilAcked(envelope('E1', '<@UBOT> ping STUB_MODI:echo:one', '1735689600.000100'));
+        assert.ok(fixture.acked.has('E1'), 'the product acked the envelope');
+
+        const running = await fixture.waitForCall('reactions.add', c => c.body['name'] === 'eyes');
+        assert.equal(running.body['channel'], 'C1');
+        assert.equal(running.body['timestamp'], '1735689600.000100');
+
+        await waitFor('a spawned stub child', () => stubRecords(stubDir).length > 0);
+        const record = stubRecords(stubDir)[0]!;
+        assert.match(String(record['prompt']), /STUB_MODI:echo:one/, 'the stub received the mention text on stdin');
+
+        await fixture.waitForCall('chat.postMessage', c => String(c.body['text'] ?? '').includes('stub reply'));
+        await fixture.waitForCall('reactions.add', c => c.body['name'] === 'white_check_mark');
+    });
+
+    await t.test('SLACK-INT-002 a steered turn delivers a real answer, never the placeholder', async () => {
+        const before = postedTexts(fixture).length;
+        const held = stubRecords(stubDir).length;
+        await fixture.emitUntilAcked(envelope('E2', '<@UBOT> first STUB_MODI:hold:s1', '1735689601.000100'));
+        await waitFor('the held child to start', () => stubRecords(stubDir).length > held);
+
+        // Different text and a different ts: the gateway drops an identical
+        // (scope, origin, text, chat, thread) within 5s as a duplicate, which
+        // would silently turn this into a one-turn test.
+        await fixture.emitUntilAcked(envelope('E3', '<@UBOT> second STUB_MODI:echo:three', '1735689602.000100'));
+        writeFileSync(join(stubDir, 'release-s1'), '');
+
+        await waitFor(
+            'a reply after the steer',
+            () => postedTexts(fixture).slice(before).some(text => text.includes('stub reply')),
+            90_000,
+        );
+        // The whole run so far, not a slice: the #655 failure is that a
+        // superseded turn posts the placeholder ANYWHERE, and nothing before
+        // this point is allowed to have produced one.
+        const all = postedTexts(fixture);
+        const placeholders = all.filter(text => PLACEHOLDERS.has(text.trim()));
+        assert.deepEqual(placeholders, [], 'a turn posted the no-response placeholder; all posts so far: ' + JSON.stringify(all));
+    });
+
+    await t.test('SLACK-INT-003 an empty terminal posts the placeholder, and says so', async () => {
+        // A channel of its own. Run in C1 the empty turn lands behind the steer
+        // sequence above and is retired as superseded, which takes the early
+        // return in bot.ts and posts nothing — a true statement about steering,
+        // not about an empty terminal. C2 gives this turn its own lane.
+        await fixture.emitUntilAcked(envelope('E4', '<@UBOT> quiet STUB_MODI:empty:q1', '1735689603.000100', 'C2'));
+        // Polling for the placeholder rather than slicing a window: an earlier
+        // turn's reply can still be in flight, and a count-based window would
+        // read that as this turn's answer.
+        //
+        // This pins TODAY'S contract rather than a wish. An empty print terminal
+        // becomes t('tg.noResponse') in collect.ts and Slack posts it; the
+        // suppression in bot.ts applies only to a superseded turn, which is
+        // SLACK-INT-002. If that is ever changed deliberately, this test is what
+        // notices, instead of a user's thread.
+        await waitFor(
+            'the localized no-response placeholder',
+            () => postedTexts(fixture, 'C2').some(text => PLACEHOLDERS.has(text.trim())),
+            45_000,
+            () => 'posted to C2: ' + JSON.stringify(postedTexts(fixture, 'C2'))
+                + '\nposted to C1: ' + JSON.stringify(postedTexts(fixture, 'C1'))
+                + '\nslack methods: ' + JSON.stringify(fixture.calls.map(c => c.method))
+                + '\nserver tail: ' + server.output().slice(-3000),
+        );
+    });
+
+    await t.test('SLACK-INT-004 a file send reserves, uploads and completes', async () => {
+        const filePath = join(workspace, 'fixture-upload.txt');
+        writeFileSync(filePath, 'cli-jaw integration upload fixture\n');
+        const res = await api(server, '/api/slack/send', {
+            method: 'POST',
+            // type must name a file kind: the send handler routes 'text' to
+            // sendSlackText and rejects it without text, so a file-only body
+            // with the default type never reaches sendSlackFile.
+            body: JSON.stringify({ chat_id: 'C1', type: 'document', file_path: filePath, caption: 'fixture' }),
+        });
+        const payload = await res.json() as { ok?: boolean; upload?: Record<string, unknown> };
+        assert.equal(res.status, 200, 'send failed: ' + JSON.stringify(payload));
+        assert.equal(payload.ok, true);
+
+        const reserved = await fixture.waitForCall('files.getUploadURLExternal');
+        assert.equal(reserved.body['filename'], 'fixture-upload.txt');
+        // The reservation hands back an https loopback URL because slack-file.ts
+        // refuses anything else; the preload downgrades it to this fixture.
+        await fixture.waitForCall('upload');
+        const completed = await fixture.waitForCall('files.completeUploadExternal');
+        const files = completed.body['files'] as { id?: string }[] | undefined;
+        assert.equal(files?.[0]?.id, 'F1');
+        assert.equal(completed.body['channel_id'], 'C1');
+    });
+});


### PR DESCRIPTION
Slack, agent lifecycle and code-mode each had a hot path that no integration test crossed. Unit coverage is dense — 1300+ files — but the three areas that absorbed the most fixes were tested with mocked modules, fake `ChildProcess` objects, or not at all, so a green suite said nothing about whether a mention reaches a reply, whether stopping one session leaves another running, or whether `/api/code` answers over HTTP.

This adds three crossings that run unskipped in the `integration` job, plus an `/api/code` case in the smoke file that already fails closed under CI.

## What each one proves

**`slack-inbound-turn.test.ts`** boots a real server with Slack enabled and drives a Socket Mode envelope through the real `initSlack`, socket client, event gate, ingress, lanes and `spawnAgent` to a posted reply. Only two things are substituted: Slack itself (a scripted Web API + websocket fixture) and the agent binary (a print-mode stub on `PATH`). Four cases: `app_mention` end to end, a steered turn that must deliver a real answer and never the "no response" placeholder (#655), an empty terminal, and a file send through `POST /api/slack/send`.

**`agent-lifecycle-real-child.test.ts`** runs two real child processes behind two chat sessions, stops one by scope over HTTP, and restarts it. `multi-session-concurrency.test.ts` is untouched and still covers the lane bookkeeping; what it cannot cover is the part with an operating system in it, because its `fakeChild` is an `EventEmitter` with an injected `terminateTree`, so no signal is ever sent and `killProcessTree` never runs. Liveness is read from the stub's own pid record rather than `/api/runtime`, because `spawn.ts` drops the map entry before the OS has reaped anything.

**`code-native-api.test.ts`** mounts the real native routes over a real `CodeSessionManager` and store with injected fake providers, and exercises create, prompt, duplicate receipt, snapshot, cancel and the negative contract over real HTTP. It also covers the three conditions from the issue comment: an owner that dies mid-turn leaves `error.code === 'orphaned_turn'`, recovery replays no native prompt (`opens` and `sends` are 0 on the new host), and a consumed `clientTurnKey` cannot start a new turn.

## Notes for review

- No product source changes. Every seam used already exists: `CodeHostOptions.providers`, binary resolution off `PATH`, and the global `fetch` that `src/slack/api.ts` resolves at call time. The Slack redirect is a `--import` preload carried into the server child through `NODE_OPTIONS`, which `bin/commands/serve.ts` forwards because it spreads `...process.env`.
- The upload URL is handed back as `https` on loopback and downgraded by that preload, because `src/slack/slack-file.ts` rejects a non-`https` `upload_url`. No TLS, no certificate.
- `tests/helpers/jaw-server.mts` fails the run under `CI` when its dependency is missing, following `api-smoke.test.ts` rather than skipping. It also fails loudly when the server rejects a fixture settings document: a v4 document missing `multiSession`, `multiSessionDefaultMigration` or `messaging` is quietly replaced with legacy defaults while the server still boots, which is how a test ends up measuring one lane instead of four and never saying so.
- The code-mode child host crashes itself through a control route instead of being signalled. Killing it from outside worked, but tsx's CLI runs the entry in a grandchild that kept the inherited pipes open, so the test process could not exit and the driver reported a stalled file 180 seconds later.
- Every wait is bounded below the 180s per-file stall watchdog, and the agent stub's hold is capped at 60s.

## Validation

Local product suites were not run: `npm test`, `npm run typecheck` and `npm run build` are all **NOT RUN** by instruction. The new files were exercised directly, and the whole integration scope was run on this branch after rebasing onto `dev` `d39957561`:

```
tests/run.mts --scope integration
tests 71 | pass 66 | fail 0 | cancelled 0 | skipped 5
```

The 5 skips are the pre-existing environment skips (`graceful-shutdown` without `dist`, multiplex activation, AGY smoke) and are the subject of #689. The authoritative evidence is the `ci-aggregate` result on this PR.

Closes #688

