### PR TITLE
feat(messaging): give the three channels one delivery receipt

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -37,6 +37,7 @@ import { shouldSkipForwarding } from '../messaging/forwarder-origin.js';
 import { sendDiscordFile } from './discord-file.js';
 import { getDiscordSendClient, sendDiscordFileRest, sendDiscordTextRest } from './send-only-client.js';
 import { invalidateDiscordSendClient } from './send-only-client.js';
+import { deliverySent, type TransportSendResult } from '../messaging/delivery-outcome.js';
 import { OutboundSendRegistry } from '../messaging/outbound-lifecycle.js';
 import type { Attachment, Interaction, Message } from 'discord.js';
 import { asSendable, asThreadLike, asTypingChannel } from './channel-types.js';
@@ -980,7 +981,7 @@ export async function shutdownDiscord() {
 
 // ─── Send Handler ───────────────────────────────────
 
-export async function discordSendHandler(req: ChannelSendRequest): Promise<{ ok: boolean; error?: string; [k: string]: unknown }> {
+export async function discordSendHandler(req: ChannelSendRequest): Promise<TransportSendResult> {
     const channelId = req.chatId || req.target?.threadId || req.target?.targetId
         || (Array.from(discordActiveChannelIds).at(-1))
         || settings["discord"]?.channelIds?.[0];
@@ -998,14 +999,15 @@ export async function discordSendHandler(req: ChannelSendRequest): Promise<{ ok:
                 const restToken = discordClient.token;
                 if (!restToken) return { ok: false, error: 'Discord client token unavailable' };
                 const outbound = discordOutboundRegistry.start();
+                let restResult;
                 try {
-                    const sendResult = await sendDiscordTextRest(restToken, String(channelId), text, { signal: outbound.signal,
+                    restResult = await sendDiscordTextRest(restToken, String(channelId), text, { signal: outbound.signal,
                         ...(nativeBodyRequests.has(req) ? { requireBodyDelivery: true } : {}) });
-                    if (!sendResult.ok) return { ok: false, error: sendResult.error || 'send failed' };
+                    if (!restResult.ok) return { ok: false, error: restResult.error || 'send failed' };
                 } finally {
                     outbound.done();
                 }
-                return { ok: true, channel_id: channelId, type: 'text' };
+                return { ok: true, channel_id: channelId, type: 'text', ...deliverySent(restResult.platformMessageId) };
             } catch (e) {
                 return { ok: false, error: (e as Error).message };
             }
@@ -1021,7 +1023,7 @@ export async function discordSendHandler(req: ChannelSendRequest): Promise<{ ok:
         };
         const fileResult = await sendDiscordFile(discordClient, target, filePath, stripUndefined({ caption: req.caption }));
         if (!fileResult.ok) return fileResult;
-        return { ok: true, channel_id: channelId, type: req.type };
+        return { ok: true, channel_id: channelId, type: req.type, ...deliverySent(fileResult.platformMessageId ?? null) };
     }
 
     const sendClient = getDiscordSendClient();
@@ -1035,14 +1037,14 @@ export async function discordSendHandler(req: ChannelSendRequest): Promise<{ ok:
         const result = await sendDiscordTextRest(sendClient.token, String(channelId), text,
             nativeBodyRequests.has(req) ? { requireBodyDelivery: true } : undefined);
         if (!result.ok) return result;
-        return { ok: true, channel_id: channelId, type: 'text' };
+        return { ok: true, channel_id: channelId, type: 'text', ...deliverySent(result.platformMessageId) };
     }
 
     const filePath = req.filePath;
     if (!filePath) return { ok: false, error: 'file_path required for non-text types' };
     const fileResult = await sendDiscordFileRest(sendClient.token, String(channelId), filePath, req.caption);
     if (!fileResult.ok) return fileResult;
-    return { ok: true, channel_id: channelId, type: req.type };
+    return { ok: true, channel_id: channelId, type: req.type, ...deliverySent(fileResult.platformMessageId) };
 }
 
 // Transport registration moved to ./register.js (lazy loader) so importing

--- a/src/discord/discord-file.ts
+++ b/src/discord/discord-file.ts
@@ -10,6 +10,7 @@ import type { RemoteTarget } from '../messaging/types.js';
 import { asSendable } from './channel-types.js';
 import { redactOutboundText, userErrorText } from '../messaging/redact.js';
 import { sendDiscordFileRest } from './send-only-client.js';
+import { deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
 
 export const DISCORD_LIMITS = {
     document: 10 * 1024 * 1024,
@@ -39,7 +40,7 @@ export async function sendDiscordFile(
     target: RemoteTarget,
     filePath: string,
     options?: { caption?: string; replyTo?: string; signal?: AbortSignal },
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: string } & Partial<LiveDeliveryFields>> {
     let fileStat;
     try {
         fileStat = await stat(filePath);
@@ -55,7 +56,9 @@ export async function sendDiscordFile(
     if (client.token) {
         const rest = await sendDiscordFileRest(client.token, resolvedId, filePath,
             options?.caption, options?.signal ? { signal: options.signal } : {});
-        return rest.ok ? { ok: true } : { ok: false, error: rest.error };
+        return rest.ok
+            ? { ok: true, ...deliverySent(rest.platformMessageId) }
+            : { ok: false, error: rest.error };
     }
     const channel = await client.channels.fetch(resolvedId);
     const sendable = asSendable(channel);
@@ -68,7 +71,9 @@ export async function sendDiscordFile(
             content: redactOutboundText(options?.caption || ''),
             files: [{ attachment: filePath, name: basename(filePath) }],
         });
-        return { ok: true };
+        // The gateway fallback has no REST response to read an id from, which is
+        // what ambiguous reports.
+        return { ok: true, ...deliverySent(null) };
     } catch (e) {
         return { ok: false, error: `Discord file send failed: ${userErrorText(e)}` };
     }

--- a/src/discord/send-only-client.ts
+++ b/src/discord/send-only-client.ts
@@ -10,7 +10,9 @@ import {
 } from './rest-scheduler.js';
 import {
     discordDeliveryError,
+    deliverySent,
     type DeliveryFailure,
+    type LiveDeliveryFields,
 } from '../messaging/delivery-outcome.js';
 
 export type DiscordSendClientResult =
@@ -37,8 +39,27 @@ export function getDiscordSendClient(): DiscordSendClientResult {
 }
 
 export type DiscordRestSendResult =
-    | { ok: true; failure?: never; error?: never; status?: never }
+    | ({ ok: true; failure?: never; error?: never; status?: never } & LiveDeliveryFields)
     | { ok: false; failure: DeliveryFailure; error: string; status?: number };
+
+/** Discord answers a message POST with the created message as JSON. The id was
+ *  being thrown away by a parse that returned undefined, so nothing downstream
+ *  could say WHICH message had been sent (#687).
+ *
+ *  Parse failures are swallowed rather than raised: a 204, an empty body or a
+ *  shape we do not recognise still means the message was posted, and letting
+ *  the scheduler turn that into ok:false would invent a transport failure out
+ *  of a successful send. */
+async function parseDiscordMessageId(response: Response): Promise<string | null> {
+    try {
+        const body: unknown = await response.json();
+        if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+        const id = (body as { id?: unknown }).id;
+        return typeof id === 'string' && id.length > 0 ? id : null;
+    } catch {
+        return null;
+    }
+}
 
 function schedulerFor(token: string): DiscordRestScheduler {
     if (cachedScheduler?.token === token) return cachedScheduler.scheduler;
@@ -49,7 +70,7 @@ function schedulerFor(token: string): DiscordRestScheduler {
 }
 
 function sendResult<T>(result: DiscordRestResult<T>): DiscordRestSendResult {
-    if (result.ok) return { ok: true };
+    if (result.ok) return { ok: true, ...deliverySent(typeof result.value === 'string' ? result.value : null) };
     return {
         ok: false,
         failure: result.failure,
@@ -83,6 +104,7 @@ export async function sendDiscordTextRest(
         return { ok: false, status: 400, error: 'discord_empty_message',
             failure: { kind: 'format', retryAfterMs: 0, code: 'empty_message', message: 'discord_empty_message' } };
     }
+    let firstId: string | null = null;
     for (const [index, chunk] of chunks.entries()) {
         // A shutdown abort between chunks is a cancellation, not a vendor
         // failure (#417).
@@ -106,11 +128,13 @@ export async function sendDiscordTextRest(
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(body),
             }),
-            parse: async () => undefined,
+            parse: parseDiscordMessageId,
         });
         if (!result.ok) return sendResult(result);
+        // First chunk wins, the same rule Slack uses for firstTs.
+        if (index === 0 && typeof result.value === 'string') firstId = result.value;
     }
-    return { ok: true };
+    return { ok: true, ...deliverySent(firstId) };
 }
 
 export async function openDiscordDm(token: string, userId: string, fetchImpl?: typeof fetch): Promise<{ ok: true; channelId: string } | { ok: false; error: string }> {
@@ -142,13 +166,15 @@ export async function sendDiscordDm(
     if (!fetchImpl) return sendDiscordTextRest(token, dm.channelId, text, extra);
     const scheduler = new DiscordRestScheduler({ token, fetchImpl });
     const chunks = chunkDiscordMessage(text);
+    let firstId: string | null = null;
     for (const [index, chunk] of chunks.entries()) {
         const body: Record<string, unknown> = { content: chunk };
         if (index === 0 && extra?.components) body['components'] = extra.components;
-        const result = await scheduler.schedule({ method: 'POST', path: `/channels/${encodeURIComponent(dm.channelId)}/messages`, routeKey: 'POST:/channels/:channel/messages', majorKey: dm.channelId, makeInit: () => ({ headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }), parse: async () => undefined });
+        const result = await scheduler.schedule({ method: 'POST', path: `/channels/${encodeURIComponent(dm.channelId)}/messages`, routeKey: 'POST:/channels/:channel/messages', majorKey: dm.channelId, makeInit: () => ({ headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }), parse: parseDiscordMessageId });
         if (!result.ok) return sendResult(result);
+        if (index === 0 && typeof result.value === 'string') firstId = result.value;
     }
-    return { ok: true };
+    return { ok: true, ...deliverySent(firstId) };
 }
 
 export async function sendDiscordFileRest(
@@ -184,7 +210,7 @@ export async function sendDiscordFileRest(
                 }
                 return { body: form };
             },
-            parse: async () => undefined,
+            parse: parseDiscordMessageId,
         });
         return sendResult(result);
     } catch (error) {

--- a/src/messaging/delivery-outcome.ts
+++ b/src/messaging/delivery-outcome.ts
@@ -21,6 +21,70 @@ export interface DeliveryFailure {
 
 export type DeliveryStatus = 'sent' | 'failed' | 'unsupported';
 
+/** How far a send got, as reported by a LIVE transport.
+ *
+ *  Separate from `DeliveryReceipt` on purpose. That type is the ChannelAdapter
+ *  port, which no production class implements, and its `status` is this string
+ *  enum. On a live send result `status` is already the HTTP code — read by
+ *  `sendResultHttpStatus` and mapped onto the response by the channel route — so
+ *  reusing it here would silently turn a real 403 or 429 into a 502. Hence
+ *  `deliveryStatus`. */
+export type DeliveryVerification = 'verified' | 'failed' | 'unavailable';
+
+export type LiveDeliveryFields = {
+    deliveryStatus: DeliveryStatus;
+    /** Null when the transport issued no id, or issued one this code cannot see. */
+    platformMessageId: string | null;
+    /** True when the transport cannot prove whether the send reached the vendor. */
+    ambiguous: boolean;
+    /** Slack posts before it can verify rendering, so `ok` and `verified` are not
+     *  the same claim. Absent on transports that never check. */
+    verification?: DeliveryVerification;
+};
+
+/** The live send-registry bag. Every delivery field is OPTIONAL here: a refusal
+ *  that never reached a vendor (no channel configured, empty text, cancelled)
+ *  has no receipt to give, and pretending otherwise would be a lie the type
+ *  system cannot catch. Leaves that DID dispatch always fill them in. */
+export type TransportSendResult = {
+    ok: boolean;
+    error?: string;
+    /** HTTP status. Never a delivery classification. */
+    status?: number;
+    deliveryStatus?: DeliveryStatus;
+    platformMessageId?: string | null;
+    ambiguous?: boolean;
+    verification?: DeliveryVerification;
+    [k: string]: unknown;
+};
+
+export function deliverySent(
+    platformMessageId: string | null,
+    extra?: { ambiguous?: boolean; verification?: DeliveryVerification },
+): LiveDeliveryFields {
+    const fields: LiveDeliveryFields = {
+        deliveryStatus: 'sent',
+        platformMessageId,
+        // No id means we cannot point at what we sent, which is exactly the
+        // condition `ambiguous` exists to report.
+        ambiguous: extra?.ambiguous ?? platformMessageId === null,
+    };
+    // exactOptionalPropertyTypes: copy only when present, never assign undefined.
+    if (extra?.verification) fields.verification = extra.verification;
+    return fields;
+}
+
+export function deliveryFailed(
+    platformMessageId: string | null,
+    extra?: { ambiguous?: boolean },
+): LiveDeliveryFields {
+    return {
+        deliveryStatus: 'failed',
+        platformMessageId,
+        ambiguous: extra?.ambiguous ?? false,
+    };
+}
+
 /** The single outbound result shape. `platformMessageId` is nullable rather than
  *  optional so a caller cannot confuse "this transport issued no id" with "the
  *  field was left off". A sent receipt always carries one. */
@@ -102,6 +166,10 @@ function failure(kind: DeliveryFailureKind, input: DeliveryErrorInput): Delivery
     };
 }
 
+/** TEST-ONLY classifier. No production Telegram send or file path imports this:
+ *  the live text path throws vendor errors rather than mapping them, and the
+ *  file path reports `statusCode`. Kept because `tests/unit/delivery-outcome.test.ts`
+ *  pins the classification table, not because anything ships through it (#687). */
 export const telegramDeliveryError: DeliveryErrorMapper = (err) => {
     const kind = classifySendFailure(err);
     const record = err && typeof err === 'object'
@@ -116,6 +184,10 @@ export const telegramDeliveryError: DeliveryErrorMapper = (err) => {
     };
 };
 
+/** TEST-ONLY classifier. Live Slack failures are built by `slackFailure` with an
+ *  HTTP `status` in `src/slack/send-only-client.ts`, so nothing in production
+ *  reaches this mapper. Kept for the classification table in
+ *  `tests/unit/delivery-outcome.test.ts` (#687). */
 export const slackDeliveryError: DeliveryErrorMapper = (err) => {
     const input = errorInput(err, 'slack');
     const code = input.code;
@@ -134,6 +206,8 @@ export const slackDeliveryError: DeliveryErrorMapper = (err) => {
     return failure(input.dispatched === false ? 'transient' : 'ambiguous', input);
 };
 
+/** The one LIVE mapper: used by `src/discord/send-only-client.ts` and
+ *  `src/discord/rest-scheduler.ts`. */
 export const discordDeliveryError: DeliveryErrorMapper = (err) => {
     const input = errorInput(err, 'discord');
     if (input.status === 401) return failure('auth', input);

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -13,6 +13,7 @@ import { decodeTurnConversation, turnConversationForChannel } from './turn-conve
 import { getRemoteBoundSessionId } from '../core/chat-sessions.js';
 import { applyOutputPolicy } from '../core/policy-hooks.js';
 import { redactChannelSecrets } from './redact.js';
+import { type TransportSendResult } from './delivery-outcome.js';
 import { log } from '../core/logger.js';
 import { recordSelfDelivery } from './turn-delivery.js';
 import { normalizeSlackBlocks, type SlackBlock } from '../slack/blocks.js';
@@ -147,7 +148,7 @@ export type ChannelSendRequest = {
 
 // ─── Transport Send Registry ────────────────────────
 
-type TransportSendFn = (req: ChannelSendRequest) => Promise<{ ok: boolean; error?: string; [k: string]: unknown }>;
+type TransportSendFn = (req: ChannelSendRequest) => Promise<TransportSendResult>;
 
 const sendFns = new Map<MessengerChannel, TransportSendFn>();
 const OUTBOUND_TYPES = new Set<OutboundType>(['text', 'voice', 'photo', 'document', 'keyboard']);

--- a/src/slack/send-only-client.ts
+++ b/src/slack/send-only-client.ts
@@ -12,6 +12,7 @@ import { boundSlackContent, expectedTableContent, type CanonicalTable, type Tabl
 import { verifySlackTables, type VerificationStatus } from './table-verification.js';
 import { expectedRichFeatures } from './render-features.js';
 import { MAX_INLINE_RATE_LIMIT_MS, classifySendFailure, retryAfterMs } from '../messaging/retry.js';
+import { deliveryFailed, deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
 import { log } from '../core/logger.js';
 
 export type SlackSendClientResult =
@@ -97,7 +98,7 @@ export async function sendSlackText(
     options: { fetchImpl?: SlackFetch; blocks?: unknown; signal?: AbortSignal; requireBodyDelivery?: boolean; sensitiveResponse?: boolean;
         onPosted?: (info: { ts?: string; messageTs: string[]; postedChunks: number; totalChunks: number }) => void | Promise<void> } = {},
 ): Promise<{ ok: boolean; error?: string; status?: number; ts?: string; sent?: boolean;
-    retryable?: boolean; delivery?: SlackDeliveryReceipt }> {
+    retryable?: boolean; delivery?: SlackDeliveryReceipt } & Partial<LiveDeliveryFields>> {
     let chunks: SlackTextPayload[];
     let shapes: TableShape[][];
     let content: CanonicalTable[][];
@@ -109,11 +110,12 @@ export async function sendSlackText(
         content = chunks.map(chunk => expectedTableContent(chunk.blocks));
         shapes = chunks.map(chunk => expectedTableShapes(chunk.blocks));
     } catch (error) {
-        if (error instanceof RangeError) return slackFailure(error.message, 400);
+        // Nothing was dispatched, so there is no receipt to give.
+        if (error instanceof RangeError) return { ...slackFailure(error.message, 400), ...deliveryFailed(null) };
         throw error;
     }
     if (options.requireBodyDelivery && !chunks.some(chunk => chunk.text.trim().length > 0)) {
-        return slackFailure('empty_message', 400);
+        return { ...slackFailure('empty_message', 400), ...deliveryFailed(null) };
     }
     const expectedTables = shapes.reduce((total, part) => total + part.length, 0);
     const features = chunks.map(chunk => expectedRichFeatures(chunk.blocks));
@@ -139,6 +141,9 @@ export async function sendSlackText(
     // authorizing a whole-answer retry or claiming unsent chunks were delivered.
     const failure = (error: string, status = 502) => ({
         ...slackFailure(error, status),
+        // Chunks already posted keep their id; the ones that did not are a known
+        // non-delivery, not a vendor-unknown outcome.
+        ...deliveryFailed(firstTs ?? null),
         ...(firstTs ? { ts: firstTs } : {}),
         ...(postedChunks ? { sent: true, retryable: false } : {}),
         ...(needsVerification || postedChunks ? { delivery: receipt() } : {}),
@@ -210,6 +215,14 @@ export async function sendSlackText(
         verifiedTables += checked.verifiedTables;
         for (const feature of checked.verifiedFeatures ?? []) verifiedFeatures.add(feature);
     }
+    const delivered = needsVerification ? receipt() : undefined;
+    // Posted is not verified. Slack can accept every chunk and still fail table
+    // readback, so the common receipt reports 'sent' with the verification state
+    // beside it rather than collapsing both into ok (#687).
     return { ok: true, ...(firstTs ? { ts: firstTs } : {}),
-        ...(needsVerification ? { sent: true, retryable: false, delivery: receipt() } : {}) };
+        ...deliverySent(firstTs ?? null, {
+            ambiguous: firstTs === undefined,
+            ...(delivered ? { verification: delivered.verification } : {}),
+        }),
+        ...(delivered ? { sent: true, retryable: false, delivery: delivered } : {}) };
 }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -89,6 +89,7 @@ import {
 } from './elicitation-buttons.js';
 import { redactOutboundPayload, redactOutboundText, logErrorText, userErrorText } from '../messaging/redact.js';
 import { sendWithRetryPolicy } from '../messaging/retry.js';
+import { deliveryFailed, deliverySent, type TransportSendResult } from '../messaging/delivery-outcome.js';
 import { handleApprovalCommand, handleApprovalCallback, registerProductionTransport, type DispatchApprovalTransport } from '../core/dispatch-approval-ingress.js';
 import { parseApprovalCallbackData } from '../messaging/approval-presentation.js';
 
@@ -486,7 +487,7 @@ function telegramPayloadDigest(update: Record<string, unknown>): string {
     return createHash('sha256').update(JSON.stringify(update)).digest('hex');
 }
 
-async function telegramSendHandler(req: ChannelSendRequest): Promise<{ ok: boolean; error?: string; [k: string]: unknown }> {
+async function telegramSendHandler(req: ChannelSendRequest): Promise<TransportSendResult> {
     // P2b: hub-member mode — this instance's own bot is disabled; relay outbound through the
     // dashboard hub (it owns the single forum-group bot token). hubCallbackUrl is SSRF-guarded.
     const hub = settings["telegramHub"];
@@ -537,11 +538,17 @@ async function telegramSendHandler(req: ChannelSendRequest): Promise<{ ok: boole
         // Scoped for shutdown cancellation (#417).
         const outbound = telegramOutboundRegistry.start();
         let sendResult;
+        // The markdown helper's return shape is pinned by an existing suite, so
+        // the id travels out through the body observer instead (#687).
+        let platformMessageId: string | null = null;
         try {
             sendResult = await sendTelegramMarkdown(bot.api, chatId, text, stripUndefined({
                 ...(nativeBodyRequests.has(req) ? { requireBodyDelivery: true } : {}),
                 message_thread_id: messageThreadId,
                 signal: outbound.signal,
+                onBodyDelivered: (id?: string) => {
+                    if (id && platformMessageId === null) platformMessageId = id;
+                },
             }));
         } finally {
             outbound.done();
@@ -549,23 +556,31 @@ async function telegramSendHandler(req: ChannelSendRequest): Promise<{ ok: boole
         // Previously the abort threw past this return, so the handler answered
         // 500 with a raw message. A cancelled send is a 499, and it is not ok.
         if (!sendResult.ok) {
-            return { ok: false, error: 'telegram_send_aborted', status: 499, chat_id: chatId, type: 'text' };
+            return { ok: false, error: 'telegram_send_aborted', status: 499, chat_id: chatId, type: 'text',
+                ...deliveryFailed(platformMessageId) };
         }
-        return { ok: true, chat_id: chatId, type: 'text' };
+        return { ok: true, chat_id: chatId, type: 'text', ...deliverySent(platformMessageId) };
     }
 
     if (req.type === 'keyboard') {
         const text = req.text?.trim();
         if (!text || !req.reply_markup) return { ok: false, error: 'text and reply_markup required for keyboard type' };
+        // sendWithRetryPolicy discards the vendor return and is shared with other
+        // callers, so capture the id inside the thunk rather than change it.
+        let platformMessageId: string | null = null;
         const sent = await sendWithRetryPolicy(
-            () => bot.api.sendMessage(chatId, redactOutboundText(text), stripUndefined({
-                message_thread_id: messageThreadId,
-                reply_markup: redactOutboundPayload(req.reply_markup) as import("@grammyjs/types").InlineKeyboardMarkup,
-            })),
+            async () => {
+                const sentMessage = await bot.api.sendMessage(chatId, redactOutboundText(text), stripUndefined({
+                    message_thread_id: messageThreadId,
+                    reply_markup: redactOutboundPayload(req.reply_markup) as import("@grammyjs/types").InlineKeyboardMarkup,
+                }));
+                const id = (sentMessage as { message_id?: unknown } | undefined)?.message_id;
+                if (typeof id === 'number' || typeof id === 'string') platformMessageId = String(id);
+            },
             (err) => log.warn('[tg:keyboard] send failed:', logErrorText(err)),
         );
-        if (!sent) return { ok: false, error: 'keyboard send failed' };
-        return { ok: true, chat_id: chatId, type: 'keyboard' };
+        if (!sent) return { ok: false, error: 'keyboard send failed', ...deliveryFailed(null) };
+        return { ok: true, chat_id: chatId, type: 'keyboard', ...deliverySent(platformMessageId) };
     }
 
     // File types

--- a/src/telegram/rich-message.ts
+++ b/src/telegram/rich-message.ts
@@ -33,16 +33,19 @@ import { abortableDelay } from '../messaging/outbound-lifecycle.js';
  * when it should not: a long rate limit or an ambiguous failure is the
  * caller's to report, not to paper over with another send.
  */
-async function attemptSend(send: () => Promise<unknown>, signal?: AbortSignal): Promise<boolean> {
+async function attemptSend(
+    send: () => Promise<unknown>,
+    signal?: AbortSignal,
+): Promise<{ fallback: boolean; value?: unknown }> {
     try {
-        await send();
-        return false;
+        const value = await send();
+        return { fallback: false, value };
     } catch (err: unknown) {
         // A lifecycle abort is a cancellation, not a vendor failure: no
         // fallback leg, no retry — surface it to the caller as-is (#417).
         if (signal?.aborted) throw err;
         const kind = classifySendFailure(err);
-        if (kind === 'format') return true;
+        if (kind === 'format') return { fallback: true };
         if (kind !== 'rate-limit') throw err;
 
         const wait = retryAfterMs(err);
@@ -54,10 +57,10 @@ async function attemptSend(send: () => Promise<unknown>, signal?: AbortSignal): 
         // Retry the SAME form, once: waiting is what the server asked for, and
         // switching format would add load rather than remove it.
         try {
-            await send();
-            return false;
+            const value = await send();
+            return { fallback: false, value };
         } catch (retryErr: unknown) {
-            if (classifySendFailure(retryErr) === 'format') return true;
+            if (classifySendFailure(retryErr) === 'format') return { fallback: true };
             throw retryErr;
         }
     }
@@ -69,7 +72,9 @@ export interface RichSendOpts {
     /** Private native completion guard; not a Bot API option. */
     requireBodyDelivery?: boolean;
     /** Private receipt observer; never forwarded to the Bot API. */
-    onBodyDelivered?: () => void;
+    /** Receives the vendor message id when one is available. Declared optional so
+     *  existing zero-argument observers stay assignable. */
+    onBodyDelivered?: (platformMessageId?: string) => void;
     /** Invalidates a receipt when the legacy final-format failure is swallowed. */
     onBodyDeliveryFailed?: () => void;
     message_thread_id?: number;
@@ -291,15 +296,26 @@ function requireTelegramBody(chunks: readonly string[], opts: RichSendOpts | und
     }
 }
 
-function observeBodyDelivery(body: string, opts: RichSendOpts | undefined): void {
+function observeBodyDelivery(body: string, opts: RichSendOpts | undefined, delivered?: unknown): void {
     if (!body.trim() || opts?.signal?.aborted || !opts?.onBodyDelivered) return;
-    notifyBodyObserver(opts.onBodyDelivered);
+    notifyBodyObserver(opts.onBodyDelivered, telegramMessageId(delivered));
 }
 
-function notifyBodyObserver(observer: (() => void) | undefined): void {
+/** grammY answers a send with the created Message; its id is a number on the
+ *  wire and a string on the common receipt. */
+function telegramMessageId(value: unknown): string | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const id = (value as { message_id?: unknown }).message_id;
+    return typeof id === 'number' || typeof id === 'string' ? String(id) : undefined;
+}
+
+function notifyBodyObserver(
+    observer: ((platformMessageId?: string) => void) | undefined,
+    platformMessageId?: string,
+): void {
     if (!observer) return;
     // Receipt instrumentation cannot turn an accepted send into a retry/failure.
-    try { void Promise.resolve(observer()).catch(() => {}); }
+    try { void Promise.resolve(platformMessageId === undefined ? observer() : observer(platformMessageId)).catch(() => {}); }
     catch { /* Observer failure never changes the legacy delivery outcome. */ }
 }
 
@@ -343,9 +359,9 @@ export async function sendTelegramMarkdown(
     for (let i = 0; i < chunks.length; i += 1) {
         if (opts?.signal?.aborted) return ABORTED;
         const withPrefix = i === 0 ? `${prefix}${chunks[i]}` : chunks[i]!;
-        let needsFallback: boolean;
+        let attempted: { fallback: boolean; value?: unknown };
         try {
-            needsFallback = await attemptSend(() =>
+            attempted = await attemptSend(() =>
                 // grammY's declared AbortSignal is the abort-controller shim type;
                 // the reaction path (reactions.ts) uses the same `as never` cast.
                 api.sendRichMessage!(chatId, { markdown: withPrefix }, richOpts(opts), opts?.signal as never), opts?.signal);
@@ -356,10 +372,10 @@ export async function sendTelegramMarkdown(
             if (opts?.signal?.aborted) return ABORTED;
             throw err;
         }
-        if (needsFallback) {
+        if (attempted.fallback) {
             const fallback = await sendHtmlFallback(api, chatId, chunks[i]!, opts, i === 0 ? prefix : '');
             if (!fallback.ok) return fallback;
-        } else observeBodyDelivery(withPrefix, opts);
+        } else observeBodyDelivery(withPrefix, opts, attempted.value);
     }
     return OK;
 }
@@ -385,21 +401,21 @@ async function sendHtmlFallback(
         if (opts?.signal?.aborted) return ABORTED;
         const withPrefix = i === 0 ? `${safePrefix}${chunks[i]}` : chunks[i]!;
         try {
-            const needsPlain = await attemptSend(
+            const htmlAttempt = await attemptSend(
                 () => api.sendMessage(chatId, withPrefix, htmlOpts, opts?.signal as never), opts?.signal);
-            if (needsPlain) {
+            if (htmlAttempt.fallback) {
                 const plain = withPrefix.replace(/<[^>]+>/g, '');
                 requireTelegramBody([plain], opts);
                 let plainFailure: unknown;
-                const plainFailedFormat = await attemptSend(async () => {
+                const plainAttempt = await attemptSend(async () => {
                     try { return await api.sendMessage(chatId, plain, plainOpts, opts?.signal as never); }
                     catch (error) { plainFailure = error; throw error; }
                 }, opts?.signal);
-                if (plainFailedFormat) {
+                if (plainAttempt.fallback) {
                     notifyBodyObserver(opts?.onBodyDeliveryFailed);
                     if (opts?.requireBodyDelivery) throw plainFailure;
-                } else observeBodyDelivery(plain, opts);
-            } else observeBodyDelivery(withPrefix, opts);
+                } else observeBodyDelivery(plain, opts, plainAttempt.value);
+            } else observeBodyDelivery(withPrefix, opts, htmlAttempt.value);
         } catch (err: unknown) {
             if (opts?.signal?.aborted) return ABORTED;
             throw err;

--- a/src/telegram/telegram-file.ts
+++ b/src/telegram/telegram-file.ts
@@ -4,6 +4,7 @@ import { stripUndefined } from '../core/strip-undefined.js';
 import { log } from '../core/logger.js';
 import { redactOutboundText, logErrorText, userErrorText } from '../messaging/redact.js';
 import { abortableDelay } from '../messaging/outbound-lifecycle.js';
+import { deliveryFailed, deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
 
 interface TelegramApiErrorLike {
     error_code?: number;
@@ -97,7 +98,8 @@ export async function sendTelegramFile(
     filePath: string,
     type: string,
     opts?: { caption?: string; threadId?: number; signal?: AbortSignal },
-): Promise<{ ok: boolean; attempts: number; error?: string; retryAfter?: number; statusCode?: number }> {
+): Promise<{ ok: boolean; attempts: number; error?: string; retryAfter?: number; statusCode?: number }
+    & Partial<LiveDeliveryFields>> {
     // Validate here, not at the call sites. The Hub's outbound relay calls this
     // transport directly and skipped the check, which is how an empty document
     // still reached the API after the guard was added.
@@ -121,20 +123,23 @@ export async function sendTelegramFile(
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         try {
             const file = new InputFile(filePath);
+            let sentMessage: unknown;
             switch (type) {
                 case 'voice':
-                    await bot.api.sendVoice(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
+                    sentMessage = await bot.api.sendVoice(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
                     break;
                 case 'photo':
-                    await bot.api.sendPhoto(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
+                    sentMessage = await bot.api.sendPhoto(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
                     break;
                 case 'document':
-                    await bot.api.sendDocument(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
+                    sentMessage = await bot.api.sendDocument(chatId, file, stripUndefined({ caption, message_thread_id }), opts?.signal as never);
                     break;
                 default:
-                    return { ok: false, attempts: attempt, error: `unsupported type: ${type}`, statusCode: 400 };
+                    return { ok: false, attempts: attempt, error: `unsupported type: ${type}`, statusCode: 400, ...deliveryFailed(null) };
             }
-            return { ok: true, attempts: attempt };
+            const rawId = (sentMessage as { message_id?: unknown } | undefined)?.message_id;
+            return { ok: true, attempts: attempt,
+                ...deliverySent(typeof rawId === 'number' || typeof rawId === 'string' ? String(rawId) : null) };
         } catch (err: unknown) {
             const e = asTgErr(err);
             const transient = isTransient(err);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -196,7 +196,7 @@ cli-jaw/
 │   │   └── events.ts         ← legacy re-export stub → events/ 모듈 (15L)
 │   ├── messaging/            ← 통합 메시징 런타임 (33 files)
 │   │   ├── runtime.ts        ← 채널 lifecycle (init/shutdown/restart) + transport registry (333L)
-│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (550L)
+│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (551L)
 │   │   ├── turn-conversation.ts ← 턴이 답하는 대화 주소 encode/decode + 채널 매칭 (60L) ✨
 │   │   ├── turn-delivery.ts  ← 에이전트 자가 전송 claim (턴 앵커 + digest, 소비형) → dispatch 중복 게시 억제 (252L) ✨
 │   │   ├── dedupe.ts         ← 배달 중복 제거 (TTL seen-set, 미만료 항목 보존) (118L) ✨
@@ -227,7 +227,7 @@ cli-jaw/
 │   │   ├── forwarder-origin.ts ← channel forwarder 공통 origin 필터 (own channel + producer-owned heartbeat skip) (39L)
 │   │   ├── channel-adapter.ts ← ChannelAdapter contract (130L)
 │   │   ├── channel-capabilities.ts ← closed capability set + generated matrix (101L)
-│   │   ├── delivery-outcome.ts ← DeliveryReceipt classification (145L)
+│   │   ├── delivery-outcome.ts ← DeliveryReceipt classification (219L)
 │   │   ├── draft-stream.ts   ← draft stream helper (180L)
 │   │   └── slack-target.ts   ← Slack target helper (74L)
 │   ├── orchestrator/         ← 직원 오케스트레이션 + 인터페이스 통합 (19 files)
@@ -332,21 +332,21 @@ cli-jaw/
 │   ├── telegram/             ← Telegram 인터페이스 (11 files)
 │   │   ├── reactions.ts     ← ACK reaction transport + ReactionTypeEmoji allowlist + notice transport (186L)
 │   │   ├── ipv4-fetch.ts    ← IPv4 fetch factory that honours init.signal (destroys on abort) (106L)
-│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1418L)
+│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1433L)
 │   │   ├── voice.ts          ← 음성 메시지 → guarded download → STT → tgOrchestrate 파이프라인 (43L)
 │   │   ├── forwarder.ts      ← text 전송 뒤 guarded local-image photo relay + escape/chunk/createForwarder (247L)
-│   │   ├── rich-message.ts   ← Bot API 10.1 rich-first send (sendTelegramMarkdown, 32k chunk, HTML/plaintext fallback) (409L)
+│   │   ├── rich-message.ts   ← Bot API 10.1 rich-first send (sendTelegramMarkdown, 32k chunk, HTML/plaintext fallback) (425L)
 │   │   ├── elicitation-buttons.ts ← single_select elicitation → inline keyboard + pending store + callback codec (110L)
 │   │   ├── hub-callback.ts   ← hub-member callback URL SSRF guard (19L)
-│   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (187L)
+│   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (192L)
 │   ├── discord/              ← Discord 인터페이스 (8 files)
-│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1049L)
+│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1051L)
 │   │   ├── reactions.ts   ← ACK reaction transport + cancellable notice REST (122L)
 │   │   ├── commands.ts       ← Discord slash command 등록 + 핸들러 (153L)
-│   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (206L) ✨
+│   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (232L) ✨
 │   │   ├── channel-types.ts  ← Discord channel type helpers (50L) ✨
 │   │   ├── forwarder.ts      ← Discord text chunk 포워딩 + guarded local-image attachment relay (98L)
-│   │   └── discord-file.ts   ← Discord 파일 전송 (75L)
+│   │   └── discord-file.ts   ← Discord 파일 전송 (80L)
 │   ├── slack/                ← Slack 인터페이스 (41 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
 │   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1918L)
@@ -369,7 +369,7 @@ cli-jaw/
 │   │   ├── ingress.ts        ← 세션별 ingress lane + synthetic top-level followup override + admitSlackRun 동기 실행 예약(sessionLanes) + 전역 다운로드 세마포어 + shutdown abort/drain (300L) ✨
 │   │   ├── inbound-file.ts   ← 인바운드 첨부 단일 IO owner (files.info → 인증 스트리밍 다운로드 → saveUpload, 파일/메시지 바이트 예산, 고정 error code) (280L) ✨
 │   │   ├── inbound-url.ts    ← 인바운드 다운로드 URL 검증 (Slack host allowlist + https-only hop + 사설망 거부) (44L) ✨
-│   │   ├── send-only-client.ts ← bot-token outbound with separate transport/verification receipts (215L)
+│   │   ├── send-only-client.ts ← bot-token outbound with separate transport/verification receipts (228L)
 │   │   ├── forwarder.ts      ← agent_done 포워딩 + guarded local-image relay (filename caption) (87L)
 │   │   ├── send-handler.ts   ← ChannelSendRequest → Slack Web API 어댑터 + 413 텍스트 다운그레이드 (70L)
 │   │   ├── manifest.ts       ← Slack 앱 표시명 검증 + bot 표시명 결정적 파생을 포함한 매니페스트 single source (`jaw slack manifest`/`setup`이 사용) (162L)

--- a/tests/unit/channel-contract-conformance.test.ts
+++ b/tests/unit/channel-contract-conformance.test.ts
@@ -46,9 +46,19 @@ type VendorLog = { calls: string[] };
 /**
  * A reference adapter driven entirely by the real capability declaration. It stands
  * in for the vendor transport, not for the contract: the declaration, the refusal
- * rule and the receipt shape under test are the shipped ones. Wiring the three live
- * transports into this port is the next migration step; until then this proves the
- * contract itself holds and that every declared capability has a reachable method.
+ * rule and the receipt shape under test are the shipped ones.
+ *
+ * NOT CONNECTED TO THE LIVE TRANSPORTS, and that is deliberate rather than
+ * pending. Slack, Discord and Telegram do not implement `ChannelAdapter` at all:
+ * they register `TransportSendFn` handlers through `registerSendTransport`, whose
+ * results carry `deliveryStatus` / `platformMessageId` / `ambiguous` (and Slack's
+ * `verification`) from `src/messaging/delivery-outcome.ts`. `DeliveryReceipt.status`
+ * asserted below is the ADAPTER PORT's string enum; on a live send result `status`
+ * is the HTTP code, which is why the live classification uses a different key.
+ *
+ * So this suite proves the port's contract holds and that every declared
+ * capability has a reachable method. It does not prove anything about
+ * `sendSlackText`, `sendDiscordTextRest` or `sendTelegramMarkdown` (#687).
  */
 function referenceAdapter(channel: MessengerChannel, vendor: VendorLog): ChannelAdapter {
     const capabilities: ChannelCapabilities = capabilitiesFor(channel);

--- a/tests/unit/messaging-delivery-receipt.test.ts
+++ b/tests/unit/messaging-delivery-receipt.test.ts
@@ -1,0 +1,80 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendSlackText } from '../../src/slack/send-only-client.ts';
+import { sendDiscordDm } from '../../src/discord/send-only-client.ts';
+import { deliveryFailed, deliverySent } from '../../src/messaging/delivery-outcome.ts';
+import { sendResultHttpStatus } from '../../src/messaging/send-result.ts';
+
+// #687: 'success' used to mean three different things. Slack meant posted,
+// Discord meant HTTP 2xx with the message id thrown away, Telegram meant the
+// call did not throw. These pin the common vocabulary that replaced that.
+
+const slackTarget = { channel: 'slack', targetId: 'D1', targetKind: 'user', peerKind: 'direct' } as const;
+
+test('a Slack text send reports the posted message id on the common receipt', async () => {
+    const fetchImpl = (async () => new Response(JSON.stringify({ ok: true, ts: '1700000000.0001' }))) as typeof fetch;
+    const result = await sendSlackText('fixture', slackTarget, 'plain answer', { fetchImpl });
+    assert.equal(result.ok, true);
+    assert.equal(result.deliveryStatus, 'sent');
+    assert.equal(result.platformMessageId, '1700000000.0001');
+    assert.equal(result.ambiguous, false);
+    // No tables and no rich features means nothing was verified, so the receipt
+    // makes no verification claim at all rather than inventing one.
+    assert.equal('verification' in result, false);
+});
+
+test('a failed Slack send keeps status as the HTTP code, not a delivery word', async () => {
+    const fetchImpl = (async () => ({
+        ok: false, status: 403, headers: new Headers(), text: async () => '',
+    })) as unknown as typeof fetch;
+    const result = await sendSlackText('fixture', slackTarget, 'plain answer', { fetchImpl });
+    assert.equal(result.ok, false);
+    assert.equal(result.deliveryStatus, 'failed');
+    // The whole reason the classification is called deliveryStatus: this key is
+    // already the HTTP code and the channel route maps the response from it.
+    assert.equal(result.status, 403);
+    assert.equal(sendResultHttpStatus(result), 403);
+});
+
+test('a Discord send carries the platform message id instead of discarding it', async () => {
+    const fetchImpl = (async (url: string | URL | Request) => {
+        const isOpen = String(url).endsWith('/users/@me/channels');
+        return new Response(JSON.stringify(isOpen ? { id: 'DM123' } : { id: '111222333444555666' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+    const result = await sendDiscordDm('token', 'USER9', 'digest payload', fetchImpl);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.platformMessageId, '111222333444555666');
+    assert.equal(result.deliveryStatus, 'sent');
+    assert.equal(result.ambiguous, false);
+});
+
+test('a Discord send that returns no readable body stays sent but ambiguous', async () => {
+    // A 204 or an unparseable body still means the message was posted. Turning
+    // that into a transport failure would invent an error out of a success.
+    const fetchImpl = (async (url: string | URL | Request) => {
+        const isOpen = String(url).endsWith('/users/@me/channels');
+        if (isOpen) return new Response(JSON.stringify({ id: 'DM123' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        return new Response('', { status: 204 });
+    }) as typeof fetch;
+    const result = await sendDiscordDm('token', 'USER9', 'digest payload', fetchImpl);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.platformMessageId, null);
+    assert.equal(result.deliveryStatus, 'sent');
+    assert.equal(result.ambiguous, true);
+});
+
+test('the common receipt can express posted-but-unverified', () => {
+    assert.deepEqual(deliverySent('1.1', { verification: 'failed' }),
+        { deliveryStatus: 'sent', platformMessageId: '1.1', ambiguous: false, verification: 'failed' });
+    // Absent rather than undefined: exactOptionalPropertyTypes, and a caller
+    // checking 'verification' in receipt must not see a key that says nothing.
+    assert.equal('verification' in deliverySent('1.1'), false);
+    assert.deepEqual(deliverySent(null),
+        { deliveryStatus: 'sent', platformMessageId: null, ambiguous: true });
+    assert.deepEqual(deliveryFailed(null),
+        { deliveryStatus: 'failed', platformMessageId: null, ambiguous: false });
+});

--- a/tests/unit/messaging-delivery-receipt.test.ts
+++ b/tests/unit/messaging-delivery-receipt.test.ts
@@ -51,13 +51,14 @@ test('a Discord send carries the platform message id instead of discarding it', 
     assert.equal(result.ambiguous, false);
 });
 
-test('a Discord send that returns no readable body stays sent but ambiguous', async () => {
-    // A 204 or an unparseable body still means the message was posted. Turning
-    // that into a transport failure would invent an error out of a success.
+test('a Discord send with an unreadable body stays sent but ambiguous', async () => {
+    // An empty or non-JSON body still means the message was posted. Turning that
+    // into a transport failure would invent an error out of a success, so the
+    // parse swallows it and reports an unknown id instead.
     const fetchImpl = (async (url: string | URL | Request) => {
         const isOpen = String(url).endsWith('/users/@me/channels');
         if (isOpen) return new Response(JSON.stringify({ id: 'DM123' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
-        return new Response('', { status: 204 });
+        return new Response('<<not json>>', { status: 200, headers: { 'Content-Type': 'text/plain' } });
     }) as typeof fetch;
     const result = await sendDiscordDm('token', 'USER9', 'digest payload', fetchImpl);
     assert.equal(result.ok, true);

--- a/tests/unit/slack-table-content.test.ts
+++ b/tests/unit/slack-table-content.test.ts
@@ -12,6 +12,13 @@ test('same-size wrong cell fails without reposting', async () => {
     const result = await sendSlackText('fixture', { channel: 'slack', targetId: 'D1', targetKind: 'user', peerKind: 'direct' }, '| H |\n| --- |\n| X |', { fetchImpl });
     assert.equal(result.ok, true);
     assert.equal(result.delivery?.verification, 'failed');
+    // #687: posted is not verified. The common receipt says the send happened
+    // AND that rendering could not be confirmed, instead of hiding the second
+    // half behind ok:true where every caller ignored it.
+    assert.equal(result.deliveryStatus, 'sent');
+    assert.equal(result.verification, 'failed');
+    assert.equal(result.platformMessageId, '1.1');
+    assert.equal(result.ambiguous, false);
     assert.match(result.delivery!.messages[0]!.error!, /table_content_mismatch:0:1:0/);
     assert.equal(result.sent, true);
     assert.equal(result.retryable, false);


### PR DESCRIPTION
`DeliveryReceipt` was a dead contract. It defines a single outbound result and `ChannelAdapter` returns it, but no production class implements that port — the live registry only ever required `{ ok }`. So "success" meant three different things:

| Channel | what `ok: true` meant |
| --- | --- |
| Slack | posted; `delivery.verification` could still be `failed`, and callers reading only `ok` saw a render failure as a success |
| Discord | HTTP 2xx, with the message id parsed and then thrown away |
| Telegram | the call did not throw |

## What changed

Live transport results now carry `deliveryStatus`, `platformMessageId` and `ambiguous`, plus `verification` where a channel actually checks.

**The classification is `deliveryStatus`, not `status`.** #687's wording asks for a common `status`, but on a live send result that key is already the HTTP code: `sendResultHttpStatus` reads it and the channel route maps the response from it. Reusing it for a `sent`/`failed` enum would not have failed typecheck — `TransportSendFn` is an index bag — it would have silently turned a real 403 or 429 into a 502. A regression test pins that a numeric `status` still round-trips.

The fields are **optional on the registry bag and filled in by every leaf that dispatched**. A refusal that never reached a vendor (no channel configured, empty text, cancelled) has no receipt to give, and the type says so rather than forcing a fake one.

Per channel:

- **Slack** already had everything and discarded none of it; the success return now lifts `delivery.verification` onto the common key, so `ok: true` with `verification: 'failed'` is finally expressible. `ts` stays absent when Slack returns none.
- **Discord** was dropping the id in three `parse` callbacks, again in `sendResult`, again in `discord-file.ts`, and a fourth time in the handler. All four hops now carry it. Parse failures are swallowed inside `parse` on purpose: a 204 or an unreadable body still means the message was posted, and letting the scheduler see a throw would manufacture a transport failure out of a successful send.
- **Telegram** keeps `sendTelegramMarkdown` returning exactly `{ ok: true }` — an existing suite deep-equals it — so the id travels out through the existing `onBodyDelivered` callback, widened to take an optional argument. The keyboard path captures its id inside the thunk rather than changing the shared `sendWithRetryPolicy` contract for one caller.

`slackDeliveryError` and `telegramDeliveryError` are imported by no production file. Rather than wire them into paths that do not want them, they are now documented as test-only, with the reason. `discordDeliveryError` is the one live mapper.

`channel-contract-conformance` now states plainly that it is not connected to the live transports and why — the three bots do not implement `ChannelAdapter` at all, so this is a standing fact rather than a pending migration.

## Scope

Extended by the coordinating session after I raised it: `src/discord/bot.ts` (`discordSendHandler` return shape only) and `src/slack/send-handler.ts`. Without the Discord handler the fix would have stopped at the leaf and never reached `sendChannelOutput`. `src/slack/send-handler.ts` needed no change — its text branch already returns `sendSlackText` directly. Nothing else in `src/discord/bot.ts` is touched; `requiresNativeBodyDelivery`, the notice store wrap and the target reply forwarder belong to #699.

## Review

Two audit rounds. The first returned FAIL on four blockers: required receipt fields would have broken every handler early return under `exactOptionalPropertyTypes`; the Discord gateway file path strips the id in a file the design never mentioned; the Telegram keyboard cannot use `onBodyDelivered` because it never calls `sendTelegramMarkdown`; and two exact-shape pins live in a test file this change cannot edit. All four are folded into the implementation above. The second round verified each fold against source and passed.

`structure/str_func.md` was regenerated with `bash structure/verify-counts.sh --fix`.

Local `npm test`, `npm run typecheck` and `npm run build` were **NOT RUN** by instruction; CI on this head is the verification evidence.

Closes #687

