### PR TITLE
test: make graceful-shutdown fail closed and pin every skip to a reason

### DIFF
--- a/tests/helpers/skip-policy.mts
+++ b/tests/helpers/skip-policy.mts
@@ -1,0 +1,167 @@
+/**
+ * The one place that says why a test file can skip, and whether CI is allowed
+ * to accept that skip (#689).
+ *
+ * Skips were not the problem on their own. The problem was that nobody could
+ * tell an intentional local affordance from a test that had quietly stopped
+ * running: tests/run.mts counts failures and never skips, so a file that opts
+ * out is indistinguishable from one that passed. Writing the reason down is
+ * half of it; the other half is tests/integration/skip-policy.test.ts, which
+ * fails when a file skips without appearing here and when an entry here no
+ * longer matches a real skip.
+ *
+ * Policies:
+ *   ci-required        the dependency EXISTS on the CI lane that runs this
+ *                      file, so a skip there is a bug. The skip is a local
+ *                      affordance and the file must fail closed under CI.
+ *   local-skip-allowed the dependency is genuinely optional; skipping is fine
+ *                      anywhere, including CI.
+ *   opt-in-isolated    needs a flag, a credential or a host CI does not have.
+ *                      Intentionally quarantined; see the note for what would
+ *                      have to change to make it required.
+ *   platform           the skip is an OS or architecture gate. It runs on the
+ *                      lane that has that platform and skips on the others,
+ *                      which is correct rather than a gap.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+export type SkipPolicy = 'ci-required' | 'local-skip-allowed' | 'opt-in-isolated' | 'platform';
+
+export interface SkipEntry {
+    file: string;
+    why: string;
+    policy: SkipPolicy;
+}
+
+export const TESTS_ROOT = resolve(import.meta.dirname, '..');
+
+export const SKIP_POLICY: SkipEntry[] = [
+    // ── integration ──────────────────────────────────────────────────────────
+    {
+        file: 'tests/integration/api-smoke.test.ts',
+        policy: 'ci-required',
+        why: 'Needs the server the integration job starts on TEST_PORT. Already fails closed: a missing server is assert.fail under CI and a skip only on a developer box. This is the pattern the rest of this table is measured against.',
+    },
+    {
+        file: 'tests/integration/graceful-shutdown.test.ts',
+        policy: 'ci-required',
+        why: 'Needs dist/bin/cli-jaw.js, which the integration job builds with npm run build before this suite. Both a missing dist and a server that will not become healthy are assert/throw under CI; the skip branches are developer-box affordances only.',
+    },
+    {
+        file: 'tests/integration/compact-api-managed.test.ts',
+        policy: 'ci-required',
+        why: 'Skips when node_modules/.bin/tsx is absent. CI runs npm ci, so tsx is always there and the skip cannot fire; it exists for a checkout without dependencies.',
+    },
+    {
+        file: 'tests/integration/multi-instance.test.ts',
+        policy: 'ci-required',
+        why: 'Same tsx-presence guard as compact-api-managed, for the same reason and with the same CI expectation.',
+    },
+    {
+        file: 'tests/integration/codex-app-multiplex-activation.test.ts',
+        policy: 'opt-in-isolated',
+        why: 'Drives a real codex-cli app-server and needs both CLI_JAW_CODEX_APP_ACTIVATION=1 and live Codex credentials, which CI has neither of. The auth-free half of this surface is covered unskipped by tests/integration/codex-app-multiplex-fixture.test.ts; this file stays for the live lane.',
+    },
+    {
+        file: 'tests/integration/agy-print-smoke.test.ts',
+        policy: 'opt-in-isolated',
+        why: 'Requires JAW_AGY_SMOKE=1 and a working AGY install performing real inference. Making it CI-required would mean paying for a model call on every PR.',
+    },
+    {
+        file: 'tests/integration/windows-ssh-classic.mts',
+        policy: 'opt-in-isolated',
+        why: 'Needs a reachable Windows sshd named by JAW_WINDOWS_SSH_HOST. Note it is an .mts file, so --scope integration never collects it at all: the skip inside it is not what keeps it out of CI, the extension is.',
+    },
+    // ── browser and smoke, outside the PR admission path ─────────────────────
+    {
+        file: 'tests/browser/manager-layout-smoke.test.ts',
+        policy: 'opt-in-isolated',
+        why: 'Needs a Chrome DevTools endpoint. The browser scope is not part of the integration job, and this file skips rather than failing when the default CDP port refuses a connection.',
+    },
+    {
+        file: 'tests/smoke/native-activity-burst.mts',
+        policy: 'opt-in-isolated',
+        why: 'Opt-in burst probe behind CLI_JAW_BURST_BROWSER / CLI_JAW_BURST_LABEL. smoke is not a runner scope and the file is .mts, so it is never collected.',
+    },
+    // ── unit: platform gates ─────────────────────────────────────────────────
+    { file: 'tests/unit/electron-jaw-spawn-orphan-kill.test.ts', policy: 'platform', why: 'POSIX process-group semantics; skipped on win32 and run on the Linux shards.' },
+    { file: 'tests/unit/electron-dropped-paths.test.ts', policy: 'platform', why: 'Needs working symlinks; skips where symlink() throws.' },
+    { file: 'tests/unit/file-open-route.test.ts', policy: 'platform', why: 'POSIX-only file-open behaviour; skipped on win32.' },
+    { file: 'tests/unit/cli-status-cache.test.ts', policy: 'platform', why: 'A POSIX-only path case skipped on win32; the rest of the file runs on every lane, so the Windows job loses one case rather than the file.' },
+    { file: 'tests/unit/default-runtime-migration.test.ts', policy: 'platform', why: 'A POSIX-only path case skipped on win32; the migration itself is asserted on every lane.' },
+    { file: 'tests/unit/path-guards.test.ts', policy: 'platform', why: 'A POSIX-only path case skipped on win32; Windows path guarding has its own cases in the windows-* files.' },
+    { file: 'tests/unit/retired-runtime-package.test.ts', policy: 'platform', why: 'POSIX-only packaging case; skipped on win32.' },
+    { file: 'tests/unit/safe-install.test.ts', policy: 'platform', why: 'POSIX-only install case; skipped on win32.' },
+    { file: 'tests/unit/settings-permissions.test.ts', policy: 'platform', why: 'Asserts POSIX mode bits, which Windows does not have.' },
+    { file: 'tests/unit/service-artifact.test.ts', policy: 'platform', why: 'Mixed gates: POSIX aliases skipped on win32, and launchd cases that need darwin.' },
+    { file: 'tests/unit/launchd-plist.test.ts', policy: 'platform', why: 'Validates a launchd plist with plutil, which only exists on darwin. Nothing on the Linux or Windows lanes can assert this and no fixture substitutes for the real parser.' },
+    { file: 'tests/unit/tcc.test.ts', policy: 'platform', why: 'macOS TCC behaviour; skipped everywhere else.' },
+    { file: 'tests/unit/pi-capability-readiness.test.ts', policy: 'platform', why: 'Pi readiness cases that depend on POSIX process behaviour; skipped on win32.' },
+    { file: 'tests/unit/gyp-python-pick.test.ts', policy: 'platform', why: 'POSIX-only python discovery; the posixOnly helper is test.skip on win32.' },
+    { file: 'tests/unit/officecli-powershell-installer.test.ts', policy: 'platform', why: 'Windows-only installer; skipped off win32.' },
+    { file: 'tests/unit/windows-spawn-primitives.test.ts', policy: 'platform', why: 'Windows-only spawn primitives; runs on the windows-unit lane.' },
+    { file: 'tests/unit/windows-service-lifecycle-honesty.test.ts', policy: 'platform', why: 'Windows-only service lifecycle; runs on the windows-unit lane.' },
+    { file: 'tests/unit/windows-installer-shims.test.ts', policy: 'platform', why: 'Windows-only installer shims; runs on the windows-unit lane.' },
+    { file: 'tests/unit/windows-native-cli-detect.test.ts', policy: 'platform', why: 'Windows-only CLI detection; the onWindows helper is test.skip off win32.' },
+    { file: 'tests/unit/sidecar-bundle-ownership.test.ts', policy: 'platform', why: 'Only meaningful on the platforms that ship a sidecar (darwin arm64/x64, linux x64); skipped elsewhere.' },
+    // ── unit: dependency present on the lane that runs them ──────────────────
+    { file: 'tests/unit/manager-notes-routes.test.ts', policy: 'ci-required', why: 'Skips without ripgrep. The Linux test shards install it, so the skip is for developer boxes.' },
+    { file: 'tests/unit/browser-connection.test.ts', policy: 'ci-required', why: 'Needs the skills_ref submodule, which CI initialises.' },
+    { file: 'tests/unit/browser-skill-policy.test.ts', policy: 'ci-required', why: 'Needs skills_ref skill documents, which CI initialises.' },
+    { file: 'tests/unit/codex-imagegen-skill.test.ts', policy: 'ci-required', why: 'Reads the imagegen skill document out of the skills_ref submodule, which CI initialises; the skip covers a checkout that has not pulled submodules.' },
+    { file: 'tests/unit/desktop-control-skill-contract.test.ts', policy: 'ci-required', why: 'Reads jaw-desktop-control/SKILL.md out of the skills_ref submodule, which CI initialises; the skip covers a checkout without submodules.' },
+    { file: 'tests/unit/skill-phase-naming.test.ts', policy: 'ci-required', why: 'Needs skills_ref documents, which CI initialises.' },
+    { file: 'tests/unit/search-skill-policy.test.ts', policy: 'ci-required', why: 'Needs the skills_ref search skill and its siblings, which CI initialises.' },
+    { file: 'tests/unit/employee-prompt.test.ts', policy: 'ci-required', why: 'Mixed: skills_ref-dependent cases plus two permanently disabled DEPRECATED patch3 cases that are not environment-dependent at all.' },
+    { file: 'tests/unit/orc-snapshot-reconnect.test.ts', policy: 'ci-required', why: 'Guards on public/js sources that exist in the repository; the skip is a stale not-yet-created guard.' },
+    { file: 'tests/unit/web-refresh-state-recovery.test.ts', policy: 'ci-required', why: 'Same stale guard on public/js sources that are present.' },
+    { file: 'tests/unit/help-renderer.test.ts', policy: 'ci-required', why: 'Skips on ERR_MODULE_NOT_FOUND for a help renderer that exists on this branch; a stale guard, not an environment fact.' },
+    { file: 'tests/unit/commands-policy.test.ts', policy: 'ci-required', why: 'Same stale ERR_MODULE_NOT_FOUND guard for a policy module that exists.' },
+    { file: 'tests/unit/native-repair-lock.test.ts', policy: 'local-skip-allowed', why: 'Skips unless the shipped lock module exposes its __testing surface, which is a property of the build rather than of the host.' },
+    { file: 'tests/unit/orchestrator-parsing.test.ts', policy: 'local-skip-allowed', why: 'Permanently disabled: every case is { skip: "DEPRECATED: patch3" }. Not environment-dependent. Recorded so it is visible; reviving or deleting it is a separate decision.' },
+];
+
+const SKIP_PATTERNS: RegExp[] = [
+    /\bt\.skip\s*\(/,
+    /\bctx\.skip\s*\(/,
+    /\b(?:test|it|describe)\.skip\b/,
+    /[{,]\s*skip\s*[:}]/,
+];
+
+/**
+ * Comments are stripped first. Two files carry a comment explaining that they
+ * deliberately do NOT skip, and counting those as skips would make the registry
+ * describe the opposite of what the file does.
+ */
+function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function walk(dir: string, out: string[]): string[] {
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            // Helpers and fixtures are machinery, not tests: a guard inside them
+            // is the helper's own control flow, not a test opting out.
+            if (entry === 'helpers' || entry === 'fixtures' || entry === 'setup' || entry === 'node_modules') continue;
+            walk(full, out);
+        } else if (entry.endsWith('.test.ts') || entry.endsWith('.mts')) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+/** Test files that contain at least one skip site, as repository-relative paths. */
+export function findSkippingFiles(): string[] {
+    const files = walk(TESTS_ROOT, []);
+    const hits: string[] = [];
+    for (const file of files) {
+        const source = stripComments(readFileSync(file, 'utf8'));
+        if (SKIP_PATTERNS.some(pattern => pattern.test(source))) {
+            hits.push('tests/' + relative(TESTS_ROOT, file).split(sep).join('/'));
+        }
+    }
+    return hits.sort();
+}

--- a/tests/integration/codex-app-multiplex-fixture.test.ts
+++ b/tests/integration/codex-app-multiplex-fixture.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The Codex-app multiplex contract that does NOT need credentials (#689).
+ *
+ * tests/integration/codex-app-multiplex-activation.test.ts is gated twice —
+ * CLI_JAW_CODEX_APP_ACTIVATION=1 and a real Codex token — so it has never run
+ * in PR CI. This file has no gate of any kind and runs on every PR.
+ *
+ * Scope, stated plainly so nobody reads more into a green run than it earns:
+ * this covers the lane and bucket ADDRESSING that decides whether two scopes
+ * share a conversation, and the pool bookkeeping that a reset depends on.
+ * Driving two overlapping turns through a live app-server, interrupting one,
+ * and resuming a persisted thread still belongs to the opt-in file, because
+ * CodexAppClient is constructed inside the pool and there is no seam that
+ * substitutes a fake without also replacing the thing under test.
+ *
+ * Addressing is worth its own coverage: every multiplex bug that reached a user
+ * was two scopes resolving to one key, or one scope resolving to two.
+ */
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCodexAppLaneKey, resolveScopedSessionBucket } from '../../src/agent/args.ts';
+import {
+    codexAppHostPoolStats,
+    invalidateCodexAppLanesForScope,
+    shutdownCodexAppHostPool,
+} from '../../src/agent/codex-host-pool.ts';
+import { getSessionBucket, upsertSessionBucket } from '../../src/core/db.ts';
+
+const SCOPE_A = 'local:lane-a';
+const SCOPE_B = 'local:lane-b';
+
+test('MPX-FIX-001: a lane key separates scopes in both lane modes', () => {
+    // native keys by scope alone: one conversation per scope regardless of the
+    // model or effort the turn happens to use.
+    assert.equal(resolveCodexAppLaneKey(SCOPE_A, 'gpt-5', 'high', 'native'), SCOPE_A);
+    assert.equal(resolveCodexAppLaneKey(SCOPE_A, 'other-model', 'low', 'native'), SCOPE_A);
+    assert.notEqual(
+        resolveCodexAppLaneKey(SCOPE_A, 'gpt-5', 'high', 'native'),
+        resolveCodexAppLaneKey(SCOPE_B, 'gpt-5', 'high', 'native'),
+    );
+
+    // fallback additionally keys by model and effort, so the same scope on a
+    // different model is a different lane rather than a resumed one.
+    assert.equal(resolveCodexAppLaneKey(SCOPE_A, 'gpt-5', 'high', 'fallback'), SCOPE_A + ':gpt-5:high');
+    assert.notEqual(
+        resolveCodexAppLaneKey(SCOPE_A, 'gpt-5', 'high', 'fallback'),
+        resolveCodexAppLaneKey(SCOPE_A, 'gpt-5', 'low', 'fallback'),
+    );
+});
+
+test('MPX-FIX-002: two scopes get two buckets, and each persists its own session id', () => {
+    const bucketA = resolveScopedSessionBucket('codex-app', 'gpt-5', null, SCOPE_A, 'high', 'native');
+    const bucketB = resolveScopedSessionBucket('codex-app', 'gpt-5', null, SCOPE_B, 'high', 'native');
+    assert.notEqual(bucketA, bucketB, 'two scopes sharing a bucket is two chats sharing a conversation');
+
+    // A non-multiplex codex-app run must NOT be handed the multiplex key shape,
+    // or the default scope stops finding the conversation it has been using.
+    const legacy = resolveScopedSessionBucket('codex-app', 'gpt-5', null, 'default', 'high', 'native', false);
+    assert.ok(!legacy.includes(SCOPE_A));
+    assert.notEqual(legacy, bucketA);
+
+    // Real SQLite, isolated home: the round trip is what a resume reads.
+    upsertSessionBucket.run(bucketA, 'session-a', 'gpt-5', 'resume-a', 0);
+    upsertSessionBucket.run(bucketB, 'session-b', 'gpt-5', 'resume-b', 0);
+    const storedA = getSessionBucket.get(bucketA) as { session_id?: string } | undefined;
+    const storedB = getSessionBucket.get(bucketB) as { session_id?: string } | undefined;
+    assert.equal(storedA?.session_id, 'session-a');
+    assert.equal(storedB?.session_id, 'session-b');
+
+    // Rewriting one lane must not disturb the other: this is the persistence
+    // half of "two scoped turns stay isolated".
+    upsertSessionBucket.run(bucketA, 'session-a2', 'gpt-5', 'resume-a2', 0);
+    assert.equal((getSessionBucket.get(bucketA) as { session_id?: string }).session_id, 'session-a2');
+    assert.equal((getSessionBucket.get(bucketB) as { session_id?: string }).session_id, 'session-b');
+});
+
+test('MPX-FIX-003: a scoped reset on an idle pool is a no-op rather than an error', () => {
+    const stats = codexAppHostPoolStats();
+    assert.equal(stats.hosts, 0, 'no test in this file may leave a host behind');
+    assert.equal(stats.lanes, 0);
+    assert.equal(stats.busyLanes, 0);
+    assert.equal(stats.closing, false);
+
+    // A reset arriving for a scope with no lanes reports zero rather than
+    // throwing. /api/session/reset calls this on every reset, including the
+    // common case where the runtime never started.
+    assert.equal(invalidateCodexAppLanesForScope(SCOPE_A), 0);
+    // null means every scope — the instance-wide reset path.
+    assert.equal(invalidateCodexAppLanesForScope(null), 0);
+});
+
+test('MPX-FIX-004: shutting down an idle pool is safe and repeatable', async () => {
+    await shutdownCodexAppHostPool({ reason: 'test', timeoutMs: 2_000 });
+    // Shutdown runs on every serve exit, including exits where no Codex host was
+    // ever created; a second call must not throw either.
+    await shutdownCodexAppHostPool({ reason: 'test-again', timeoutMs: 2_000 });
+    assert.equal(codexAppHostPoolStats().hosts, 0);
+});

--- a/tests/integration/graceful-shutdown.test.ts
+++ b/tests/integration/graceful-shutdown.test.ts
@@ -5,15 +5,28 @@ import fs from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { findFreePort } from '../helpers/jaw-server.mts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..', '..');
 const CLI_ENTRY = join(ROOT, 'dist', 'bin', 'cli-jaw.js');
 const HAS_DIST = fs.existsSync(CLI_ENTRY);
+const IN_CI = !!process.env['CI'];
 
-function pickPort(seed = 0) {
-    const base = 46800 + seed * 100;
-    return base + Math.floor(Math.random() * 80);
+/**
+ * A missing dist is a developer-box fact and a broken job under CI: the
+ * integration workflow runs npm run build before this suite precisely so that
+ * dist/bin/cli-jaw.js and the assets it loads exist. Skipping there would turn
+ * a failed build into a green run, which is the same shape as the #661 loss.
+ * This is the api-smoke.test.ts rule applied to the file that needed it most.
+ */
+function requireDist(t: { skip(reason: string): void }): boolean {
+    if (HAS_DIST) return true;
+    if (IN_CI) {
+        assert.fail('dist/bin/cli-jaw.js is missing under CI — the integration job runs "npm run build" before this suite, so this is a broken job, not a missing local build');
+    }
+    t.skip('dist not built; run npm run build to exercise shutdown locally');
+    return false;
 }
 
 async function sleep(ms: number) {
@@ -22,7 +35,10 @@ async function sleep(ms: number) {
 
 async function isHealthy(port: number) {
     try {
-        const res = await fetch(`http://localhost:${port}/api/health`);
+        // Bounded. Without a timeout a half-open socket parks this fetch
+        // indefinitely and the 30s waitForHealth loop never gets to iterate —
+        // a fail-closed test that hangs is not an improvement on a green skip.
+        const res = await fetch(`http://localhost:${port}/api/health`, { signal: AbortSignal.timeout(2000) });
         return res.ok;
     } catch {
         return false;
@@ -56,7 +72,10 @@ async function runSignalCase(
     signalTarget: 'parent' | 'group' = 'parent',
 ) {
     const home = fs.mkdtempSync(join(tmpdir(), `jaw-shutdown-it-${seed}-`));
-    const port = pickPort(seed);
+    // A probed free port, not a random one in a fixed band: files run
+    // concurrently under process isolation, so two cases could pick the same
+    // number and the loser would look like a server that refused to boot.
+    const port = await findFreePort();
     const child = spawn(
         process.execPath,
         [CLI_ENTRY, '--home', home, 'serve', '--port', String(port), '--no-open'],
@@ -69,10 +88,19 @@ async function runSignalCase(
     try {
         try {
             await waitForHealth(port);
-        } catch {
-            // Server failed to start — skip test (CI may lack native modules)
+        } catch (error) {
             child.kill('SIGKILL');
             fs.rmSync(home, { recursive: true, force: true });
+            // Under CI the server not booting IS the finding. The stderr was
+            // already being captured here and then thrown away, which is why
+            // every past occurrence read as an environment quirk rather than as
+            // the failure it is.
+            if (IN_CI) {
+                throw new Error(
+                    `serve failed to become healthy on port ${port} under CI (${(error as Error).message}).\n`
+                    + `child stderr:\n${stderr || '(empty)'}`,
+                );
+            }
             return 'skipped';
         }
         const startedAt = Date.now();
@@ -98,12 +126,16 @@ async function runSignalCase(
     return 'ok';
 }
 
-test('GSI-001: serve exits within timeout on SIGTERM and closes port', { skip: !HAS_DIST && 'dist not built' }, async (t) => {
+test('GSI-001: serve exits within timeout on SIGTERM and closes port', async (t) => {
+    if (!requireDist(t)) return;
     const result = await runSignalCase('SIGTERM', 1);
-    if (result === 'skipped') t.skip('server failed to start (CI environment)');
+    // Unreachable under CI: runSignalCase throws there instead of reporting a
+    // sentinel, so this branch is a developer-box affordance only.
+    if (result === 'skipped') t.skip('server failed to start locally');
 });
 
-test('GSI-002: serve exits within timeout on SIGINT and closes port', { skip: !HAS_DIST && 'dist not built' }, async (t) => {
+test('GSI-002: serve exits within timeout on SIGINT and closes port', async (t) => {
+    if (!requireDist(t)) return;
     const result = await runSignalCase('SIGINT', 2, 'group');
-    if (result === 'skipped') t.skip('server failed to start (CI environment)');
+    if (result === 'skipped') t.skip('server failed to start locally');
 });

--- a/tests/integration/skip-policy.test.ts
+++ b/tests/integration/skip-policy.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Keeps the skip registry honest (#689).
+ *
+ * tests/run.mts counts failures and ignores skips, so a file that quietly stops
+ * running looks exactly like one that passed. #661 is the precedent: a driver
+ * bug reported 2 of 6 tests in a file and a green ci-aggregate hid a real
+ * failure. A prose table would rot the same way, so the table is executable:
+ * a new skipping file fails this test until someone writes down why, and an
+ * entry that no longer matches a real skip fails it until someone removes it.
+ *
+ * Granularity is per FILE, not per line. Several worktrees edit tests/unit in
+ * parallel, and adding a case to an already-registered file should not break
+ * anyone. A brand-new skipping file should, and does.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SKIP_POLICY, findSkippingFiles, type SkipPolicy } from '../helpers/skip-policy.mts';
+
+const POLICIES: SkipPolicy[] = ['ci-required', 'local-skip-allowed', 'opt-in-isolated', 'platform'];
+
+test('SKIP-POLICY-001: every skipping test file states why it skips', () => {
+    const listed = new Set(SKIP_POLICY.map(entry => entry.file));
+    const unlisted = findSkippingFiles().filter(file => !listed.has(file));
+    assert.deepEqual(
+        unlisted,
+        [],
+        'these test files skip without a recorded reason. Add an entry to tests/helpers/skip-policy.mts '
+        + 'saying why the skip exists and whether CI is allowed to accept it:\n  ' + unlisted.join('\n  '),
+    );
+});
+
+test('SKIP-POLICY-002: every recorded entry still matches a real skip', () => {
+    const found = new Set(findSkippingFiles());
+    const stale = SKIP_POLICY.map(entry => entry.file).filter(file => !found.has(file));
+    assert.deepEqual(
+        stale,
+        [],
+        'these entries no longer describe a file that skips. Remove them from tests/helpers/skip-policy.mts '
+        + 'rather than leaving the table describing a past state:\n  ' + stale.join('\n  '),
+    );
+});
+
+test('SKIP-POLICY-003: every entry carries a reason and a known policy', () => {
+    const seen = new Set<string>();
+    for (const entry of SKIP_POLICY) {
+        assert.ok(!seen.has(entry.file), 'duplicate entry for ' + entry.file);
+        seen.add(entry.file);
+        assert.ok(POLICIES.includes(entry.policy), entry.file + ' has an unknown policy: ' + entry.policy);
+        // A reason short enough to be a label is not a reason. The point of the
+        // table is that a reader who did not write the skip can judge it.
+        assert.ok(entry.why.trim().length >= 40, entry.file + ' needs a real explanation, not a label: ' + entry.why);
+    }
+});
+
+test('SKIP-POLICY-004: the two files that fail closed under CI still do', () => {
+    // These are the anchors of the whole classification. api-smoke has always
+    // failed closed; graceful-shutdown is the one #689 was opened about, and if
+    // its CI branch is ever removed the table would still claim ci-required
+    // while the file green-skips again.
+    for (const file of ['tests/integration/api-smoke.test.ts', 'tests/integration/graceful-shutdown.test.ts']) {
+        const entry = SKIP_POLICY.find(candidate => candidate.file === file);
+        assert.ok(entry, file + ' must be recorded');
+        assert.equal(entry.policy, 'ci-required', file + ' is the pattern the table is measured against');
+    }
+});


### PR DESCRIPTION
`graceful-shutdown` could fail in CI and still report green. If `dist/bin/cli-jaw.js` was missing, both cases skipped — even though the integration job builds it immediately before this suite. If the server never became healthy, `runSignalCase` returned a `'skipped'` sentinel that became `t.skip('server failed to start (CI environment)')`, and the stderr it had already captured was discarded. That is the same shape as #661: a test that did not run, reported as a test that passed.

## What changes

**`graceful-shutdown` fails closed.** A missing dist under `CI` is now `assert.fail` naming the build step that should have produced it; a server that will not become healthy throws with the captured stderr attached. Both skip branches survive only on a developer box. Two related repairs while in there: the health probe is bounded, because an unbounded `fetch` against a half-open socket parks the 30s wait loop and a fail-closed test that hangs is no better than a green skip; and the port is probed rather than picked at random in a fixed band, where two concurrent files could collide and the loser would look like a server that refused to boot.

**An auth-free multiplex file.** `codex-app-multiplex-activation.test.ts` needs `CLI_JAW_CODEX_APP_ACTIVATION=1` and a real Codex token, so it has never run on a PR. `codex-app-multiplex-fixture.test.ts` has no gate and covers the half that needs neither: the lane keys and session buckets that decide whether two scopes share a conversation, against real SQLite, plus the pool bookkeeping a reset depends on. Its header states plainly what it does not cover — two live turns through an app-server stay in the opt-in file — so a green run cannot be read as more than it is.

**One enforced skip registry.** `tests/helpers/skip-policy.mts` lists all 43 test files that contain a skip, each with a reason and one of four policies: `ci-required` (the dependency exists on the lane that runs it, so a skip there is a bug), `local-skip-allowed`, `opt-in-isolated` (needs a flag, credential or host CI does not have), and `platform`. `skip-policy.test.ts` fails when a file skips without an entry, and when an entry no longer matches a real skip, so the table cannot rot into fiction in either direction.

## Notes for review

- The registry is built from the live tree, not from the table in the issue, which is stale in both line numbers and count. It also records two things that table missed: `tests/unit/orchestrator-parsing.test.ts` is permanently disabled with `DEPRECATED: patch3` rather than environment-gated, and `tests/integration/windows-ssh-classic.mts` is kept out of CI by its `.mts` extension — `--scope integration` collects only `*.test.ts`, so the skip inside it is not what excludes it.
- Enforcement is per file, not per line, so adding a case to an already-registered file does not break the worktrees editing `tests/unit` in parallel. A brand-new skipping file does break it, which is the point.
- The scanner strips comments first. Two files carry a comment explaining that they deliberately do **not** skip, and counting those would make the registry describe the opposite of what they do.
- The plan called for grepping each `ci-required` file for a `process.env.CI` guard near its skip. That was dropped: proximity in a text scan is not reachability, and a false red there would be blamed on the scanner rather than on the skip. `graceful-shutdown` proves its CI behaviour structurally in the diff instead.

## Validation

Local product suites were not run: `npm test`, `npm run typecheck` and `npm run build` are all **NOT RUN** by instruction. After rebasing onto `dev` `1ed0fea2f`:

```
tests/run.mts --scope integration
tests 79 | pass 74 | fail 0 | cancelled 0 | skipped 5
```

The 5 local skips are `graceful-shutdown` ×2 (no fresh `dist` on this machine — in CI both ran and passed), AGY smoke, multiplex activation, and the tsx guard. On the previous CI run for #719 the integration job already showed `GSI-001` and `GSI-002` passing, so the fail-closed change tightens a path that CI exercises rather than one it skips.

Authoritative evidence is the `ci-aggregate` result on this PR.

Closes #689

