### PR TITLE
test(slack): assert the outbound answer log masks credentials

### DIFF
--- a/tests/unit/slack-delivery-helper.test.ts
+++ b/tests/unit/slack-delivery-helper.test.ts
@@ -3,6 +3,8 @@ import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { settings } from '../../src/core/config.ts';
 import { broadcast } from '../../src/core/bus.ts';
+import { log } from '../../src/core/logger.ts';
+import { redactChannelSecrets } from '../../src/messaging/redact.ts';
 
 // Drive the real Slack bot producers. Collection, gateway admission, ACK,
 // progress, identity and the outbound Slack transports are faked; no socket,
@@ -203,4 +205,28 @@ test('the ACK settles when the body is posted, before readback verification fini
         `ACK must settle before send resolves: ${JSON.stringify(operations)}`,
     );
     assert.ok(operations.indexOf('ack:success') < operations.indexOf('send:resolved'));
+});
+
+test('the outbound answer log masks credentials the agent echoed', async t => {
+    // #697 names src/slack/bot.ts as a hot path whose masking fixes landed
+    // without tests. This line writes AGENT OUTPUT to the log ring and the
+    // console on every delivered turn, so it is where a credential the model
+    // repeated back would actually leak - and #686 just moved it out of
+    // runReply into the shared helper's onSent hook, which is exactly when an
+    // unasserted contract quietly stops holding.
+    const secret = ['xoxb', '1234567890', '1234567890', 'abcdefghijklmnopqrstuvwx'].join('-');
+    const masked = redactChannelSecrets(secret);
+    const lines: string[] = [];
+    t.mock.method(log, 'info', (...args: unknown[]) => { lines.push(args.map(value => String(value)).join(' ')); });
+
+    // The masker runs before the 80-character truncation, so putting the
+    // credential first keeps this about masking rather than about slicing.
+    body = `${secret} is the token you asked about`;
+    await run();
+    await drain();
+
+    const outbound = lines.find(line => line.startsWith('[slack:out'));
+    assert.ok(outbound, `no outbound log line was emitted: ${JSON.stringify(lines)}`);
+    assert.ok(!outbound.includes(secret), `raw credential reached the log: ${outbound}`);
+    assert.ok(outbound.includes(masked), `masked form missing: ${outbound}`);
 });


### PR DESCRIPTION
PR #715 closed the `d5fab24614` gap — the two fail-open token-claim warnings in `runSlackInit` now assert their masking. But #697's scope item 3 names the whole hot path, not that one commit, and `src/slack/bot.ts` still has four `redactOutboundText` call sites with no assertion on any of them.

This takes the one that matters most: the `[slack:out]` answer log. It writes **agent output** to the log ring and the console on every delivered Slack turn, so it is the site where a credential the model repeated back would actually leak. It is also the line PR #710 physically moved out of `runReply` into the shared helper's `onSent` hook — which is exactly the moment an unasserted contract quietly stops holding.

The test drives the real `src/slack/bot.ts` direct path through the existing harness, delivers an answer whose text begins with a credential, and asserts three things about the emitted line: it was emitted at all, the raw credential is absent, and the masked form is present. It fails if `redactOutboundText` is removed from that line.

Two details worth knowing:

- Masking happens **before** the 80-character truncation (`redactOutboundText(text).slice(0, 80)`), so the credential goes at the start of the body. Otherwise the test could pass because truncation dropped the token rather than because masking worked.
- The fixture credential is assembled at runtime and the expected masked string is computed with `redactChannelSecrets`, not hardcoded. A literal bot-token shape in source trips GitHub push protection, which blocked PR #715's first push.

Test-only; no production change. `Refs #697` rather than `Closes` — the issue is shared, and W1's half already merged as #712.

Local `npm test`, `npm run typecheck` and `npm run build` were **NOT RUN** by instruction; CI on this head is the verification evidence.

Refs #697

