### PR TITLE
test(slack): prove the steered turn ran, and list the helpers this work added

### DIFF
--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -9,12 +9,18 @@ not a scope. Files here are imported or spawned by a test that is.
 
 | File | Shape | Driven by |
 | --- | --- | --- |
+| `jaw-server.mts` | Spawns an isolated product server with its own home, settings and port; probes readiness, captures the child's output, and fails closed under `CI` | `tests/integration/slack-inbound-turn.test.ts`, `agent-lifecycle-real-child.test.ts`, `graceful-shutdown.test.ts` |
+| `slack-fixture.mts` | A scripted Slack: Web API over HTTP plus Socket Mode over a real websocket, recording every call | `tests/integration/slack-inbound-turn.test.ts` |
+| `slack-api-preload.mjs` | `--import` preload that redirects a server child's Slack traffic at the fixture through `globalThis.fetch` | the same test, via `NODE_OPTIONS` |
+| `code-fake-providers.mts` | Injectable Code providers that never spawn a runtime, with per-instance open/send counters | `tests/integration/code-native-api.test.ts` |
+| `code-host-child.mts` | A child Code host that can crash itself mid-turn, so recovery has a real orphan to seal | `tests/integration/code-native-api.test.ts` |
+| `skip-policy.mts` | The registry of every test file that skips, with a reason and a CI policy, plus the detector both it and its test use | `tests/integration/skip-policy.test.ts` |
 | `code-native-qa-server.mjs` | Supervises a built Manager with mocked Code providers, plus a `/__qa` control surface | `tests/browser/code-native-workbench.test.ts`, `tests/browser/retired-runtime-settings.test.ts` |
 | `hosted-manager-qa.mjs` | Hosted Manager + Playwright QA driver | the `workflow_dispatch`-only Hosted Manager QA job |
 
-Both need a build and a browser, which is why they sit outside the PR-admission
-path. A helper that an `integration` test depends on must not: that job runs on
-every code PR and feeds `ci-aggregate`.
+The last two need a build and a browser, which is why they sit outside the
+PR-admission path. A helper that an `integration` test depends on must not: that
+job runs on every code PR and feeds `ci-aggregate`.
 
 ## Rules for a new helper
 

--- a/tests/integration/skip-policy.test.ts
+++ b/tests/integration/skip-policy.test.ts
@@ -14,7 +14,10 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { SKIP_POLICY, findSkippingFiles, type SkipPolicy } from '../helpers/skip-policy.mts';
+import { TESTS_ROOT } from '../helpers/skip-policy.mts';
 
 const POLICIES: SkipPolicy[] = ['ci-required', 'local-skip-allowed', 'opt-in-isolated', 'platform'];
 
@@ -52,14 +55,34 @@ test('SKIP-POLICY-003: every entry carries a reason and a known policy', () => {
     }
 });
 
-test('SKIP-POLICY-004: the two files that fail closed under CI still do', () => {
-    // These are the anchors of the whole classification. api-smoke has always
-    // failed closed; graceful-shutdown is the one #689 was opened about, and if
-    // its CI branch is ever removed the table would still claim ci-required
-    // while the file green-skips again.
+test('SKIP-POLICY-004: the two anchor files really do fail closed under CI', () => {
+    // These two are the anchors of the whole classification. api-smoke has
+    // always failed closed; graceful-shutdown is the one #689 was opened about.
+    //
+    // Asserting only that the TABLE says ci-required would be circular: if the
+    // CI branch were removed from either file the table would keep claiming it
+    // while the file green-skipped again, which is the exact failure this
+    // registry exists to prevent. So these two are also read.
+    //
+    // This is deliberately NOT applied to every ci-required entry. Proximity in
+    // a text scan is not reachability, and a false red across forty files would
+    // be blamed on this test rather than on the skip. Two named files whose
+    // fail-closed branch is the subject of the issue are worth the exactness.
     for (const file of ['tests/integration/api-smoke.test.ts', 'tests/integration/graceful-shutdown.test.ts']) {
         const entry = SKIP_POLICY.find(candidate => candidate.file === file);
         assert.ok(entry, file + ' must be recorded');
         assert.equal(entry.policy, 'ci-required', file + ' is the pattern the table is measured against');
+
+        const source = readFileSync(join(TESTS_ROOT, '..', file), 'utf8');
+        assert.match(
+            source,
+            /process\.env(?:\.CI|\['CI'\]|\["CI"\])/,
+            file + ' is recorded as ci-required but no longer looks at process.env.CI',
+        );
+        assert.match(
+            source,
+            /assert\.fail\(|throw new Error\(/,
+            file + ' is recorded as ci-required but has no failure path; a ci-required file must fail rather than skip when its dependency is missing',
+        );
     }
 });

--- a/tests/integration/slack-inbound-turn.test.ts
+++ b/tests/integration/slack-inbound-turn.test.ts
@@ -163,6 +163,17 @@ test('SLACK-INT: a mention crosses from socket envelope to posted reply', { time
         await fixture.emitUntilAcked(envelope('E3', '<@UBOT> second STUB_MODI:echo:three', '1735689602.000100'));
         writeFileSync(join(stubDir, 'release-s1'), '');
 
+        // The second mention must actually have produced a turn. Without this a
+        // steer that silently DROPPED the follow-up would still satisfy the wait
+        // below, because releasing the first held child produces a reply on its
+        // own — the test would be measuring the release, not the steer.
+        await waitFor(
+            'a child for the steering mention',
+            () => stubRecords(stubDir).some(record => String(record['prompt']).includes('STUB_MODI:echo:three')),
+            60_000,
+            () => 'stub prompts seen: ' + JSON.stringify(stubRecords(stubDir).map(r => String(r['prompt']).slice(-60))),
+        );
+
         await waitFor(
             'a reply after the steer',
             () => postedTexts(fixture).slice(before).some(text => text.includes('stub reply')),


### PR DESCRIPTION
Two small follow-ups to #719 and #721, both found by a final review pass after those merged.

**The helpers README listed two files and there are now eight.** That document is where the new integration crossings point a reader to learn the harness contract — fail closed or do not guard, surface the child's output, bound every wait under the driver's stall watchdog — so a table that does not match its own directory is the failure it warns about two paragraphs later.

**`SLACK-INT-002` could pass without proving the steered turn ran.** It emitted a second mention while the first turn was held, released the hold, then waited for any real reply and asserted no "no response" placeholder anywhere. Releasing the first child produces a reply on its own, so a steer that silently dropped the follow-up would still have satisfied that wait: the test would have been measuring the release rather than the steer. It now also waits for a child carrying the second mention's directive, which is the part that fails if the follow-up is dropped. The placeholder assertion — the actual #655 symptom — was already sound and is unchanged.

Verified locally on `dev`: `SLACK-INT-001..004` pass, and the added wait is bounded at 60s, well under the 180s per-file watchdog. Local product suites are **NOT RUN** by instruction; the authoritative evidence is `ci-aggregate` on this PR.

Refs #688, #689, #655

