### PR TITLE
refactor(pi): give the RPC child one launch, reader, and frame owner

### DIFF
--- a/src/agent/pi-runtime.ts
+++ b/src/agent/pi-runtime.ts
@@ -681,21 +681,38 @@ type AbortWait = {
 };
 
 /**
- * Cap for the persistent RPC session's stderr accumulator, matching the 4000
- * used by every sibling handler in this file. The persistent session is the
- * one that needed it most: it outlives a single run.
+ * Cap for an RPC session's stderr accumulator. The persistent session is the one
+ * that needed it most — it outlives a single run — but both readers share the
+ * constant so the two cannot silently drift apart again (#701).
  */
-const PI_PERSISTENT_STDERR_MAX_CHARS = 4000;
+const PI_RPC_STDERR_MAX_CHARS = 4000;
 
-export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options: {
+/**
+ * The one owner of Pi RPC child creation.
+ *
+ * `spawnPersistentPiRpc` and `spawnPiRpc` used to carry byte-identical copies of
+ * this block, so every abort, capability and cleanup fix had to be applied twice
+ * and in practice landed on one path only (#701). What actually differs between a
+ * pooled session and a one-shot execution is the turn API layered on top — a
+ * long-lived prompt loop versus a single dispatched prompt — not how the child is
+ * launched, owned, or paired with its capability probe.
+ *
+ * The version probe is returned as a thunk rather than started here, on purpose.
+ * Both callers must still start it at their own current point, after their stream
+ * and lifecycle handlers are attached and before `owner.seal()`, so the relative
+ * order of the two children is exactly what it was. For the same reason this
+ * function is synchronous: a spawn failure reports through `error` on a later
+ * tick, which a caller attaching handlers in the same turn cannot miss.
+ */
+function launchPiRpcExecution(profile: PiProfile, pi: PiSettings, options: {
     model: string;
     effort?: string;
     cwd: string;
     sessionId?: string;
     root?: string;
-}): PiRpcSession {
+}) {
     const dir = ensurePiRuntimeConfig(pi, profile.id, options.effort || '', options.root);
-    const inherited = { ...process.env }, cwd = options.cwd, profileId = profile.id, initialEffort = options.effort;
+    const inherited = { ...process.env }, cwd = options.cwd;
     const cmd = resolvePiCommand(inherited);
     const args = [
         ...cmd.baseArgs,
@@ -720,10 +737,71 @@ export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options
         ...(launch.useShell ? { shell: true } : {}),
     });
     owner.track('rpc', child);
+    return { cmd, child, owner,
+        startVersionProbe: () => startPiVersionProbe(versionLaunch, cwd, versionEnv, owner, identityCurrent) };
+}
+
+/**
+ * Shared NDJSON reader for an RPC child's stdout.
+ *
+ * `flush` is the close-time tail: it drains the decoder and hands over a final
+ * partial line. It deliberately carries no receipt check, because both callers'
+ * `dispatch` already refuses an unconfirmed child, and it must stay on `close`
+ * rather than `exit` so the caller's own settlement still runs after it.
+ */
+function readPiRpcLines(child: ChildProcess, dispatch: (line: string) => void): { flush: () => void } {
     const decoder = new StringDecoder('utf8');
     let buffer = '';
-    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+        buffer += decoder.write(chunk);
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        const clamped = clampPendingLine(buffer);
+        if (clamped.overflowed) {
+            console.warn('[jaw:pi] stdout line exceeded the pending-line cap without a newline — truncating');
+            buffer = clamped.buffer;
+        }
+        for (const line of lines) if (line.trim()) dispatch(line.trim());
+    });
+    return {
+        flush: () => {
+            buffer += decoder.end();
+            if (buffer.trim()) dispatch(buffer.trim());
+            buffer = '';
+        },
+    };
+}
+
+/**
+ * Shared RPC frame encoder: request id, JSON body, newline.
+ *
+ * Each caller keeps its OWN liveness guard and refusal message. A pooled session
+ * and a one-shot execution genuinely disagree about what "writable" means — the
+ * session consults its own closing/poisoned state, the execution consults
+ * `doneSettled` and `signalCode` — and collapsing those two predicates into one
+ * would quietly change when a prompt is refused. Only the encoding is shared, and
+ * `seq` stays per writer.
+ */
+function createPiFrameWriter(child: ChildProcess, writable: () => boolean, refusal: string) {
     let seq = 1;
+    return (type: string, fields: Record<string, unknown> = {}): number => {
+        if (!writable()) throw new Error(refusal);
+        const id = seq++;
+        child.stdin!.write(`${JSON.stringify({ id, type, ...fields })}\n`);
+        return id;
+    };
+}
+
+export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options: {
+    model: string;
+    effort?: string;
+    cwd: string;
+    sessionId?: string;
+    root?: string;
+}): PiRpcSession {
+    const profileId = profile.id, initialEffort = options.effort;
+    const { cmd, child, owner, startVersionProbe } = launchPiRpcExecution(profile, pi, options);
+    let stderr = '';
     const stderrReader = createTextStreamReader();
     let activePrompt: PersistentPrompt | null = null;
     let abortWait: AbortWait | null = null;
@@ -734,12 +812,8 @@ export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options
     let closePromise: Promise<void> | undefined;
     let failureClaim: { error: Error; stopped: boolean } | undefined;
 
-    const write = (type: string, fields: Record<string, unknown> = {}): number => {
-        if (!session.alive || !child.stdin.writable) throw new Error('pi rpc session is not writable');
-        const id = seq++;
-        child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`);
-        return id;
-    };
+    const write = createPiFrameWriter(child,
+        () => session.alive && child.stdin.writable, 'pi rpc session is not writable');
     const settleAbort = (): void => {
         if (!abortWait || !abortWait.accepted || !abortWait.terminal) return;
         const wait = abortWait;
@@ -916,23 +990,13 @@ export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options
         kill() { void closeSession(true).catch(() => {}); },
     };
 
-    child.stdout?.on('data', (chunk) => {
-        buffer += decoder.write(chunk);
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-        const clamped = clampPendingLine(buffer);
-        if (clamped.overflowed) {
-            console.warn('[jaw:pi] stdout line exceeded the pending-line cap without a newline — truncating');
-            buffer = clamped.buffer;
-        }
-        for (const line of lines) if (line.trim()) dispatchLine(line.trim());
-    });
+    const stdoutLines = readPiRpcLines(child, dispatchLine);
     child.stderr?.on('data', (chunk) => {
         // Persistent RPC sessions live for the pool's idle window (15 min) and
         // longer under load, so an uncapped accumulator grows for the whole
         // session lifetime. Every sibling handler in this file caps at 4000.
-        // Second reader, never the stdout decoder above (#382, rule 1).
-        if (stderr.length < PI_PERSISTENT_STDERR_MAX_CHARS) stderr += stderrReader.write(chunk);
+        // Its own reader, never the shared stdout decoder (#382, rule 1).
+        if (stderr.length < PI_RPC_STDERR_MAX_CHARS) stderr += stderrReader.write(chunk);
     });
     child.on('error', (error) => failSession(error));
     child.stdin?.on('error', error => failSession(error));
@@ -947,11 +1011,13 @@ export function spawnPersistentPiRpc(profile: PiProfile, pi: PiSettings, options
     });
     child.on('close', (code) => {
         closed = true;
-        buffer += decoder.end();
-        if (buffer.trim() && owner.receipt?.rpc !== 'unconfirmed') dispatchLine(buffer.trim());
+        // dispatchLine itself refuses an unconfirmed child, so the tail needs no
+        // second receipt check here. failSession must stay AFTER the flush: it
+        // poisons the session, and dispatchLine drops anything once poisoned.
+        stdoutLines.flush();
         failSession(new Error(`pi rpc session exited with code ${String(code)}`));
     });
-    version = startPiVersionProbe(versionLaunch, cwd, versionEnv, owner, identityCurrent);
+    version = startVersionProbe();
     prepared = version.done.then(observation => {
         if (!session.alive) throw new Error('pi rpc session closed during preparation');
         settledProtocol = observation.status === 0 && piSupportsSettled(observation.stdout);
@@ -977,44 +1043,17 @@ export function spawnPiRpc(profile: PiProfile, pi: PiSettings, options: {
     root?: string;
 }): { child: ChildProcess; done: Promise<PiPromptResult & { code: number; sessionId?: string | null }>;
     cleanup: Promise<PiExecutionCleanupReceipt> } {
-    const dir = ensurePiRuntimeConfig(pi, profile.id, options.effort || '', options.root);
-    const inherited = { ...process.env }, cwd = options.cwd, effort = options.effort;
+    const effort = options.effort;
     const onEvent = options.onEvent, onRawRecord = options.onRawRecord;
     const fullPrompt = options.sysPrompt ? `${options.sysPrompt}\n\n${options.prompt}` : options.prompt;
     const hasHistory = fullPrompt.includes('[Recent Context]');
-    const cmd = resolvePiCommand(inherited);
-    const args = [
-        ...cmd.baseArgs,
-        '--mode', 'rpc',
-        '--no-context-files',
-        '--tools', 'read,bash,edit,write,grep,find,ls',
-        '--provider', profile.id,
-        '--model', options.model || profile.model,
-        '--api-key', profile.apiKey || 'dummy',
-        ...(options.sessionId ? ['--session-id', options.sessionId] : []),
-    ];
-    const launch = resolvePiSpawn(cmd.command, args);
-    const versionLaunch = resolvePiSpawn(cmd.command, [...cmd.baseArgs, '--version']);
-    const identityCurrent = capturePiLaunchIdentity(cmd, launch);
-    const rpcEnv = mergeEnvWindowsSafe({ ...inherited, PI_CODING_AGENT_DIR: dir }, launch.envDelta);
-    const versionEnv = mergeEnvWindowsSafe({ ...inherited, PI_CODING_AGENT_DIR: dir }, versionLaunch.envDelta);
-    const owner = createPiExecutionCleanup();
-    const child = spawn(launch.command, launch.args, {
-        cwd,
-        env: rpcEnv,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        ...(launch.useShell ? { shell: true } : {}),
-    });
-    owner.track('rpc', child);
-    const decoder = new StringDecoder('utf8');
-    let buffer = '';
+    const { child, owner, startVersionProbe } = launchPiRpcExecution(profile, pi, options);
     let stderr = '';
     const stderrReader = createTextStreamReader();
     let sessionId: string | null = null;
     let doneSettled = false, promptDispatched = false;
     let turn: PiTurnAccumulator | null = null;
     let version: ReturnType<typeof startPiVersionProbe> | undefined;
-    let seq = 1;
     let promptId = 0;
     let finish!: (code?: number, status?: RuntimeTurnOutcome['status'], error?: Error) => void;
     const done = new Promise<PiPromptResult & { code: number; sessionId?: string | null }>((resolve, reject) => {
@@ -1065,30 +1104,22 @@ export function spawnPiRpc(profile: PiProfile, pi: PiSettings, options: {
             version?.cancel();
             void owner.teardown().then(() => finish(code ?? 1, signal || child.killed ? 'stopped' : 'error'));
         });
-        child.stdout?.on('data', (chunk) => {
-            buffer += decoder.write(chunk);
-            const lines = buffer.split('\n');
-            buffer = lines.pop() ?? '';
-            const clamped = clampPendingLine(buffer);
-            if (clamped.overflowed) {
-                console.warn('[jaw:pi] stdout line exceeded the pending-line cap without a newline — truncating');
-                buffer = clamped.buffer;
-            }
-            for (const line of lines) if (line.trim()) dispatchLine(line.trim());
+        const stdoutLines = readPiRpcLines(child, dispatchLine);
+        child.stderr?.on('data', (chunk) => {
+            if (stderr.length < PI_RPC_STDERR_MAX_CHARS) stderr += stderrReader.write(chunk);
         });
-        child.stderr?.on('data', (chunk) => { if (stderr.length < 4000) stderr += stderrReader.write(chunk); });
         child.on('close', (code, signal) => {
-            if (buffer.trim()) dispatchLine(buffer.trim());
+            // The shared reader also drains the decoder here, which this path did not
+            // do before: a partial UTF-8 sequence at EOF now surfaces as U+FFFD rather
+            // than vanishing. finish() stays after the flush so a trailing terminal
+            // record can still settle the turn as complete.
+            stdoutLines.flush();
             finish(code ?? 1, signal || child.killed ? 'stopped' : 'error');
         });
     });
-    const write = (type: string, fields: Record<string, unknown> = {}) => {
-        if (doneSettled || child.exitCode !== null || child.signalCode !== null || child.killed || !child.stdin?.writable)
-            throw new Error('pi rpc execution is not writable');
-        const id = seq++;
-        child.stdin.write(JSON.stringify({ id, type, ...fields }) + '\n');
-        return id;
-    };
+    const write = createPiFrameWriter(child, () => !doneSettled && child.exitCode === null
+        && child.signalCode === null && !child.killed && Boolean(child.stdin?.writable),
+        'pi rpc execution is not writable');
     const originalKill = child.kill.bind(child);
     child.kill = (signal?: NodeJS.Signals | number): boolean => {
         const stopSignal = signal === undefined || signal === 15 ? 'SIGTERM'
@@ -1100,7 +1131,7 @@ export function spawnPiRpc(profile: PiProfile, pi: PiSettings, options: {
         return sent;
     };
     Object.defineProperty(child, PI_EXECUTION_CANCEL, { value: () => { child.kill('SIGTERM'); } });
-    version = startPiVersionProbe(versionLaunch, cwd, versionEnv, owner, identityCurrent);
+    version = startVersionProbe();
     void version.done.then(observation => {
         if (doneSettled) return;
         if (child.killed || child.exitCode !== null || child.signalCode !== null) {

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -168,7 +168,7 @@ cli-jaw/
 │   │   ├── agy-bootstrap.ts  ← AGY bootstrap/context preparation helpers (237L)
 │   │   ├── agy-capabilities.ts ← AGY `--help`/`--version` capability probe + cached optional flag support map + legacy emit-all fallback marker (124L)
 │   │   ├── agy-transcript-watcher.ts ← AGY transcript/log watcher and session-id extraction support (291L)
-│   │   ├── pi-runtime.ts     ← Pi profile 정규화 + isolated `PI_CODING_AGENT_DIR` models/settings 생성 + `pi --offline --list-models` discovery + `pi --mode rpc` JSONL parser/spawner (1118L) ✨
+│   │   ├── pi-runtime.ts     ← Pi profile 정규화 + isolated `PI_CODING_AGENT_DIR` models/settings 생성 + `pi --offline --list-models` discovery + `pi --mode rpc` JSONL parser/spawner (단일 launch/reader/writer 소유자) (1149L) ✨
 │   │   ├── lifecycle-handler.ts ← child lifecycle + fallback/retry + queue resume orchestration + clearEmployeeSession on resume failure + stale resume fresh retry + kickGoalContinuation export + clearGoalTimers + goal continuation boundary row (1413L)
 │   │   ├── kiro-auth.ts      ← Kiro CLI auth store reader (resolveKiroDataPath, readKiroAuthFromStore, resolveKiroProfileArn, regionFromProfileArn, listKiroConversationIdsForCwd, resolveKiroSessionIdAfterSpawn, extractKiroSessionIdFromV2Store) (314L)
 │   │   ├── kiro-models.ts    ← Kiro live model inventory (KiroModelEntry, KiroModelInventory, parseKiroModelListJson, fetchKiroModelInventory) (98L)

--- a/tests/unit/pi-runtime.test.ts
+++ b/tests/unit/pi-runtime.test.ts
@@ -276,16 +276,33 @@ test('Pi model discovery falls back to the offline Pi inventory', async () => {
     }
 });
 
-test('Pi launch sites retain the shared Windows resolver, including both capability plans', async () => {
+test('Pi launch sites retain the shared Windows resolver, and RPC children have one owner', async () => {
     // Previously this pinned the exact `shell: true` guard that #367 removes: any
-    // non-.exe command on Windows got a shell. The list, two RPC and two version plans route through
+    // non-.exe command on Windows got a shell. Every plan routes through
     // resolvePiSpawn, which resolves an npm .cmd shim to its interpreter and only
     // falls back to a shell when resolution FAILS.
     const source = await readFile(new URL('../../src/agent/pi-runtime.ts', import.meta.url), 'utf8');
     // Supplemental source wiring only, not Windows execution certification.
-    // Both version plans share one asynchronous spawn helper.
-    assert.equal(source.split('resolvePiSpawn(cmd.command').length - 1, 5, 'all five plans must resolve');
-    assert.equal(source.split('...(launch.useShell ? { shell: true } : {})').length - 1, 4);
+    // Three plans remain: list-models, plus the RPC and version pair inside the one
+    // launch owner. This used to be five because the persistent and one-shot spawners
+    // each carried a byte-identical copy of that pair (#701).
+    assert.equal(source.split('resolvePiSpawn(cmd.command').length - 1, 3, 'all three plans must resolve');
+    assert.equal(source.split('...(launch.useShell ? { shell: true } : {})').length - 1, 3);
     // The old unconditional guard must be gone.
     assert.doesNotMatch(source, /const isCmdShim = process\.platform === 'win32'/);
+    // A bare count cannot tell consolidation apart from a deleted launch site, and the
+    // duplication is the actual defect: an abort or cleanup fix kept landing on one
+    // spawner only. Pin the property instead — neither RPC entry point launches its
+    // own child. The slices stop at each function so that listPiModels and the version
+    // probe, which legitimately spawn, stay outside.
+    const persistent = source.slice(
+        source.indexOf('export function spawnPersistentPiRpc'),
+        source.indexOf('export function spawnPiRpc'),
+    );
+    const oneShot = source.slice(source.indexOf('export function spawnPiRpc'));
+    assert.ok(persistent.length > 0 && oneShot.length > 0, 'both Pi RPC entry points must exist');
+    for (const [name, body] of [['spawnPersistentPiRpc', persistent], ['spawnPiRpc', oneShot]] as const) {
+        assert.doesNotMatch(body, /\bspawn\(/, name + ' must not launch a child of its own');
+        assert.match(body, /launchPiRpcExecution\(/, name + ' must launch through the shared owner');
+    }
 });


### PR DESCRIPTION
Pi's RPC child had three owners. `spawnPersistentPiRpc` and `spawnPiRpc` carried byte-identical copies of the launch block (`ensurePiRuntimeConfig` → `resolvePiCommand` → args → `resolvePiSpawn` ×2 → `capturePiLaunchIdentity` → `mergeEnvWindowsSafe` ×2 → `createPiExecutionCleanup` → `spawn` → `owner.track`), the NDJSON stdout reader, and the JSON frame encoder. Every abort, capability, and cleanup fix had to be applied twice and in practice landed on one path only — `a71cb3909`, `7ce874329`, `a7bed4321`, `6f681a289` each touched one spawner or the other.

This collapses those three copies into `launchPiRpcExecution`, `readPiRpcLines`, and `createPiFrameWriter`. Neither entry point spawns a child of its own any more.

## The issue body is partly stale

Re-verified against `dev` @ `2087531b5` before starting. Two of the three reported defects are already fixed, because #681 and #683 landed after the issue was filed:

| Issue claim | Status on this tree |
| --- | --- |
| lease 없는 cancel이 `killProcessTree` + 5s SIGKILL로 떨어진다 (`spawn.ts:2570-2578`) | **Stale.** `requestCancel` is `cancelOwnedPiProcess` → `ownProcess(child).terminate('cancel')` (`spawn.ts:2540-2548`). There are zero direct `killProcessTree(` call sites left in `spawn.ts`. |
| Pi의 `wasSteer` 계산에 `interrupt`가 빠져 있다 | **Stale.** Both Pi exit paths use `isLifecycleSteerReason` (`spawn.ts:2611`, `:2640`), which accepts `steer|interrupt|dup-registration`. `gateway.ts:133` records `interrupt` on `child.pid` before `cancelTurn` (`spawn.ts:627`), and `cancelHook` (`:2552`) captures the exit settler for it, so the string does reach `consumeKillReason`. |
| RPC 생성/cleanup이 두 벌이다 | **Real.** Fixed here. |

## Scope: `Refs`, not `Closes`

The issue's completion conditions are (1) one RPC create/cleanup copy, (2) employee `killAgentById` and main `cancelTurn` on the same Pi cancel port, (3) Pi `interrupt` through the same salvage/queue guards as Claude.

(1) is done here and (3) is already true. **(2) is not**, and this PR does not pretend otherwise. Pooled children never enter `activeProcesses`, so `cancelOwnedPiProcess` is not the door main cancel uses: main goes `lease.cancel()` → `session.abort()` or `session.kill()` (`runtime-pool.ts:291`). Satisfying (2) means the `runPiTurn` → `runNativeRuntime` alignment from proposed-scope item 2, which is a `spawn.ts` restructure and belongs in its own change. An earlier draft hung `PI_EXECUTION_CANCEL` on the persistent child to close the gap; review rejected it as a door nobody calls that would additionally let a later caller force-kill an abort-capable pooled session. It was dropped. **#701 should stay open.**

## What is deliberately not merged

The two runtimes genuinely disagree in three places, and flattening them would be a silent behaviour change:

- **Write liveness.** A session consults its own `closing`/`poisoned` state; an execution consults `doneSettled` and `signalCode`. Each caller keeps its own predicate and refusal message; only the encoding is shared, and `seq` stays per writer.
- **Probe continuation.** Only the persistent path records abort capability and readiness.
- **Probe start time.** `startVersionProbe` is returned as a thunk so both callers still start the probe at their current point, leaving the relative order of the two children unchanged. The factory is synchronous for the same reason: a spawn failure reports through `error` on a later tick, which a caller attaching handlers in the same turn cannot miss. `owner.seal()` stays at the callers.

## One intentional behaviour change

The one-shot `close` handler now drains the `StringDecoder`, which it previously skipped while the persistent path always did. A partial UTF-8 sequence at EOF now surfaces as U+FFFD instead of vanishing, and can produce one extra parse-failure warning. Complete NDJSON is byte-identical, since `decoder.end()` returns `''`.

## Test change

`pi-runtime.test.ts` counted the duplicated launch sites: 5 `resolvePiSpawn(cmd.command` plans and 4 shell spreads. Consolidation makes those 3 and 3, so the counts are updated. A bare count cannot distinguish consolidation from a deleted launch site, so the test now also pins the property that actually matters — neither `spawnPersistentPiRpc` nor `spawnPiRpc` contains a bare `spawn(`, and both call `launchPiRpcExecution`. The slices stop at each function so `listPiModels` and the version probe, which legitimately spawn, stay outside.

The other source-text gates were checked and are unaffected: WLS-026's `/mergeEnvWindowsSafe\([^)]*launch\.envDelta\)/` still matches inside the factory, WSF-013's `decideShellFallback` lives in `resolvePiSpawn`, and `line-buffer-bound`'s `buffer = lines.pop()` is still followed by `clampPendingLine` within its 6-line window.

## NOT COVERED BY CI

- **No Windows execution proof.** `resolvePiSpawn`, `useShell`, and `envDelta` are asserted as source wiring only. `windows-unit` does not launch a real Pi child, so the factory's Windows launch path is unproven at runtime.
- **The U+FFFD delta is unexercised.** No fixture feeds a truncated multi-byte sequence at EOF, so the new one-shot `decoder.end()` behaviour is reasoned about, not tested. Existing fixtures are ASCII and end on complete lines.
- **Probe/RPC ordering is argued, not asserted.** No test pins "handlers attach before the child can emit". The claim rests on Node emitting spawn failures on a later tick; `pi-capability-readiness` only asserts both children exist and that the probe does not block the parent.
- **Pooled-session cancel is untouched and unproven here.** Completion condition 2 is out of scope, so nothing in this PR exercises `lease.cancel()` against `killAgentById`.
- **No local suite was run.** Per the delivery constraint for this branch, `npm test`, `npm run build`, and `tsc` were NOT RUN locally; typecheck evidence comes only from `gate:typecheck` inside `ci-aggregate`.
- **`structure/verify-counts.sh` is not in `ci-aggregate`.** It runs under `install-risk-gate.mjs`. The `pi-runtime.ts` entry in `str_func.md` was updated by hand (1118L → 1149L). The pre-existing `public/ total` mismatch (~103033 vs 103287) is present on unmodified `dev` and was left alone rather than absorbed into this diff.

Refs #701
