### PR TITLE
refactor(messaging): one owner for the native-body predicate, notice records, and target-reply admission

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -34,6 +34,9 @@ import { handleDiscordSlashCommand, registerDiscordSlashCommands } from './comma
 import { createDiscordForwarder, relayDiscordImages } from './forwarder.js';
 import { nextDeliverySeq, pendingDeliveryAnchor, wasSelfDelivered } from '../messaging/turn-delivery.js';
 import { shouldSkipForwarding } from '../messaging/forwarder-origin.js';
+import { requiresNativeBodyDelivery } from '../messaging/native-body.js';
+import { createQueueNoticeRecorder } from '../messaging/queue-notice-record.js';
+import { admitTargetReply } from '../messaging/target-reply-guard.js';
 import { sendDiscordFile } from './discord-file.js';
 import { getDiscordSendClient, sendDiscordFileRest, sendDiscordTextRest } from './send-only-client.js';
 import { invalidateDiscordSendClient } from './send-only-client.js';
@@ -153,26 +156,24 @@ let targetReplyForwarderInstalled = false;
 // Identity-local option: survives the existing router without adding an HTTP field.
 const nativeBodyRequests = new WeakSet<ChannelSendRequest>();
 
-function requiresNativeBodyDelivery(data: Record<string, unknown>): boolean {
-    return (data['runtimeFinality'] === 'present' || data['runtimeFinality'] === 'absent')
-        && (data['runtimeStatus'] === 'done' || data['runtimeStatus'] === 'error' || data['runtimeStatus'] === 'stopped');
-}
-
 function installDiscordTargetReplyForwarder(): void {
     if (targetReplyForwarderInstalled) return;
     targetReplyForwarderInstalled = true;
     addBroadcastListener((type, data) => {
-        if (type !== 'orchestrate_done' || data["origin"] !== 'discord' || !data["text"]) return;
         // Queued turns only: an ordinary reply is posted by the dispatch path
         // that is still awaiting it, and answering here too would double-post.
         // Errors included: after a restart nothing else will show them.
-        if (data["fromQueue"] !== true) return;
-        const target = data["target"] as RemoteTarget | undefined;
-        if (!target || target.channel !== 'discord' || !target.targetId) return;
-        if (data["requestId"] && pendingQueueRequestIds.has(String(data["requestId"]))) return;
-        const text = String(data['text']);
+        const admitted = admitTargetReply(type, data, {
+            channel: 'discord',
+            event: 'orchestrate_done',
+            accept: ['fromQueue'],
+            requireText: true,
+            hasPendingWaiter: requestId => pendingQueueRequestIds.has(requestId),
+        });
+        if (!admitted) return;
+        const { target, text } = admitted;
         const request: ChannelSendRequest = { channel: 'discord', type: 'text', text, target };
-        if (requiresNativeBodyDelivery(data)) {
+        if (admitted.requireBodyDelivery) {
             if (!text.trim()) return;
             nativeBodyRequests.add(request);
         }
@@ -263,33 +264,11 @@ const discordOutboundRegistry = new OutboundSendRegistry();
 const DISCORD_NOTICE_DRAIN_MS = DISCORD_REACTION_TIMEOUT_MS * 2 + 3000;
 
 // ─── Durable notice records (#418) ──────────────────
-// The registry above is process-local; these wrap the store that outlives the
+// The registry above is process-local; this wraps the store that outlives the
 // process. Best-effort by contract: a durable write is a convenience for the NEXT
-// boot, so letting it throw would fail the turn the user is waiting on.
-
-function reserveDiscordNoticeRecord(requestId: string, target: RemoteTarget): void {
-    try {
-        getQueueNoticeStore()?.reserve({ requestId, channel: 'discord', target });
-    } catch (e) {
-        log.info('[discord:queue-notice] reserve failed', logErrorText(e));
-    }
-}
-
-function attachDiscordNoticeRecord(requestId: string, messageId: string): void {
-    try {
-        getQueueNoticeStore()?.attachMessageId(requestId, messageId);
-    } catch (e) {
-        log.info('[discord:queue-notice] attach failed', logErrorText(e));
-    }
-}
-
-function closeDiscordNoticeRecord(requestId: string): void {
-    try {
-        getQueueNoticeStore()?.close(requestId);
-    } catch (e) {
-        log.info('[discord:queue-notice] close failed', logErrorText(e));
-    }
-}
+// boot, so letting it throw would fail the turn the user is waiting on. The
+// contract is shared with the other two bots (#699).
+const discordNoticeRecord = createQueueNoticeRecorder('discord', '[discord:queue-notice]');
 
 /**
  * Close a queue notice as ANSWERED from the standing forwarder, which never
@@ -325,7 +304,7 @@ async function closeDiscordNoticeAsAnsweredByRequestId(requestId: string): Promi
                 if (code !== 10008 && code !== 404) throw e;
             }
         }
-        closeDiscordNoticeRecord(requestId);
+        discordNoticeRecord.close(requestId);
     } catch (e) {
         log.info('[discord:queue-notice] answered-close failed', logErrorText(e));
     }
@@ -433,7 +412,7 @@ async function dcOrchestrate(msg: Message, prompt: string, displayMsg: string) {
                 ]);
                 // Closed in-process, so the durable record has nothing left to
                 // restore on the next boot.
-                if (requestId) closeDiscordNoticeRecord(requestId);
+                if (requestId) discordNoticeRecord.close(requestId);
             } finally {
                 // Centralized here: every terminal path routes through a claim, so
                 // unregistering in one place is what makes "exactly once" true.
@@ -472,7 +451,7 @@ async function dcOrchestrate(msg: Message, prompt: string, displayMsg: string) {
                         notice.close('expired'),
                         ack?.settle('failure') ?? Promise.resolve(),
                     ]);
-                    if (requestId) closeDiscordNoticeRecord(requestId);
+                    if (requestId) discordNoticeRecord.close(requestId);
                     return;
                 }
                 const channel = asSendable(msg.channel);
@@ -517,7 +496,7 @@ async function dcOrchestrate(msg: Message, prompt: string, displayMsg: string) {
                     notice.close(delivered ? 'answered' : 'expired'),
                     ack?.settle(delivered ? 'success' : 'failure') ?? Promise.resolve(),
                 ]);
-                if (requestId) closeDiscordNoticeRecord(requestId);
+                if (requestId) discordNoticeRecord.close(requestId);
                 {
                     const relayScope = discordOutboundRegistry.start();
                     await relayDiscordImages(msg.client, target, body, {
@@ -542,7 +521,7 @@ async function dcOrchestrate(msg: Message, prompt: string, displayMsg: string) {
         void ack?.to('running', { wasQueued: true });
         // Reserved BEFORE the post: a record with no id restores to nothing, while
         // a posted message with no record is unreachable forever (#418).
-        if (requestId) reserveDiscordNoticeRecord(requestId, target);
+        if (requestId) discordNoticeRecord.reserve(requestId, target);
         const posted = await msg.reply(
             t('tg.queued', { count: result.pending }, currentLocale()),
         ).catch((e: unknown) => {
@@ -551,13 +530,13 @@ async function dcOrchestrate(msg: Message, prompt: string, displayMsg: string) {
         });
         if (posted) {
             notice.bind(createDiscordNoticeTransport(posted));
-            if (requestId) attachDiscordNoticeRecord(requestId, posted.id);
+            if (requestId) discordNoticeRecord.attach(requestId, posted.id);
         } else {
             // No handle will ever arrive, so a deferred close would wait for a
             // bind that cannot happen and the drain would burn its deadline.
             notice.abandon();
             // The reservation describes a message that does not exist.
-            if (requestId) closeDiscordNoticeRecord(requestId);
+            if (requestId) discordNoticeRecord.close(requestId);
             // Then close the turn out properly: abandoning the notice alone would
             // leave the listener, the request-id claim, the timer and the running
             // reaction alive until the 5-minute timeout or shutdown.

--- a/src/messaging/native-body.ts
+++ b/src/messaging/native-body.ts
@@ -1,0 +1,32 @@
+// ─── Native runtime terminal tags ────────────────────
+// A producer stamps `runtimeFinality` + `runtimeStatus` on a turn that ran
+// through a native runtime adapter. Four places were asking the same question
+// with the same hand-copied boolean: the three chat bots and the orchestrator's
+// collector. #784d6162b spread the delivery half of that rule across the bots,
+// so every change to one common delivery rule cost three identical edits.
+//
+// The two QUESTIONS are kept apart on purpose. `hasNativeRuntimeTags` is the
+// neutral observation — these tags are present, so this payload came from a
+// native runtime terminal. `requiresNativeBodyDelivery` is a DELIVERY policy
+// that currently happens to be the same test. Collect asks the first one: it
+// uses the answer to ignore a foreign native terminal, latch `nativeSeen` and
+// pick its terminal text. If a later delivery tighten (non-empty text, an
+// origin match, a request id) were folded into a single shared function, it
+// would silently change collector matching and timeout diagnostics too.
+
+/** True when this broadcast payload carries native runtime terminal tags. */
+export function hasNativeRuntimeTags(data: Record<string, unknown>): boolean {
+    return (data['runtimeFinality'] === 'present' || data['runtimeFinality'] === 'absent')
+        && (data['runtimeStatus'] === 'done' || data['runtimeStatus'] === 'error' || data['runtimeStatus'] === 'stopped');
+}
+
+/**
+ * True when the body for this payload must be delivered through the native
+ * receipt path rather than the legacy best-effort one.
+ *
+ * Separate from `hasNativeRuntimeTags` so the delivery rule can gain conditions
+ * without moving the collector's listener semantics with it.
+ */
+export function requiresNativeBodyDelivery(data: Record<string, unknown>): boolean {
+    return hasNativeRuntimeTags(data);
+}

--- a/src/messaging/queue-notice-record.ts
+++ b/src/messaging/queue-notice-record.ts
@@ -1,0 +1,59 @@
+// ─── Durable queue-notice record writes ──────────────
+// The store itself (`queue-notice-store.ts`) is deliberately a plain SQLite
+// object with no logger and no opinion about failure. Every bot then wrapped it
+// in the same three functions — reserve, attach, close — differing only in the
+// channel literal and the log prefix, because the CONTRACT around those writes
+// is not the store's: a durable write is a convenience for the NEXT boot, so
+// letting it throw would fail the turn the user is actually waiting on.
+//
+// That contract is what lives here. The store stays a store.
+
+import { log } from '../core/logger.js';
+import { logErrorText } from './redact.js';
+import { getQueueNoticeStore } from './queue-notice-store.js';
+import type { MessengerChannel, RemoteTarget } from './types.js';
+
+export type QueueNoticeRecorder = {
+    /** Claim the row BEFORE the notice is posted. */
+    reserve(requestId: string, target: RemoteTarget): void;
+    /** Bind the posted message id to its reservation. */
+    attach(requestId: string, messageId: string): void;
+    /** Drop the record. */
+    close(requestId: string): void;
+};
+
+/**
+ * Best-effort durable-notice writes for one channel.
+ *
+ * `logPrefix` is the channel's own log tag rather than something derived from
+ * `channel`: Telegram logs under `[tg:…]` while its channel literal is
+ * `telegram`, and existing log greps depend on that.
+ */
+export function createQueueNoticeRecorder(
+    channel: MessengerChannel,
+    logPrefix: string,
+): QueueNoticeRecorder {
+    return {
+        reserve(requestId: string, target: RemoteTarget): void {
+            try {
+                getQueueNoticeStore()?.reserve({ requestId, channel, target });
+            } catch (e) {
+                log.info(`${logPrefix} reserve failed`, logErrorText(e));
+            }
+        },
+        attach(requestId: string, messageId: string): void {
+            try {
+                getQueueNoticeStore()?.attachMessageId(requestId, messageId);
+            } catch (e) {
+                log.info(`${logPrefix} attach failed`, logErrorText(e));
+            }
+        },
+        close(requestId: string): void {
+            try {
+                getQueueNoticeStore()?.close(requestId);
+            } catch (e) {
+                log.info(`${logPrefix} close failed`, logErrorText(e));
+            }
+        },
+    };
+}

--- a/src/messaging/target-reply-guard.ts
+++ b/src/messaging/target-reply-guard.ts
@@ -1,0 +1,102 @@
+// ─── Standing target-reply admission ─────────────────
+// Each chat bot installs a standing `orchestrate_done` listener so an answer
+// whose waiter is gone still reaches the conversation it was asked in. A
+// restart destroys the live waiter; a mid-run steer leaves the follow-up answer
+// with no waiter at all (#655); a queued turn's dispatcher may never have
+// existed. Without the listener the user's message simply vanishes.
+//
+// The three listeners had drifted into three different guards for the same
+// decision, and the drift was invisible: Discord admitted only `fromQueue`,
+// Telegram only `replyViaTarget`, Slack all three. Which identities a channel
+// admits is a real per-channel decision — a channel whose dispatch path already
+// answers ordinary turns must not answer them here too, or the user sees the
+// reply twice. So the difference is kept, but as DATA (`accept`) rather than as
+// three hand-maintained control flows.
+//
+// What this owns is admission only: is this event mine, is the target a real
+// address on my channel, and is somebody else already going to answer it. The
+// send, the queue-notice close, the image relay and the elicitation keyboards
+// stay in the bot, because those differ in substance and not just in shape.
+//
+// This is NOT `shouldSkipForwarding` (forwarder-origin.ts). That one governs the
+// last-active `agent_done` forwarders, a different event and a different job.
+
+import { requiresNativeBodyDelivery } from './native-body.js';
+import { isRemoteTarget, type MessengerChannel, type RemoteTarget } from './types.js';
+
+/**
+ * Why this turn has no waiter of its own.
+ *
+ * - `fromQueue`: it was restored from the queue, possibly after a restart.
+ * - `fromSteer`: a steer retired the run that owned it (#655).
+ * - `replyViaTarget`: it was forwarded in carrying its own destination.
+ */
+export type TargetReplyIdentity = 'fromQueue' | 'fromSteer' | 'replyViaTarget';
+
+export type TargetReplyGuardOptions = {
+    /** The asking channel. Matched against both `origin` and `target.channel`. */
+    channel: MessengerChannel;
+    /** Broadcast event this forwarder listens for. */
+    event: string;
+    /** Identities this channel accepts. An empty list admits nothing. */
+    accept: readonly TargetReplyIdentity[];
+    /** Reject a falsy `text` at admission, before any target work. */
+    requireText?: boolean;
+    /** A live requester already listening for this exact result. */
+    hasPendingWaiter?: (requestId: string) => boolean;
+    /** Shutdown latch; checked first so a stopping channel admits nothing. */
+    stopping?: () => boolean;
+};
+
+export type AdmittedTargetReply = {
+    /** Validated address. A copy, so a listener cannot mutate the payload's. */
+    target: RemoteTarget;
+    /** Empty string when the payload carried no string request id. */
+    requestId: string;
+    /** `data.text` as a string. Channels that rewrite it (Slack's error copy)
+     *  compute their own and ignore this. */
+    text: string;
+    requireBodyDelivery: boolean;
+};
+
+/**
+ * Decide whether this broadcast is a target reply this channel must deliver.
+ *
+ * Returns null for every rejection. Nothing here has a side effect, so the
+ * order of the checks is observational only; it runs cheapest-first.
+ *
+ * The empty-native-body skip is deliberately NOT done here. Telegram and
+ * Discord drop those at admission, but Slack drops them inside its delivery
+ * lane, after the delivery ledger has been entered. Moving Slack's check
+ * earlier would change which runs the ledger ever sees.
+ */
+export function admitTargetReply(
+    type: string,
+    data: Record<string, unknown>,
+    options: TargetReplyGuardOptions,
+): AdmittedTargetReply | null {
+    if (options.stopping?.()) return null;
+    if (type !== options.event) return null;
+    if (data['origin'] !== options.channel) return null;
+    if (options.requireText && !data['text']) return null;
+    if (!options.accept.some(identity => data[identity] === true)) return null;
+
+    // A cast is not a check. Telegram and Discord used to take the payload's
+    // target on trust, which let a malformed address (an empty `targetId`, say)
+    // through to a transport that then fell back to the last-active chat — the
+    // answer lands in a conversation nobody asked in. Validate the address.
+    const rawTarget = data['target'];
+    if (!isRemoteTarget(rawTarget) || rawTarget.channel !== options.channel) return null;
+
+    // Matches the historical guards: any truthy request id is stringified for
+    // the waiter lookup, while the returned id stays string-typed.
+    const rawRequestId = data['requestId'];
+    if (rawRequestId && options.hasPendingWaiter?.(String(rawRequestId))) return null;
+
+    return {
+        target: { ...rawTarget },
+        requestId: typeof rawRequestId === 'string' ? rawRequestId : '',
+        text: String(data['text'] ?? ''),
+        requireBodyDelivery: requiresNativeBodyDelivery(data),
+    };
+}

--- a/src/orchestrator/collect.ts
+++ b/src/orchestrator/collect.ts
@@ -10,6 +10,7 @@ import {
 } from './pipeline.js';
 import { t } from '../core/i18n.js';
 import { isRenderableError } from '../messaging/error-block.js';
+import { hasNativeRuntimeTags } from '../messaging/native-body.js';
 import type { RuntimeLivenessIdentity, RuntimeTurnOutcome } from '../shared/runtime-contract.js';
 import { settings } from '../core/config.js';
 import { getActiveChatSession } from '../core/chat-sessions.js';
@@ -99,8 +100,10 @@ export function orchestrateAndCollectData(
         const handler = (type: string, data: Record<string, any>) => {
             if (settled) return;
             if (meta['_strictRequestOwnership'] === true && !matchesNativeIdentity(data)) return;
-            const native = (data['runtimeFinality'] === 'present' || data['runtimeFinality'] === 'absent')
-                && (data['runtimeStatus'] === 'done' || data['runtimeStatus'] === 'error' || data['runtimeStatus'] === 'stopped');
+            // Same observation the delivery layer makes, through the neutral
+            // predicate rather than the delivery-named one: this listener uses
+            // it to ignore a foreign native terminal, not to choose a transport.
+            const native = hasNativeRuntimeTags(data);
             // A mismatched native terminal must not remove this request's
             // listener, extend its timeout, or contaminate its diagnostic.
             if (native && !matchesNativeIdentity(data)) return;

--- a/src/slack/bot.ts
+++ b/src/slack/bot.ts
@@ -75,6 +75,9 @@ import type { SlackProgressOutcome } from './progress.js';
 import { createSlackForwarder, relaySlackImages } from './forwarder.js';
 import { nextDeliverySeq, wasSelfDelivered } from '../messaging/turn-delivery.js';
 import { shouldSkipForwarding } from '../messaging/forwarder-origin.js';
+import { requiresNativeBodyDelivery } from '../messaging/native-body.js';
+import { createQueueNoticeRecorder } from '../messaging/queue-notice-record.js';
+import { admitTargetReply } from '../messaging/target-reply-guard.js';
 import { handleSlackSlashCommand } from './commands.js';
 import { logErrorText, redactOutboundText } from '../messaging/redact.js';
 import { downloadAndSaveSlackFiles, type FailedSlackFile } from './inbound-file.js';
@@ -207,34 +210,11 @@ function hasPendingQueueWaiter(requestId: string): boolean {
 }
 
 // ─── Durable notice records (#418) ──────────────────
-// The handles above are process-local; these three wrap the store that outlives
-// the process. Every one of them is best-effort by contract: a durable write is a
-// convenience for the NEXT boot, and letting it throw here would fail the turn the
-// user is actually waiting on.
-
-function reserveSlackNoticeRecord(requestId: string, target: RemoteTarget): void {
-    try {
-        getQueueNoticeStore()?.reserve({ requestId, channel: 'slack', target });
-    } catch (e) {
-        log.info('[slack:queue-notice] reserve failed', logErrorText(e));
-    }
-}
-
-function attachSlackNoticeRecord(requestId: string, ts: string): void {
-    try {
-        getQueueNoticeStore()?.attachMessageId(requestId, ts);
-    } catch (e) {
-        log.info('[slack:queue-notice] attach failed', logErrorText(e));
-    }
-}
-
-function closeSlackNoticeRecord(requestId: string): void {
-    try {
-        getQueueNoticeStore()?.close(requestId);
-    } catch (e) {
-        log.info('[slack:queue-notice] close failed', logErrorText(e));
-    }
-}
+// The handles above are process-local; this wraps the store that outlives the
+// process. Best-effort by contract: a durable write is a convenience for the
+// NEXT boot, and letting it throw here would fail the turn the user is actually
+// waiting on. The contract is shared with the other two bots (#699).
+const slackNoticeRecord = createQueueNoticeRecorder('slack', '[slack:queue-notice]');
 
 /**
  * Close a queue notice as ANSWERED from a path that never held the live handle.
@@ -258,7 +238,7 @@ async function closeSlackNoticeAsAnsweredByRequestId(
         if (record.messageId) {
             await createSlackNoticeTransport(token, record.target.targetId, record.messageId).delete(signal);
         }
-        if (current()) closeSlackNoticeRecord(requestId);
+        if (current()) slackNoticeRecord.close(requestId);
     } catch (e) {
         log.info('[slack:queue-notice] answered-close failed', logErrorText(e));
     }
@@ -447,11 +427,6 @@ function buildSlackTarget(event: SlackMessageEvent): RemoteTarget {
  * carried through the queue rather than on whoever spoke most recently.
  */
 let targetReplyForwarderInstalled = false;
-
-function requiresNativeBodyDelivery(data: Record<string, unknown>): boolean {
-    return (data['runtimeFinality'] === 'present' || data['runtimeFinality'] === 'absent')
-        && (data['runtimeStatus'] === 'done' || data['runtimeStatus'] === 'error' || data['runtimeStatus'] === 'stopped');
-}
 
 function bodyProgressOutcome(
     data: Record<string, unknown>, delivered: boolean,
@@ -685,14 +660,14 @@ function trackSlackReply(options: SlackReplyOptions): void {
             });
         }, true);
     }
-    reserveSlackNoticeRecord(requestId, target);
+    slackNoticeRecord.reserve(requestId, target);
     display = createSlackProgressLifecycle({
         token, target, requestId, scope: session.scope, sessionId: session.chatSessionId, locale,
         ...(options.workingDir ? { workingDir: options.workingDir } : {}),
         ...(recipientUserId ? { recipientUserId } : {}),
         registerTeardown: registerSlackProgressTeardown,
-        onPosted: ts => attachSlackNoticeRecord(requestId, ts),
-        onTerminalConfirmed: () => closeSlackNoticeRecord(requestId),
+        onPosted: ts => slackNoticeRecord.attach(requestId, ts),
+        onTerminalConfirmed: () => slackNoticeRecord.close(requestId),
         onExecutionOutcome: outcome => { executionOutcome = outcome; },
         onActivity: () => { if (started) resetTimer(); },
         onSeal: () => { shutdownSealed = true; void settleAck('failure'); void endTracking(executionOutcome ?? 'expired'); },
@@ -717,7 +692,6 @@ function installSlackTargetReplyForwarder(): void {
     targetReplyForwarderInstalled = true;
     addBroadcastListener((type, data) => {
         observeSlackReplyControl(type, data);
-        if (slackStopping || type !== 'orchestrate_done' || data["origin"] !== 'slack') return;
         // Only captured queued/restart delivery authority can use this fallback.
         // Ordinary direct turns retain their awaiting dispatch owner.
         //
@@ -727,20 +701,26 @@ function installSlackTargetReplyForwarder(): void {
         // A steered turn is the same shape of orphan as a queued one: ingress
         // returns early unless the disposition is new_run, so a mid-run steer leaves
         // NO waiter for the follow-up answer (#655). Accept all three identities.
-        if (data["fromQueue"] !== true && data["fromSteer"] !== true && data["replyViaTarget"] !== true) return;
-        const rawTarget = data['target'];
-        if (!isRemoteTarget(rawTarget) || rawTarget.channel !== 'slack') return;
-        const target = { ...rawTarget };
-        // A live requester is already listening for this exact result; posting
-        // here too would double-post it.
-        if (data["requestId"] && hasPendingQueueWaiter(String(data["requestId"]))) return;
+        //
+        // `observeSlackReplyControl` above stays OUTSIDE this admission: it acts on
+        // steer/queue control events, not on `orchestrate_done`, and folding it in
+        // would silence boot/orphan start proof and steer tracking.
+        const admitted = admitTargetReply(type, data, {
+            channel: 'slack',
+            event: 'orchestrate_done',
+            accept: ['fromQueue', 'fromSteer', 'replyViaTarget'],
+            hasPendingWaiter: hasPendingQueueWaiter,
+            stopping: () => slackStopping,
+        });
+        if (!admitted) return;
+        const { target } = admitted;
         const token = getSlackSendClient().token;
         if (!token) return;
         const generation = lifecycleGeneration;
-        const requireBodyDelivery = requiresNativeBodyDelivery(data);
+        const requireBodyDelivery = admitted.requireBodyDelivery;
         const text = data['error'] === true && !requireBodyDelivery
             ? t('slack.progress.failure', {}, currentLocale()) : String(data['text'] ?? '');
-        const requestId = typeof data['requestId'] === 'string' ? data['requestId'] : '';
+        const requestId = admitted.requestId;
         const scope = slackReplyDelivery.scope(requestId, target)
             ?? (typeof data['scope'] === 'string' ? data['scope'] : 'default');
         void slackReplyDelivery.deliver(requestId, target, anchor => sessionLanes.runDetachedTurn(scope, async () => {
@@ -845,14 +825,14 @@ async function slackOrchestrate(
             let resultData: Record<string, unknown> = {};
             const current = () => !shutdownSealed && !slackStopping && !signal.aborted && generation === lifecycleGeneration;
             if (!current()) return;
-            if (ctx.requestId) reserveSlackNoticeRecord(ctx.requestId, target);
+            if (ctx.requestId) slackNoticeRecord.reserve(ctx.requestId, target);
             const display = createSlackProgressLifecycle({
                 token, target, requestId: ctx.requestId, scope: ctx.scope, sessionId: ctx.chatSessionId, locale,
                 ...(workingDir ? { workingDir } : {}),
                 ...(dedupe.recipientUserId ? { recipientUserId: dedupe.recipientUserId } : {}),
                 registerTeardown: registerSlackProgressTeardown,
-                onPosted: ts => attachSlackNoticeRecord(ctx.requestId, ts),
-                onTerminalConfirmed: () => closeSlackNoticeRecord(ctx.requestId),
+                onPosted: ts => slackNoticeRecord.attach(ctx.requestId, ts),
+                onTerminalConfirmed: () => slackNoticeRecord.close(ctx.requestId),
                 onExecutionOutcome: outcome => { executionOutcome = outcome; },
                 onSeal: () => { shutdownSealed = true; void settleAck('failure'); },
             });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -43,6 +43,9 @@ import type { InboundEnvelope } from '../messaging/types.js';
 import { registerSendTransport, sendChannelOutput } from '../messaging/send.js';
 import { nextDeliverySeq, pendingDeliveryAnchor, wasSelfDelivered } from '../messaging/turn-delivery.js';
 import { shouldSkipForwarding } from '../messaging/forwarder-origin.js';
+import { requiresNativeBodyDelivery } from '../messaging/native-body.js';
+import { createQueueNoticeRecorder } from '../messaging/queue-notice-record.js';
+import { admitTargetReply } from '../messaging/target-reply-guard.js';
 import type { RemoteTarget } from '../messaging/types.js';
 import type { ChannelSendRequest } from '../messaging/send.js';
 import {
@@ -204,26 +207,27 @@ function attachTelegramForwarder(bot: Bot) {
 // Private request identity, never accepted from a send payload or saved settings.
 const nativeBodyRequests = new WeakSet<ChannelSendRequest>();
 
-function requiresNativeBodyDelivery(data: Record<string, unknown>): boolean {
-    return (data['runtimeFinality'] === 'present' || data['runtimeFinality'] === 'absent')
-        && (data['runtimeStatus'] === 'done' || data['runtimeStatus'] === 'error' || data['runtimeStatus'] === 'stopped');
-}
-
 function installTelegramTargetReplyForwarder(): void {
     if (targetReplyForwarderInstalled) return;
     targetReplyForwarderInstalled = true;
     addBroadcastListener((type, data) => {
-        if (type !== 'orchestrate_done' || data["origin"] !== 'telegram' || data["replyViaTarget"] !== true) return;
-        if (!data["text"]) return;
-        const target = data["target"] as RemoteTarget | undefined;
-        if (!target || target.channel !== 'telegram') return;
+        // Telegram admits ONLY hub-forwarded replies: its own queued and direct
+        // turns are answered by the dispatch path that is still awaiting them.
+        const admitted = admitTargetReply(type, data, {
+            channel: 'telegram',
+            event: 'orchestrate_done',
+            accept: ['replyViaTarget'],
+            requireText: true,
+        });
+        if (!admitted) return;
+        const { target } = admitted;
         const request: ChannelSendRequest = {
             channel: 'telegram',
             type: 'text',
-            text: String(data["text"]),
+            text: admitted.text,
             target,
         };
-        if (requiresNativeBodyDelivery(data)) {
+        if (admitted.requireBodyDelivery) {
             if (!request.text?.trim()) return;
             nativeBodyRequests.add(request);
         }
@@ -284,33 +288,11 @@ async function disposeTelegramRuntime(poller: { stop(): Promise<void> } | null):
 }
 
 // ─── Durable notice records (#418) ──────────────────
-// The registry above is process-local; these wrap the store that outlives the
+// The registry above is process-local; this wraps the store that outlives the
 // process. Best-effort by contract: a durable write is a convenience for the NEXT
-// boot, so letting it throw would fail the turn the user is waiting on.
-
-function reserveTelegramNoticeRecord(requestId: string, target: RemoteTarget): void {
-    try {
-        getQueueNoticeStore()?.reserve({ requestId, channel: 'telegram', target });
-    } catch (e) {
-        log.info('[tg:queue-notice] reserve failed', logErrorText(e));
-    }
-}
-
-function attachTelegramNoticeRecord(requestId: string, messageId: string): void {
-    try {
-        getQueueNoticeStore()?.attachMessageId(requestId, messageId);
-    } catch (e) {
-        log.info('[tg:queue-notice] attach failed', logErrorText(e));
-    }
-}
-
-function closeTelegramNoticeRecord(requestId: string): void {
-    try {
-        getQueueNoticeStore()?.close(requestId);
-    } catch (e) {
-        log.info('[tg:queue-notice] close failed', logErrorText(e));
-    }
-}
+// boot, so letting it throw would fail the turn the user is waiting on. The
+// contract is shared with the other two bots (#699).
+const telegramNoticeRecord = createQueueNoticeRecorder('telegram', '[tg:queue-notice]');
 
 /**
  * Rewrite notices left behind by a previous run.
@@ -901,7 +883,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                     ]);
                     // Closed in-process, so the durable record has nothing left to
                     // restore on the next boot.
-                    if (requestId) closeTelegramNoticeRecord(requestId);
+                    if (requestId) telegramNoticeRecord.close(requestId);
                     unregister();
                     reject(reason);
                 });
@@ -923,7 +905,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                                 notice.close('expired'),
                                 ackHandle?.settle('failure') ?? Promise.resolve(),
                             ]);
-                            if (requestId) closeTelegramNoticeRecord(requestId);
+                            if (requestId) telegramNoticeRecord.close(requestId);
                             unregister();
                             resolve();
                             return;
@@ -956,7 +938,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                                     notice.close('expired'),
                                     ackHandle?.settle('failure') ?? Promise.resolve(),
                                 ]);
-                                if (requestId) closeTelegramNoticeRecord(requestId);
+                                if (requestId) telegramNoticeRecord.close(requestId);
                                 unregister();
                                 reject(new Error('telegram_send_aborted'));
                                 return;
@@ -968,7 +950,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                                 notice.close('expired'),
                                 ackHandle?.settle('failure') ?? Promise.resolve(),
                             ]);
-                            if (requestId) closeTelegramNoticeRecord(requestId);
+                            if (requestId) telegramNoticeRecord.close(requestId);
                             unregister();
                             reject(error);
                             return;
@@ -978,7 +960,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                             notice.close('answered'),
                             ackHandle?.settle('success') ?? Promise.resolve(),
                         ]);
-                        if (requestId) closeTelegramNoticeRecord(requestId);
+                        if (requestId) telegramNoticeRecord.close(requestId);
                         unregister();
                         resolve();
                         {
@@ -1009,12 +991,12 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                 // Reserved BEFORE the post: a record with no id restores to
                 // nothing, while a posted message with no record is unreachable
                 // forever (#418).
-                if (requestId) reserveTelegramNoticeRecord(requestId, responseTarget);
+                if (requestId) telegramNoticeRecord.reserve(requestId, responseTarget);
                 const posted = await ctx.reply(t('tg.queued', { count: result.pending }, currentLocale()));
                 // The exported factory, not an inline object: tests drive the same
                 // binding production uses.
                 notice.bind(createTelegramNoticeTransport(ctx.api, chat.id, posted.message_id));
-                if (requestId) attachTelegramNoticeRecord(requestId, String(posted.message_id));
+                if (requestId) telegramNoticeRecord.attach(requestId, String(posted.message_id));
                 await finalDelivery;
             } catch (error) {
                 // A failed notice post means no handle will ever arrive; without
@@ -1023,7 +1005,7 @@ async function _initTelegramInner(): Promise<TransportStartOutcome> {
                 notice.abandon();
                 // The reservation describes a message that was never posted, or a
                 // turn that just ended; either way the next boot must not hunt it.
-                if (requestId) closeTelegramNoticeRecord(requestId);
+                if (requestId) telegramNoticeRecord.close(requestId);
                 finalDeliveryControl.cancel?.(error);
                 await finalDelivery.catch(() => { });
                 telegramFinalDeliveryFailures.add(ctx.update.update_id);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -225,6 +225,9 @@ cli-jaw/
 │   │   ├── ack-reaction.ts   ← inbound ACK reaction lifecycle (serialized transitions + per-channel defaults + nested ack merge) (269L)
 │   │   ├── queue-notice.ts   ← queue-notice lifecycle (deferred close + bind race drain + bounded shutdown registry) (208L)
 │   │   ├── forwarder-origin.ts ← channel forwarder 공통 origin 필터 (own channel + producer-owned heartbeat skip) (39L)
+│   │   ├── native-body.ts    ← native runtime terminal 태그 술어 + 배달 정책 래퍼 (3봇+collector 공유) (32L) ✨
+│   │   ├── queue-notice-record.ts ← durable notice 기록 best-effort 래퍼 factory (channel+logPrefix) (59L) ✨
+│   │   ├── target-reply-guard.ts ← standing target-reply 공통 admission (accept identity 데이터화 + 주소 검증) (102L) ✨
 │   │   ├── channel-adapter.ts ← ChannelAdapter contract (130L)
 │   │   ├── channel-capabilities.ts ← closed capability set + generated matrix (101L)
 │   │   ├── delivery-outcome.ts ← DeliveryReceipt classification (219L)
@@ -236,7 +239,7 @@ cli-jaw/
 │   │   ├── distribute.ts     ← runSingleAgent + buildPlanPrompt + parallel helpers + tiered findEmployee + employee resume diagnostics + virtual employee session-skip (518L)
 │   │   ├── parser.ts         ← triage + subtask JSON + verdict 파싱 + isResetIntent (176L)
 │   │   ├── gateway.ts        ← submitMessage 통합 진입점 (WebUI+CLI+TG+Discord 공통) + working_dir scoped insertMessage (346L)
-│   │   ├── collect.ts        ← orchestrateAndCollect + orchestrateAndCollectData (176L)
+│   │   ├── collect.ts        ← orchestrateAndCollect + orchestrateAndCollectData (179L)
 │   │   ├── session-work.ts   ← hasChatSessionWork — 세션 삭제 전 진행중 작업 관측 (활성 run·큐·replay는 정확 매칭, drain/retry/hold/worker/lane은 scope 단위 보수적 판정) (42L) ✨
 │   │   ├── scope.ts          ← remote binding key + channel gate + local session scope + captured execution binding; legacy findActiveScope만 default fallback (86L)
 │   │   ├── worker-monitor.ts ← Worker stall detection — activity timestamps + stall/disconnect/timeout callbacks (58L)
@@ -332,7 +335,7 @@ cli-jaw/
 │   ├── telegram/             ← Telegram 인터페이스 (11 files)
 │   │   ├── reactions.ts     ← ACK reaction transport + ReactionTypeEmoji allowlist + notice transport (186L)
 │   │   ├── ipv4-fetch.ts    ← IPv4 fetch factory that honours init.signal (destroys on abort) (106L)
-│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1433L)
+│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1415L)
 │   │   ├── voice.ts          ← 음성 메시지 → guarded download → STT → tgOrchestrate 파이프라인 (43L)
 │   │   ├── forwarder.ts      ← text 전송 뒤 guarded local-image photo relay + escape/chunk/createForwarder (247L)
 │   │   ├── rich-message.ts   ← Bot API 10.1 rich-first send (sendTelegramMarkdown, 32k chunk, HTML/plaintext fallback) (425L)
@@ -340,7 +343,7 @@ cli-jaw/
 │   │   ├── hub-callback.ts   ← hub-member callback URL SSRF guard (19L)
 │   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (192L)
 │   ├── discord/              ← Discord 인터페이스 (8 files)
-│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1051L)
+│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1030L)
 │   │   ├── reactions.ts   ← ACK reaction transport + cancellable notice REST (122L)
 │   │   ├── commands.ts       ← Discord slash command 등록 + 핸들러 (153L)
 │   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (232L) ✨
@@ -349,7 +352,7 @@ cli-jaw/
 │   │   └── discord-file.ts   ← Discord 파일 전송 (80L)
 │   ├── slack/                ← Slack 인터페이스 (41 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
-│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1918L)
+│   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1898L)
 │   │   ├── api.ts            ← Slack Web API fetch wrapper (HTTP 200 + ok:false를 실패로 처리, credential/URL redaction, Retry-After) (442L)
 │   │   ├── format.ts         ← CommonMark → mrkdwn 변환 + code-fence 보존 chunking (222L)
 │   │   ├── blocks.ts         ← Block Kit validation and per-table message splitting (143L)

--- a/tests/unit/messaging-target-reply-guard.test.ts
+++ b/tests/unit/messaging-target-reply-guard.test.ts
@@ -1,0 +1,166 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { admitTargetReply, type TargetReplyGuardOptions } from '../../src/messaging/target-reply-guard.ts';
+import type { MessengerChannel, RemoteTarget } from '../../src/messaging/types.ts';
+
+const target = (channel: MessengerChannel, over: Partial<RemoteTarget> = {}): RemoteTarget => ({
+    channel, targetKind: 'channel', peerKind: 'channel', targetId: 'C1', ...over,
+});
+
+/** The three forwarders as they are actually installed (#699). */
+const SLACK: TargetReplyGuardOptions = {
+    channel: 'slack', event: 'orchestrate_done',
+    accept: ['fromQueue', 'fromSteer', 'replyViaTarget'],
+};
+const TELEGRAM: TargetReplyGuardOptions = {
+    channel: 'telegram', event: 'orchestrate_done',
+    accept: ['replyViaTarget'], requireText: true,
+};
+const DISCORD: TargetReplyGuardOptions = {
+    channel: 'discord', event: 'orchestrate_done',
+    accept: ['fromQueue'], requireText: true,
+};
+
+const done = (channel: MessengerChannel, over: Record<string, unknown> = {}) => ({
+    origin: channel, text: 'answer', target: target(channel), ...over,
+});
+
+// ─── The guard split the three bots had drifted into ───
+// This is the difference #699 asked to be pinned. It is a real per-channel
+// decision, not an accident: a channel whose dispatch path already answers
+// ordinary turns must not answer them here too.
+
+test('TRG-001: Discord admits fromQueue and nothing else', () => {
+    assert.ok(admitTargetReply('orchestrate_done', done('discord', { fromQueue: true }), DISCORD));
+    assert.equal(admitTargetReply('orchestrate_done', done('discord', { replyViaTarget: true }), DISCORD), null);
+    assert.equal(admitTargetReply('orchestrate_done', done('discord', { fromSteer: true }), DISCORD), null);
+    assert.equal(admitTargetReply('orchestrate_done', done('discord'), DISCORD), null);
+});
+
+test('TRG-002: Telegram admits replyViaTarget and nothing else', () => {
+    assert.ok(admitTargetReply('orchestrate_done', done('telegram', { replyViaTarget: true }), TELEGRAM));
+    assert.equal(admitTargetReply('orchestrate_done', done('telegram', { fromQueue: true }), TELEGRAM), null);
+    assert.equal(admitTargetReply('orchestrate_done', done('telegram', { fromSteer: true }), TELEGRAM), null);
+});
+
+test('TRG-003: Slack admits all three orphan identities', () => {
+    // A mid-run steer leaves no waiter for the follow-up answer (#655), which is
+    // the same shape of orphan as a queued turn.
+    for (const identity of ['fromQueue', 'fromSteer', 'replyViaTarget']) {
+        assert.ok(admitTargetReply('orchestrate_done', done('slack', { [identity]: true }), SLACK), identity);
+    }
+    assert.equal(admitTargetReply('orchestrate_done', done('slack'), SLACK), null);
+});
+
+test('TRG-004: only the literal boolean true is an identity', () => {
+    for (const forged of ['true', 1, {}, [], 'yes']) {
+        assert.equal(admitTargetReply('orchestrate_done', done('discord', { fromQueue: forged }), DISCORD), null,
+            JSON.stringify(forged));
+    }
+});
+
+// ─── Shared admission ───────────────────────────────
+
+test('TRG-005: another event type is never admitted', () => {
+    assert.equal(admitTargetReply('agent_done', done('slack', { fromQueue: true }), SLACK), null);
+    assert.equal(admitTargetReply('steer_started', done('slack', { fromQueue: true }), SLACK), null);
+});
+
+test('TRG-006: origin and target channel must BOTH be this channel', () => {
+    // isRemoteTarget only proves the channel is SOME messenger, so the guard has
+    // to compare both fields itself.
+    assert.equal(admitTargetReply('orchestrate_done',
+        { origin: 'telegram', text: 'x', target: target('slack'), fromQueue: true }, SLACK), null);
+    assert.equal(admitTargetReply('orchestrate_done',
+        { origin: 'slack', text: 'x', target: target('telegram'), fromQueue: true }, SLACK), null);
+});
+
+test('TRG-007: a malformed address is rejected rather than sent to last-active', () => {
+    // Telegram and Discord used to cast this without checking. An empty targetId
+    // reached a transport that then fell back to the last-active chat, so the
+    // answer landed in a conversation nobody asked in.
+    const bad: Array<unknown> = [
+        undefined, null, 'C1', {},
+        { channel: 'telegram', targetKind: 'channel', peerKind: 'channel', targetId: '' },
+        { channel: 'telegram', targetKind: 'channel', peerKind: 'channel' },
+        { channel: 'telegram', targetKind: 'nonsense', peerKind: 'channel', targetId: 'C1' },
+        { channel: 'telegram', targetKind: 'channel', peerKind: 'channel', targetId: 'C1', threadId: 7 },
+    ];
+    for (const value of bad) {
+        assert.equal(admitTargetReply('orchestrate_done',
+            { origin: 'telegram', text: 'x', target: value, replyViaTarget: true }, TELEGRAM), null,
+            JSON.stringify(value));
+    }
+});
+
+test('TRG-008: the admitted target is a copy, so a listener cannot mutate the payload', () => {
+    const payload = done('slack', { fromQueue: true });
+    const admitted = admitTargetReply('orchestrate_done', payload, SLACK);
+    assert.ok(admitted);
+    admitted.target.targetId = 'MUTATED';
+    assert.equal((payload.target as RemoteTarget).targetId, 'C1');
+});
+
+// ─── Live waiter ────────────────────────────────────
+
+test('TRG-009: a live waiter suppresses the fallback, so the answer is not posted twice', () => {
+    const waited: string[] = [];
+    const opts = { ...DISCORD, hasPendingWaiter: (id: string) => { waited.push(id); return id === 'R1'; } };
+    assert.equal(admitTargetReply('orchestrate_done', done('discord', { fromQueue: true, requestId: 'R1' }), opts), null);
+    assert.ok(admitTargetReply('orchestrate_done', done('discord', { fromQueue: true, requestId: 'R2' }), opts));
+    assert.deepEqual(waited, ['R1', 'R2']);
+});
+
+test('TRG-010: Telegram asks no waiter, because it keeps no pending queue ids', () => {
+    assert.equal(TELEGRAM.hasPendingWaiter, undefined);
+    const admitted = admitTargetReply('orchestrate_done',
+        done('telegram', { replyViaTarget: true, requestId: 'R1' }), TELEGRAM);
+    assert.equal(admitted?.requestId, 'R1');
+});
+
+test('TRG-011: a non-string request id is still stringified for the waiter lookup', () => {
+    const seen: string[] = [];
+    const opts = { ...DISCORD, hasPendingWaiter: (id: string) => { seen.push(id); return false; } };
+    const admitted = admitTargetReply('orchestrate_done', done('discord', { fromQueue: true, requestId: 7 }), opts);
+    assert.deepEqual(seen, ['7']);
+    // The returned id stays string-typed, which is what the notice store needs.
+    assert.equal(admitted?.requestId, '');
+});
+
+// ─── Text and shutdown ──────────────────────────────
+
+test('TRG-012: Telegram and Discord reject falsy text at admission; Slack does not', () => {
+    for (const empty of ['', undefined, null, 0]) {
+        assert.equal(admitTargetReply('orchestrate_done',
+            done('discord', { fromQueue: true, text: empty }), DISCORD), null, JSON.stringify(empty));
+    }
+    // Slack rewrites an error payload into its own failure copy, so it cannot
+    // decide emptiness before that rewrite.
+    assert.ok(admitTargetReply('orchestrate_done', done('slack', { fromQueue: true, text: '' }), SLACK));
+});
+
+test('TRG-013: a stopping channel admits nothing', () => {
+    let stopping = false;
+    const opts = { ...SLACK, stopping: () => stopping };
+    assert.ok(admitTargetReply('orchestrate_done', done('slack', { fromQueue: true }), opts));
+    stopping = true;
+    assert.equal(admitTargetReply('orchestrate_done', done('slack', { fromQueue: true }), opts), null);
+});
+
+test('TRG-014: native runtime tags are reported so the bot can require body delivery', () => {
+    const native = admitTargetReply('orchestrate_done',
+        done('discord', { fromQueue: true, runtimeFinality: 'present', runtimeStatus: 'done' }), DISCORD);
+    assert.equal(native?.requireBodyDelivery, true);
+    const legacy = admitTargetReply('orchestrate_done', done('discord', { fromQueue: true }), DISCORD);
+    assert.equal(legacy?.requireBodyDelivery, false);
+    // A half-tagged payload is not native: both tags have to be present.
+    const half = admitTargetReply('orchestrate_done',
+        done('discord', { fromQueue: true, runtimeStatus: 'done' }), DISCORD);
+    assert.equal(half?.requireBodyDelivery, false);
+});
+
+test('TRG-015: an empty accept list admits nothing', () => {
+    const opts = { ...DISCORD, accept: [] as const };
+    assert.equal(admitTargetReply('orchestrate_done', done('discord', { fromQueue: true }), opts), null);
+});


### PR DESCRIPTION
Three pieces of glue sat on top of the shared ACK/queue-notice layer in three copies, one per chat bot, and the copies had already drifted apart. This folds them into `src/messaging/` and pins the one difference that is real.

## What was duplicated

| Rule | Was | Now |
| --- | --- | --- |
| native-body predicate | `slack/bot.ts:451`, `telegram/bot.ts:207`, `discord/bot.ts:156`, **and** `orchestrator/collect.ts:102` | `messaging/native-body.ts` |
| durable notice record wrap (reserve/attach/close) | `slack/bot.ts:215`, `telegram/bot.ts:291`, `discord/bot.ts:270` | `messaging/queue-notice-record.ts` |
| standing target-reply guard | `slack/bot.ts:715`, `telegram/bot.ts:212`, `discord/bot.ts:161` | `messaging/target-reply-guard.ts` |

The ACK state machine and the queue-notice ordering are untouched. They were already owned by `messaging/ack-reaction.ts` and `messaging/queue-notice.ts`, and the issue says not to rewrite them.

## Two corrections to the issue body

The issue was written against `b5ea3c0ab`. Two of its claims no longer hold at `dev`:

- **There were four copies of the native-body predicate, not three.** `src/orchestrator/collect.ts:102-103` carries the same boolean inline. It is fixed here too.
- **"Only Discord checks `fromQueue` and closes the notice" is wrong.** Slack also closes the notice after delivering (`bot.ts:763-764`) and accepts all three orphan identities since #655. The actual split today is Slack `{fromQueue, fromSteer, replyViaTarget}` / Telegram `{replyViaTarget}` / Discord `{fromQueue}`.

## Why the guard is extracted but the send is not

`admitTargetReply` owns admission only: is this event mine, is the target a real address on my channel, and is somebody else already going to answer it. Send, queue-notice close, image relay and elicitation keyboards stay in each bot, because those differ in substance rather than in shape — Slack's path runs through `slackReplyDelivery`, `sessionLanes` and a self-delivery check that the other two have no equivalent of.

Which identities a channel accepts stays a per-channel decision, because it is one: a channel whose dispatch path already answers ordinary turns must not answer them here too, or the user sees the reply twice. The difference is now data (`accept`) instead of three hand-maintained control flows, and `tests/unit/messaging-target-reply-guard.test.ts` asserts it.

Two things deliberately kept where they were:

- **`observeSlackReplyControl` stays the first line of the Slack listener**, outside the admission. It acts on `steer_started`, `queue_update`, `queued_run_started` and `request_settled` — not on `orchestrate_done` — so folding it into a guard that only runs for `orchestrate_done` would silence boot/orphan start proof and steer tracking.
- **The empty-native-body skip stays in each bot.** Telegram and Discord drop those at admission; Slack drops them inside its delivery lane, after the delivery ledger has been entered. Moving Slack's check earlier would change which runs the ledger ever sees.

Also not done, and why:

- The Telegram and Discord `nativeBodyRequests` WeakSets are **not** merged. `sendChannelOutput` spread-clones the request when `fullAccess` is set (`messaging/send.ts:411-425`), and a shared set marked in one module and read in another would silently lose the marker.
- No shared installer in `messaging/`. `discord/bot.ts` is lazily imported through `discord/register.ts`, so a module-scope install in `messaging/` would attach an `orchestrate_done` listener for channels that were never enabled.

## One intentional behaviour change

Telegram and Discord now validate the target with `isRemoteTarget()` instead of casting it. A malformed address — an empty `targetId`, say — used to reach a transport that then fell back to the last-active chat, so the answer landed in a conversation nobody asked in. Every current target builder (`buildTelegramTarget`, hub `forwardToInstance`, `buildDiscordTarget`) passes the check; what closes is the misdelivery path.

## NOT COVERED BY CI

- **No live channel.** CI has no Slack, Telegram or Discord connection. The guard is proven as a pure function and the bots are proven to compile against it; that a real `orchestrate_done` from a restarted instance still reaches a real channel is not proven here.
- **The `isRemoteTarget` tightening is argued, not demonstrated.** The claim that every current producer emits a valid `RemoteTarget` comes from reading `buildTelegramTarget`, `forwardToInstance` and `buildDiscordTarget`. A queued payload persisted by an older build with a missing `targetKind`/`peerKind`, or a numeric `threadId`, would newly be dropped. No producer emitting that shape was found, and no test covers replaying an old queue row.
- **Discord's lazy-install timing is unchanged but untested.** Nothing here proves the Discord listener still installs only when `register.ts` pulls in `bot.ts`.
- **No local suite was run.** Per the task's instructions `npm test`, `npm run build`, `npx tsc` and `npm install` were not executed; the push used `--no-verify`. `node scripts/check-private-boundary.mjs` passed for both the index and the outgoing range. Type checking and the unit suite are proven only by `ci-aggregate` on this PR.

Closes #699

