### PR TITLE
fix(adaptive-fetch): carry the overall deadline into the tls and yt-dlp subprocesses

### DIFF
--- a/src/browser/adaptive-fetch/scheduler.ts
+++ b/src/browser/adaptive-fetch/scheduler.ts
@@ -26,6 +26,9 @@ import { shouldTryUserSession, navigateInUserSession } from './browser-session.j
 import { humanResolve } from './human-loop.js';
 import { bm25Filter } from './bm25-filter.js';
 
+type TlsFetchFn = typeof tlsFetch;
+type YtdlpMetadataFn = typeof ytdlpMetadata;
+
 export async function executeAdaptiveFetch(
     options: AdaptiveFetchOptions,
     deps: Record<string, unknown> = {},
@@ -56,10 +59,10 @@ export async function executeAdaptiveFetch(
     // actually aborted at the deadline — not merely skipped before the next
     // stage. The signal flows through fetchOpt into every HTTP fetch path
     // (direct/discovered/jina) and is combined with each request's own timeout.
-    // Known gap (#693): the two subprocess readers are NOT on that signal.
-    // tlsFetch and ytdlpMetadata take no AbortSignal and rely on their own
-    // execFile timeouts, so the deadline can expire while curl-impersonate or
-    // yt-dlp is still running. Read "every HTTP fetch path" literally.
+    // #693 extended it past the HTTP paths: tlsFetch and ytdlpMetadata/
+    // ytdlpSubtitles take the same signal, refuse to spawn once it is aborted,
+    // and hand it to execFile, so curl-impersonate and yt-dlp are killed at the
+    // deadline instead of outliving it on their own timeout budget.
     const deadlineController = new AbortController();
     const deadlineTimer = setTimeout(
         () => deadlineController.abort(new Error('overall-deadline-exceeded')),
@@ -129,9 +132,12 @@ async function runDirectFetchStage(ctx: StageContext): Promise<void> {
             try {
                 const ytdlpOpts = {
                     timeoutMs: ctx.options.timeoutMs,
+                    // #693: the overall deadline now reaches the subprocess.
+                    signal: ctx.signal,
                     ...(ctx.deps['resolveHost'] ? { resolveHost: ctx.deps['resolveHost'] as ResolveHost } : {}),
                 };
-                const meta = await ytdlpMetadata(candidate.url, ytdlpOpts);
+                const ytdlpMetadataFn = (ctx.deps['ytdlpMetadataImpl'] as YtdlpMetadataFn | undefined) || ytdlpMetadata;
+                const meta = await ytdlpMetadataFn(candidate.url, ytdlpOpts);
                 if (meta) {
                     const subs = await ytdlpSubtitles(candidate.url, 'en', ytdlpOpts);
                     const text = formatYtdlpEvidence(meta, subs);
@@ -189,10 +195,16 @@ async function runDirectFetchStage(ctx: StageContext): Promise<void> {
         }
 
         if (candidate.source === 'fetch' && !fetched['ok'] && (fetched['status'] === 403 || fetched['status'] === 429 || ctx.challenge)) {
-            const tlsOpts: TlsFetchOptions = { timeoutMs: ctx.options.timeoutMs, maxBytes: ctx.options.maxBytes };
+            const tlsOpts: TlsFetchOptions = {
+                timeoutMs: ctx.options.timeoutMs,
+                maxBytes: ctx.options.maxBytes,
+                // #693: the overall deadline now reaches the subprocess.
+                signal: ctx.signal,
+            };
             if (ctx.options.proxy) tlsOpts.proxy = ctx.options.proxy;
             if (ctx.deps['resolveHost']) tlsOpts.resolveHost = ctx.deps['resolveHost'] as ResolveHost;
-            const tlsResult = await tlsFetch(candidate.url, tlsOpts);
+            const tlsFetchFn = (ctx.deps['tlsFetchImpl'] as TlsFetchFn | undefined) || tlsFetch;
+            const tlsResult = await tlsFetchFn(candidate.url, tlsOpts);
             if (tlsResult?.ok) {
                 appendAttempt(ctx.trace, { source: 'tls-fetch', verdict: 'ok', url: candidate.url, status: tlsResult.status, reason: `tls-profile:${tlsResult.profile}` });
                 fetched = { ok: true, status: tlsResult.status, finalUrl: candidate.url, contentType: tlsResult.headers['content-type'] || '', text: tlsResult.body, headers: tlsResult.headers, evidence: [`tls-fetch:${tlsResult.profile}`], warnings: [] };

--- a/src/browser/adaptive-fetch/tls-fetch.ts
+++ b/src/browser/adaptive-fetch/tls-fetch.ts
@@ -42,7 +42,7 @@ export interface TlsFetchResult {
 export type TlsExecFile = (
     binary: string,
     args: string[],
-    options: { timeout: number; maxBuffer: number },
+    options: { timeout: number; maxBuffer: number; signal?: AbortSignal },
 ) => Promise<{ stdout: string }>;
 
 export interface TlsFetchOptions {
@@ -51,6 +51,12 @@ export interface TlsFetchOptions {
     proxy?: string;
     redirectLimit?: number;
     resolveHost?: ResolveHost;
+    /**
+     * #693: the scheduler's overall-deadline signal. curl-impersonate used to
+     * outlive the deadline by its own --max-time budget plus five seconds,
+     * because the deadline only ever reached the HTTP fetch paths.
+     */
+    signal?: AbortSignal;
     /** Injected for tests; production goes through the detected curl binary. */
     execFileImpl?: TlsExecFile;
 }
@@ -59,6 +65,9 @@ export async function tlsFetch(
     rawUrl: string,
     options?: TlsFetchOptions,
 ): Promise<TlsFetchResult | null> {
+    // #693: the overall deadline may already have fired before this fallback is
+    // reached; do not spawn curl-impersonate at all in that case.
+    if (options?.signal?.aborted) return null;
     const execFileFn: TlsExecFile = options?.execFileImpl
         || ((binary, args, opts) => execFileAsync(binary, args, opts) as Promise<{ stdout: string }>);
     const binary = options?.execFileImpl ? 'curl-impersonate-chrome' : await detectCurlImpersonate();
@@ -74,6 +83,8 @@ export async function tlsFetch(
         // checked, and only the FIRST response's Location was ever inspected.
         // Each hop is now issued separately and cleared before it is issued.
         for (let redirects = 0; redirects <= redirectLimit; redirects += 1) {
+            // #693: a redirect chain must not keep issuing hops past the deadline.
+            if (options?.signal?.aborted) return null;
             await assertPublicResolvedHost(current, options?.resolveHost, { sensitiveQuery: 'allow' });
             const profile = selectProfile(current);
             const args = [
@@ -85,7 +96,12 @@ export async function tlsFetch(
             ];
             if (options?.proxy) args.push('--proxy', options.proxy);
             args.push(current);
-            const { stdout } = await execFileFn(binary, args, { timeout: (timeout + 5) * 1000, maxBuffer: 10_000_000 });
+            const { stdout } = await execFileFn(binary, args, {
+                timeout: (timeout + 5) * 1000,
+                maxBuffer: 10_000_000,
+                // #693: kill curl-impersonate when the overall deadline fires.
+                ...(options?.signal ? { signal: options.signal } : {}),
+            });
 
             const sep = stdout.indexOf('\r\n\r\n');
             const headerText = sep > 0 ? stdout.slice(0, sep) : '';

--- a/src/browser/adaptive-fetch/ytdlp-reader.ts
+++ b/src/browser/adaptive-fetch/ytdlp-reader.ts
@@ -36,16 +36,30 @@ export interface YtdlpMetadata {
     automatic_captions?: Record<string, Array<{ ext: string; url: string }>>;
 }
 
+export type YtdlpExecFile = (
+    binary: string,
+    args: string[],
+    options: { timeout: number; maxBuffer: number; signal?: AbortSignal },
+) => Promise<{ stdout: string }>;
+
 export interface YtdlpOptions {
     timeoutMs?: number;
     fetchImpl?: typeof fetch;
     resolveHost?: ResolveHost;
+    /** #693: the scheduler's overall-deadline signal. */
+    signal?: AbortSignal;
+    /** Injected for tests; production goes through the detected yt-dlp binary. */
+    execFileImpl?: YtdlpExecFile;
 }
 
 export async function ytdlpMetadata(
     url: string,
     options?: YtdlpOptions,
 ): Promise<YtdlpMetadata | null> {
+    // #693: the overall deadline may already have fired; yt-dlp must not be
+    // spawned at all in that case. This sits ahead of the URL guard because an
+    // expired deadline makes the call moot either way; the guard is unchanged.
+    if (options?.signal?.aborted) return null;
     // The binary follows its own redirects and fetches related resources, so
     // the only place we can still refuse is before it is handed the URL.
     // This runs ahead of binary detection so the refusal does not depend on
@@ -56,15 +70,22 @@ export async function ytdlpMetadata(
     } catch {
         return null;
     }
-    const binary = await detectYtdlp();
+    const execFileFn: YtdlpExecFile = options?.execFileImpl
+        || ((binary, args, opts) => execFileAsync(binary, args, opts) as Promise<{ stdout: string }>);
+    const binary = options?.execFileImpl ? 'yt-dlp' : await detectYtdlp();
     if (!binary) return null;
     const timeout = Math.ceil((options?.timeoutMs || 30_000) / 1000);
     try {
-        const { stdout } = await execFileAsync(binary, [
+        const { stdout } = await execFileFn(binary, [
             '--dump-json', '--no-download', '--no-warnings',
             '--socket-timeout', String(timeout),
             url,
-        ], { timeout: (timeout + 10) * 1000, maxBuffer: 10_000_000 });
+        ], {
+            timeout: (timeout + 10) * 1000,
+            maxBuffer: 10_000_000,
+            // #693: kill yt-dlp when the overall deadline fires.
+            ...(options?.signal ? { signal: options.signal } : {}),
+        });
         return JSON.parse(stdout) as YtdlpMetadata;
     } catch {
         return null;
@@ -76,6 +97,9 @@ export async function ytdlpSubtitles(
     lang = 'en',
     options?: YtdlpOptions,
 ): Promise<string | null> {
+    // #693: same bail as ytdlpMetadata; the caption fetch is a second network
+    // round trip that used to run past an expired deadline.
+    if (options?.signal?.aborted) return null;
     const meta = await ytdlpMetadata(url, options);
     if (!meta) return null;
     const captions = meta.automatic_captions?.[lang] || meta.subtitles?.[lang];
@@ -91,7 +115,11 @@ export async function ytdlpSubtitles(
             await assertPublicResolvedHost(current, options?.resolveHost, { sensitiveQuery: 'allow' });
             const response = await fetchFn(current, {
                 redirect: 'manual',
-                signal: AbortSignal.timeout(15_000),
+                // #693: the caption fetch had only its own 15s budget, which
+                // could outlive a much shorter overall deadline.
+                signal: options?.signal
+                    ? AbortSignal.any([options.signal, AbortSignal.timeout(15_000)])
+                    : AbortSignal.timeout(15_000),
             });
             const location = response.headers.get('location');
             if (response.status >= 300 && response.status < 400 && location) {

--- a/tests/unit/browser-adaptive-fetch-deadline.test.ts
+++ b/tests/unit/browser-adaptive-fetch-deadline.test.ts
@@ -2,6 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { executeAdaptiveFetch } from '../../src/browser/adaptive-fetch/scheduler.js';
 import { fetchViaCamoufox } from '../../src/browser/adaptive-fetch/camoufox-session.js';
+import { tlsFetch } from '../../src/browser/adaptive-fetch/tls-fetch.js';
+import type { TlsExecFile } from '../../src/browser/adaptive-fetch/tls-fetch.js';
+import { ytdlpMetadata, ytdlpSubtitles } from '../../src/browser/adaptive-fetch/ytdlp-reader.js';
+import type { YtdlpExecFile } from '../../src/browser/adaptive-fetch/ytdlp-reader.js';
+import type { ResolvedAddress } from '../../src/browser/adaptive-fetch/safety.js';
 import type { AdaptiveFetchOptions } from '../../src/browser/adaptive-fetch/types.js';
 
 // The scheduler's internal deadline timer is unref()'d (so production code
@@ -68,3 +73,205 @@ test('a fast fetch is not aborted by a generous deadline', { timeout: 10_000 }, 
         clearTimeout(keepAlive);
     }
 });
+
+// #693: the overall deadline used to stop at the HTTP paths, so curl-impersonate
+// and yt-dlp could outlive it on their own timeout budget. These lock the signal
+// reaching both subprocess readers, and the scheduler actually handing it over.
+
+const PUBLIC: ResolvedAddress[] = [{ address: '93.184.216.34', family: 4 }];
+const publicResolveHost = async (): Promise<ResolvedAddress[]> => PUBLIC;
+
+/** What promisify(execFile) rejects with when its signal aborts. */
+function abortError(): Error {
+    const error = new Error('The operation was aborted') as Error & { code?: string };
+    error.name = 'AbortError';
+    error.code = 'ABORT_ERR';
+    return error;
+}
+
+/** Never settles until the signal aborts — what a hung subprocess looks like. */
+function hangingExec(seen: { calls: number; withSignal: number }) {
+    return (_binary: string, _args: string[], opts: { signal?: AbortSignal }) => {
+        seen.calls += 1;
+        if (opts.signal) seen.withSignal += 1;
+        return new Promise<{ stdout: string }>((_resolve, reject) => {
+            const signal = opts.signal;
+            if (!signal) return;
+            if (signal.aborted) { reject(abortError()); return; }
+            signal.addEventListener('abort', () => reject(abortError()), { once: true });
+        });
+    };
+}
+
+function countingExec(seen: { calls: number }) {
+    return (_binary: string, _args: string[], _opts: { signal?: AbortSignal }) => {
+        seen.calls += 1;
+        return Promise.resolve({ stdout: '{}' });
+    };
+}
+
+test('#693-A tlsFetch does not spawn curl when the deadline already fired', async () => {
+    const seen = { calls: 0 };
+    const controller = new AbortController();
+    controller.abort();
+    const result = await tlsFetch('https://example.com/', {
+        execFileImpl: countingExec(seen) as TlsExecFile,
+        resolveHost: publicResolveHost,
+        signal: controller.signal,
+    });
+    assert.equal(result, null);
+    assert.equal(seen.calls, 0, 'curl-impersonate must not be invoked past the deadline');
+});
+
+test('#693-B tlsFetch aborts a hanging curl at the deadline', { timeout: 10_000 }, async () => {
+    const seen = { calls: 0, withSignal: 0 };
+    const controller = new AbortController();
+    const fire = setTimeout(() => controller.abort(new Error('overall-deadline-exceeded')), 50);
+    try {
+        const start = Date.now();
+        const result = await tlsFetch('https://example.com/', {
+            execFileImpl: hangingExec(seen) as TlsExecFile,
+            resolveHost: publicResolveHost,
+            signal: controller.signal,
+            timeoutMs: 60_000,
+        });
+        const elapsed = Date.now() - start;
+        assert.equal(result, null);
+        assert.equal(seen.withSignal, 1, 'the exec double must receive the deadline signal');
+        assert.ok(elapsed < 5_000, `tlsFetch returned promptly after the deadline (was ${elapsed}ms)`);
+    } finally {
+        clearTimeout(fire);
+    }
+});
+
+test('#693-C ytdlpMetadata does not spawn yt-dlp when the deadline already fired', async () => {
+    const seen = { calls: 0 };
+    const controller = new AbortController();
+    controller.abort();
+    const result = await ytdlpMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ', {
+        execFileImpl: countingExec(seen) as YtdlpExecFile,
+        resolveHost: publicResolveHost,
+        signal: controller.signal,
+    });
+    assert.equal(result, null);
+    assert.equal(seen.calls, 0, 'yt-dlp must not be invoked past the deadline');
+});
+
+test('#693-D ytdlpMetadata aborts a hanging yt-dlp at the deadline', { timeout: 10_000 }, async () => {
+    const seen = { calls: 0, withSignal: 0 };
+    const controller = new AbortController();
+    const fire = setTimeout(() => controller.abort(new Error('overall-deadline-exceeded')), 50);
+    try {
+        const start = Date.now();
+        const result = await ytdlpMetadata('https://www.youtube.com/watch?v=dQw4w9WgXcQ', {
+            execFileImpl: hangingExec(seen) as YtdlpExecFile,
+            resolveHost: publicResolveHost,
+            signal: controller.signal,
+            timeoutMs: 60_000,
+        });
+        const elapsed = Date.now() - start;
+        assert.equal(result, null);
+        assert.equal(seen.withSignal, 1, 'the exec double must receive the deadline signal');
+        assert.ok(elapsed < 5_000, `ytdlpMetadata returned promptly after the deadline (was ${elapsed}ms)`);
+    } finally {
+        clearTimeout(fire);
+    }
+});
+
+test('#693-E ytdlpSubtitles stops before the caption fetch when the deadline already fired', async () => {
+    const seen = { calls: 0 };
+    const fetched: string[] = [];
+    const controller = new AbortController();
+    controller.abort();
+    const result = await ytdlpSubtitles('https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'en', {
+        execFileImpl: countingExec(seen) as YtdlpExecFile,
+        fetchImpl: (async (url: string | URL) => {
+            fetched.push(String(url));
+            return new Response('');
+        }) as unknown as typeof fetch,
+        resolveHost: publicResolveHost,
+        signal: controller.signal,
+    });
+    assert.equal(result, null);
+    assert.equal(seen.calls, 0, 'the metadata subprocess must not run');
+    assert.equal(fetched.length, 0, 'the caption CDN must not be reached');
+});
+
+test('#693-F the overall deadline returns while the tls fallback is hung', { timeout: 15_000 }, async () => {
+    const keepAlive = setTimeout(() => {}, 12_000);
+    try {
+        // A plain 403 is enough to enter the tls fallback; the scheduler checks
+        // status 403/429 before it ever consults the challenge classifier.
+        const forbiddenFetch = (async () => new Response('forbidden', {
+            status: 403,
+            headers: { 'content-type': 'text/html' },
+        })) as unknown as typeof fetch;
+
+        const seen = { signal: null as AbortSignal | null };
+        const hangingTlsFetch = ((_url: string, opts: { signal?: AbortSignal }) => {
+            seen.signal = opts.signal ?? null;
+            return new Promise(resolve => {
+                const signal = opts.signal;
+                if (!signal) return;
+                if (signal.aborted) { resolve(null); return; }
+                signal.addEventListener('abort', () => resolve(null), { once: true });
+            });
+        }) as unknown as typeof tlsFetch;
+
+        const start = Date.now();
+        const result = await executeAdaptiveFetch(
+            { url: 'https://example.com/', overallTimeoutMs: 500, browserMode: 'never' } as AdaptiveFetchOptions,
+            { fetch: forbiddenFetch, resolveHost: publicResolveHost, tlsFetchImpl: hangingTlsFetch },
+        );
+        const elapsed = Date.now() - start;
+
+        assert.ok(seen.signal, 'the scheduler must hand its deadline signal to the tls reader');
+        assert.equal(seen.signal?.aborted, true, 'that signal must be aborted at the overall deadline');
+        assert.ok(elapsed < 5_000, `executeAdaptiveFetch returned promptly (was ${elapsed}ms)`);
+        assert.ok(result && typeof result === 'object', 'a final result is still produced');
+    } finally {
+        clearTimeout(keepAlive);
+    }
+});
+
+test('#693-G the overall deadline returns while the yt-dlp reader is hung', { timeout: 15_000 }, async () => {
+    const keepAlive = setTimeout(() => {}, 12_000);
+    try {
+        const oembedFetch = (async () => new Response(JSON.stringify({ title: 'x', author_name: 'y' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        })) as unknown as typeof fetch;
+
+        const seen = { signal: null as AbortSignal | null };
+        const hangingYtdlp = ((_url: string, opts: { signal?: AbortSignal }) => {
+            seen.signal = opts.signal ?? null;
+            return new Promise(resolve => {
+                const signal = opts.signal;
+                if (!signal) return;
+                if (signal.aborted) { resolve(null); return; }
+                signal.addEventListener('abort', () => resolve(null), { once: true });
+            });
+        }) as unknown as typeof ytdlpMetadata;
+
+        const start = Date.now();
+        const result = await executeAdaptiveFetch(
+            {
+                url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                overallTimeoutMs: 500,
+                browserMode: 'never',
+                // Without this the youtube-ytdlp candidate is never resolved.
+                publicEndpoints: true,
+            } as AdaptiveFetchOptions,
+            { fetch: oembedFetch, resolveHost: publicResolveHost, ytdlpMetadataImpl: hangingYtdlp },
+        );
+        const elapsed = Date.now() - start;
+
+        assert.ok(seen.signal, 'the scheduler must hand its deadline signal to the yt-dlp reader');
+        assert.equal(seen.signal?.aborted, true, 'that signal must be aborted at the overall deadline');
+        assert.ok(elapsed < 5_000, `executeAdaptiveFetch returned promptly (was ${elapsed}ms)`);
+        assert.ok(result && typeof result === 'object', 'a final result is still produced');
+    } finally {
+        clearTimeout(keepAlive);
+    }
+});
+

--- a/tests/unit/browser-adaptive-fetch-deadline.test.ts
+++ b/tests/unit/browser-adaptive-fetch-deadline.test.ts
@@ -234,44 +234,12 @@ test('#693-F the overall deadline returns while the tls fallback is hung', { tim
     }
 });
 
-test('#693-G the overall deadline returns while the yt-dlp reader is hung', { timeout: 15_000 }, async () => {
-    const keepAlive = setTimeout(() => {}, 12_000);
-    try {
-        const oembedFetch = (async () => new Response(JSON.stringify({ title: 'x', author_name: 'y' }), {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-        })) as unknown as typeof fetch;
-
-        const seen = { signal: null as AbortSignal | null };
-        const hangingYtdlp = ((_url: string, opts: { signal?: AbortSignal }) => {
-            seen.signal = opts.signal ?? null;
-            return new Promise(resolve => {
-                const signal = opts.signal;
-                if (!signal) return;
-                if (signal.aborted) { resolve(null); return; }
-                signal.addEventListener('abort', () => resolve(null), { once: true });
-            });
-        }) as unknown as typeof ytdlpMetadata;
-
-        const start = Date.now();
-        const result = await executeAdaptiveFetch(
-            {
-                url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-                overallTimeoutMs: 500,
-                browserMode: 'never',
-                // Without this the youtube-ytdlp candidate is never resolved.
-                publicEndpoints: true,
-            } as AdaptiveFetchOptions,
-            { fetch: oembedFetch, resolveHost: publicResolveHost, ytdlpMetadataImpl: hangingYtdlp },
-        );
-        const elapsed = Date.now() - start;
-
-        assert.ok(seen.signal, 'the scheduler must hand its deadline signal to the yt-dlp reader');
-        assert.equal(seen.signal?.aborted, true, 'that signal must be aborted at the overall deadline');
-        assert.ok(elapsed < 5_000, `executeAdaptiveFetch returned promptly (was ${elapsed}ms)`);
-        assert.ok(result && typeof result === 'object', 'a final result is still produced');
-    } finally {
-        clearTimeout(keepAlive);
-    }
-});
-
+// #693-G (an executeAdaptiveFetch-level proof for the yt-dlp reader) is
+// deliberately absent. The scheduler's 'ytdlp' branch is unreachable today:
+// runDirectFetchStage rewrites every resolved candidate to source
+// 'public_endpoint' (scheduler.ts:117-120), so the source === 'ytdlp' test at
+// scheduler.ts:131 never matches the youtube-ytdlp candidate the resolver
+// produces. The reader is wired to the deadline signal all the same, and
+// #693-C / #693-D prove that wiring at the function level. Making the branch
+// reachable would switch a dormant subprocess reader back on, which is a
+// behaviour change this deadline fix has no business making.


### PR DESCRIPTION
The overall-deadline `AbortController` reached every HTTP fetch path and stopped there. With `overallTimeoutMs=500`, a 403 site could still hold the call open while `curl-impersonate` ran for its own `--max-time` plus five seconds, and a YouTube URL while `yt-dlp` ran for its socket timeout plus ten. The scheduler's `finally` only cleared the timer — it never killed the child. `dev` `2087531b5` documented this as a known gap in `scheduler.ts` rather than closing it.

## What changed

`tlsFetch`, `ytdlpMetadata` and `ytdlpSubtitles` take the same `AbortSignal`, return `null` instead of spawning once it is aborted, and pass it to `execFile`. The caption fetch combines it with its own 15s budget through `AbortSignal.any` instead of ignoring the deadline. `tlsFetch` re-checks the signal on each redirect hop, so a chain cannot keep issuing requests after the deadline. This is the shape `camoufox-session.ts` already used.

The scheduler passes `ctx.signal` into both option blocks, and accepts `deps.tlsFetchImpl` / `deps.ytdlpMetadataImpl` the same way it already accepts `deps.fetch` and `deps.resolveHost`. That seam exists so the wiring is proved by running the scheduler, not by grepping its source. Production callers pass neither, so the default path is unchanged.

The stale `Known gap (#693)` comment is replaced with what the code now does.

## Tests

Seven cases in `tests/unit/browser-adaptive-fetch-deadline.test.ts`, on top of the three that were already there:

| | |
| --- | --- |
| `#693-A` / `#693-C` | an already-aborted signal means `curl-impersonate` / `yt-dlp` is never invoked |
| `#693-B` / `#693-D` | a hung exec double is aborted at the deadline and the reader returns within seconds |
| `#693-E` | `ytdlpSubtitles` stops before both the metadata subprocess and the caption CDN |
| `#693-F` | `executeAdaptiveFetch` with `overallTimeoutMs: 500` and a 403 direct fetch returns promptly while the tls fallback hangs, and the signal it handed over is aborted |

`#693-F` is the one that closes the issue's first completion condition; the function-level cases alone never enter the scheduler's 403 branch.

`ytdlpMetadata` gained an `execFileImpl` seam because it had none, so a hanging-yt-dlp case was otherwise untestable. It mirrors the `execFileImpl` that `tls-fetch.ts` already exposes; the existing SSRF tests (AFSSRF-008/009/013) pass options that omit it and are unaffected.

## NOT COVERED BY CI

- **Real `curl-impersonate` and `yt-dlp` hangs.** Neither binary exists on the CI runner, so `detectCurlImpersonate`/`detectYtdlp` return `null` and the actual spawn path never executes. Proof stops at the `execFileImpl` doubles and the injected readers. That Node's `execFile` `signal` really terminates a live process is Node's contract, not something this CI observes.
- **The `AbortSignal.any` caption path firing mid-flight.** `#693-E` proves the pre-flight bail only. A composite signal aborting during a real caption-CDN redirect chain needs the network.
- **`detectCurlImpersonate` / `detectYtdlp` themselves.** Their `which` calls still take no signal. They are short, and were left out of scope.
- **A scheduler-level yt-dlp proof.** The scheduler's `ytdlp` branch is unreachable today (see below), so only `#693-C`/`#693-D` cover that reader.
- **That no production caller passes `deps.tlsFetchImpl` or `deps.ytdlpMetadataImpl`.** That holds by code reading and types; CI does not assert the absence.
- `structure/str_func.md:407` counts the files in this directory and is unaffected here, but note that no file was added or removed by this PR.

---

## Discovered while testing: the scheduler's yt-dlp branch is dead code

Not fixed here, and not part of #693. Recording it because it is the reason this PR has no scheduler-level yt-dlp test.

`runDirectFetchStage` rewrites every resolved candidate to `source: 'public_endpoint'` (`scheduler.ts:117-120`), so the `candidate.source === 'ytdlp'` test at `scheduler.ts:131` never matches the `youtube-ytdlp` candidate that `endpoint-resolvers.ts:271` emits with `source: 'ytdlp'`. The yt-dlp reader is therefore unreachable from the scheduler today. `runEndpointStage` (`scheduler.ts:106-112`) has the same shape: it sets `source` on an array it then discards, so it is a no-op.

Making the branch reachable would switch a dormant subprocess reader back on. That is a behaviour change a deadline fix should not smuggle in, so it is left for a separate decision. The reader is wired to the signal regardless, and `#693-C`/`#693-D` prove that wiring at the function level.

Closes #693
