### PR TITLE
test: give the copy-pasted Slack, route, and browser stubs one contract each

### DIFF
--- a/scripts/ci/windows-unit-manifest.txt
+++ b/scripts/ci/windows-unit-manifest.txt
@@ -18,3 +18,9 @@ tests/unit/claude-sdk-control.test.ts
 tests/unit/claude-sdk-core-hardening.test.ts
 tests/unit/claude-sdk-deferred-core.test.ts
 
+# Schema migration only runs against a home that already exists, so every
+# fresh-CLI_JAW_HOME CI run skips it everywhere else. These two build an old
+# home and walk the source tree by path, which is where Windows separators and
+# the better-sqlite3 prebuild actually differ (#691).
+tests/unit/db-schema-migration.test.ts
+tests/unit/db-legacy-mention-watch-surface.test.ts

--- a/tests/browser/manager-notes-file-management-smoke.test.ts
+++ b/tests/browser/manager-notes-file-management-smoke.test.ts
@@ -1,26 +1,9 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
-import { chromium, type Browser, type Page } from 'playwright-core';
+import { test } from 'node:test';
+import { type Page } from 'playwright-core';
 import { cleanupDashboardNotes } from './manager-notes-cleanup';
 import { withManagerBrowserLock } from './manager-browser-test-lock';
-
-const MANAGER_URL = process.env.MANAGER_DASHBOARD_URL || 'http://127.0.0.1:24576/';
-
-const browsers: Browser[] = [];
-
-async function pageForManager(): Promise<Page> {
-    const browser = await chromium.launch({ headless: true });
-    browsers.push(browser);
-    const context = await browser.newContext();
-    return await context.newPage();
-}
-
-async function pageApiStatus(page: Page, path: string): Promise<number> {
-    return await page.evaluate(async (notePath) => {
-        const response = await fetch(`/api/dashboard/notes/file?path=${encodeURIComponent(notePath)}`);
-        return response.status;
-    }, path);
-}
+import { MANAGER_URL, pageApiStatus, pageForManager } from './manager-notes-page';
 
 async function waitForPageApiStatus(page: Page, path: string, expected: number): Promise<void> {
     const deadline = Date.now() + 20000;
@@ -48,10 +31,6 @@ async function seedNote(page: Page, notePath: string): Promise<void> {
         });
     }, { notePath });
 }
-
-after(async () => {
-    await Promise.allSettled(browsers.map(browser => browser.close()));
-});
 
 async function pressDeleteAndHandleDialog(
     page: Page,

--- a/tests/browser/manager-notes-page.ts
+++ b/tests/browser/manager-notes-page.ts
@@ -1,0 +1,41 @@
+/**
+ * One headless page for the Manager notes smokes.
+ *
+ * Four files launched Chromium, pushed the browser onto a local `browsers`
+ * array and registered the same `after()` closer — three of them under an
+ * identical `pageForManager`, the fourth inline. Owning the array here means
+ * the cleanup cannot be forgotten by the next file that needs a page.
+ *
+ * This is NOT the same helper as `pageForManager` in manager-layout-smoke:
+ * that one connects to an already-running browser over CDP, takes a
+ * `TestContext` and skips when no browser is there. Same name, different
+ * contract, deliberately not merged.
+ */
+import { after } from 'node:test';
+import { chromium, type Browser, type Page } from 'playwright-core';
+
+export const MANAGER_URL = process.env.MANAGER_DASHBOARD_URL || 'http://127.0.0.1:24576/';
+
+const browsers: Browser[] = [];
+
+/** A fresh headless browser, context and page. The browser is closed for you. */
+export async function pageForManager(): Promise<Page> {
+    const browser = await chromium.launch({ headless: true });
+    browsers.push(browser);
+    const context = await browser.newContext();
+    return await context.newPage();
+}
+
+/** The notes file API's status code, read from inside the page's own origin. */
+export async function pageApiStatus(page: Page, path: string): Promise<number> {
+    return await page.evaluate(async (notePath) => {
+        const response = await fetch(`/api/dashboard/notes/file?path=${encodeURIComponent(notePath)}`);
+        return response.status;
+    }, path);
+}
+
+// Importing this module adopts its cleanup: every browser it launched closes
+// when the importing file's tests finish.
+after(async () => {
+    await Promise.allSettled(browsers.map(browser => browser.close()));
+});

--- a/tests/browser/manager-notes-refresh-stability-smoke.test.ts
+++ b/tests/browser/manager-notes-refresh-stability-smoke.test.ts
@@ -1,20 +1,10 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
-import { chromium, type Browser } from 'playwright-core';
+import { test } from 'node:test';
 import { withManagerBrowserLock } from './manager-browser-test-lock';
-
-const MANAGER_URL = process.env.MANAGER_DASHBOARD_URL || 'http://127.0.0.1:24576/';
-const browsers: Browser[] = [];
-
-after(async () => {
-    await Promise.allSettled(browsers.map(browser => browser.close()));
-});
+import { MANAGER_URL, pageForManager } from './manager-notes-page';
 
 test('notes sidebar does not refetch tree/index on every render while active', async () => await withManagerBrowserLock(async () => {
-    const browser = await chromium.launch({ headless: true });
-    browsers.push(browser);
-    const context = await browser.newContext();
-    const page = await context.newPage();
+    const page = await pageForManager();
 
     await page.goto(MANAGER_URL, { waitUntil: 'domcontentloaded' });
     await page.evaluate(async () => {

--- a/tests/browser/manager-notes-rich-authoring-smoke.test.ts
+++ b/tests/browser/manager-notes-rich-authoring-smoke.test.ts
@@ -1,21 +1,12 @@
 import assert from 'node:assert/strict';
-import { after, test, type TestContext } from 'node:test';
-import { chromium, type Browser, type Locator, type Page } from 'playwright-core';
+import { test, type TestContext } from 'node:test';
+import { type Locator, type Page } from 'playwright-core';
 import { cleanupDashboardNotes } from './manager-notes-cleanup';
 import { withManagerBrowserLock } from './manager-browser-test-lock';
-
-const MANAGER_URL = process.env.MANAGER_DASHBOARD_URL || 'http://127.0.0.1:24576/';
-const browsers: Browser[] = [];
+import { MANAGER_URL, pageForManager } from './manager-notes-page';
 
 function serialTest(name: string, fn: (t: TestContext) => unknown | Promise<unknown>): void {
     test(name, { concurrency: false }, async t => await withManagerBrowserLock(async () => await fn(t)));
-}
-
-async function pageForManager(): Promise<Page> {
-    const browser = await chromium.launch({ headless: true });
-    browsers.push(browser);
-    const context = await browser.newContext();
-    return await context.newPage();
 }
 
 async function seedRichNote(page: Page, notePath: string): Promise<void> {
@@ -170,10 +161,6 @@ async function waitForSavedContent(
     assert.ok(predicate(latest), `${message}\nLatest content:\n${latest}`);
     return latest;
 }
-
-after(async () => {
-    await Promise.allSettled(browsers.map(browser => browser.close()));
-});
 
 serialTest('notes WYSIWYG authoring keeps the primary toolbar compact', async () => {
     const page = await pageForManager();

--- a/tests/browser/manager-notes-tree-multi-delete-smoke.test.ts
+++ b/tests/browser/manager-notes-tree-multi-delete-smoke.test.ts
@@ -1,18 +1,9 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
-import { chromium, type Browser, type Page } from 'playwright-core';
+import { test } from 'node:test';
+import { type Page } from 'playwright-core';
 import { cleanupDashboardNotes } from './manager-notes-cleanup';
 import { withManagerBrowserLock } from './manager-browser-test-lock';
-
-const MANAGER_URL = process.env.MANAGER_DASHBOARD_URL || 'http://127.0.0.1:24576/';
-const browsers: Browser[] = [];
-
-async function pageForManager(): Promise<Page> {
-    const browser = await chromium.launch({ headless: true });
-    browsers.push(browser);
-    const context = await browser.newContext();
-    return await context.newPage();
-}
+import { MANAGER_URL, pageApiStatus, pageForManager } from './manager-notes-page';
 
 async function seedNote(page: Page, notePath: string): Promise<void> {
     await page.evaluate(async ({ notePath }) => {
@@ -24,17 +15,6 @@ async function seedNote(page: Page, notePath: string): Promise<void> {
         });
     }, { notePath });
 }
-
-async function pageApiStatus(page: Page, path: string): Promise<number> {
-    return await page.evaluate(async (notePath) => {
-        const response = await fetch(`/api/dashboard/notes/file?path=${encodeURIComponent(notePath)}`);
-        return response.status;
-    }, path);
-}
-
-after(async () => {
-    await Promise.allSettled(browsers.map(browser => browser.close()));
-});
 
 test('notes tree multi-select Delete trashes every selected entry in one keystroke', async () => await withManagerBrowserLock(async () => {
     const page = await pageForManager();

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -11,6 +11,7 @@ not a scope. Files here are imported or spawned by a test that is.
 | --- | --- | --- |
 | `jaw-server.mts` | Spawns an isolated product server with its own home, settings and port; probes readiness, captures the child's output, and fails closed under `CI` | `tests/integration/slack-inbound-turn.test.ts`, `agent-lifecycle-real-child.test.ts`, `graceful-shutdown.test.ts` |
 | `slack-fetch.mts` | The one Slack fetch stub: sequential or method-keyed response queues, parsed request bodies, and specs for a Slack error, a 429 with `retry-after`, or a transport-level response with an empty body | the six `tests/unit/slack-*.test.ts` files and `slack-fetch-harness.test.ts` |
+| `with-server.mts` | The one listen/close owner for route tests: `listen(0, '127.0.0.1')` behind an error listener, then `closeAllConnections()` before `close()`, then an optional after-hook | the sixteen `tests/unit` route suites that used to hand-roll `withServer` |
 | `slack-fixture.mts` | A scripted Slack: Web API over HTTP plus Socket Mode over a real websocket, recording every call | `tests/integration/slack-inbound-turn.test.ts` |
 | `slack-api-preload.mjs` | `--import` preload that redirects a server child's Slack traffic at the fixture through `globalThis.fetch` | the same test, via `NODE_OPTIONS` |
 | `code-fake-providers.mts` | Injectable Code providers that never spawn a runtime, with per-instance open/send counters | `tests/integration/code-native-api.test.ts` |

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -10,6 +10,7 @@ not a scope. Files here are imported or spawned by a test that is.
 | File | Shape | Driven by |
 | --- | --- | --- |
 | `jaw-server.mts` | Spawns an isolated product server with its own home, settings and port; probes readiness, captures the child's output, and fails closed under `CI` | `tests/integration/slack-inbound-turn.test.ts`, `agent-lifecycle-real-child.test.ts`, `graceful-shutdown.test.ts` |
+| `slack-fetch.mts` | The one Slack fetch stub: sequential or method-keyed response queues, parsed request bodies, and specs for a Slack error, a 429 with `retry-after`, or a transport-level response with an empty body | the six `tests/unit/slack-*.test.ts` files and `slack-fetch-harness.test.ts` |
 | `slack-fixture.mts` | A scripted Slack: Web API over HTTP plus Socket Mode over a real websocket, recording every call | `tests/integration/slack-inbound-turn.test.ts` |
 | `slack-api-preload.mjs` | `--import` preload that redirects a server child's Slack traffic at the fixture through `globalThis.fetch` | the same test, via `NODE_OPTIONS` |
 | `code-fake-providers.mts` | Injectable Code providers that never spawn a runtime, with per-instance open/send counters | `tests/integration/code-native-api.test.ts` |

--- a/tests/helpers/slack-fetch.mts
+++ b/tests/helpers/slack-fetch.mts
@@ -1,0 +1,194 @@
+/**
+ * One Slack fetch harness for the Slack unit tests.
+ *
+ * Six files had grown their own `makeFetch` under the same comment, and the
+ * copies had stopped agreeing: only history coerced numeric form values, only
+ * roster routed responses by Slack method, and only outbound could produce a
+ * non-200 status, a `retry-after` header or an empty body. The other five were
+ * pinned to "always HTTP 200 with ok:true", so a 429 or an `invalid_arguments`
+ * fixture written in one file proved nothing about the rest.
+ *
+ * Seam: `slackApi` (src/slack/api.ts) never reads `response.ok` or
+ * `response.json()`. It reads `status`, optionally `headers.get('retry-after')`
+ * and `headers.get('x-oauth-scopes')`, then `text()` — or `body.getReader()`
+ * when one is present, which is why this harness deliberately omits `body` and
+ * lets `readBoundedResponse` fall back to `text()`. `headers` is a real
+ * `Headers` instance because `parseRetryAfterMs` calls `.get` on it; a plain
+ * object throws there and `slackApi` reports the throw as status 502.
+ *
+ * The one caller that reads the transport directly is
+ * `src/slack/slack-file.ts` step 2: it POSTs to the presigned upload URL and
+ * checks `upload.ok` / `upload.status` without a body. That is what
+ * `slackRaw()` is for.
+ */
+
+/** A Slack JSON body. `__status` and `__headers` shape the HTTP envelope. */
+export type SlackJsonSpec = Record<string, unknown> & {
+    __status?: number;
+    __headers?: Record<string, string>;
+};
+
+/** A transport-level response: HTTP ok/status decided directly, body optional. */
+export type SlackRawSpec = {
+    __raw: true;
+    ok: boolean;
+    status: number;
+    headers?: Record<string, string>;
+    text?: string;
+};
+
+export type SlackFetchSpec = SlackJsonSpec | SlackRawSpec;
+
+export type SlackFetchCall = {
+    url: string;
+    /**
+     * The Slack RPC name, taken from the last URL segment — `users.list`, not
+     * `POST`. The HTTP verb stays on `init.method`, which is where
+     * slack-outbound reads it.
+     */
+    method: string;
+    /** Parsed request body. Non-string bodies (FormData) record as `{}`. */
+    body: Record<string, unknown>;
+    /**
+     * The original `init`, by reference. Not cloned and not normalized:
+     * slack-outbound indexes `init.headers` as a plain object, compares
+     * `String(init.body)` to a form string, and asserts `body instanceof
+     * FormData`. Wrapping or serializing any of that would make those checks
+     * vacuous.
+     */
+    init: RequestInit | undefined;
+};
+
+export type SlackFetchOptions = {
+    /**
+     * Coerce digit-only form values to numbers. On by default: history asserts
+     * `body.limit === 10`, and no test compares a digit-only value to a string
+     * (`ts`, `oldest` and `latest` all carry a dot, so they stay strings).
+     */
+    coerceNumeric?: boolean;
+};
+
+export type SlackFetchHarness = {
+    impl: typeof fetch;
+    calls: SlackFetchCall[];
+};
+
+/** Slack application error on HTTP 200 — the documented Slack failure shape. */
+export function slackError(error: string, extra: Record<string, unknown> = {}): SlackJsonSpec {
+    return { ok: false, error, ...extra };
+}
+
+/** `invalid_arguments`, which is what Slack returns for a JSON-encoded form call. */
+export function slackInvalidArguments(extra: Record<string, unknown> = {}): SlackJsonSpec {
+    return slackError('invalid_arguments', extra);
+}
+
+/**
+ * A real rate limit: HTTP 429, a `retry-after` header, and the `ratelimited`
+ * error string. The string matters — `isRetryableSlackError` and
+ * `noRetryOnRateLimit` both match it exactly, and a bare `{ ok: false }`
+ * degrades to `unknown_error`, which is not retryable and would let a
+ * "one call only" assertion pass without touching the retry path at all.
+ */
+export function slackRateLimited(retryAfterSeconds: number): SlackJsonSpec {
+    return {
+        ok: false,
+        error: 'ratelimited',
+        __status: 429,
+        __headers: { 'retry-after': String(retryAfterSeconds) },
+    };
+}
+
+/** A transport-level response, for the presigned upload POST and table readback. */
+export function slackRaw(spec: Omit<SlackRawSpec, '__raw'>): SlackRawSpec {
+    return { __raw: true, ...spec };
+}
+
+function isRaw(spec: SlackFetchSpec): spec is SlackRawSpec {
+    return '__raw' in spec && spec.__raw === true;
+}
+
+function parseBody(init: RequestInit | undefined, coerceNumeric: boolean): Record<string, unknown> {
+    const raw = init?.body;
+    if (typeof raw !== 'string') return {};
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+        } catch {
+            return {};
+        }
+    }
+    const body: Record<string, unknown> = {};
+    for (const [key, value] of new URLSearchParams(raw)) {
+        body[key] = coerceNumeric && /^\d+$/.test(value) ? Number(value) : value;
+    }
+    return body;
+}
+
+function respond(spec: SlackFetchSpec | undefined): Response {
+    const chosen: SlackFetchSpec = spec ?? { ok: true };
+    if (isRaw(chosen)) {
+        const text = chosen.text ?? '';
+        return {
+            ok: chosen.ok,
+            status: chosen.status,
+            headers: new Headers(chosen.headers ?? {}),
+            text: async () => text,
+        // justified: the harness implements only the Response surface slackApi reads
+        } as unknown as Response;
+    }
+    const record: SlackJsonSpec = { ...chosen };
+    const status = typeof record['__status'] === 'number' ? record['__status'] : 200;
+    const headers = new Headers(record['__headers'] ?? {});
+    delete record['__status'];
+    delete record['__headers'];
+    return {
+        // HTTP ok stays true for a JSON spec: Slack reports application errors
+        // as `{ ok: false }` on a 200, and even its 429 carries a JSON body.
+        ok: true,
+        status,
+        headers,
+        text: async () => JSON.stringify(record),
+    // justified: the harness implements only the Response surface slackApi reads
+    } as unknown as Response;
+}
+
+/**
+ * Build an injectable `fetch` plus the calls it recorded.
+ *
+ * Pass an array to replay responses in order, or an object keyed by Slack
+ * method to replay per method. Both exhaust to their LAST spec rather than
+ * running out: roster's membership ceiling and `users.list` cap each hand over
+ * one page that always carries a cursor and then assert the call count, so
+ * replay is what bounds those loops. An unscripted method answers `{ ok: true }`.
+ */
+export function makeSlackFetch(
+    specs: SlackFetchSpec[] | Record<string, SlackFetchSpec[]>,
+    options: SlackFetchOptions = {},
+): SlackFetchHarness {
+    const coerceNumeric = options.coerceNumeric !== false;
+    const calls: SlackFetchCall[] = [];
+    const sequential = Array.isArray(specs) ? specs : null;
+    const script = Array.isArray(specs) ? null : specs;
+    let index = 0;
+    const cursors: Record<string, number> = {};
+
+    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        const method = href.split('/').pop() ?? '';
+        calls.push({ url: href, method, body: parseBody(init, coerceNumeric), init });
+        if (sequential) {
+            const spec = sequential[Math.min(index, sequential.length - 1)];
+            index += 1;
+            return respond(spec);
+        }
+        const queue = script?.[method] ?? [{ ok: true }];
+        const at = Math.min(cursors[method] ?? 0, queue.length - 1);
+        cursors[method] = (cursors[method] ?? 0) + 1;
+        return respond(queue[at]);
+    }) as unknown as typeof fetch;
+
+    return { impl, calls };
+}

--- a/tests/helpers/with-server.mts
+++ b/tests/helpers/with-server.mts
@@ -1,0 +1,95 @@
+/**
+ * One listen/close owner for the route tests.
+ *
+ * Sixteen unit files had hand-rolled `withServer`, and the copies disagreed
+ * about the part that matters. Ten destroyed open connections before closing,
+ * one closed first and destroyed after, and five never destroyed at all. Three
+ * attached a listen `'error'` listener and none of the three removed it once
+ * listening succeeded. The close order is not cosmetic: an aborted SSE socket
+ * lingers server-side until the next heartbeat write fails, so `close()` on its
+ * own can sit there holding a `listen(0)` port while the next file is trying to
+ * get one.
+ *
+ * This module owns listen and close. It does not own the app: route
+ * registrars, auth middleware and per-file request helpers stay in the test
+ * that needs them, passed in through `setup`.
+ */
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import express, { type Express } from 'express';
+
+export type WithServerOptions = {
+    /** Use this app instead of a fresh `express()`. */
+    app?: Express;
+    /** `express.json()`, optionally with options such as `{ limit: '64kb' }`. */
+    json?: boolean | Parameters<typeof express.json>[0];
+    /** `app.set('query parser', ...)`, which the trace routes need as 'extended'. */
+    queryParser?: string;
+    /** Register routes and middleware. Runs before the server is created. */
+    setup?: (app: Express) => void | Promise<void>;
+    /** Runs AFTER close, matching where the route tests already reset state. */
+    after?: () => void | Promise<void>;
+};
+
+export type ServerContext = {
+    app: Express;
+    server: Server;
+    baseUrl: string;
+    port: number;
+};
+
+/**
+ * Start an app on an ephemeral loopback port, run `fn`, then always destroy
+ * open connections and close.
+ *
+ * `fn` receives the base URL first so the existing `async baseUrl => ...`
+ * call sites read unchanged; the full context is available as a second
+ * argument when a test needs the app or the server itself.
+ */
+export async function withServer<T>(
+    fn: (baseUrl: string, context: ServerContext) => Promise<T>,
+    options: WithServerOptions = {},
+): Promise<T> {
+    const app = options.app ?? express();
+    if (options.json) app.use(express.json(options.json === true ? undefined : options.json));
+    if (options.queryParser) app.set('query parser', options.queryParser);
+    await options.setup?.(app);
+
+    const server: Server = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error): void => reject(error);
+        server.once('error', onError);
+        server.listen(0, '127.0.0.1', () => {
+            // Removed on success so a later connection error cannot settle a
+            // promise that is already resolved, which is what the three files
+            // that attached this listener left open.
+            server.off('error', onError);
+            resolve();
+        });
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object', 'server did not bind a port');
+    const context: ServerContext = {
+        app, server, port: address.port, baseUrl: `http://127.0.0.1:${address.port}`,
+    };
+
+    try {
+        return await fn(context.baseUrl, context);
+    } finally {
+        server.closeAllConnections();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+        await options.after?.();
+    }
+}
+
+/**
+ * Bind options once and return a `withServer` for a whole file.
+ *
+ * This is what replaces a file-local `async function withServer`: the app
+ * description moves into one call and every existing call site keeps its
+ * `async baseUrl => ...` shape.
+ */
+export function serverHarness(options: WithServerOptions = {}) {
+    return <T>(fn: (baseUrl: string, context: ServerContext) => Promise<T>): Promise<T> =>
+        withServer(fn, options);
+}

--- a/tests/unit/activity-routes.test.ts
+++ b/tests/unit/activity-routes.test.ts
@@ -1,13 +1,13 @@
 import '../setup/isolated-home.ts';
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { createChatSession, deleteChatSession, forkChatSession, setActiveChatSession } from '../../src/core/chat-sessions.js';
 import { db, insertMessageWithTraceRun } from '../../src/core/db.js';
 import { appendTraceEvent, finalizeTraceRun, getTraceRun, linkTraceRunToMessage, startTraceRun } from '../../src/trace/store.js';
 import { recordRuntimeEvent, type RuntimeEventContext } from '../../src/agent/runtime/events.js';
 import type { RuntimeEventBody } from '../../src/shared/runtime-contract.js';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 // Keep real SQLite ownership/replay; inject only a repository failure at its public seam.
 const journal = await import('../../src/trace/activity-journal.js');
@@ -38,28 +38,19 @@ async function readResponse(base: string, path: string, status = 200) {
     return body;
 }
 
-async function withServer(
+// The callback is a prefixed `get`, and the session reset has to run after the
+// server is closed — which is exactly the shared helper's `after` hook.
+const withServer = (
     fn: (get: (path: string, status?: number) => ReturnType<typeof readResponse>) => Promise<void>,
     auth: Auth = (_req, _res, next) => next(),
-): Promise<void> {
-    const app = express();
-    app.set('query parser', 'extended');
-    registerTraceRoutes(app, auth);
-    const server = createServer(app);
-    await new Promise<void>((resolve, reject) => {
-        server.once('error', reject);
-        server.listen(0, '127.0.0.1', resolve);
-    });
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn((path, status = 200) => readResponse(`http://127.0.0.1:${address.port}/api/traces`, path, status));
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-        setActiveChatSession('default');
-    }
-}
+): Promise<void> => withHttpServer(
+    baseUrl => fn((path, status = 200) => readResponse(`${baseUrl}/api/traces`, path, status)),
+    {
+        queryParser: 'extended',
+        setup: app => registerTraceRoutes(app, auth),
+        after: () => setActiveChatSession('default'),
+    },
+);
 
 function ownedRun(sessionId = createChatSession('activity-route-owner').id, audience: 'public' | 'internal' = 'public') {
     const scope = `mention-watch:route:${sessionId}`;

--- a/tests/unit/chat-session-routes.test.ts
+++ b/tests/unit/chat-session-routes.test.ts
@@ -1,9 +1,8 @@
 import '../setup/isolated-home.ts';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
 import { readFileSync } from 'node:fs';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerChatSessionRoutes } from '../../src/routes/chat-sessions.ts';
 import { db } from '../../src/core/db.ts';
 import { addBroadcastListener, clearAllBroadcastListeners } from '../../src/core/bus.ts';
@@ -21,6 +20,7 @@ import { createQueueController } from '../../src/agent/spawn/queue.ts';
 import { SessionLanes, sessionLanes } from '../../src/orchestrator/session-lanes.ts';
 import { scopeForChatSession } from '../../src/orchestrator/scope.ts';
 import { claimWorker, clearAllWorkers } from '../../src/orchestrator/worker-registry.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 const IDS = ['route-delete', 'route-active', 'route-queued', 'route-hold', 'route-worker', 'route-lane', 'route-remote'];
 
@@ -29,21 +29,7 @@ function testAuth(req: Request, res: Response, next: NextFunction): void {
     else res.status(401).json({ error: 'Unauthorized' });
 }
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    app.use(express.json());
-    registerChatSessionRoutes(app, testAuth);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+const withServer = serverHarness({ json: true, setup: app => registerChatSessionRoutes(app, testAuth) });
 
 function insertSession(id: string, seq: number): void {
     db.prepare('INSERT INTO chat_sessions (id, seq, label) VALUES (?, ?, ?)').run(id, seq, id);

--- a/tests/unit/code-routes.test.ts
+++ b/tests/unit/code-routes.test.ts
@@ -1,12 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import express from 'express';
-import { once } from 'node:events';
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { registerCodeRoutes } from '../../src/routes/code.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 function git(cwd: string, args: string[]): string {
     const env = { ...process.env };
@@ -14,17 +13,9 @@ function git(cwd: string, args: string[]): string {
     return execFileSync('git', ['-c', 'core.hooksPath=/dev/null', '-c', 'commit.gpgsign=false',
         '-c', 'user.name=Fixture', '-c', 'user.email=fixture@localhost', ...args], { cwd, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
 }
-async function withServer(run: (url: string) => Promise<void>): Promise<void> {
-    const app = express();
-    app.use(express.json());
-    registerCodeRoutes(app, (_req, _res, next) => next());
-    const server = app.listen(0, '127.0.0.1');
-    await once(server, 'listening');
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try { await run(`http://127.0.0.1:${address.port}`); }
-    finally { await new Promise<void>(resolve => { server.close(() => resolve()); server.closeAllConnections(); }); }
-}
+// The local copy closed before destroying connections; the shared helper
+// destroys first, which is the order the rest of the route tests use.
+const withServer = serverHarness({ json: true, setup: app => registerCodeRoutes(app, (_req, _res, next) => next()) });
 
 test('workspace metadata validates absolute directories and reports non-repositories honestly', async t => {
     const folder = mkdtempSync(join(tmpdir(), 'code-git-empty-'));

--- a/tests/unit/code-workspace-pick-route-runtime.test.ts
+++ b/tests/unit/code-workspace-pick-route-runtime.test.ts
@@ -1,7 +1,8 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { resolve } from 'node:path';
+import { serverHarness } from '../helpers/with-server.mts';
 
 // Slice 210a reinforcement (pre-220): the source-string contract in
 // code-workspace-pick-route-contract.test.ts locks the PickResult -> HTTP map
@@ -32,19 +33,9 @@ const { registerCodeRoutes } = await import('../../src/routes/code.ts');
 
 const noAuth = (_req: Request, _res: Response, next: NextFunction) => next();
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    app.use(express.json());
-    registerCodeRoutes(app, noAuth);
-    const server = app.listen(0);
-    try {
-        const address = server.address();
-        assert.ok(address && typeof address === 'object');
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        await new Promise<void>(r => server.close(() => r()));
-    }
-}
+// Was `app.listen(0)` with no host and no wait for 'listening'; the shared
+// helper binds loopback and awaits it, which is how these tests already connect.
+const withServer = serverHarness({ json: true, setup: app => registerCodeRoutes(app, noAuth) });
 
 test('picked status returns 200 with the chosen path and no settings mutation fields', async () => {
     pick.next = async () => ({ status: 'picked', path: '/tmp/chosen-workspace' });

--- a/tests/unit/discord-dispatch-approval-ingress.test.ts
+++ b/tests/unit/discord-dispatch-approval-ingress.test.ts
@@ -4,8 +4,8 @@ import { settings } from '../../src/core/config.js';
 import { dispatchApprovalStore } from '../../src/core/dispatch-approval.js';
 import { createTestTransport } from '../../src/core/dispatch-approval-ingress.js';
 import { handleDiscordMessage } from '../../src/discord/bot.js';
+import { pendingDispatchApproval as pending } from './helpers/dispatch-approval.ts';
 
-function pending() { return dispatchApprovalStore.create({ target: { kind: 'agent', name: 'A' }, projectRoot: '/r', task: 't', mutable: false, scope: null, fanOutCap: 1 }); }
 function message(id: string, text: string, bot = false): any { return { id: `m-${Math.random()}`, author: { id, bot }, content: text, channelId: 'dm', attachments: { size: 0 }, guild: null }; }
 test('Discord gateway handler accepts only allowlisted non-self human on trusted transport', async () => {
     settings['dispatchApproval'] = { operators: { slack: [], telegram: [], discord: ['D1'] }, ttlSeconds: 120 };

--- a/tests/unit/electron-metrics-route.test.ts
+++ b/tests/unit/electron-metrics-route.test.ts
@@ -1,7 +1,5 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import express from 'express';
-import http from 'node:http';
 import {
     CLI_JAW_ELECTRON_HEADER,
     createElectronMetricsRouter,
@@ -9,6 +7,7 @@ import {
     validateMetricsSnapshot,
     type MetricsSnapshot,
 } from '../../src/manager/routes/electron-metrics.js';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 function sampleSnapshot(overrides: Partial<MetricsSnapshot> = {}): MetricsSnapshot {
     return {
@@ -24,29 +23,16 @@ function sampleSnapshot(overrides: Partial<MetricsSnapshot> = {}): MetricsSnapsh
     };
 }
 
-async function withServer(
-    fn: (baseUrl: string) => Promise<void>,
-    storeTtlMs?: number,
-): Promise<void> {
-    const app = express();
-    app.use(express.json({ limit: '64kb' }));
-    const store = createElectronMetricsStore(storeTtlMs);
-    app.use(
-        '/api/dashboard/electron-metrics',
-        createElectronMetricsRouter({ store }),
-    );
-    const server = http.createServer(app);
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    try {
-        const address = server.address();
-        assert.ok(address && typeof address === 'object');
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        await new Promise<void>((resolve, reject) => {
-            server.close((err) => (err ? reject(err) : resolve()));
-        });
-    }
-}
+// The store TTL differs per call. Closing now destroys open connections first,
+// so close() no longer has to wait one out.
+const withServer = (fn: (baseUrl: string) => Promise<void>, storeTtlMs?: number): Promise<void> =>
+    withHttpServer(fn, {
+        json: { limit: '64kb' },
+        setup: app => {
+            const store = createElectronMetricsStore(storeTtlMs);
+            app.use('/api/dashboard/electron-metrics', createElectronMetricsRouter({ store }));
+        },
+    });
 
 test('GET without electron header reports not-in-electron', async () => {
     await withServer(async (baseUrl) => {

--- a/tests/unit/helpers/dispatch-approval.ts
+++ b/tests/unit/helpers/dispatch-approval.ts
@@ -1,0 +1,23 @@
+/**
+ * The pending dispatch-approval row the three channel ingress tests share.
+ *
+ * slack-, discord- and telegram-dispatch-approval-ingress.test.ts each carried
+ * a byte-identical one-liner. They are asserting one policy across three
+ * transports, so the fixture they compare against should be one object, not
+ * three copies that can drift apart silently.
+ *
+ * Other `pending()` functions under tests/unit share only the name — runtime
+ * request views and runtime-default migration markers — and are not this.
+ */
+import { dispatchApprovalStore } from '../../../src/core/dispatch-approval.js';
+
+export function pendingDispatchApproval(): ReturnType<typeof dispatchApprovalStore.create> {
+    return dispatchApprovalStore.create({
+        target: { kind: 'agent', name: 'A' },
+        projectRoot: '/r',
+        task: 't',
+        mutable: false,
+        scope: null,
+        fanOutCap: 1,
+    });
+}

--- a/tests/unit/image-serving-route.test.ts
+++ b/tests/unit/image-serving-route.test.ts
@@ -3,11 +3,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { createServer, type Server } from 'node:http';
-import express, { type RequestHandler } from 'express';
+import { type RequestHandler } from 'express';
 import { registerStaticRoutes } from '../../src/routes/static.ts';
 import { settings } from '../../src/core/config.ts';
 import { errorHandler } from '../../src/http/error-middleware.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 const MIME_CASES = new Map([
     ['image.png', 'image/png'],
@@ -21,24 +21,20 @@ const MIME_CASES = new Map([
     ['video.ogg', 'video/ogg'],
 ]);
 
-async function withServer(run: (baseUrl: string, authCalls: () => number) => Promise<void>): Promise<void> {
-    const app = express();
+// The auth counter is owned here because the callback reports it; the shared
+// helper still owns listen and close.
+function withServer(run: (baseUrl: string, authCalls: () => number) => Promise<void>): Promise<void> {
     let calls = 0;
     const requireAuth: RequestHandler = (_req, _res, next) => {
         calls += 1;
         next();
     };
-    registerStaticRoutes(app, requireAuth, { projectRoot: path.resolve(import.meta.dirname, '../..') });
-    app.use(errorHandler);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await run(`http://127.0.0.1:${address.port}`, () => calls);
-    } finally {
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
+    return withHttpServer(baseUrl => run(baseUrl, () => calls), {
+        setup: app => {
+            registerStaticRoutes(app, requireAuth, { projectRoot: path.resolve(import.meta.dirname, '../..') });
+            app.use(errorHandler);
+        },
+    });
 }
 
 test('GET /api/image enforces roots, media types, headers, and status mapping', async () => {

--- a/tests/unit/link-preview-route.test.ts
+++ b/tests/unit/link-preview-route.test.ts
@@ -2,9 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerLinkPreviewRoutes } from '../../src/routes/link-preview.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 const realFetch = globalThis.fetch.bind(globalThis);
 const publicResolveHost = async () => [{ address: '93.184.216.34', family: 4 }];
@@ -13,22 +13,12 @@ function noAuth(_req: Request, _res: Response, next: NextFunction): void {
     next();
 }
 
-async function withServer(
+// Host resolution differs per call. Closing now destroys open connections too,
+// which this file did not do before.
+const withServer = (
     fn: (baseUrl: string) => Promise<void>,
     options: Parameters<typeof registerLinkPreviewRoutes>[2] = { resolveHost: publicResolveHost },
-): Promise<void> {
-    const app = express();
-    registerLinkPreviewRoutes(app, noAuth, options);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+): Promise<void> => withHttpServer(fn, { setup: app => registerLinkPreviewRoutes(app, noAuth, options) });
 
 function installFetchMock(handler: (url: string, init?: RequestInit) => Response | Promise<Response>): void {
     Object.defineProperty(globalThis, 'fetch', {

--- a/tests/unit/message-activity-answer.test.ts
+++ b/tests/unit/message-activity-answer.test.ts
@@ -1,14 +1,14 @@
 import '../setup/isolated-home.ts';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer } from 'node:http';
-import express, { type Request, type Response, type NextFunction } from 'express';
+import { type Request, type Response, type NextFunction } from 'express';
 import * as database from '../../src/core/db.ts';
 import { createChatSession, deleteChatSession, forkChatSession, setActiveChatSession } from '../../src/core/chat-sessions.ts';
 import { startTraceRun, getTraceRun } from '../../src/trace/store.ts';
 import { recordRuntimeEvent } from '../../src/agent/runtime/events.ts';
 import { registerMessageRoutes } from '../../src/routes/messages.ts';
 import { registerTraceRoutes } from '../../src/routes/traces.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 // Independent expected limit from241's public wire contract, not from the DUT.
 const CAP = 16 * 1024 * 1024;
@@ -28,30 +28,26 @@ function fixture() {
     return { sessionId, runId, insert, path: `/api/messages/by-trace/${runId}?session=${sessionId}` };
 }
 
-async function withServer(
+// Same shape as activity-routes: a custom `get` and a session reset that has to
+// run after close.
+const withServer = (
     fn: (get: (path: string, status?: number) => Promise<{ body: ApiBody; text: string }>) => Promise<void>,
     auth: Auth = (_req, _res, next) => next(),
-) {
-    const app = express(); app.set('query parser', 'extended');
-    registerMessageRoutes(app, auth); registerTraceRoutes(app, auth);
-    const server = createServer(app);
-    await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', resolve); });
-    const address = server.address(); assert.ok(address && typeof address === 'object');
-    try {
-        await fn(async (path, status = 200) => {
-            const response = await fetch(`http://127.0.0.1:${address.port}${path}`, { signal: AbortSignal.timeout(5000) });
-            const text = await response.text();
-            assert.equal(response.status, status, `${path}: ${text.slice(0, 180)}`);
-            assert.equal(response.headers.get('cache-control'), 'no-store', path);
-            assert.ok(Buffer.byteLength(text) <= CAP, 'actual response body obeys byte cap');
-            return { body: JSON.parse(text), text };
-        });
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-        setActiveChatSession('default');
-    }
-}
+): Promise<void> => withHttpServer(
+    baseUrl => fn(async (path, status = 200) => {
+        const response = await fetch(`${baseUrl}${path}`, { signal: AbortSignal.timeout(5000) });
+        const text = await response.text();
+        assert.equal(response.status, status, `${path}: ${text.slice(0, 180)}`);
+        assert.equal(response.headers.get('cache-control'), 'no-store', path);
+        assert.ok(Buffer.byteLength(text) <= CAP, 'actual response body obeys byte cap');
+        return { body: JSON.parse(text) as ApiBody, text };
+    }),
+    {
+        queryParser: 'extended',
+        setup: app => { registerMessageRoutes(app, auth); registerTraceRoutes(app, auth); },
+        after: () => setActiveChatSession('default'),
+    },
+);
 
 test('unique saved answer is exact despite canonical redaction and missing reverse trace link', { timeout: 10000 }, async () => {
     const f = fixture();

--- a/tests/unit/rate-limit-http.test.ts
+++ b/tests/unit/rate-limit-http.test.ts
@@ -1,12 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express from 'express';
 import {
     createRateLimiter,
     createRateLimitMiddleware,
     type RateLimitConfig,
 } from '../../src/core/rate-limit.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 function testBudgets(browserPoll = 2): RateLimitConfig['budgets'] {
     return {
@@ -18,34 +17,22 @@ function testBudgets(browserPoll = 2): RateLimitConfig['budgets'] {
     };
 }
 
-async function withServer(
-    browserPoll: number,
-    fn: (baseUrl: string) => Promise<void>,
-): Promise<void> {
-    const app = express();
-    const limiter = createRateLimiter({ budgets: testBudgets(browserPoll) });
-    app.use(createRateLimitMiddleware({
-        authToken: 'secret',
-        lanAllowed: () => false,
-        isPrivateIp: () => false,
-        limiter,
-    }));
-    app.all('/api/*path', (_req, res) => res.json({ ok: true }));
-    app.get('/outside', (_req, res) => res.json({ ok: true }));
-    const server: Server = createServer(app);
-    await new Promise<void>((resolve, reject) => {
-        server.once('error', reject);
-        server.listen(0, '127.0.0.1', () => resolve());
+// The budget is per call, so the middleware is built here; the shared helper
+// owns listen (including the 'error' listener) and close.
+const withServer = (browserPoll: number, fn: (baseUrl: string) => Promise<void>): Promise<void> =>
+    withHttpServer(fn, {
+        setup: app => {
+            const limiter = createRateLimiter({ budgets: testBudgets(browserPoll) });
+            app.use(createRateLimitMiddleware({
+                authToken: 'secret',
+                lanAllowed: () => false,
+                isPrivateIp: () => false,
+                limiter,
+            }));
+            app.all('/api/*path', (_req, res) => res.json({ ok: true }));
+            app.get('/outside', (_req, res) => res.json({ ok: true }));
+        },
     });
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
 
 async function exhaustBrowser(baseUrl: string): Promise<Response> {
     assert.equal((await fetch(`${baseUrl}/api/status`)).status, 200);

--- a/tests/unit/session-hub-routing.test.ts
+++ b/tests/unit/session-hub-routing.test.ts
@@ -1,7 +1,6 @@
 import '../setup/isolated-home.ts';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,21 +9,13 @@ import { db } from '../../src/core/db.ts';
 import { settings } from '../../src/core/config.ts';
 import { registerMessageRoutes } from '../../src/routes/messages.ts';
 import { registerSessionPageRoute, registerStaticRoutes } from '../../src/routes/static.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 function noAuth(_req: Request, _res: Response, next: NextFunction): void { next(); }
 
-async function withServer(app: express.Express, fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+// Each test builds its own app, so the app arrives per call rather than once.
+const withServer = (app: express.Express, fn: (baseUrl: string) => Promise<void>): Promise<void> =>
+    withHttpServer(fn, { app });
 
 afterEach(() => {
     db.prepare("DELETE FROM messages WHERE session_id IN ('hub-a', 'hub-b')").run();

--- a/tests/unit/session-write-unknown-session.test.ts
+++ b/tests/unit/session-write-unknown-session.test.ts
@@ -1,33 +1,24 @@
 import '../setup/isolated-home.ts';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerAgentControlRoutes } from '../../src/routes/agent-control.ts';
 import { registerCommandRoutes } from '../../src/routes/command.ts';
 import { db } from '../../src/core/db.ts';
 import { settings } from '../../src/core/config.ts';
 import { createChatSession, resolveOrCreateRemoteSession, setActiveChatSession } from '../../src/core/chat-sessions.ts';
 import { addBroadcastListener, clearAllBroadcastListeners } from '../../src/core/bus.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 function noAuth(_req: Request, _res: Response, next: NextFunction): void { next(); }
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    app.use(express.json());
-    registerAgentControlRoutes(app, noAuth);
-    registerCommandRoutes(app, noAuth);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+const withServer = serverHarness({
+    json: true,
+    setup: app => {
+        registerAgentControlRoutes(app, noAuth);
+        registerCommandRoutes(app, noAuth);
+    },
+});
 
 function post(baseUrl: string, path: string, body?: unknown): Promise<globalThis.Response> {
     return fetch(`${baseUrl}${path}`, {

--- a/tests/unit/slack-conversation.test.ts
+++ b/tests/unit/slack-conversation.test.ts
@@ -20,28 +20,10 @@ import {
     slackConversationCacheStats,
 } from '../../src/slack/conversation.ts';
 import { primeSlackIdentityCache, resetSlackIdentityCache } from '../../src/slack/identity.ts';
+import { makeSlackFetch } from '../helpers/slack-fetch.mts';
 
 const TOKEN = 'xoxb-not-a-real-token-000';
 const TEAM = 'T0TEST';
-
-function makeFetch(responses: Array<Record<string, unknown>>) {
-    const calls: Array<{ body: Record<string, unknown> }> = [];
-    let i = 0;
-    const impl = (async (_url: string | URL | Request, init?: RequestInit) => {
-        const params = new URLSearchParams(String(init?.body ?? ''));
-        const body: Record<string, unknown> = {};
-        for (const [k, v] of params) body[k] = v;
-        calls.push({ body });
-        const spec = responses[Math.min(i, responses.length - 1)];
-        i++;
-        return {
-            ok: true, status: 200,
-            text: async () => JSON.stringify(spec ?? { ok: true }),
-        } as unknown as Response;
-    // justified: the harness implements only the Response surface slackApi reads
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
 
 test.beforeEach(() => {
     resetSlackConversationCache();
@@ -52,7 +34,7 @@ test.beforeEach(() => {
 // ─── conversations.info mapping ─────────────────────
 
 test('a public channel maps name, kind, topic, and member count', async () => {
-    const { impl, calls } = makeFetch([{
+    const { impl, calls } = makeSlackFetch([{
         ok: true,
         channel: {
             id: 'C1', name: 'eng-platform', is_channel: true,
@@ -78,7 +60,7 @@ test('private, dm and mpim conversations are classified distinctly', async () =>
     for (const [channel, expected] of cases) {
         resetSlackConversationCache();
         resetConversationRateLimitForTest();
-        const { impl } = makeFetch([{ ok: true, channel }]);
+        const { impl } = makeSlackFetch([{ ok: true, channel }]);
         const info = await resolveConversationInfo(
             TOKEN, String(channel['id']), { teamId: TEAM, fetchImpl: impl },
         );
@@ -87,7 +69,7 @@ test('private, dm and mpim conversations are classified distinctly', async () =>
 });
 
 test('an unresolved conversation falls back to the id and its prefix', async () => {
-    const { impl } = makeFetch([{ ok: false, error: 'channel_not_found' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'channel_not_found' }]);
     const info = await resolveConversationInfo(TOKEN, 'C404', { teamId: TEAM, fetchImpl: impl });
     assert.equal(info.resolved, false);
     assert.equal(info.name, 'C404', 'the id stands in for the name');
@@ -95,18 +77,18 @@ test('an unresolved conversation falls back to the id and its prefix', async () 
 });
 
 test('a missing scope degrades without throwing', async () => {
-    const { impl } = makeFetch([{ ok: false, error: 'missing_scope', needed: 'channels:read' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'channels:read' }]);
     const info = await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
     assert.equal(info.resolved, false);
     assert.equal(info.id, 'C1');
 });
 
 test('a channel-scoped permission error does not blind other channels', async () => {
-    const denied = makeFetch([{ ok: false, error: 'no_permission' }]);
+    const denied = makeSlackFetch([{ ok: false, error: 'no_permission' }]);
     await resolveConversationInfo(TOKEN, 'CPRIVATE', { teamId: TEAM, fetchImpl: denied.impl });
 
     resetConversationRateLimitForTest();
-    const other = makeFetch([{ ok: true, channel: { id: 'COPEN', name: 'general', is_channel: true } }]);
+    const other = makeSlackFetch([{ ok: true, channel: { id: 'COPEN', name: 'general', is_channel: true } }]);
     const info = await resolveConversationInfo(TOKEN, 'COPEN', { teamId: TEAM, fetchImpl: other.impl });
     // A workspace-wide capability lock here would be the outage the lock exists
     // to prevent.
@@ -115,7 +97,7 @@ test('a channel-scoped permission error does not blind other channels', async ()
 });
 
 test('a channel name or topic cannot forge a prompt line', async () => {
-    const { impl } = makeFetch([{
+    const { impl } = makeSlackFetch([{
         ok: true,
         channel: {
             id: 'C1', name: 'ops', is_channel: true,
@@ -128,7 +110,7 @@ test('a channel name or topic cannot forge a prompt line', async () => {
 });
 
 test('an empty topic is omitted rather than stored blank', async () => {
-    const { impl } = makeFetch([{
+    const { impl } = makeSlackFetch([{
         ok: true, channel: { id: 'C1', name: 'ops', is_channel: true, topic: { value: '   ' } },
     }]);
     const info = await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
@@ -136,7 +118,7 @@ test('an empty topic is omitted rather than stored blank', async () => {
 });
 
 test('a successful lookup is cached', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
     assert.equal(calls.length, 1);
@@ -148,7 +130,7 @@ test('a successful lookup is cached', async () => {
 const replies = (messages: Array<Record<string, unknown>>) => ({ ok: true, messages });
 
 test('participants come from message authors, not reply_users', async () => {
-    const { impl } = makeFetch([{
+    const { impl } = makeSlackFetch([{
         ok: true,
         // reply_users names a bot that never authored anything in this thread.
         reply_users: ['B999'],
@@ -163,7 +145,7 @@ test('participants come from message authors, not reply_users', async () => {
 });
 
 test('a bot marker wins over user on a dual-marker message', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', user: 'U9', bot_id: 'B1', text: 'from an app' },
     ])]);
@@ -175,7 +157,7 @@ test('a bot marker wins over user on a dual-marker message', async () => {
 });
 
 test('a bot-only thread still reports participants', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', bot_id: 'B1', text: 'alert' },
         { ts: '100.2', bot_id: 'B2', text: 'ack' },
     ])]);
@@ -185,7 +167,7 @@ test('a bot-only thread still reports participants', async () => {
 });
 
 test('a message with no author is skipped rather than inventing a participant', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', subtype: 'channel_join', text: 'joined' },
     ])]);
@@ -197,7 +179,7 @@ test('participants are de-duplicated and bounded', async () => {
     const messages = Array.from({ length: 40 }, (_, i) => ({
         ts: `100.${i}`, user: `U${i % 20}`, text: 'x',
     }));
-    const { impl } = makeFetch([replies(messages)]);
+    const { impl } = makeSlackFetch([replies(messages)]);
     const thread = await resolveThreadInfo(TOKEN, 'C1', '100.0', { teamId: TEAM, fetchImpl: impl });
     assert.ok(thread.participants.length <= 12, 'the cap bounds the prompt cost');
     assert.equal(new Set(thread.participants.map(p => p.id)).size, thread.participants.length);
@@ -205,7 +187,7 @@ test('participants are de-duplicated and bounded', async () => {
 
 test('cached identity names are used; misses show the raw id', async () => {
     primeSlackIdentityCache(TEAM, [{ id: 'U1', profile: { display_name: '김병준' } }]);
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', user: 'U2', text: 'reply' },
     ])]);
@@ -216,7 +198,7 @@ test('cached identity names are used; misses show the raw id', async () => {
 
 test('the parent message text is captured and truncated', async () => {
     const long = 'x'.repeat(500);
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: long },
         { ts: '100.2', user: 'U2', text: 'reply' },
     ])]);
@@ -226,7 +208,7 @@ test('the parent message text is captured and truncated', async () => {
 });
 
 test('missing Slack total remains unknown while fetched count includes parent', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', user: 'U2', text: 'a' },
         { ts: '100.3', user: 'U3', text: 'b' },
@@ -241,7 +223,7 @@ test('missing Slack total remains unknown while fetched count includes parent', 
 test('reply count prefers the parent reply_count over the fetched window', async () => {
     // The window is capped at 50, so counting messages would report a
     // 500-reply thread as 49. Slack's own count on the parent is authoritative.
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent', reply_count: 500 },
         { ts: '100.2', user: 'U2', text: 'a' },
         { ts: '100.3', user: 'U3', text: 'b' },
@@ -252,7 +234,7 @@ test('reply count prefers the parent reply_count over the fetched window', async
 
 test('retained prefetch text is bounded per message', async () => {
     const huge = 'x'.repeat(40_000);
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', user: 'U2', text: huge },
     ])]);
@@ -263,28 +245,28 @@ test('retained prefetch text is bounded per message', async () => {
 });
 
 test('conversations.info and conversations.replies do not share a start slot', async () => {
-    const info = makeFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
+    const info = makeSlackFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: info.impl });
     // No rate-limit reset: a shared clock would decline this immediately, which
     // is exactly the starvation the per-method split prevents.
-    const thread = makeFetch([replies([{ ts: '100.1', user: 'U1', text: 'parent' }])]);
+    const thread = makeSlackFetch([replies([{ ts: '100.1', user: 'U1', text: 'parent' }])]);
     const result = await resolveThreadInfo(TOKEN, 'C1', '100.1', { teamId: TEAM, fetchImpl: thread.impl });
     assert.equal(thread.calls.length, 1, 'the thread lookup has its own budget');
     assert.equal(result.resolved, true);
 });
 
 test('a missing scope on conversations.info does not lock conversations.replies', async () => {
-    const denied = makeFetch([{ ok: false, error: 'missing_scope', needed: 'channels:read' }]);
+    const denied = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'channels:read' }]);
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: denied.impl });
     // Different methods need different scopes; one must not lock the other out.
-    const thread = makeFetch([replies([{ ts: '100.1', user: 'U1', text: 'parent' }])]);
+    const thread = makeSlackFetch([replies([{ ts: '100.1', user: 'U1', text: 'parent' }])]);
     const result = await resolveThreadInfo(TOKEN, 'C1', '100.1', { teamId: TEAM, fetchImpl: thread.impl });
     assert.equal(thread.calls.length, 1);
     assert.equal(result.resolved, true);
 });
 
 test('a failed thread lookup degrades to an empty participant list', async () => {
-    const { impl } = makeFetch([{ ok: false, error: 'thread_not_found' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'thread_not_found' }]);
     const thread = await resolveThreadInfo(TOKEN, 'C1', '100.1', { teamId: TEAM, fetchImpl: impl });
     assert.equal(thread.resolved, false);
     assert.deepEqual(thread.participants, []);
@@ -296,7 +278,7 @@ test('pagination retains the parent plus the newest 50 replies', async () => {
         ({ ts: `100.${String(i + 2).padStart(3, '0')}`, user: 'U1', text: `reply-${i + 1}` }));
     const second = Array.from({ length: 11 }, (_, i) =>
         ({ ts: `101.${String(i).padStart(3, '0')}`, user: 'U2', text: `reply-${i + 50}` }));
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, messages: [{ ts: '100.1', user: 'U0', text: 'parent', reply_count: 60 }, ...first], response_metadata: { next_cursor: 'page-2' } },
         { ok: true, messages: second, response_metadata: { next_cursor: '' } },
     ]);
@@ -313,14 +295,14 @@ test('thread pagination stops after ten pages even if Slack repeats a cursor cha
         ok: true, messages: i === 0 ? [{ ts: '100.1', user: 'U0', text: 'parent' }] : [],
         response_metadata: { next_cursor: `page-${i + 2}` },
     }));
-    const { impl, calls } = makeFetch(responses);
+    const { impl, calls } = makeSlackFetch(responses);
     const thread = await resolveThreadInfo(TOKEN, 'C1', '100.1', { teamId: TEAM, fetchImpl: impl });
     assert.equal(thread.resolved, true);
     assert.equal(calls.length, 10);
 });
 
 test('raw messages are retained for the first-entry prefetch', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '100.1', user: 'U1', text: 'parent' },
         { ts: '100.2', user: 'U2', text: 'reply' },
     ])]);
@@ -338,7 +320,7 @@ test('cachedNameMap omits ids that are not cached', () => {
 });
 
 test('resetting the cache forces the next lookup to call again', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
     resetSlackConversationCache();
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
@@ -346,7 +328,7 @@ test('resetting the cache forces the next lookup to call again', async () => {
 });
 
 test('a workspace switch does not serve the previous team name', async () => {
-    const { impl } = makeFetch([
+    const { impl } = makeSlackFetch([
         { ok: true, channel: { id: 'C1', name: 'old-team', is_channel: true } },
         { ok: true, channel: { id: 'C1', name: 'new-team', is_channel: true } },
     ]);
@@ -358,7 +340,7 @@ test('a workspace switch does not serve the previous team name', async () => {
 });
 
 test('an already-aborted caller costs no API call', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, channel: { id: 'C1', name: 'ops' } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, channel: { id: 'C1', name: 'ops' } }]);
     const controller = new AbortController();
     controller.abort();
     const info = await resolveConversationInfo(
@@ -369,10 +351,10 @@ test('an already-aborted caller costs no API call', async () => {
 });
 
 test('the start-rate gate declines rather than queueing', async () => {
-    const first = makeFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
+    const first = makeSlackFetch([{ ok: true, channel: { id: 'C1', name: 'ops', is_channel: true } }]);
     await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: first.impl });
     // No reset here: the next distinct channel hits the 1.2s gate.
-    const second = makeFetch([{ ok: true, channel: { id: 'C2', name: 'other', is_channel: true } }]);
+    const second = makeSlackFetch([{ ok: true, channel: { id: 'C2', name: 'other', is_channel: true } }]);
     const info = await resolveConversationInfo(TOKEN, 'C2', { teamId: TEAM, fetchImpl: second.impl });
     assert.equal(second.calls.length, 0, 'a declined start must not call Slack');
     assert.equal(info.resolved, false, 'and must degrade immediately, not wait');
@@ -389,7 +371,7 @@ test('the top-level history prefetch borrows the same per-method clock', () => {
 });
 
 test('an empty channel or token degrades without calling', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const noChannel = await resolveConversationInfo(TOKEN, '', { teamId: TEAM, fetchImpl: impl });
     const noToken = await resolveConversationInfo('', 'C1', { teamId: TEAM, fetchImpl: impl });
     assert.equal(calls.length, 0);
@@ -398,7 +380,7 @@ test('an empty channel or token degrades without calling', async () => {
 });
 
 test('thread cache omits rich bodies and files while retaining bounded provenance', async () => {
-    const { impl } = makeFetch([{ ok: true, messages: [{ ts: '100.1', user: 'U1', text: 'x'.repeat(1000),
+    const { impl } = makeSlackFetch([{ ok: true, messages: [{ ts: '100.1', user: 'U1', text: 'x'.repeat(1000),
         blocks: [{ type: 'section', text: { text: 'rich'.repeat(10000) } }], attachments: [{ text: 'attachment' }],
         reactions: [{ name: 'eyes', count: 2 }], files: [{ id: 'F1', url_private_download: 'https://files.slack.com/private' }],
         edited: { ts: '101.0' } }] }]);
@@ -418,7 +400,7 @@ test('reversed pages and duplicate parent retain the numeric newest fifty unique
         resetSlackConversationCache();
         const pages = [rows.slice(0, 30), rows.slice(30)];
         if (reversed) pages.reverse();
-        const { impl } = makeFetch(pages.map((page, i) => ({ ok: true,
+        const { impl } = makeSlackFetch(pages.map((page, i) => ({ ok: true,
             messages: [parent, ...page.reverse(), parent],
             response_metadata: { next_cursor: i === 0 ? 'next' : '' } })));
         const result = await resolveThreadInfo(TOKEN, 'C1', '1.0', { teamId: TEAM, fetchImpl: impl });
@@ -442,7 +424,7 @@ test('cursor cycles, missing continuation, page cap and page error preserve part
     ];
     for (const spec of cases) {
         resetSlackConversationCache();
-        const { impl, calls } = makeFetch(spec.pages);
+        const { impl, calls } = makeSlackFetch(spec.pages);
         const result = await resolveThreadInfo(TOKEN, 'C1', '1.0', { teamId: TEAM, fetchImpl: impl });
         assert.equal(calls.length, spec.calls);
         assert.equal(result.partial, true);
@@ -471,7 +453,7 @@ test('abort during second page returns bounded first-page evidence and never a c
 });
 
 test('ten full rich pages retain only bounded text and scalar fields', async () => {
-    const { impl } = makeFetch(Array.from({ length: 10 }, (_, page) => ({ ok: true,
+    const { impl } = makeSlackFetch(Array.from({ length: 10 }, (_, page) => ({ ok: true,
         messages: Array.from({ length: 50 }, (_, i) => ({ ts: `${page * 50 + i + 1}.0`, text: '😀'.repeat(1000),
             blocks: [{ type: 'section', text: { text: 'rich'.repeat(1000) } }], files: [{ id: 'F1' }] })),
         response_metadata: { next_cursor: `page${page}` } })));
@@ -487,7 +469,7 @@ test('ten full rich pages retain only bounded text and scalar fields', async () 
 });
 
 test('numeric timestamp order preserves adjacent microseconds without float rounding', async () => {
-    const { impl } = makeFetch([replies([
+    const { impl } = makeSlackFetch([replies([
         { ts: '9999999999.000002', text: 'second' },
         { ts: '9999999999.000001', text: 'first' },
         { ts: '9.0', text: 'parent' },
@@ -501,13 +483,13 @@ test('numeric timestamp order preserves adjacent microseconds without float roun
 test('an MPIM missing_scope never locks plain channel lookups', async () => {
     // needed: mpim:read proves only the MPIM grant is absent; the method-wide
     // capability lock would blind every channel/DM name lookup for 30 minutes.
-    const mpim = makeFetch([{ ok: false, error: 'missing_scope', needed: 'mpim:read' }]);
+    const mpim = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'mpim:read' }]);
     const info = await resolveConversationInfo(TOKEN, 'G1MPIM', { teamId: TEAM, fetchImpl: mpim.impl });
     assert.equal(info.resolved, false);
     assert.equal(info.kind, 'group_dm');
 
     resetConversationRateLimitForTest();
-    const other = makeFetch([{ ok: true, channel: { id: 'COPEN', name: 'general', is_channel: true } }]);
+    const other = makeSlackFetch([{ ok: true, channel: { id: 'COPEN', name: 'general', is_channel: true } }]);
     const after = await resolveConversationInfo(TOKEN, 'COPEN', { teamId: TEAM, fetchImpl: other.impl });
     assert.equal(after.resolved, true);
     assert.equal(after.name, 'general');

--- a/tests/unit/slack-dispatch-approval-ingress.test.ts
+++ b/tests/unit/slack-dispatch-approval-ingress.test.ts
@@ -4,8 +4,8 @@ import { settings } from '../../src/core/config.js';
 import { dispatchApprovalStore } from '../../src/core/dispatch-approval.js';
 import { createTestTransport } from '../../src/core/dispatch-approval-ingress.js';
 import { handleSlackEnvelope, setSlackSelfUserIdForTest } from '../../src/slack/bot.js';
+import { pendingDispatchApproval as pending } from './helpers/dispatch-approval.ts';
 
-function pending() { return dispatchApprovalStore.create({ target: { kind: 'agent', name: 'A' }, projectRoot: '/r', task: 't', mutable: false, scope: null, fanOutCap: 1 }); }
 test('Slack socket envelope accepts only allowlisted human on trusted transport', async () => {
     settings['dispatchApproval'] = { operators: { slack: ['U1'], telegram: [], discord: [] }, ttlSeconds: 120 };
     const transport = createTestTransport('slack');

--- a/tests/unit/slack-fetch-harness.test.ts
+++ b/tests/unit/slack-fetch-harness.test.ts
@@ -1,0 +1,136 @@
+// What the shared Slack harness is for: one stub spec, three product surfaces.
+//
+// Six Slack unit files used to carry their own `makeFetch`, and every copy was
+// pinned to "HTTP 200, ok:true". A 429 or an `invalid_arguments` fixture could
+// therefore only ever be written in slack-outbound, and it proved nothing about
+// conversation or history — which is how the same Slack send/readback subject
+// ended up being fixed repeatedly in separate files.
+//
+// Each surface gets its OWN harness instance built from the SAME spec constant.
+// The spec is what is shared; the call log is not, so every assertion counts
+// only its own requests.
+import '../setup/isolated-home.ts';
+import test, { beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    makeSlackFetch,
+    slackInvalidArguments,
+    slackRateLimited,
+    slackRaw,
+} from '../helpers/slack-fetch.mts';
+import { slackApi } from '../../src/slack/api.ts';
+import {
+    resetConversationRateLimitForTest,
+    resetSlackConversationCache,
+    resolveConversationInfo,
+} from '../../src/slack/conversation.ts';
+import { fetchSlackHistory } from '../../src/slack/history.ts';
+import { resetSlackIdentityCache } from '../../src/slack/identity.ts';
+import { sendSlackText } from '../../src/slack/send-only-client.ts';
+import { slackTargetFromId } from '../../src/messaging/slack-target.ts';
+
+const TOKEN = 'xoxb-not-a-real-token-000';
+const TEAM = 'T0TEST';
+
+// Two minutes, deliberately. src/slack/send-only-client.ts retries inline only
+// when the wait is at or under MAX_INLINE_RATE_LIMIT_MS (5s), so a two-minute
+// retry-after drives the rate-limit classification without spending real time
+// in the unit shard. History is held to one call by `noRetryOnRateLimit`, the
+// only seam it has — its backoff is a hardcoded 1s sleep with no injectable
+// clock (src/slack/history.ts callWithRetry).
+const RATE_LIMITED = slackRateLimited(120);
+
+beforeEach(() => {
+    // A 429 suppresses that conversation for 60s and the per-method start gate
+    // holds for 1.2s. Without both resets a later call returns the same
+    // degraded value having issued no request at all, and the assertion would
+    // pass while proving nothing.
+    resetSlackConversationCache();
+    resetConversationRateLimitForTest();
+    resetSlackIdentityCache();
+});
+
+test('one rate-limit spec reaches conversation, history, and outbound', async () => {
+    const conversation = makeSlackFetch([RATE_LIMITED]);
+    const info = await resolveConversationInfo(TOKEN, 'C1', { teamId: TEAM, fetchImpl: conversation.impl });
+    // conversations.info never retries: it degrades to the raw id.
+    assert.equal(info.resolved, false);
+    assert.equal(info.name, 'C1');
+    assert.equal(conversation.calls.length, 1);
+
+    const history = makeSlackFetch([RATE_LIMITED]);
+    const window = await fetchSlackHistory(TOKEN, 'C1', {
+        limit: 10, fetchImpl: history.impl, noRetryOnRateLimit: true,
+    });
+    if (window.ok) assert.fail('a rate-limited history read must not report ok');
+    // `code` carries Slack's raw error; `error` is operator prose.
+    assert.equal(window.code, 'ratelimited');
+    assert.equal(history.calls.length, 1);
+
+    const outbound = makeSlackFetch([RATE_LIMITED]);
+    const sent = await sendSlackText(TOKEN, slackTargetFromId('C1'), 'hi', { fetchImpl: outbound.impl });
+    assert.equal(sent.ok, false);
+    assert.equal(sent.status, 429);
+    // retry-after is seconds on the wire and milliseconds in the result.
+    assert.equal(sent.retryAfterMs, 120_000);
+    assert.equal(outbound.calls.length, 1);
+});
+
+test('one invalid_arguments spec reaches conversation and history', async () => {
+    const conversation = makeSlackFetch([slackInvalidArguments()]);
+    const info = await resolveConversationInfo(TOKEN, 'C2', { teamId: TEAM, fetchImpl: conversation.impl });
+    assert.equal(info.resolved, false);
+    assert.equal(conversation.calls.length, 1);
+
+    const history = makeSlackFetch([slackInvalidArguments()]);
+    const window = await fetchSlackHistory(TOKEN, 'C2', { limit: 10, fetchImpl: history.impl });
+    if (window.ok) assert.fail('invalid_arguments must not report ok');
+    assert.equal(window.code, 'invalid_arguments');
+    // Not retryable, so no second request and no backoff — unlike ratelimited.
+    assert.equal(history.calls.length, 1);
+});
+
+test('the harness can answer at the transport level, not only with a Slack body', async () => {
+    // The presigned upload POST in src/slack/slack-file.ts reads upload.ok and
+    // upload.status directly and never parses a body. slackApi reaching the
+    // same empty response reports unknown_error while keeping the HTTP status.
+    const transport = makeSlackFetch([slackRaw({ ok: false, status: 502 })]);
+    const result = await slackApi(TOKEN, 'auth.test', {}, { fetchImpl: transport.impl });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 502);
+    assert.equal(result.error, 'unknown_error');
+    assert.equal(transport.calls.length, 1);
+});
+
+test('calls record the Slack method, the parsed body, and the original init', async () => {
+    const harness = makeSlackFetch({
+        'conversations.history': [{ ok: true, messages: [] }],
+    });
+    await fetchSlackHistory(TOKEN, 'C3', { limit: 25, fetchImpl: harness.impl });
+    const call = harness.calls[0];
+    assert.ok(call);
+    // The Slack RPC name, not the HTTP verb — roster filters on this.
+    assert.equal(call.method, 'conversations.history');
+    assert.equal(call.body['channel'], 'C3');
+    // Digit-only form values arrive as numbers, which is what history asserts.
+    assert.equal(call.body['limit'], 25);
+    // The HTTP verb stays where slack-outbound reads it, on the original init.
+    assert.equal(call.init?.method, 'POST');
+});
+
+test('an unscripted method answers ok and a spent queue replays its last entry', async () => {
+    // Both behaviours are load-bearing: roster scripts one paging response and
+    // then asserts the call ceiling, which only terminates because the last
+    // spec replays.
+    const harness = makeSlackFetch({ 'conversations.history': [{ ok: true, messages: [], has_more: false }] });
+    const first = await fetchSlackHistory(TOKEN, 'C4', { fetchImpl: harness.impl });
+    const second = await fetchSlackHistory(TOKEN, 'C4', { fetchImpl: harness.impl });
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(harness.calls.length, 2);
+
+    const unscripted = makeSlackFetch({ 'users.list': [{ ok: true, members: [] }] });
+    const result = await slackApi(TOKEN, 'team.info', {}, { fetchImpl: unscripted.impl });
+    assert.equal(result.ok, true);
+});

--- a/tests/unit/slack-history.test.ts
+++ b/tests/unit/slack-history.test.ts
@@ -10,37 +10,12 @@ import {
     SLACK_HISTORY_MAX_LIMIT,
     type SlackHistoryMessage,
 } from '../../src/slack/history.ts';
-
-// ─── fetch capture harness (slack-outbound.test.ts pattern) ──
-
-type Captured = { url: string; body: Record<string, unknown> };
-
-function makeFetch(responses: Array<Record<string, unknown>>) {
-    const calls: Captured[] = [];
-    let i = 0;
-    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
-        // history.ts sends form-encoded bodies (conversations.replies rejects
-        // JSON with invalid_arguments — see history.ts callWithRetry).
-        const params = new URLSearchParams(String(init?.body ?? ''));
-        const body: Record<string, unknown> = {};
-        for (const [k, v] of params) body[k] = /^\d+$/.test(v) ? Number(v) : v;
-        calls.push({ url: String(url), body });
-        const spec = responses[Math.min(i, responses.length - 1)];
-        i++;
-        return {
-            ok: true,
-            status: 200,
-            text: async () => JSON.stringify(spec ?? { ok: true }),
-        } as unknown as Response;
-    // justified: the harness implements only the Response surface slackApi reads
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
+import { makeSlackFetch } from '../helpers/slack-fetch.mts';
 
 const TOKEN = 'xoxb-not-a-real-token-000';
 
 test('fetchSlackHistory normalizes messages and hasMore', async () => {
-    const { impl, calls } = makeFetch([{
+    const { impl, calls } = makeSlackFetch([{
         ok: true,
         has_more: true,
         messages: [
@@ -62,7 +37,7 @@ test('fetchSlackHistory normalizes messages and hasMore', async () => {
 });
 
 test('fetchSlackReplies passes the thread ts and clamps the limit', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, messages: [{ ts: '1.0', user: 'U1', text: 'parent' }] }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, messages: [{ ts: '1.0', user: 'U1', text: 'parent' }] }]);
     const result = await fetchSlackReplies(TOKEN, 'C1', '1.0', { limit: 9999, fetchImpl: impl });
     assert.ok(result.ok);
     assert.ok(calls[0]!.url.endsWith('/conversations.replies'));
@@ -71,7 +46,7 @@ test('fetchSlackReplies passes the thread ts and clamps the limit', async () => 
 });
 
 test('limit clamps low end to 1', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, messages: [] }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, messages: [] }]);
     await fetchSlackHistory(TOKEN, 'C1', { limit: 0, fetchImpl: impl });
     // 0 is falsy → default 50, negative clamps to 1
     assert.equal(calls[0]!.body['limit'], 50);
@@ -80,7 +55,7 @@ test('limit clamps low end to 1', async () => {
 });
 
 test('missing_scope surfaces the needed scope and never the token', async () => {
-    const { impl } = makeFetch([{ ok: false, error: 'missing_scope', needed: 'mpim:history' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'mpim:history' }]);
     const result = await fetchSlackHistory(TOKEN, 'G-mpim', { fetchImpl: impl });
     assert.ok(!result.ok);
     assert.match(result.error, /mpim:history/);
@@ -88,7 +63,7 @@ test('missing_scope surfaces the needed scope and never the token', async () => 
 });
 
 test('ratelimited retries once and succeeds (activation: retry path fires)', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: false, error: 'ratelimited' },
         { ok: true, messages: [{ ts: '1.0', user: 'U1', text: 'after retry' }] },
     ]);
@@ -101,7 +76,7 @@ test('ratelimited retries once and succeeds (activation: retry path fires)', asy
 });
 
 test('non-retryable errors do not retry', async () => {
-    const { impl, calls } = makeFetch([{ ok: false, error: 'channel_not_found' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'channel_not_found' }]);
     const result = await fetchSlackHistory(TOKEN, 'CBAD', { fetchImpl: impl });
     assert.ok(!result.ok);
     assert.equal(calls.length, 1);
@@ -142,7 +117,7 @@ test('a token pasted into a Slack message is redacted from formatted output', ()
 });
 
 test('fetchSlackReplies forwards and returns the pagination cursor', async () => {
-    const { impl, calls } = makeFetch([{
+    const { impl, calls } = makeSlackFetch([{
         ok: true, messages: [], response_metadata: { next_cursor: 'cursor-next' },
     }]);
     const result = await fetchSlackReplies(TOKEN, 'C1', '1.0', {
@@ -184,7 +159,7 @@ test('GET /api/slack/history rejects a missing channel and reports slack-off', a
 
 test('history rich payload and cursor-only continuation survive normalization', async () => {
     const blocks = [{ type: 'table', rows: [[{ type: 'raw_text', text: 'Item' }], [{ type: 'raw_text', text: 'Value' }]] }];
-    const { impl } = makeFetch([{ ok: true, messages: [{ ts: '2.0', blocks, reactions: [{ name: 'eyes', count: 2 }], edited: { ts: '3.0' } }], response_metadata: { next_cursor: 'next' } }]);
+    const { impl } = makeSlackFetch([{ ok: true, messages: [{ ts: '2.0', blocks, reactions: [{ name: 'eyes', count: 2 }], edited: { ts: '3.0' } }], response_metadata: { next_cursor: 'next' } }]);
     const result = await fetchSlackHistory(TOKEN, 'C1', { fetchImpl: impl });
     assert.ok(result.ok);
     assert.equal(result.hasMore, true);
@@ -194,7 +169,7 @@ test('history rich payload and cursor-only continuation survive normalization', 
 });
 
 test('replies forwards time bounds and inclusive', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, messages: [] }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, messages: [] }]);
     await fetchSlackReplies(TOKEN, 'C1', '1.0', { oldest: '2.0', latest: '3.0', inclusive: true, fetchImpl: impl });
     assert.equal(calls[0]?.body.oldest, '2.0');
     assert.equal(calls[0]?.body.latest, '3.0');
@@ -266,7 +241,7 @@ test('HTTP history forwards pagination and rejects malformed options before Slac
 
 test('normalized oversized blocks cannot evict ts/text from agent output', async () => {
     const { slackHistoryForAgent, formatHistoryForAgentDetailed } = await import('../../src/slack/history.ts');
-    const { impl } = makeFetch([{ ok: true, messages: [{ ts: '1.0', text: 'required body', blocks: [{ text: 'x'.repeat(64000) }] }] }]);
+    const { impl } = makeSlackFetch([{ ok: true, messages: [{ ts: '1.0', text: 'required body', blocks: [{ text: 'x'.repeat(64000) }] }] }]);
     const fetched = await fetchSlackHistory(TOKEN, 'C1', { fetchImpl: impl });
     assert.ok(fetched.ok);
     const messages = slackHistoryForAgent(fetched.messages);

--- a/tests/unit/slack-identity-characterization.test.ts
+++ b/tests/unit/slack-identity-characterization.test.ts
@@ -22,30 +22,10 @@ import {
     missingScopeWarnedForTest,
 } from '../../src/slack/identity.ts';
 import { settings } from '../../src/core/config.ts';
+import { makeSlackFetch } from '../helpers/slack-fetch.mts';
 
 const TOKEN = 'xoxb-not-a-real-token-000';
 const TEAM = 'T0TEST';
-
-/** Fetch harness: records calls, replays a queued response per call. */
-function makeFetch(responses: Array<Record<string, unknown>>) {
-    const calls: Array<{ body: Record<string, unknown> }> = [];
-    let i = 0;
-    const impl = (async (_url: string | URL | Request, init?: RequestInit) => {
-        const params = new URLSearchParams(String(init?.body ?? ''));
-        const body: Record<string, unknown> = {};
-        for (const [k, v] of params) body[k] = v;
-        calls.push({ body });
-        const spec = responses[Math.min(i, responses.length - 1)];
-        i++;
-        return {
-            ok: true,
-            status: 200,
-            text: async () => JSON.stringify(spec ?? { ok: true }),
-        } as unknown as Response;
-    // justified: the harness implements only the Response surface slackApi reads
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
 
 const userOk = (id: string, name: string) => ({
     ok: true, user: { id, profile: { display_name: name } },
@@ -68,7 +48,7 @@ test.beforeEach(() => resetSlackIdentityCache());
 
 test('a non-numeric identityCacheTtlMs falls back to the default rather than expiring instantly', async () => {
     await withTtl('nonsense', async () => {
-        const { impl, calls } = makeFetch([userOk('U1', 'Jun')]);
+        const { impl, calls } = makeSlackFetch([userOk('U1', 'Jun')]);
         await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
         // A bad TTL must not be read as 0: that would disable the cache entirely.
         await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
@@ -78,7 +58,7 @@ test('a non-numeric identityCacheTtlMs falls back to the default rather than exp
 
 test('identityCacheTtlMs is clamped to the floor, so a tiny value still caches', async () => {
     await withTtl(1, async () => {
-        const { impl, calls } = makeFetch([userOk('U1', 'Jun')]);
+        const { impl, calls } = makeSlackFetch([userOk('U1', 'Jun')]);
         await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
         await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
         // 1ms would have expired between the two calls if it were honoured raw.
@@ -89,12 +69,12 @@ test('identityCacheTtlMs is clamped to the floor, so a tiny value still caches',
 // ─── Negative-cache classes ─────────────────────────
 
 test('user_not_found and a transport failure are both negatively cached', async () => {
-    const notFound = makeFetch([{ ok: false, error: 'user_not_found' }]);
+    const notFound = makeSlackFetch([{ ok: false, error: 'user_not_found' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U404' }, { teamId: TEAM, fetchImpl: notFound.impl });
     await resolveSlackIdentity(TOKEN, { userId: 'U404' }, { teamId: TEAM, fetchImpl: notFound.impl });
     assert.equal(notFound.calls.length, 1, 'user_not_found must suppress the retry');
 
-    const transient = makeFetch([{ ok: false, error: 'internal_error' }]);
+    const transient = makeSlackFetch([{ ok: false, error: 'internal_error' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U500' }, { teamId: TEAM, fetchImpl: transient.impl });
     await resolveSlackIdentity(TOKEN, { userId: 'U500' }, { teamId: TEAM, fetchImpl: transient.impl });
     assert.equal(transient.calls.length, 1, 'a transient failure must suppress the retry');
@@ -103,7 +83,7 @@ test('user_not_found and a transport failure are both negatively cached', async 
 });
 
 test('a negative entry is keyed per id, so one failure does not suppress another user', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: false, error: 'user_not_found' },
         userOk('U2', 'Sujin'),
     ]);
@@ -116,40 +96,40 @@ test('a negative entry is keyed per id, so one failure does not suppress another
 // ─── Capability lock ────────────────────────────────
 
 test('the capability lock is shared across users.info and bots.info', async () => {
-    const scope = makeFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
+    const scope = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: scope.impl });
     assert.equal(scope.calls.length, 1);
 
     // A bot lookup goes through bots.info, but the latch is global today.
-    const bot = makeFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
+    const bot = makeSlackFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
     const identity = await resolveSlackIdentity(TOKEN, { botId: 'B1' }, { teamId: TEAM, fetchImpl: bot.impl });
     assert.equal(bot.calls.length, 0, 'the shared latch must suppress the bot lookup too');
     assert.equal(identity.resolved, false);
 });
 
 test('a successful lookup after the lock lapses clears it for everyone', async () => {
-    const scope = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const scope = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: scope.impl });
 
     // Lapse the lock: exactly one caller is admitted to re-probe.
     setCapabilityLockForTest(Date.now() - 1);
-    const probe = makeFetch([userOk('U2', 'Jun')]);
+    const probe = makeSlackFetch([userOk('U2', 'Jun')]);
     const probed = await resolveSlackIdentity(TOKEN, { userId: 'U2' }, { teamId: TEAM, fetchImpl: probe.impl });
     assert.equal(probed.resolved, true, 'the probe should be admitted');
 
     // The success unlocked it, so an unrelated id is looked up normally.
-    const after = makeFetch([userOk('U3', 'Sujin')]);
+    const after = makeSlackFetch([userOk('U3', 'Sujin')]);
     const later = await resolveSlackIdentity(TOKEN, { userId: 'U3' }, { teamId: TEAM, fetchImpl: after.impl });
     assert.equal(after.calls.length, 1, 'the lock must be fully released by a success');
     assert.equal(later.name, 'Sujin');
 });
 
 test('only one caller probes when the lock lapses; the rest degrade without calling', async () => {
-    const scope = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const scope = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: scope.impl });
     setCapabilityLockForTest(Date.now() - 1);
 
-    const probe = makeFetch([userOk('UA', 'A')]);
+    const probe = makeSlackFetch([userOk('UA', 'A')]);
     const [a, b] = await Promise.all([
         resolveSlackIdentity(TOKEN, { userId: 'UA' }, { teamId: TEAM, fetchImpl: probe.impl }),
         resolveSlackIdentity(TOKEN, { userId: 'UB' }, { teamId: TEAM, fetchImpl: probe.impl }),
@@ -162,11 +142,11 @@ test('only one caller probes when the lock lapses; the rest degrade without call
 // ─── In-flight slot lifecycle ───────────────────────
 
 test('a failed lookup releases its in-flight slot so a later call can retry', async () => {
-    const fail = makeFetch([{ ok: false, error: 'internal_error' }]);
+    const fail = makeSlackFetch([{ ok: false, error: 'internal_error' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: fail.impl });
     // Clear the negative suppression but keep the process alive.
     resetSlackIdentityCache();
-    const ok = makeFetch([userOk('U1', 'Jun')]);
+    const ok = makeSlackFetch([userOk('U1', 'Jun')]);
     const identity = await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: ok.impl });
     assert.equal(ok.calls.length, 1, 'the slot must not stay occupied after a failure');
     assert.equal(identity.name, 'Jun');
@@ -176,7 +156,7 @@ test('a failed lookup releases its in-flight slot so a later call can retry', as
 
 test('user and bot identities occupy separate cache partitions', async () => {
     primeSlackIdentityCache(TEAM, [{ id: 'U1', profile: { display_name: 'Jun' } }]);
-    const bot = makeFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
+    const bot = makeSlackFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
     await resolveSlackIdentity(TOKEN, { botId: 'B1' }, { teamId: TEAM, fetchImpl: bot.impl });
     const stats = slackIdentityCacheStats();
     assert.equal(stats.users, 1, 'the user partition holds the primed user');
@@ -192,7 +172,7 @@ test('priming is workspace-scoped: another team does not read the cached name', 
 // ─── Batch resolution ───────────────────────────────
 
 test('batch resolution reports partial when the top-up cap is reached', async () => {
-    const { impl } = makeFetch([userOk('U1', 'Jun')]);
+    const { impl } = makeSlackFetch([userOk('U1', 'Jun')]);
     const batch = await resolveSlackIdentities(
         TOKEN,
         Array.from({ length: 4 }, (_, i) => ({ userId: `U${i}` })),
@@ -207,7 +187,7 @@ test('batch resolution serves cached entries without any API call', async () => 
         { id: 'U1', profile: { display_name: 'Jun' } },
         { id: 'U2', profile: { display_name: 'Sujin' } },
     ]);
-    const { impl, calls } = makeFetch([userOk('U9', 'nobody')]);
+    const { impl, calls } = makeSlackFetch([userOk('U9', 'nobody')]);
     const batch = await resolveSlackIdentities(
         TOKEN, [{ userId: 'U1' }, { userId: 'U2' }],
         { teamId: TEAM, fetchImpl: impl, minIntervalMs: 0 },
@@ -220,7 +200,7 @@ test('batch resolution serves cached entries without any API call', async () => 
 // ─── Reset ──────────────────────────────────────────
 
 test('reset clears the negative cache as well as the positive partitions', async () => {
-    const fail = makeFetch([{ ok: false, error: 'user_not_found' }]);
+    const fail = makeSlackFetch([{ ok: false, error: 'user_not_found' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U404' }, { teamId: TEAM, fetchImpl: fail.impl });
     assert.ok(slackIdentityCacheStats().negative >= 1);
     resetSlackIdentityCache();
@@ -259,7 +239,7 @@ test('a stale missing_scope cannot consume the warn latch a reset just cleared',
     );
 
     // And the latch is genuinely spendable afterwards by a live failure.
-    const fresh = makeFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
+    const fresh = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U2' }, { teamId: 'T0NEW', fetchImpl: fresh.impl });
     assert.equal(fresh.calls.length, 1, 'the new workspace must still be probed');
     assert.equal(

--- a/tests/unit/slack-identity.test.ts
+++ b/tests/unit/slack-identity.test.ts
@@ -21,29 +21,10 @@ import {
 } from '../../src/slack/identity.ts';
 import { resolveSenderIdentity } from '../../src/slack/identity.ts';
 import { settings } from '../../src/core/config.ts';
+import { makeSlackFetch } from '../helpers/slack-fetch.mts';
 
 const TOKEN = 'xoxb-not-a-real-token-000';
 const TEAM = 'T0TEST';
-
-function makeFetch(responses: Array<Record<string, unknown>>) {
-    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
-    let i = 0;
-    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
-        const params = new URLSearchParams(String(init?.body ?? ''));
-        const body: Record<string, unknown> = {};
-        for (const [k, v] of params) body[k] = v;
-        calls.push({ url: String(url), body });
-        const spec = responses[Math.min(i, responses.length - 1)];
-        i++;
-        return {
-            ok: true,
-            status: 200,
-            text: async () => JSON.stringify(spec ?? { ok: true }),
-        } as unknown as Response;
-    // justified: the harness implements only the Response surface slackApi reads
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
 
 const userOk = (over: Record<string, unknown> = {}) => ({
     ok: true,
@@ -139,7 +120,7 @@ test('identityFromEvent reads a plain human message', () => {
 
 test('resolves a user and caches it', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     const first = await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(first.name, 'Jun');
     assert.equal(first.resolved, true);
@@ -151,7 +132,7 @@ test('resolves a user and caches it', async () => {
 
 test('a different workspace does not reuse the cached name', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         userOk(),
         { ok: true, user: { id: 'U1', profile: { display_name: 'Other' } } },
     ]);
@@ -164,7 +145,7 @@ test('a different workspace does not reuse the cached name', async () => {
 
 test('missing_scope degrades to the id and never throws', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
     const identity = await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(identity.resolved, false);
     assert.equal(identity.name, 'U1');
@@ -172,7 +153,7 @@ test('missing_scope degrades to the id and never throws', async () => {
 
 test('a repeated missing_scope stops calling the API', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'missing_scope', needed: 'users:read' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     await resolveSlackIdentity(TOKEN, { userId: 'U2' }, { teamId: TEAM, fetchImpl: impl });
     await resolveSlackIdentity(TOKEN, { userId: 'U3' }, { teamId: TEAM, fetchImpl: impl });
@@ -181,7 +162,7 @@ test('a repeated missing_scope stops calling the API', async () => {
 
 test('resetting the cache lifts the capability lockout', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(calls.length, 1);
     resetSlackIdentityCache();
@@ -191,7 +172,7 @@ test('resetting the cache lifts the capability lockout', async () => {
 
 test('user_not_found is negatively cached', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: false, error: 'user_not_found' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'user_not_found' }]);
     const a = await resolveSlackIdentity(TOKEN, { userId: 'U404' }, { teamId: TEAM, fetchImpl: impl });
     const b = await resolveSlackIdentity(TOKEN, { userId: 'U404' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(a.resolved, false);
@@ -209,7 +190,7 @@ test('a transport failure degrades without throwing', async () => {
 
 test('a bot inline name resolves without any API call', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const identity = await resolveSlackIdentity(
         TOKEN, { botId: 'B1', inlineName: 'Ledger' }, { teamId: TEAM, fetchImpl: impl },
     );
@@ -220,7 +201,7 @@ test('a bot inline name resolves without any API call', async () => {
 
 test('a bare bot id resolves through bots.info', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, bot: { id: 'B1', name: 'Ledger' } }]);
     const identity = await resolveSlackIdentity(TOKEN, { botId: 'B1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(identity.name, 'Ledger');
     assert.ok(calls[0]!.url.endsWith('/bots.info'));
@@ -228,7 +209,7 @@ test('a bare bot id resolves through bots.info', async () => {
 
 test('a human inline hint never bypasses id resolution', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     const identity = await resolveSlackIdentity(
         TOKEN, { userId: 'U1', inlineName: 'spoofed' }, { teamId: TEAM, fetchImpl: impl },
     );
@@ -238,7 +219,7 @@ test('a human inline hint never bypasses id resolution', async () => {
 
 test('a human inline hint is used only after degradation, still unresolved', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch([{ ok: false, error: 'user_not_found' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'user_not_found' }]);
     const identity = await resolveSlackIdentity(
         TOKEN, { userId: 'U1', inlineName: 'Jun[x]' }, { teamId: TEAM, fetchImpl: impl },
     );
@@ -248,7 +229,7 @@ test('a human inline hint is used only after degradation, still unresolved', asy
 
 test('concurrent lookups of the same id share one request', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     const [a, b] = await Promise.all([
         resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl }),
         resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl }),
@@ -261,7 +242,7 @@ test('concurrent lookups of the same id share one request', async () => {
 test('one caller aborting does not cancel the other waiter', async () => {
     resetSlackIdentityCache();
     const controller = new AbortController();
-    const { impl } = makeFetch([userOk()]);
+    const { impl } = makeSlackFetch([userOk()]);
     const aborted = resolveSlackIdentity(
         TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl, signal: controller.signal },
     );
@@ -277,7 +258,7 @@ test('an already-aborted signal returns without dispatching a request', async ()
     resetSlackIdentityCache();
     const controller = new AbortController();
     controller.abort();
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     const identity = await resolveSlackIdentity(
         TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl, signal: controller.signal },
     );
@@ -287,7 +268,7 @@ test('an already-aborted signal returns without dispatching a request', async ()
 
 test('a cached name expires once its TTL passes', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([userOk(), { ok: true, user: { id: 'U1', profile: { display_name: 'Later' } } }]);
+    const { impl, calls } = makeSlackFetch([userOk(), { ok: true, user: { id: 'U1', profile: { display_name: 'Later' } } }]);
     const slack = (globalThis as Record<string, any>);
     const first = await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(first.name, 'Jun');
@@ -314,7 +295,7 @@ test('primeSlackIdentityCache warms lookups so later reads cost nothing', async 
     assert.equal(cached.get('U1')?.name, '김병준');
     assert.equal(cached.size, 2, 'a miss must simply be absent');
 
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(calls.length, 0, 'the warmed entry must serve the lookup');
 });
@@ -332,7 +313,7 @@ test('primed names are sanitized on the exposed fields too', () => {
 
 test('batch resolution bounds the top-up and reports partial', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: true, user: { id: 'U', profile: { display_name: 'X' } } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, user: { id: 'U', profile: { display_name: 'X' } } }]);
     const refs = Array.from({ length: 8 }, (_, i) => ({ userId: `U${i}` }));
     const batch = await resolveSlackIdentities(TOKEN, refs, {
         teamId: TEAM, fetchImpl: impl, topUpLimit: 3, minIntervalMs: 0,
@@ -450,7 +431,7 @@ test('a lookup issued before a reset cannot re-latch missing_scope afterwards', 
     release!();
     await inFlight;                      // the stale result lands after the reset
 
-    const { impl, calls } = makeFetch([userOk()]);
+    const { impl, calls } = makeSlackFetch([userOk()]);
     const after = await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: 'T_NEW', fetchImpl: impl });
     assert.equal(calls.length, 1, 'the new token must still be allowed to call Slack');
     assert.equal(after.resolved, true);
@@ -480,7 +461,7 @@ test('only one probe is admitted when the capability lock lapses', async () => {
     // Letting every concurrent caller through on expiry would restore exactly the
     // per-message API storm the lock exists to prevent.
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'U1' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(calls.length, 1);
 
@@ -496,11 +477,11 @@ test('the negative cache evicts by expiry, not by insertion accident', async () 
     // trimTo used to read `expiresAt` off a bare timestamp, so the sort compared
     // undefined and eviction order was arbitrary.
     resetSlackIdentityCache();
-    const { impl } = makeFetch([{ ok: false, error: 'user_not_found' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'user_not_found' }]);
     await resolveSlackIdentity(TOKEN, { userId: 'UGONE' }, { teamId: TEAM, fetchImpl: impl });
     assert.equal(slackIdentityCacheStats().negative, 1);
 
-    const { impl: impl2, calls: calls2 } = makeFetch([userOk()]);
+    const { impl: impl2, calls: calls2 } = makeSlackFetch([userOk()]);
     await resolveSlackIdentity(TOKEN, { userId: 'UGONE' }, { teamId: TEAM, fetchImpl: impl2 });
     assert.equal(calls2.length, 0, 'the negative entry still suppresses the repeat lookup');
 });

--- a/tests/unit/slack-outbound.test.ts
+++ b/tests/unit/slack-outbound.test.ts
@@ -13,42 +13,17 @@ import { toMrkdwn, chunkSlackMessage } from '../../src/slack/format.ts';
 import { sendSlackText, resolveSlackDmChannel } from '../../src/slack/send-only-client.ts';
 import { sendSlackFile, validateSlackFileSize } from '../../src/slack/slack-file.ts';
 import { slackTargetFromId } from '../../src/messaging/slack-target.ts';
+import { makeSlackFetch, slackRaw, type SlackFetchSpec } from '../helpers/slack-fetch.mts';
 
-// ─── fetch capture harness ──────────────────────────
+// ─── local composers over the shared harness ────────
 
 type Captured = { url: string; init: RequestInit | undefined };
-
-function makeFetch(responses: Array<Record<string, unknown> | { __raw: true; ok: boolean; status: number; headers?: Record<string, string> }>) {
-    const calls: Captured[] = [];
-    let i = 0;
-    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
-        calls.push({ url: String(url), init });
-        const spec = responses[Math.min(i, responses.length - 1)];
-        i++;
-        if (spec && '__raw' in spec) {
-            const headers = new Headers(spec.headers ?? {});
-            return { ok: spec.ok, status: spec.status, headers, text: async () => '' } as unknown as Response;
-        }
-        const record = (spec ?? { ok: true }) as Record<string, unknown>;
-        const headers = new Headers((record['__headers'] as Record<string, string> | undefined) ?? {});
-        const body = { ...record };
-        delete body['__headers'];
-        return {
-            ok: true,
-            status: typeof record['__status'] === 'number' ? record['__status'] : 200,
-            headers,
-            text: async () => JSON.stringify(body),
-        } as unknown as Response;
-    // justified: the capture harness implements only the Response surface these modules read
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
 
 const raw = (text: string) => ({ type: 'raw_text', text });
 const rich = (text: string, style: Record<string, boolean>) => ({ type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text, style }] }] });
 // Readback fixtures are hand-specified, never derived from the outgoing blocks.
-function makeTableFetch(tables: unknown[][][], postResponses: Parameters<typeof makeFetch>[0] = [{ ok: true, ts: '2.1' }]) {
-    const posts = makeFetch(postResponses);
+function makeTableFetch(tables: unknown[][][], postResponses: SlackFetchSpec[] = [{ ok: true, ts: '2.1' }]) {
+    const posts = makeSlackFetch(postResponses);
     const reads: Captured[] = [];
     let index = 0;
     const impl = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -77,14 +52,14 @@ function headerOf(call: Captured, name: string): string | undefined {
 test('slackApi treats HTTP 200 with ok:false as failure', async () => {
     // Slack signals application errors with a 200. Checking response.ok alone
     // silently swallows every auth, scope, and argument failure.
-    const { impl } = makeFetch([{ ok: false, error: 'not_in_channel' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'not_in_channel' }]);
     const result = await slackApi('xoxb-t', 'chat.postMessage', { channel: 'C1' }, { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.equal(result.error, 'not_in_channel');
 });
 
 test('slackApi sends a bearer token and JSON body by default', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     await slackApi('xoxb-secret', 'chat.postMessage', { channel: 'C1' }, { fetchImpl: impl });
     assert.equal(calls[0]!.init?.method, 'POST');
     assert.equal(headerOf(calls[0]!, 'Authorization'), 'Bearer xoxb-secret');
@@ -95,7 +70,7 @@ test('slackApi sends a bearer token and JSON body by default', async () => {
 test('slackApi form mode POSTs urlencoded, never GET', async () => {
     // files.getUploadURLExternal takes form-encoded args. An earlier draft sent
     // it as GET, which is not Slack's documented contract.
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     await slackApi('xoxb-t', 'files.getUploadURLExternal', { filename: 'a.txt', length: 12 }, { fetchImpl: impl, form: true });
     assert.equal(calls[0]!.init?.method, 'POST');
     assert.match(String(headerOf(calls[0]!, 'Content-Type')), /x-www-form-urlencoded/);
@@ -464,7 +439,7 @@ test('chunkSlackMessage terminates on fenced input (loop-progress guard)', () =>
 // ─── outbound text ──────────────────────────────────
 
 test('sendSlackText omits thread_ts for a non-threaded target', () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     return sendSlackText('xoxb-t', slackTargetFromId('C1'), 'hi', { fetchImpl: impl }).then(() => {
         const body = bodyOf(calls[0]!);
         assert.equal(body['channel'], 'C1');
@@ -474,13 +449,13 @@ test('sendSlackText omits thread_ts for a non-threaded target', () => {
 });
 
 test('sendSlackText passes thread_ts when the target carries one', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     await sendSlackText('xoxb-t', slackTargetFromId('C1', { threadTs: '1.1' }), 'hi', { fetchImpl: impl });
     assert.equal(bodyOf(calls[0]!)['thread_ts'], '1.1');
 });
 
 test('sendSlackText preserves standard Markdown in rich blocks', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, ts: '1.1' }, { ok: true, messages: [{ ts: '1.1', blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'bold', style: { bold: true } }] }] }] }] }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, ts: '1.1' }, { ok: true, messages: [{ ts: '1.1', blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements: [{ type: 'text', text: 'bold', style: { bold: true } }] }] }] }] }]);
     await sendSlackText('xoxb-t', slackTargetFromId('C1'), '**bold**', { fetchImpl: impl });
     assert.deepEqual(bodyOf(calls[0]!)['blocks'], [{ type: 'markdown', text: '**bold**' }]);
 });
@@ -508,7 +483,7 @@ test('Slack table delivery preserves prose/table order, pipes and the parent thr
 });
 
 test('Slack tables in code fences remain code examples', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, ts: '1.1' }, { ok: true, messages: [{ ts: '1.1', blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_preformatted', elements: [{ type: 'text', text: '| A | B |' }] }] }] }] }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, ts: '1.1' }, { ok: true, messages: [{ ts: '1.1', blocks: [{ type: 'rich_text', elements: [{ type: 'rich_text_preformatted', elements: [{ type: 'text', text: '| A | B |' }] }] }] }] }]);
     const code = '```md\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```';
     await sendSlackText('xoxb-t', slackTargetFromId('D1'), code, { fetchImpl: impl });
     assert.equal(calls.length, 2);
@@ -550,7 +525,7 @@ test('Slack rejects oversized tables before sending any preceding prose', async 
         `| ${Array.from({ length: 21 }, (_, i) => i).join(' | ')} |\n| ${Array(21).fill('---').join(' | ')} |\n| ${Array(21).fill('x').join(' | ')} |`,
         `| A | B |\n| --- | --- |\n| 1 | ${'x'.repeat(9100)} |`,
     ]) {
-        const { impl, calls } = makeFetch([{ ok: true }]);
+        const { impl, calls } = makeSlackFetch([{ ok: true }]);
         const result = await sendSlackText('xoxb-t', slackTargetFromId('D1'), `앞 문장\n\n${table}`, { fetchImpl: impl });
         assert.equal(result.ok, false);
         assert.equal(result.status, 400);
@@ -561,7 +536,7 @@ test('Slack rejects oversized tables before sending any preceding prose', async 
 
 test('Slack table blocks and fallback are redacted identically on rate-limit retry', async () => {
     const { impl, calls } = makeTableFetch([[[raw('이름'), raw('값')], [raw('토큰'), raw('xoxb-test...redacted')]]], [
-        { __raw: true, ok: false, status: 429, headers: { 'retry-after': '0.001' } },
+        slackRaw({ ok: false, status: 429, headers: { 'retry-after': '0.001' } }),
         { ok: true, ts: '2.2' },
     ]);
     const secret = 'xoxb-test-only-redaction-canary';
@@ -576,14 +551,14 @@ test('Slack table blocks and fallback are redacted identically on rate-limit ret
 });
 
 test('sendSlackText posts one call per chunk', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const long = Array.from({ length: 300 }, (_, i) => `line ${i} ${'x'.repeat(30)}`).join('\n');
     await sendSlackText('xoxb-t', slackTargetFromId('C1'), long, { fetchImpl: impl });
     assert.ok(calls.length > 1, `expected multiple posts, got ${calls.length}`);
 });
 
 test('sendSlackText surfaces a mapped error message', async () => {
-    const { impl } = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const { impl } = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     const result = await sendSlackText('xoxb-t', slackTargetFromId('C1'), 'hi', { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.match(String(result.error), /scope/i);
@@ -592,7 +567,7 @@ test('sendSlackText surfaces a mapped error message', async () => {
 // ─── DM open ────────────────────────────────────────
 
 test('resolveSlackDmChannel opens a DM for a user id', async () => {
-    const { impl, calls } = makeFetch([{ ok: true, channel: { id: 'D999' } }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true, channel: { id: 'D999' } }]);
     const result = await resolveSlackDmChannel('xoxb-t', 'U123', impl);
     assert.equal(result.channelId, 'D999');
     assert.match(calls[0]!.url, /conversations\.open/);
@@ -600,7 +575,7 @@ test('resolveSlackDmChannel opens a DM for a user id', async () => {
 });
 
 test('resolveSlackDmChannel passes a D-id straight through', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const result = await resolveSlackDmChannel('xoxb-t', 'D555', impl);
     assert.equal(result.channelId, 'D555');
     assert.equal(calls.length, 0, 'an existing DM id must not cost an API call');
@@ -616,9 +591,9 @@ function tempFile(contents = 'hello'): string {
 }
 
 test('sendSlackFile performs the three-step external upload in order', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, upload_url: 'https://files.slack.com/upload/abc', file_id: 'F1' },
-        { __raw: true, ok: true, status: 200 },
+        slackRaw({ ok: true, status: 200 }),
         // The completion has to echo the reserved id back; a bare ok is now unconfirmed.
         { ok: true, files: [{ id: 'F1' }] },
     ]);
@@ -632,9 +607,9 @@ test('sendSlackFile performs the three-step external upload in order', async () 
 
 test('sendSlackFile does not send the bot token to the upload URL', async () => {
     // Step 2 is not a Slack API method: no Authorization header belongs there.
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, upload_url: 'https://files.slack.com/upload/abc', file_id: 'F1' },
-        { __raw: true, ok: true, status: 200 },
+        slackRaw({ ok: true, status: 200 }),
         { ok: true },
     ]);
     await sendSlackFile('xoxb-t', slackTargetFromId('C1'), tempFile(), { fetchImpl: impl });
@@ -642,9 +617,9 @@ test('sendSlackFile does not send the bot token to the upload URL', async () => 
 });
 
 test('sendSlackFile threads the completion call', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, upload_url: 'https://u', file_id: 'F1' },
-        { __raw: true, ok: true, status: 200 },
+        slackRaw({ ok: true, status: 200 }),
         { ok: true },
     ]);
     await sendSlackFile('xoxb-t', slackTargetFromId('C1', { threadTs: '1.1' }), tempFile(), {
@@ -657,7 +632,7 @@ test('sendSlackFile threads the completion call', async () => {
 });
 
 test('sendSlackFile fails cleanly when the URL reservation fails', async () => {
-    const { impl, calls } = makeFetch([{ ok: false, error: 'missing_scope' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'missing_scope' }]);
     const result = await sendSlackFile('xoxb-t', slackTargetFromId('C1'), tempFile(), { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.match(String(result.error), /scope/i);
@@ -665,7 +640,7 @@ test('sendSlackFile fails cleanly when the URL reservation fails', async () => {
 });
 
 test('sendSlackFile reports a missing file without calling the API', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const result = await sendSlackFile('xoxb-t', slackTargetFromId('C1'), '/nope/missing.txt', { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.match(String(result.error), /not found/i);
@@ -683,7 +658,7 @@ test('validateSlackFileSize rejects oversize uploads with a 413', () => {
 test('sendSlackFile rejects an empty file locally', async () => {
     // Slack answers a zero-length reservation with `missing_argument`, which
     // reads as a client bug; fail with something the operator can act on.
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const result = await sendSlackFile('xoxb-t', slackTargetFromId('C1'), tempFile(''), { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.match(String(result.error), /empty file/i);
@@ -831,7 +806,7 @@ test('slackSendHandler posts the text of an opted-in keyboard downgrade and reco
 });
 
 test('blocks ride on the first sendSlackText chunk', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     const blocks = [{ type: 'actions', elements: [{ type: 'button', text: { type: 'plain_text', text: 'Approve' }, action_id: 'appr:x' }] }];
     await sendSlackText('xoxb-t', slackTargetFromId('C1'), 'hi', { fetchImpl: impl, blocks });
     const body = bodyOf(calls[0]!);
@@ -840,7 +815,7 @@ test('blocks ride on the first sendSlackText chunk', async () => {
 });
 
 test('a short Slack rate limit retries the same chunk once', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: false, error: 'ratelimited', __headers: { 'retry-after': '0.01' }, __status: 429 },
         { ok: true },
     ]);
@@ -852,7 +827,7 @@ test('a short Slack rate limit retries the same chunk once', async () => {
 });
 
 test('a long Slack rate limit is not waited out and is not retried', async () => {
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: false, error: 'ratelimited', __headers: { 'retry-after': '120' }, __status: 429 },
     ]);
     const started = Date.now();
@@ -863,7 +838,7 @@ test('a long Slack rate limit is not waited out and is not retried', async () =>
 });
 
 test('not_in_channel is not retried', async () => {
-    const { impl, calls } = makeFetch([{ ok: false, error: 'not_in_channel' }]);
+    const { impl, calls } = makeSlackFetch([{ ok: false, error: 'not_in_channel' }]);
     const result = await sendSlackText('xoxb-t', slackTargetFromId('C1'), 'hi', { fetchImpl: impl });
     assert.equal(result.ok, false);
     assert.equal(calls.length, 1);
@@ -880,7 +855,7 @@ test('not_in_channel is not retried', async () => {
 const FAKE_APP_TOKEN = `xapp-1-A01234567-${'1'.repeat(13)}-${'b'.repeat(64)}`;
 
 test('SOR-001: blocks are masked, including values nested inside them', async () => {
-    const { impl, calls } = makeFetch([{ ok: true }]);
+    const { impl, calls } = makeSlackFetch([{ ok: true }]);
     await sendSlackText('xoxb-t', slackTargetFromId('C1'), 'hi', {
         fetchImpl: impl,
         blocks: [{
@@ -897,7 +872,7 @@ test('SOR-001: blocks are masked, including values nested inside them', async ()
 test('SOR-002: the rate-limit retry sends the masked blocks too', async () => {
     // The leak had two exits. This is the second one: throttle the first send
     // and check what actually goes out on the retry.
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         // 0.01s, matching the existing inline-retry test: a wait of exactly 0
         // does not qualify for the inline retry, so the second send never
         // happens and the assertion below would be vacuous.
@@ -925,9 +900,9 @@ test('SOR-003: the paths that already masked still do', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'jaw-slack-redact-'));
     const filePath = join(dir, 'note.txt');
     writeFileSync(filePath, 'x');
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, upload_url: 'https://files.slack.com/upload', file_id: 'F1' },
-        { __raw: true, ok: true, status: 200 },
+        slackRaw({ ok: true, status: 200 }),
         { ok: true, files: [{ id: 'F1' }] },
     ]);
     await sendSlackFile('xoxb-t', slackTargetFromId('C1'), filePath, {
@@ -946,9 +921,9 @@ test('SOR-004: the filename is masked everywhere it reaches Slack', async () => 
     const dir = mkdtempSync(join(tmpdir(), 'jaw-slack-redact-name-'));
     const filePath = join(dir, `${FAKE_APP_TOKEN}.txt`);
     writeFileSync(filePath, 'x');
-    const { impl, calls } = makeFetch([
+    const { impl, calls } = makeSlackFetch([
         { ok: true, upload_url: 'https://files.slack.com/upload', file_id: 'F1' },
-        { __raw: true, ok: true, status: 200 },
+        slackRaw({ ok: true, status: 200 }),
         { ok: true, files: [{ id: 'F1' }] },
     ]);
 

--- a/tests/unit/slack-roster.test.ts
+++ b/tests/unit/slack-roster.test.ts
@@ -12,41 +12,17 @@ import {
     formatRosterForAgent,
 } from '../../src/slack/roster.ts';
 import { getCachedSlackIdentities, resetSlackIdentityCache } from '../../src/slack/identity.ts';
+import { makeSlackFetch } from '../helpers/slack-fetch.mts';
 
 const TOKEN = 'xoxb-not-a-real-token-000';
 const TEAM = 'T0TEST';
-
-type Call = { method: string; body: Record<string, string> };
-
-/** Route scripted responses by Slack method so page order stays readable. */
-function makeFetch(script: Record<string, Array<Record<string, unknown>>>) {
-    const calls: Call[] = [];
-    const cursors: Record<string, number> = {};
-    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
-        const method = String(url).split('/').pop() || '';
-        const params = new URLSearchParams(String(init?.body ?? ''));
-        const body: Record<string, string> = {};
-        for (const [k, v] of params) body[k] = v;
-        calls.push({ method, body });
-        const queue = script[method] ?? [{ ok: true }];
-        const index = Math.min(cursors[method] ?? 0, queue.length - 1);
-        cursors[method] = (cursors[method] ?? 0) + 1;
-        return {
-            ok: true,
-            status: 200,
-            text: async () => JSON.stringify(queue[index]),
-        } as unknown as Response;
-    // justified: the harness implements only the Response surface slackApi reads
-    }) as unknown as typeof fetch;
-    return { impl, calls };
-}
 
 const user = (id: string, name: string, over: Record<string, unknown> = {}) =>
     ({ id, profile: { display_name: name }, ...over });
 
 test('channel members resolve to names through one users.list join', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch({
+    const { impl, calls } = makeSlackFetch({
         'conversations.members': [{ ok: true, members: ['U1', 'U2'] }],
         'users.list': [{ ok: true, members: [user('U1', '김병준'), user('U2', 'Ada')] }],
     });
@@ -60,13 +36,13 @@ test('channel members resolve to names through one users.list join', async () =>
 
 test('members already in the identity cache cost no call at all', async () => {
     resetSlackIdentityCache();
-    const warm = makeFetch({
+    const warm = makeSlackFetch({
         'conversations.members': [{ ok: true, members: ['U1'] }],
         'users.list': [{ ok: true, members: [user('U1', 'Jun')] }],
     });
     await fetchSlackChannelMembers(TOKEN, 'C1', { teamId: TEAM, fetchImpl: warm.impl });
 
-    const second = makeFetch({ 'conversations.members': [{ ok: true, members: ['U1'] }] });
+    const second = makeSlackFetch({ 'conversations.members': [{ ok: true, members: ['U1'] }] });
     const result = await fetchSlackChannelMembers(TOKEN, 'C1', { teamId: TEAM, fetchImpl: second.impl });
     assert.ok(result.ok);
     assert.equal(result.members[0]!.name, 'Jun');
@@ -75,7 +51,7 @@ test('members already in the identity cache cost no call at all', async () => {
 
 test('membership pagination follows the cursor', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch({
+    const { impl, calls } = makeSlackFetch({
         'conversations.members': [
             { ok: true, members: ['U1'], response_metadata: { next_cursor: 'c2' } },
             { ok: true, members: ['U2'] },
@@ -92,7 +68,7 @@ test('membership pagination follows the cursor', async () => {
 
 test('membership walk stops at its page ceiling and says so', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch({
+    const { impl, calls } = makeSlackFetch({
         // Always another cursor: without a cap this walks forever.
         'conversations.members': [{ ok: true, members: ['U1'], response_metadata: { next_cursor: 'more' } }],
         'users.list': [{ ok: true, members: [user('U1', 'A')] }],
@@ -105,7 +81,7 @@ test('membership walk stops at its page ceiling and says so', async () => {
 
 test('the users.list join is bounded even when the target never appears', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch({
+    const { impl, calls } = makeSlackFetch({
         'conversations.members': [{ ok: true, members: ['U_MISSING'] }],
         // Endless directory that never contains the member being looked for.
         'users.list': [{ ok: true, members: [user('UX', 'X')], response_metadata: { next_cursor: 'more' } }],
@@ -119,7 +95,7 @@ test('the users.list join is bounded even when the target never appears', async 
 
 test('an unresolved member is listed rather than silently dropped', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch({
+    const { impl } = makeSlackFetch({
         'conversations.members': [{ ok: true, members: ['U1', 'U_GHOST'] }],
         'users.list': [{ ok: true, members: [user('U1', 'Jun')] }],
         'users.info': [{ ok: false, error: 'user_not_found' }],
@@ -132,7 +108,7 @@ test('an unresolved member is listed rather than silently dropped', async () => 
 
 test('missing_scope surfaces as operator prose, not a raw error code', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch({
+    const { impl } = makeSlackFetch({
         'conversations.members': [{ ok: false, error: 'missing_scope', needed: 'channels:read' }],
     });
     const result = await fetchSlackChannelMembers(TOKEN, 'C1', { teamId: TEAM, fetchImpl: impl });
@@ -142,7 +118,7 @@ test('missing_scope surfaces as operator prose, not a raw error code', async () 
 
 test('workspace users always send a limit', async () => {
     resetSlackIdentityCache();
-    const { impl, calls } = makeFetch({
+    const { impl, calls } = makeSlackFetch({
         'users.list': [{ ok: true, members: [user('U1', 'Jun')] }],
         'team.info': [{ ok: true, team: { name: 'Acme' } }],
     });
@@ -161,7 +137,7 @@ test('bots and deactivated accounts are excluded unless asked for', async () => 
         user('U3', 'Gone', { deleted: true }),
     ];
     const plain = await fetchSlackWorkspaceUsers(TOKEN, {
-        teamId: TEAM, fetchImpl: makeFetch({ 'users.list': [{ ok: true, members: directory }] }).impl,
+        teamId: TEAM, fetchImpl: makeSlackFetch({ 'users.list': [{ ok: true, members: directory }] }).impl,
     });
     assert.ok(plain.ok);
     assert.deepEqual(plain.members.map(m => m.id), ['U1']);
@@ -169,7 +145,7 @@ test('bots and deactivated accounts are excluded unless asked for', async () => 
     resetSlackIdentityCache();
     const full = await fetchSlackWorkspaceUsers(TOKEN, {
         teamId: TEAM, includeBots: true, includeDeleted: true,
-        fetchImpl: makeFetch({ 'users.list': [{ ok: true, members: directory }] }).impl,
+        fetchImpl: makeSlackFetch({ 'users.list': [{ ok: true, members: directory }] }).impl,
     });
     assert.ok(full.ok);
     assert.deepEqual(full.members.map(m => m.id), ['U1', 'U2', 'U3']);
@@ -177,14 +153,14 @@ test('bots and deactivated accounts are excluded unless asked for', async () => 
 
 test('a workspace read warms the identity cache for later inbound messages', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch({ 'users.list': [{ ok: true, members: [user('U1', '김병준')] }] });
+    const { impl } = makeSlackFetch({ 'users.list': [{ ok: true, members: [user('U1', '김병준')] }] });
     await fetchSlackWorkspaceUsers(TOKEN, { teamId: TEAM, fetchImpl: impl });
     assert.equal(getCachedSlackIdentities(TEAM, ['U1']).get('U1')?.name, '김병준');
 });
 
 test('a missing team:read scope does not fail the roster', async () => {
     resetSlackIdentityCache();
-    const { impl } = makeFetch({
+    const { impl } = makeSlackFetch({
         'users.list': [{ ok: true, members: [user('U1', 'Jun')] }],
         'team.info': [{ ok: false, error: 'missing_scope', needed: 'team:read' }],
     });

--- a/tests/unit/sse-events-route.test.ts
+++ b/tests/unit/sse-events-route.test.ts
@@ -1,31 +1,19 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerEventsRoutes, getSseMetrics, exceedsBackpressureLimit, SSE_MAX_BUFFER_BYTES } from '../../src/routes/events.ts';
 import { broadcast } from '../../src/core/bus.ts';
 import { publish, currentSeq } from '../../src/core/event-bus.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 function noAuth(_req: Request, _res: Response, next: NextFunction): void {
     next();
 }
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    registerEventsRoutes(app, noAuth);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        // Aborted SSE sockets linger server-side until the next heartbeat
-        // write fails — force-destroy them so close() resolves immediately.
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+// The shared helper always destroys open connections before closing, which is
+// what this suite needs: an aborted SSE socket lingers server-side until the
+// next heartbeat write fails.
+const withServer = serverHarness({ setup: app => registerEventsRoutes(app, noAuth) });
 
 /** Read from an SSE response body until pred matches or timeout. */
 async function readUntil(

--- a/tests/unit/sse-scope-filter.test.ts
+++ b/tests/unit/sse-scope-filter.test.ts
@@ -1,26 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerEventsRoutes } from '../../src/routes/events.ts';
 import { currentSeq, publish } from '../../src/core/event-bus.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 function noAuth(_req: Request, _res: Response, next: NextFunction): void { next(); }
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    registerEventsRoutes(app, noAuth);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+const withServer = serverHarness({ setup: app => registerEventsRoutes(app, noAuth) });
 
 async function readUntil(body: ReadableStream<Uint8Array>, marker: string): Promise<string> {
     const reader = body.getReader();

--- a/tests/unit/telegram-dispatch-approval-ingress.test.ts
+++ b/tests/unit/telegram-dispatch-approval-ingress.test.ts
@@ -4,8 +4,8 @@ import { settings } from '../../src/core/config.js';
 import { dispatchApprovalStore } from '../../src/core/dispatch-approval.js';
 import { createTestTransport } from '../../src/core/dispatch-approval-ingress.js';
 import { handleTelegramUpdate, setTelegramBotUserIdForTest } from '../../src/telegram/bot.js';
+import { pendingDispatchApproval as pending } from './helpers/dispatch-approval.ts';
 
-function pending() { return dispatchApprovalStore.create({ target: { kind: 'agent', name: 'A' }, projectRoot: '/r', task: 't', mutable: false, scope: null, fanOutCap: 1 }); }
 test('Telegram polling handler accepts only allowlisted human on trusted transport', () => {
     settings['dispatchApproval'] = { operators: { slack: [], telegram: [42], discord: [] }, ttlSeconds: 120 };
     const transport = createTestTransport('telegram');

--- a/tests/unit/trace-routes.test.ts
+++ b/tests/unit/trace-routes.test.ts
@@ -1,27 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerTraceRoutes } from '../../src/routes/traces.ts';
 import { appendTraceEvent, startTraceRun } from '../../src/trace/store.ts';
+import { serverHarness } from '../helpers/with-server.mts';
 
 function noAuth(_req: Request, _res: Response, next: NextFunction): void {
     next();
 }
 
-async function withServer(fn: (baseUrl: string) => Promise<void>): Promise<void> {
-    const app = express();
-    registerTraceRoutes(app, noAuth);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+const withServer = serverHarness({ setup: app => registerTraceRoutes(app, noAuth) });
 
 test('trace routes expose public traces with bounded event pages', async () => {
     const runId = startTraceRun({ cli: 'codex', audience: 'public' });

--- a/tests/unit/unified-search-contract.test.ts
+++ b/tests/unit/unified-search-contract.test.ts
@@ -1,9 +1,8 @@
 import '../setup/isolated-home.ts';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
 import { readFileSync } from 'node:fs';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { registerSearchRoutes } from '../../src/routes/search.ts';
 import { SearchCoordinator } from '../../src/search/coordinator.ts';
 import {
@@ -20,6 +19,7 @@ import type {
     SearchQuery,
     SearchResultEnvelope,
 } from '../../src/search/contract.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 type SearchImplementation = (
     query: SearchQuery,
@@ -72,23 +72,9 @@ function testAuth(req: Request, res: Response, next: NextFunction): void {
     else res.status(401).json({ error: 'Unauthorized' });
 }
 
-async function withServer(
-    coordinator: SearchCoordinator,
-    fn: (baseUrl: string) => Promise<void>,
-): Promise<void> {
-    const app = express();
-    registerSearchRoutes(app, testAuth, coordinator);
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
+// The coordinator differs per call, so only registration lives here.
+const withServer = (coordinator: SearchCoordinator, fn: (baseUrl: string) => Promise<void>): Promise<void> =>
+    withHttpServer(fn, { setup: app => registerSearchRoutes(app, testAuth, coordinator) });
 
 async function json(response: Response | globalThis.Response): Promise<Record<string, any>> {
     return await response.json() as Record<string, any>;

--- a/tests/unit/wiki-routes.test.ts
+++ b/tests/unit/wiki-routes.test.ts
@@ -1,8 +1,7 @@
 import '../setup/isolated-home.ts';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createServer, type Server } from 'node:http';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import { mkdtempSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -10,6 +9,7 @@ import { registerWikiRoutes } from '../../src/routes/wiki.ts';
 import {
     DEFAULT_WIKI_CONFIG, normalizeWikiConfig, readWikiConfig, wikiProviderHealth, writeWikiConfig,
 } from '../../src/wiki/config.ts';
+import { withServer as withHttpServer } from '../helpers/with-server.mts';
 
 function tempRoot(): string {
     return join(mkdtempSync(join(tmpdir(), 'jaw-wiki-route-')), 'vault');
@@ -22,26 +22,17 @@ type ServerOptions = {
     providerHealth?: typeof wikiProviderHealth;
 };
 
-async function withServer(fn: (baseUrl: string) => Promise<void>, options: ServerOptions = {}): Promise<void> {
-    const app = express();
-    app.use(express.json());
-    const auth = options.auth ?? ((_q: Request, _s: Response, next: NextFunction) => next());
-    registerWikiRoutes(app, auth, {
-        forbiddenRoots: () => options.forbiddenRoots ?? [],
-        ...(options.scaffold ? { scaffold: options.scaffold } : {}),
-        ...(options.providerHealth ? { providerHealth: options.providerHealth } : {}),
+// Options arrive per call, so this only assembles the app; listen and close
+// belong to the shared helper.
+const withServer = (fn: (baseUrl: string) => Promise<void>, options: ServerOptions = {}): Promise<void> =>
+    withHttpServer(fn, {
+        json: true,
+        setup: app => registerWikiRoutes(app, options.auth ?? ((_q: Request, _s: Response, next: NextFunction) => next()), {
+            forbiddenRoots: () => options.forbiddenRoots ?? [],
+            ...(options.scaffold ? { scaffold: options.scaffold } : {}),
+            ...(options.providerHealth ? { providerHealth: options.providerHealth } : {}),
+        }),
     });
-    const server: Server = createServer(app);
-    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    assert.ok(address && typeof address === 'object');
-    try {
-        await fn(`http://127.0.0.1:${address.port}`);
-    } finally {
-        server.closeAllConnections();
-        await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-}
 
 const post = (baseUrl: string, path: string, body: unknown) => fetch(`${baseUrl}${path}`, {
     method: 'POST',

--- a/tests/unit/worker-events.test.ts
+++ b/tests/unit/worker-events.test.ts
@@ -30,7 +30,10 @@ function diff(d: InstanceDiff): void {
     publish('worker', 'instance-status-changed', { ...d } as unknown as Record<string, unknown>);
 }
 
-function makeFetch(latest: Record<string, unknown> | null) {
+// Not a Slack stub: this one answers the Manager's own /api/events hydration
+// over `json()`. tests/helpers/slack-fetch.mts is the Slack contract; the name
+// stays distinct so the two are not mistaken for the same harness.
+function makeEventsFetch(latest: Record<string, unknown> | null) {
     const calls: string[] = [];
     const fetchImpl = async (url: string) => {
         calls.push(url);
@@ -42,7 +45,7 @@ function makeFetch(latest: Record<string, unknown> | null) {
 function freshBridge(latest: Record<string, unknown> | null) {
     stopWorkerEventBridge();
     FakeEventSource.instances = [];
-    const { calls, fetchImpl } = makeFetch(latest);
+    const { calls, fetchImpl } = makeEventsFetch(latest);
     startWorkerEventBridge({
         fetchImpl: fetchImpl as never,
         EventSourceImpl: FakeEventSource as never,


### PR DESCRIPTION
Closes #698

Three test stubs had been copy-pasted until the copies stopped meaning the same thing. This replaces each family with one owner.

## Slack `makeFetch` — six forks

The six Slack unit files shared a comment ("the harness implements only the Response surface slackApi reads") and nothing else. Only `slack-history` coerced numeric form values, only `slack-roster` routed responses by Slack method, and only `slack-outbound` could produce a non-200 status, a `retry-after` header or an empty body. The other five were pinned to HTTP 200 with `ok:true`, so a 429 or an `invalid_arguments` fixture written in one file proved nothing about the rest.

`tests/helpers/slack-fetch.mts` keeps every behaviour the forks relied on — last-spec replay, per-method scripts, digit-only form values as numbers — and adds the envelope none of them could express: `slackError`, `slackInvalidArguments`, `slackRateLimited` and `slackRaw`.

Two constraints are load-bearing and deliberate:

- `call.method` is the Slack RPC name from the URL, because `slack-roster` filters on it. The HTTP verb stays on `call.init.method`, where `slack-outbound` reads it.
- `init` is recorded by reference, never cloned or normalized. `slack-outbound` indexes `init.headers` as a plain object, compares `String(init.body)` to a form string, and asserts `body instanceof FormData`; wrapping any of that would make those checks vacuous.

`tests/unit/slack-fetch-harness.test.ts` is the completion condition from the issue: one `slackRateLimited(120)` constant fed to conversation, history and outbound, with each surface pinned to what it actually does. It never sleeps — history is held to a single call by `noRetryOnRateLimit` (its backoff is a hardcoded 1s with no injectable clock), and a two-minute `retry-after` is above the 5s inline-retry cap in `send-only-client`.

## Route `withServer` — sixteen forks

Ten destroyed open connections before closing, `code-routes` closed first and destroyed after, and five never destroyed at all. Three attached a listen `'error'` listener and none removed it once listening succeeded. `code-workspace-pick-route-runtime` bound every interface with `app.listen(0)` and never waited for `'listening'`.

That is the port leak, not a style difference: an aborted SSE socket lingers server-side until the next heartbeat write fails, so `close()` on its own can sit holding a `listen(0)` port while the next file is trying to get one.

`tests/helpers/with-server.mts` owns listen and close for all sixteen. It binds loopback behind an error listener it removes on success, always destroys connections before closing, and runs an optional after-hook afterwards — which is where `activity-routes` and `message-activity-answer` already reset the active chat session.

It does not own the app. Eight files now describe theirs in one `serverHarness({...})` line with every call site unchanged; the eight whose callback or arguments genuinely differ (a prefixed `get`, an auth-call counter, a per-call coordinator, budget or app) keep a small wrapper that only assembles the app. No file still contains listen or close code.

## Browser and approval helpers

Four Manager notes smokes each launched Chromium, kept their own `browsers` array and registered the same `after()` closer. `tests/browser/manager-notes-page.ts` owns the launch, the registry and the cleanup. The three byte-identical `pending()` one-liners over `dispatchApprovalStore` move to `tests/unit/helpers/dispatch-approval.ts`.

## Corrections to the issue body

The issue was written against `dev` b5ea3c0ab and its counts still hold at `0fac27ea1`, with two details different from what it describes:

- `pageForManager` is three copies, not "3-4 files". `manager-layout-smoke` has a function of the same name with a different contract — it connects to an already-running browser over CDP, takes a `TestContext` and skips when none is there. It is deliberately not merged. A fourth notes smoke (`manager-notes-refresh-stability`) had the same body inlined without extracting a function, and is included.
- `pageApiStatus` is duplicated in two files, not three.

`worker-events.test.ts` also had a `makeFetch`, but it answers the Manager's own `/api/events` hydration over `json()` and is not a Slack stub. It is renamed `makeEventsFetch` rather than merged, so "one `makeFetch`" is true by reading rather than by exception.

## NOT COVERED BY CI

- **`tests/browser/**` is not run by any PR job.** `test.yml` has no `browser`-scope job; `ci-aggregate` requires `changes`, `test`, `integration`, `gates` and `windows-unit` only. `hosted-manager-qa` is `workflow_dispatch`-only and its file list does not include the notes smokes. **The `manager-notes-page.ts` extraction and all four migrated smokes are unproven by this PR's CI.** They were verified by reading: the three extracted bodies were byte-identical, and the fourth was the same code inlined.
- **No typecheck covers `tests/`.** `tsconfig.json` excludes it and the suites run under tsx, which transpiles without checking. A generic or signature error in either new helper surfaces only as a failing test, not as a type error.
- **The `withServer` close-path change is proven only where a test observes it.** Every migrated suite awaits its fetches before closing, so the fix is the absence of a leaked socket rather than an assertion. Nothing here asserts that a port is released.
- **Windows coverage is unchanged.** `windows-unit-manifest.txt` is an allowlist of `tests/unit/*.test.ts`; helpers cannot be entries and `slack-fetch-harness.test.ts` was not added to the Windows lane.
- **Local suites were not run** (`npm test`, `npm run build`, `npx tsc`, `npm install` are all NOT RUN by instruction). `check-private-boundary` and `check-path-length` were run locally and pass. All other evidence is this PR's `ci-aggregate` at the exact head SHA.
- **A pre-existing `str_func.md` drift is left alone.** `verify-counts.sh` reports `public/ total` documented as ~103033L against 103287L actual. This branch touches no `public/` file, so the drift predates it and is not repaired here.



## Added after the fleet landed: Windows lane

#691 added `db-schema-migration` and `db-legacy-mention-watch-surface`, but its fence did not include `scripts/ci/windows-unit-manifest.txt`. This PR owns that file, so both are now on the Windows lane (validator reports 18 files).

`db-schema-migration` builds a home predating `PRAGMA user_version` and opens it with better-sqlite3 by path; every other CI run gets a fresh `CLI_JAW_HOME`, so the migration it covers is dead code outside a test that constructs an old home deliberately. `db-legacy-mention-watch-surface` walks `src/` and `bin/` comparing repo-relative paths and already normalizes separators, which nothing verified on Windows until now.

`stop-kills-workers.test.ts` is a further candidate — it spawns and kills real children, and that path differs on Windows — but it is not from #691 and is deliberately left off this PR.
