### PR TITLE
fix(stop): actually stop employees on a user stop, and record the stop

### DIFF
--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -43,7 +43,7 @@ import {
 } from './session-persistence.js';
 import { isCompactMarkerRow } from '../core/compact.js';
 import { isRuntimeSettingsMutationInFlight, waitForRuntimeSettingsIdle } from '../core/runtime-settings-gate.js';
-import { hasBlockingWorkers, hasPendingWorkerReplays, getActiveWorkers, clearAllWorkers, clearWorkersForScope } from '../orchestrator/worker-registry.js';
+import { hasBlockingWorkers, hasPendingWorkerReplays, getActiveWorkers, clearAllWorkers, clearWorkersForScope, cancelWorker } from '../orchestrator/worker-registry.js';
 import { sanitizeWorkerProgressTools } from '../orchestrator/worker-progress.js';
 import { handleAgentExit, setSpawnAgent, setMainMetaHandler } from './lifecycle-handler.js';
 import { buildServicePath } from '../core/runtime-path.js';
@@ -421,6 +421,17 @@ export function killAgentById(agentId: string): boolean {
     if (!proc) return false;
     try {
         if (cancelOwnedPiProcess(proc, 'user')) return true;
+        // Record the stop the way killActiveAgent does for a main run (below). Only
+        // the Pi branch above used to stamp a reason, so a deliberately stopped
+        // employee on every other runtime reached handleAgentExit with
+        // wasKilled=false and was classified as a crash. For an employee with a
+        // non-zero exit that is not cosmetic: lifecycle-handler's employee retry
+        // branch (`isEmployee && code !== 0 && !wasKilled`) respawns the very turn
+        // the caller just cancelled.
+        //
+        // Live pid only, for the same reason cancelOwnedPiProcess checks: stamping
+        // an already-exited pid is how a recycled pid inherits a foreign kill reason.
+        if (proc.pid && !hasChildExited(proc)) killReasons.set(proc.pid, 'user');
         // Same owner as killActiveAgent. The hand-rolled version here escalated on a
         // bare 3s timer with no liveness re-check, so a CLI that traps SIGTERM either
         // survived or, worse, the delayed SIGKILL landed on a recycled PID. Worker
@@ -590,10 +601,27 @@ export { armExitSettle, settleExit, waitForExitSettled };
  * 프론트는 (1) 낙관 bubble + (2) applyQueuedOverlay 가 만든 queued bubble = 2개를 보여준다.
  */
 function clearWorkerSlotsOnStop(scopeKey: string, reason: string) {
-    const active = getActiveWorkers(scopeKey).length;
-    if (active === 0 && !hasPendingWorkerReplays(scopeKey)) return;
+    const active = getActiveWorkers(scopeKey);
+    if (active.length === 0 && !hasPendingWorkerReplays(scopeKey)) return;
+    // Clearing the registry only forgets the slot; it never stopped the child.
+    // Claude employees die earlier, inside cancelClaudeScope(..., includeWorkers),
+    // so before this every OTHER runtime's employee survived a user stop: still
+    // running, still streaming into a scope the boss had abandoned, still holding
+    // its isolated cwd. The two sibling paths already get this right —
+    // orchestrateReset kills before clearing (orchestrator/pipeline.ts) and the
+    // worker timeout calls killAgentById (orchestrator/distribute.ts) — only the
+    // stop path was missing it.
+    //
+    // cancelWorker matches reset: deleting a slot leaves its worker run row
+    // 'running' forever, because finishWorker and failWorker both no-op once the
+    // slot is gone. getActiveWorkers returns a fresh array, so killing inside this
+    // loop cannot mutate what is being iterated.
+    for (const slot of active) {
+        killAgentById(slot.agentId);
+        cancelWorker(slot.agentId);
+    }
     clearWorkersForScope(scopeKey);
-    console.log(`[jaw:stop] cleared worker registry (active=${active}, scope=${scopeKey}, reason=${reason})`);
+    console.log(`[jaw:stop] stopped and cleared worker registry (active=${active.length}, scope=${scopeKey}, reason=${reason})`);
 }
 
 function clearMainLiveRunOnStop(scopeKey: string, reason: string): void {

--- a/src/agent/spawn.ts
+++ b/src/agent/spawn.ts
@@ -600,22 +600,25 @@ export { armExitSettle, settleExit, waitForExitSettled };
  * 도 검사하므로, 이걸 비우지 않으면 stop 직후 새 메시지가 busy 분기 → 큐로 떨어지고
  * 프론트는 (1) 낙관 bubble + (2) applyQueuedOverlay 가 만든 queued bubble = 2개를 보여준다.
  */
+/**
+ * Stop the scope's employees, then forget them.
+ *
+ * Clearing the registry only forgets the slot; it never stopped the child. Claude
+ * employees die earlier, inside cancelClaudeScope(..., includeWorkers), so the gap
+ * was invisible there — and every OTHER runtime's employee survived a user stop:
+ * still running, still streaming into a scope the boss had abandoned, still holding
+ * its isolated cwd. The two sibling paths already get this right: orchestrateReset
+ * kills before clearing (orchestrator/pipeline.ts) and the worker timeout calls
+ * killAgentById (orchestrator/distribute.ts). Only the stop path was missing it.
+ *
+ * cancelWorker matches reset for the same reason: deleting a slot leaves its worker
+ * run row 'running' forever, because finishWorker and failWorker both no-op once the
+ * slot is gone. getActiveWorkers returns a fresh array, so killing inside the loop
+ * cannot mutate what is being iterated.
+ */
 function clearWorkerSlotsOnStop(scopeKey: string, reason: string) {
     const active = getActiveWorkers(scopeKey);
     if (active.length === 0 && !hasPendingWorkerReplays(scopeKey)) return;
-    // Clearing the registry only forgets the slot; it never stopped the child.
-    // Claude employees die earlier, inside cancelClaudeScope(..., includeWorkers),
-    // so before this every OTHER runtime's employee survived a user stop: still
-    // running, still streaming into a scope the boss had abandoned, still holding
-    // its isolated cwd. The two sibling paths already get this right —
-    // orchestrateReset kills before clearing (orchestrator/pipeline.ts) and the
-    // worker timeout calls killAgentById (orchestrator/distribute.ts) — only the
-    // stop path was missing it.
-    //
-    // cancelWorker matches reset: deleting a slot leaves its worker run row
-    // 'running' forever, because finishWorker and failWorker both no-op once the
-    // slot is gone. getActiveWorkers returns a fresh array, so killing inside this
-    // loop cannot mutate what is being iterated.
     for (const slot of active) {
         killAgentById(slot.agentId);
         cancelWorker(slot.agentId);

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -145,7 +145,7 @@ cli-jaw/
 │   │   ├── claude-runtime-run.ts ← native Claude main adaptation to shared host/lifecycle and fallback terminal ordering (293L)
 │   │   ├── prompt-context.ts ← history/operational/partial boundaries and bounded accepted Cursor redirects (201L)
 │   │   ├── steer-input-guard.ts ← transient scoped Stop fence through fallback enqueue (33L)
-│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4090L)
+│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4093L)
 │   │   ├── spawn/            ← spawn 서브모듈 (3 files)
 │   │   │   ├── queue.ts      ← QueueItem persistent DB queue + processQueue race fix + enqueue/dequeue + drainRecoveredQueue (부팅 시 복구 큐 기동, server.ts가 transport 준비 후 호출) + `_fromQueue` 표식 (대기자 없는 턴을 채널이 답할 수 있게) (694L)
 │   │   │   ├── resume.ts     ← session resume logic + stale resume detection (117L)

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -145,7 +145,7 @@ cli-jaw/
 │   │   ├── claude-runtime-run.ts ← native Claude main adaptation to shared host/lifecycle and fallback terminal ordering (293L)
 │   │   ├── prompt-context.ts ← history/operational/partial boundaries and bounded accepted Cursor redirects (201L)
 │   │   ├── steer-input-guard.ts ← transient scoped Stop fence through fallback enqueue (33L)
-│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4062L)
+│   │   ├── spawn.ts          ← CLI spawn + ACP/Codex App/Pi RPC/AGY/Kiro plain text/log session capture + v2 SQLite session resume + 큐 + 메모리 flush + 429 retry timer + isAgentBusy/isSteerInProgress + buildHistoryBlock compact cutoff + working_dir scoping + enqueue→processQueue race fix + QueueItem persistent DB queue + makeCleanEnv PATH augment (4090L)
 │   │   ├── spawn/            ← spawn 서브모듈 (3 files)
 │   │   │   ├── queue.ts      ← QueueItem persistent DB queue + processQueue race fix + enqueue/dequeue + drainRecoveredQueue (부팅 시 복구 큐 기동, server.ts가 transport 준비 후 호출) + `_fromQueue` 표식 (대기자 없는 턴을 채널이 답할 수 있게) (694L)
 │   │   │   ├── resume.ts     ← session resume logic + stale resume detection (117L)

--- a/tests/unit/stop-kills-workers.test.ts
+++ b/tests/unit/stop-kills-workers.test.ts
@@ -1,0 +1,129 @@
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import type { ChildProcess } from 'node:child_process';
+
+const { killActiveAgent, killAgentById, activeProcesses } = await import('../../src/agent/spawn.ts');
+const registry = await import('../../src/orchestrator/worker-registry.ts');
+const { getWorkerRunRecord } = await import('../../src/orchestrator/worker-run-store.ts');
+
+/** A plain long-lived child standing in for an employee CLI. */
+async function spawnIdleChild(): Promise<ChildProcess> {
+    const child = spawn(process.execPath, ['-e',
+        "setInterval(() => {}, 1000); process.stdout.write('READY');",
+    ]);
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('worker fixture never reported ready')), 10_000);
+        child.stdout!.on('data', (chunk: Buffer) => {
+            if (chunk.toString().includes('READY')) { clearTimeout(timer); resolve(); }
+        });
+        child.once('error', error => { clearTimeout(timer); reject(error); });
+    });
+    return child;
+}
+
+function enlistWorker(agentId: string, scopeId: string, child: ChildProcess) {
+    const slot = registry.claimWorker({ id: agentId, name: agentId }, 'stop fixture', { scopeId });
+    activeProcesses.set(agentId, child);
+    return slot;
+}
+
+function retire(agentId: string, child: ChildProcess): void {
+    activeProcesses.delete(agentId);
+    registry.clearWorkersForScope('sw-user');
+    registry.clearWorkersForScope('sw-steer');
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+}
+
+// ─── SW-001 ───
+//
+// A user stop cleared the worker registry but never signalled the child. Claude
+// employees died earlier inside cancelClaudeScope, so the gap was invisible there
+// and every other runtime's employee kept running against a scope the boss had
+// already abandoned. orchestrateReset and the worker timeout both already kill
+// before clearing; only the stop path did not (#701).
+
+test('SW-001: a user stop actually stops a non-Claude employee, not just its registry slot',
+    { timeout: 20_000 }, async () => {
+    const child = await spawnIdleChild();
+    const agentId = 'sw-001-worker';
+    const slot = enlistWorker(agentId, 'sw-user', child);
+    try {
+        assert.equal(registry.getActiveWorkers('sw-user').length, 1, 'fixture must be registered as running');
+
+        killActiveAgent('sw-user', 'user');
+
+        await once(child, 'exit');
+        assert.notEqual(child.exitCode === null && child.signalCode === null, true,
+            'the employee child must be stopped, not merely forgotten');
+        assert.equal(registry.getActiveWorkers('sw-user').length, 0, 'the slot must still be cleared');
+        // Deleting a slot leaves its run row 'running' forever, because finishWorker
+        // and failWorker both no-op once the slot is gone. Reset already cancels.
+        assert.equal(getWorkerRunRecord(slot.runId)?.status, 'cancelled',
+            'the worker run must be recorded as cancelled, not left running');
+    } finally {
+        retire(agentId, child);
+    }
+});
+
+// ─── SW-002 ───
+//
+// Only the Pi branch of killAgentById stamped a kill reason, so a deliberately
+// stopped employee on any other runtime reached handleAgentExit with
+// wasKilled=false. That is what the employee retry branch keys on, so the stop
+// could respawn the very turn the caller had just cancelled.
+
+test('SW-002: killAgentById records the stop for a non-Pi worker so it is not read as a crash',
+    { timeout: 20_000 }, async () => {
+    const child = await spawnIdleChild();
+    const agentId = 'sw-002-worker';
+    activeProcesses.set(agentId, child);
+    try {
+        assert.ok(child.pid, 'fixture must have a pid');
+        assert.equal(killAgentById(agentId), true, 'the worker kill port must accept a live child');
+        await once(child, 'exit');
+    } finally {
+        activeProcesses.delete(agentId);
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }
+
+    // killReasons is module-private with no read accessor, so the recording itself
+    // is checked structurally — scoped to this one function body rather than by
+    // counting occurrences file-wide. What it pins is the ordering that matters: the
+    // Pi early return sits above, and the generic terminate below must be preceded by
+    // a live-pid stamp. The CONSEQUENCE (handleAgentExit seeing wasKilled=true and
+    // therefore skipping the employee retry) is not executed here.
+    const source = await readFile(new URL('../../src/agent/spawn.ts', import.meta.url), 'utf8');
+    const start = source.indexOf('export function killAgentById');
+    assert.ok(start > 0, 'killAgentById must exist');
+    const body = source.slice(start, source.indexOf('\nexport ', start + 1));
+    const stamp = body.indexOf('killReasons.set(');
+    const terminate = body.indexOf('ownProcess(proc).terminate(');
+    assert.ok(stamp > 0, 'killAgentById must record a kill reason for non-Pi workers');
+    assert.ok(terminate > stamp, 'the kill reason must be recorded before the child is terminated');
+    assert.match(body.slice(Math.max(0, stamp - 120), stamp), /hasChildExited\(proc\)/,
+        'only a live pid may be stamped, or a recycled pid inherits a foreign kill reason');
+});
+
+// ─── SW-003 ───
+//
+// A steer replaces the boss turn and deliberately keeps its workers, so the new
+// kill must stay bound to the user/api stop that clears the registry.
+
+test('SW-003: a steer leaves employees running', { timeout: 20_000 }, async () => {
+    const child = await spawnIdleChild();
+    const agentId = 'sw-003-worker';
+    enlistWorker(agentId, 'sw-steer', child);
+    try {
+        killActiveAgent('sw-steer', 'steer');
+        await new Promise(resolve => setTimeout(resolve, 300));
+        assert.equal(child.exitCode, null, 'a steer must not reap an employee');
+        assert.equal(child.signalCode, null, 'a steer must not signal an employee');
+        assert.equal(registry.getActiveWorkers('sw-steer').length, 1, 'a steer must keep the worker slot');
+    } finally {
+        retire(agentId, child);
+    }
+});


### PR DESCRIPTION
A scoped user stop cleared the worker registry but never stopped the worker. `clearWorkerSlotsOnStop` read `getActiveWorkers(scopeKey)` only for its `.length`, then called `clearWorkersForScope`. Claude employees die earlier inside `cancelClaudeScope(..., includeWorkers)`, so the gap was invisible there — and every other runtime's employee survived the stop: still running, still streaming into a scope the boss had abandoned, still holding its isolated cwd.

The two sibling paths already do this correctly. `orchestrateReset` does `getActiveWorkers` → `killAgentById` → `cancelWorker` → clear, and the worker timeout calls `killAgentById`. Only the stop path was missing it. `cancelWorker` is included for the same reason reset includes it: deleting a slot leaves its worker run row `running` forever, because `finishWorker` and `failWorker` both no-op once the slot is gone.

## Why this is two changes and not one

Killing those children exposes a second defect that makes the first one dangerous on its own.

`killAgentById` recorded a kill reason only on its Pi branch, via `cancelOwnedPiProcess(proc, 'user')`. Every other runtime fell through to `ownProcess(proc).terminate('cancel')` without stamping `killReasons`, so a deliberately stopped employee reached `handleAgentExit` with `wasKilled=false` and was classified as a crash. The employee retry branch keys on exactly that — `isEmployee && code !== 0 && !wasKilled` — so shipping the kill alone would have **respawned the turn the user just cancelled**. Recording the reason puts employee stop on the same classification main stop already uses in `killActiveAgent`.

Only a live pid is stamped, matching the Pi branch's own check. Writing a reason to an already-exited pid is how a recycled pid inherits a foreign kill reason.

## Not a behaviour change for steer

`clearWorkerSlotsOnStop` runs only for `'user'` and `'api'`. A steer still replaces the boss turn and deliberately keeps its workers; `'interrupt'` likewise still leaves them up. SW-003 pins that so the new kill cannot quietly widen.

## Relationship to #701

This is **not** the `runPiTurn` → `runNativeRuntime` alignment, and it does not close #701. It is the observable half of the employee/main divergence that issue describes, fixed directly.

I investigated the alignment and recommend against it, with the reasoning recorded for the issue rather than attempted here:

- `runNativeRuntime` requires a `NativeRuntimeSession` and throws `native_run_requires_claim_and_finalize` unless both `claimTurnOutcome` and `finalizeTurn` exist. Only `AcpRuntimeSession` and `ClaudeSdkSession` implement that interface; `PiRpcSession` has no turnId-keyed logical terminal at all, so that handshake is new machinery rather than an adapter.
- It always does `host.acquire(signal)` then `session.send(prompt)`. The Pi employee path has no lease and no session: `spawnPiRpc` has already dispatched the prompt after its version probe before `runPiTurn` is even called.
- Most decisively, the abort-vs-kill policy is **already** a single shared decision point. `runtime-pool.ts` `cancelLease` is generic over `ManagedRuntime` and every pooled runtime's lease uses it; `piRuntime` merely supplies `interrupt`/`kill`. But `runNativeRuntime` cancels through `session.cancel()`, never `lease.cancel()` — so routing main Pi through it would *remove* Pi from the shared policy. That is the opposite of consolidation.
- The motivation is also weaker than it looks: employee stop does not lose partial output today, because the overridden `child.kill` calls `finish(1, 'stopped')` and the accumulator snapshot preserves `partialText`.

## NOT COVERED BY CI

- **The retry-suppression consequence is not executed.** SW-002 proves the child dies and pins, structurally and scoped to `killAgentById`'s own body, that a live-pid kill reason is recorded before `terminate`. It does **not** drive `handleAgentExit` and observe the employee retry branch being skipped. `killReasons` is module-private with no read accessor, so that half is reasoned, not run.
- **Only a plain Node child is exercised.** SW-001/002/003 use a generic idle child, not a real Pi, codex-app, print, or Claude employee. The per-runtime exit handlers that now fire during a stop are not exercised.
- **Downstream stop noise is unmeasured.** Killing employees on stop means `worker_disconnected` and worklog error rows can now appear where a silent orphan used to be. Reset and timeout already produce this, so it is pre-existing shape, but no test asserts the resulting UI.
- **No local suite was run.** Per this branch's constraint, `npm test`, `npm run build`, and `tsc` were NOT RUN locally; typecheck evidence comes only from `gate:typecheck` inside `ci-aggregate`.
- **`structure/verify-counts.sh` is not in `ci-aggregate`.** The `spawn.ts` entry in `str_func.md` was updated by hand (4062L → 4090L). The pre-existing `public/ total` mismatch is present on unmodified `dev` and was left alone.

Refs #701
