### PR TITLE
fix(channels): refuse a file send the vendor will not name, and keep its caption claim

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1002,7 +1002,9 @@ export async function discordSendHandler(req: ChannelSendRequest): Promise<Trans
         };
         const fileResult = await sendDiscordFile(discordClient, target, filePath, stripUndefined({ caption: req.caption }));
         if (!fileResult.ok) return fileResult;
-        return { ok: true, channel_id: channelId, type: req.type, ...deliverySent(fileResult.platformMessageId ?? null) };
+        return { ok: true, channel_id: channelId, type: req.type,
+            ...(fileResult.confirmation ? { confirmation: fileResult.confirmation } : {}),
+            ...deliverySent(fileResult.platformMessageId ?? null) };
     }
 
     const sendClient = getDiscordSendClient();
@@ -1023,7 +1025,9 @@ export async function discordSendHandler(req: ChannelSendRequest): Promise<Trans
     if (!filePath) return { ok: false, error: 'file_path required for non-text types' };
     const fileResult = await sendDiscordFileRest(sendClient.token, String(channelId), filePath, req.caption);
     if (!fileResult.ok) return fileResult;
-    return { ok: true, channel_id: channelId, type: req.type, ...deliverySent(fileResult.platformMessageId) };
+    return { ok: true, channel_id: channelId, type: req.type,
+        ...(fileResult.confirmation ? { confirmation: fileResult.confirmation } : {}),
+        ...deliverySent(fileResult.platformMessageId) };
 }
 
 // Transport registration moved to ./register.js (lazy loader) so importing

--- a/src/discord/discord-file.ts
+++ b/src/discord/discord-file.ts
@@ -10,7 +10,10 @@ import type { RemoteTarget } from '../messaging/types.js';
 import { asSendable } from './channel-types.js';
 import { redactOutboundText, userErrorText } from '../messaging/redact.js';
 import { sendDiscordFileRest } from './send-only-client.js';
-import { deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
+import { deliveryFailed, deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
+import {
+    DISCORD_FILE_UNCONFIRMED, FILE_UNCONFIRMED_STATUS, type FileConfirmation,
+} from '../messaging/file-receipt.js';
 
 export const DISCORD_LIMITS = {
     document: 10 * 1024 * 1024,
@@ -40,7 +43,11 @@ export async function sendDiscordFile(
     target: RemoteTarget,
     filePath: string,
     options?: { caption?: string; replyTo?: string; signal?: AbortSignal },
-): Promise<{ ok: boolean; error?: string } & Partial<LiveDeliveryFields>> {
+): Promise<{
+    ok: boolean; error?: string; status?: number;
+    /** Present once a send was attempted; absent on a local refusal. */
+    confirmation?: FileConfirmation;
+} & Partial<LiveDeliveryFields>> {
     let fileStat;
     try {
         fileStat = await stat(filePath);
@@ -56,9 +63,20 @@ export async function sendDiscordFile(
     if (client.token) {
         const rest = await sendDiscordFileRest(client.token, resolvedId, filePath,
             options?.caption, options?.signal ? { signal: options.signal } : {});
-        return rest.ok
-            ? { ok: true, ...deliverySent(rest.platformMessageId) }
-            : { ok: false, error: rest.error };
+        // Forward the whole verdict. Collapsing a failure to { ok, error } threw
+        // `confirmation` away on the path that actually runs in production — a
+        // connected gateway client is the normal case — and `sendChannelOutput`
+        // needs that field to tell an unconfirmed upload (whose caption may
+        // already be on screen) from a refusal that delivered nothing.
+        if (rest.ok) {
+            return { ok: true, confirmation: rest.confirmation ?? 'confirmed', ...deliverySent(rest.platformMessageId) };
+        }
+        return {
+            ok: false, error: rest.error,
+            ...(rest.confirmation ? { confirmation: rest.confirmation } : {}),
+            ...(rest.status !== undefined ? { status: rest.status } : {}),
+            ...deliveryFailed(null, { ambiguous: rest.confirmation === 'unconfirmed' }),
+        };
     }
     const channel = await client.channels.fetch(resolvedId);
     const sendable = asSendable(channel);
@@ -67,13 +85,22 @@ export async function sendDiscordFile(
     }
 
     try {
-        await sendable.send({
+        // discord.js returns the created Message here, but `asSendable` types
+        // `send` as Promise<unknown>, so the id is narrowed rather than assumed.
+        const sent: unknown = await sendable.send({
             content: redactOutboundText(options?.caption || ''),
             files: [{ attachment: filePath, name: basename(filePath) }],
         });
-        // The gateway fallback has no REST response to read an id from, which is
-        // what ambiguous reports.
-        return { ok: true, ...deliverySent(null) };
+        const rawId = (sent as { id?: unknown } | null | undefined)?.id;
+        const messageId = typeof rawId === 'string' && rawId.trim() ? rawId : null;
+        if (messageId === null) {
+            return {
+                ok: false, confirmation: 'unconfirmed',
+                error: DISCORD_FILE_UNCONFIRMED, status: FILE_UNCONFIRMED_STATUS,
+                ...deliveryFailed(null, { ambiguous: true }),
+            };
+        }
+        return { ok: true, confirmation: 'confirmed', ...deliverySent(messageId) };
     } catch (e) {
         return { ok: false, error: `Discord file send failed: ${userErrorText(e)}` };
     }

--- a/src/discord/send-only-client.ts
+++ b/src/discord/send-only-client.ts
@@ -10,10 +10,14 @@ import {
 } from './rest-scheduler.js';
 import {
     discordDeliveryError,
+    deliveryFailed,
     deliverySent,
     type DeliveryFailure,
     type LiveDeliveryFields,
 } from '../messaging/delivery-outcome.js';
+import {
+    DISCORD_FILE_UNCONFIRMED, FILE_UNCONFIRMED_STATUS, type FileConfirmation,
+} from '../messaging/file-receipt.js';
 
 export type DiscordSendClientResult =
     | { token: string; reason?: never; status?: never }
@@ -39,8 +43,9 @@ export function getDiscordSendClient(): DiscordSendClientResult {
 }
 
 export type DiscordRestSendResult =
-    | ({ ok: true; failure?: never; error?: never; status?: never } & LiveDeliveryFields)
-    | { ok: false; failure: DeliveryFailure; error: string; status?: number };
+    | ({ ok: true; failure?: never; error?: never; status?: never; confirmation?: FileConfirmation } & LiveDeliveryFields)
+    | ({ ok: false; failure: DeliveryFailure; error: string; status?: number; confirmation?: FileConfirmation }
+        & Partial<LiveDeliveryFields>);
 
 /** Discord answers a message POST with the created message as JSON. The id was
  *  being thrown away by a parse that returned undefined, so nothing downstream
@@ -212,7 +217,27 @@ export async function sendDiscordFileRest(
             },
             parse: parseDiscordMessageId,
         });
-        return sendResult(result);
+        // The scheduler's leniency is right for the endpoints it shares: 204 IS
+        // the documented success for reactions, deletes and unpin. It is not
+        // documented for Create Message, which returns the created message
+        // object — so an empty or unreadable body here means something other
+        // than Discord answered, the same threat Slack refuses. Decide that
+        // HERE rather than in the scheduler or in the shared `sendResult`,
+        // both of which also carry Discord text sends.
+        if (result.ok && typeof result.value !== 'string') {
+            return {
+                ok: false, confirmation: 'unconfirmed',
+                failure: {
+                    kind: 'ambiguous', retryAfterMs: 0,
+                    code: DISCORD_FILE_UNCONFIRMED, message: DISCORD_FILE_UNCONFIRMED,
+                },
+                error: DISCORD_FILE_UNCONFIRMED,
+                status: FILE_UNCONFIRMED_STATUS,
+                ...deliveryFailed(null, { ambiguous: true }),
+            };
+        }
+        const sent = sendResult(result);
+        return sent.ok ? { ...sent, confirmation: 'confirmed' } : sent;
     } catch (error) {
         const statusCode = (error as { statusCode?: number }).statusCode;
         const failure = discordDeliveryError({

--- a/src/manager/routes/telegram-hub.ts
+++ b/src/manager/routes/telegram-hub.ts
@@ -108,8 +108,15 @@ export function createDashboardTelegramHubRouter(): Router {
         const caption = typeof b.caption === 'string' ? b.caption.slice(0, 1024) : undefined;
         const reply_markup = type === 'keyboard' && b.reply_markup && typeof b.reply_markup === 'object' ? b.reply_markup : undefined;
         const r = await sendToTopic(chatId, threadId, stripUndefined({ type, text, filePath, caption, reply_markup }));
+        // `confirmation` rides through for the same reason `bodyDelivered` does:
+        // the member instance reads it to decide whether an unconfirmed file
+        // upload may still claim its caption. Dropping it here made an
+        // unconfirmed send indistinguishable from a refusal, so the member
+        // posted the caption a second time beside a file that had most likely
+        // arrived.
         res.status(r.ok ? 200 : 502).json(stripUndefined({ ok: r.ok, error: r.error,
-            ...(typeof r.bodyDelivered === 'boolean' ? { bodyDelivered: r.bodyDelivered } : {}) }));
+            ...(typeof r.bodyDelivered === 'boolean' ? { bodyDelivered: r.bodyDelivered } : {}),
+            ...(r.confirmation ? { confirmation: r.confirmation } : {}) }));
     });
 
     return router;

--- a/src/manager/telegram-hub/hub-bot.ts
+++ b/src/manager/telegram-hub/hub-bot.ts
@@ -15,6 +15,7 @@ import { downloadTelegramFile, buildMediaPrompt, TELEGRAM_DOWNLOAD_LIMITS } from
 import { saveUpload } from '../../agent/spawn.js';
 import { redactOutboundPayload, redactOutboundText, logErrorText, userErrorText } from '../../messaging/redact.js';
 import { sendWithRetryPolicy } from '../../messaging/retry.js';
+import type { FileConfirmation } from '../../messaging/file-receipt.js';
 import { internalFetch } from '../internal-fetch.js';
 
 let hubBot: Bot | null = null;
@@ -481,7 +482,12 @@ export async function sendToTopic(
     chatId: string,
     threadId: string,
     payload: { type: string; text?: string; filePath?: string; caption?: string; reply_markup?: unknown },
-): Promise<{ ok: boolean; error?: string; bodyDelivered?: boolean }> {
+): Promise<{
+    ok: boolean; error?: string; bodyDelivered?: boolean;
+    /** File sends only. Forwarded so the member instance can tell an
+     *  unconfirmed upload from a refusal (#700). */
+    confirmation?: FileConfirmation;
+}> {
     stopTopicTyping(chatId, threadId);
     if (!hubBot) return { ok: false, error: 'hub bot not running' };
     const message_thread_id = Number(threadId) > 1 ? Number(threadId) : undefined;

--- a/src/manager/telegram-hub/hub-bot.ts
+++ b/src/manager/telegram-hub/hub-bot.ts
@@ -513,7 +513,13 @@ export async function sendToTopic(
         }
         const { sendTelegramFile } = await import('../../telegram/telegram-file.js');
         const r = await sendTelegramFile(hubBot, chatId, payload.filePath!, payload.type, stripUndefined({ caption: payload.caption, threadId: message_thread_id }));
-        return stripUndefined({ ok: r.ok, error: r.error ? userErrorText(r.error) : undefined });
+        // `confirmation` rides along for one reason: the member instance gates
+        // its caption self-delivery claim on it, and folding this result down to
+        // { ok, error } made an unconfirmed upload indistinguishable from a
+        // refusal — so the member posted the caption again beside a file that
+        // had most likely arrived. Nothing else about hub routing changes here.
+        return stripUndefined({ ok: r.ok, error: r.error ? userErrorText(r.error) : undefined,
+            confirmation: r.confirmation });
     } catch (e: unknown) {
         console.error('[tg:hub:outbound]', logErrorText(e));
         return { ok: false, error: userErrorText(e),

--- a/src/messaging/file-receipt.ts
+++ b/src/messaging/file-receipt.ts
@@ -44,6 +44,10 @@ export const FILE_UNCONFIRMED_STATUS = 502;
  * posted; an unconfirmed send may already be on screen, so posting the same
  * caption again is the more visible harm.
  */
-export function isUnconfirmedSend(result: { confirmation?: unknown } | null | undefined): boolean {
-    return result?.confirmation === 'unconfirmed';
+export function isUnconfirmedSend(result: unknown): boolean {
+    // `unknown` rather than a shape: every field on a transport result is
+    // optional, so a structural parameter type triggers TypeScript's weak-type
+    // check and rejects the very results this is meant to read.
+    return !!result && typeof result === 'object'
+        && (result as { confirmation?: unknown }).confirmation === 'unconfirmed';
 }

--- a/src/messaging/file-receipt.ts
+++ b/src/messaging/file-receipt.ts
@@ -1,0 +1,49 @@
+// ─── File delivery confirmation ──────────────────────
+// `ok` and "we can prove it landed" were the same bit on two of the three
+// channels, and they are not the same claim. Slack already refused a completion
+// that did not echo the reserved file id back, because an intermediary
+// answering {"ok":true} would otherwise be reported as a delivered upload.
+// Telegram and Discord reported the same situation as success with
+// `ambiguous: true` — a flag no consumer read.
+//
+// Both vendors document enough to decide it:
+//
+// - Telegram returns the sent Message. `message_id` is 0 for an ephemeral or
+//   server-scheduled message, and the docs say that message "will be unusable
+//   until it is actually sent". A zero id is therefore not weak proof, it is
+//   proof of the opposite.
+// - Discord's Create Message is documented to return a message object. 204 No
+//   Content is documented only for reactions, deletes and unpin. An empty body
+//   on a message POST means something other than Discord answered.
+//
+// `confirmation` is deliberately a TOP-LEVEL field on the send result.
+// `sendChannelOutput` reads it to decide whether an unconfirmed send may still
+// claim its caption, and a nested receipt would not be visible there.
+
+export type FileConfirmation = 'confirmed' | 'unconfirmed';
+
+/** Stable error codes, one per channel, so a caller can tell an unconfirmed
+ *  send from a refusal without string-matching a vendor message. They also keep
+ *  the result off `sendResultHttpStatus`'s bare-502 default, which reads to an
+ *  agent as "retry me" — the one thing that must not happen when the upload may
+ *  already have landed. */
+export const SLACK_FILE_UNCONFIRMED = 'slack_file_completion_unconfirmed';
+export const TELEGRAM_FILE_UNCONFIRMED = 'telegram_file_send_unconfirmed';
+export const DISCORD_FILE_UNCONFIRMED = 'discord_file_send_unconfirmed';
+
+/** Not 4xx: nothing about the request was wrong. Not a plain failure either —
+ *  the bytes may well be on screen. */
+export const FILE_UNCONFIRMED_STATUS = 502;
+
+/**
+ * True when a send failed only because the vendor would not name what it
+ * accepted.
+ *
+ * The distinction matters exactly once, in `sendChannelOutput`: a hard refusal
+ * (400, 413, auth) delivered nothing, so the turn's own answer must still be
+ * posted; an unconfirmed send may already be on screen, so posting the same
+ * caption again is the more visible harm.
+ */
+export function isUnconfirmedSend(result: { confirmation?: unknown } | null | undefined): boolean {
+    return result?.confirmation === 'unconfirmed';
+}

--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -14,6 +14,7 @@ import { getRemoteBoundSessionId } from '../core/chat-sessions.js';
 import { applyOutputPolicy } from '../core/policy-hooks.js';
 import { redactChannelSecrets } from './redact.js';
 import { type TransportSendResult } from './delivery-outcome.js';
+import { isUnconfirmedSend } from './file-receipt.js';
 import { log } from '../core/logger.js';
 import { recordSelfDelivery } from './turn-delivery.js';
 import { normalizeSlackBlocks, type SlackBlock } from '../slack/blocks.js';
@@ -521,7 +522,13 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     const sanitized = result.ok === false && typeof result.error === 'string'
         ? { ...result, error: redactChannelSecrets(result.error) }
         : result;
-    stampOutboundSend(channel, sanitized.ok !== false, {
+    // An unconfirmed file send is not an outbound failure and not a proven
+    // success: the vendor took the bytes but would not name what it made. It is
+    // counted as dispatched here, because the alternative — counting it as a
+    // failed send — would report a channel as broken every time an intermediary
+    // answered with an empty body.
+    const unconfirmed = isUnconfirmedSend(sanitized);
+    stampOutboundSend(channel, sanitized.ok !== false || unconfirmed, {
         targetId: req.target?.targetId,
         type: typeof req.type === 'string' ? req.type : undefined,
         viaAgent: req.fromAgentSurface === true,
@@ -529,7 +536,11 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
     // Only a send that actually reached the user can excuse skipping the
     // dispatch post, and only `req.target` is the resolved destination — the
     // caller's target may have been absent and filled in by the chain above.
-    if (req.fromAgentSurface && sanitized.ok !== false) {
+    // `unconfirmed` is admitted here and a hard refusal is not, which is the
+    // whole distinction: a 400, a 413 or an auth failure put nothing on screen,
+    // so the turn's own answer still has to be posted. An unconfirmed upload may
+    // already be visible, and posting the same caption again is the louder bug.
+    if (req.fromAgentSurface && (sanitized.ok !== false || unconfirmed)) {
         // Only what the transport ACTUALLY put on screen may be claimed. A
         // `photo`/`document`/`voice` send carries the file and the CAPTION, and
         // reading `req.caption` here is what keeps that true: the promotion above

--- a/src/routes/messaging.ts
+++ b/src/routes/messaging.ts
@@ -45,6 +45,7 @@ function telegramTargetForClaim(chatId: string | number, threadId?: number): Rem
 }
 import { validateChannelCredentials } from '../messaging/channel-validate.js';
 import { sendResultHttpStatus } from '../messaging/send-result.js';
+import { isUnconfirmedSend } from '../messaging/file-receipt.js';
 import { getSlackSendClient } from '../slack/send-only-client.js';
 import { getSlackSelfUserId } from '../slack/bot.js';
 import { fetchSlackHistory, fetchSlackReplies, formatHistoryForAgentDetailed, slackHistoryForAgent } from '../slack/history.js';
@@ -364,28 +365,38 @@ export function registerMessagingRoutes(app: Express, requireAuth: AuthMiddlewar
             const caption = req.body?.caption ? String(req.body.caption) : undefined;
             const result = await sendTelegramFile(sendClient.client, chatId, safePath, type, stripUndefined({ caption, threadId: messageThreadId }));
 
-            if (!result.ok) {
-                const sc = result.statusCode || 502;
-                res.status(sc).json({
-                    error: result.error, attempts: result.attempts,
-                    ...(result.retryAfter != null && { retry_after: result.retryAfter }),
-                });
-                return;
-            }
             // The FILE is never claimed: whether those bytes reached the user
             // cannot be proven from a path later (see messaging/turn-delivery.ts).
             // The caption is different — Telegram renders it as the message text
             // under the upload, so the user can see it, and an answer equal to it
             // would otherwise be posted a second time. Same rule the canonical
             // route follows for file sends.
-            if (caption) {
+            //
+            // An UNCONFIRMED upload is claimed too. Telegram took the bytes and
+            // would not name the message it made, so the caption may well be on
+            // screen; gating the claim on `ok` alone is exactly what let the
+            // dispatch path post the same words a second time beside a file that
+            // had most likely arrived. A hard refusal (400, 413, auth) still
+            // claims nothing, because it delivered nothing.
+            const unconfirmed = isUnconfirmedSend(result);
+            if (caption && (result.ok || unconfirmed)) {
                 recordSelfDelivery({
                     target: telegramTargetForClaim(chatId, messageThreadId),
                     channel: 'telegram',
                     text: caption,
                 });
             }
-            res.json({ ok: true, chat_id: chatId, type, attempts: result.attempts });
+            if (!result.ok) {
+                const sc = result.statusCode || 502;
+                res.status(sc).json({
+                    error: result.error, attempts: result.attempts,
+                    ...(result.confirmation ? { confirmation: result.confirmation } : {}),
+                    ...(result.retryAfter != null && { retry_after: result.retryAfter }),
+                });
+                return;
+            }
+            res.json({ ok: true, chat_id: chatId, type, attempts: result.attempts,
+                ...(result.confirmation ? { confirmation: result.confirmation } : {}) });
         } catch (e: unknown) {
             log.error('[telegram:send]', logErrorText(e));
             const statusCode = httpStatus(e, 500);

--- a/src/slack/slack-file.ts
+++ b/src/slack/slack-file.ts
@@ -11,6 +11,9 @@ import { basename } from 'node:path';
 import type { RemoteTarget } from '../messaging/types.js';
 import { slackApi, describeSlackError, redactSlackTokens, type SlackFetch } from './api.js';
 import { redactOutboundText } from '../messaging/redact.js';
+import {
+    FILE_UNCONFIRMED_STATUS, SLACK_FILE_UNCONFIRMED, type FileConfirmation,
+} from '../messaging/file-receipt.js';
 
 // Slack's per-file ceiling is 1 GB, but a chat transport has no business
 // streaming that. 50 MiB matches the inbound attachment cap the Discord
@@ -40,6 +43,11 @@ export type SlackFileSendResult = {
     status?: number;
     grantedScopes?: string;
     retryAfterMs?: number;
+    /** The same top-level vocabulary the other two channels now speak. Slack's
+     *  behaviour is unchanged: what used to be a bare `ok: false` for a
+     *  completion with no `files[]` echo is still `ok: false`, and now also
+     *  says WHY in a word every channel shares. */
+    confirmation?: FileConfirmation;
 } & ({
     ok: true; sent: true;
     upload: SlackFileUploadReceipt & { stage: 'completion'; state: 'completed'; fileId: string };
@@ -141,8 +149,10 @@ export async function sendSlackFile(
     // reported as a delivered upload. Confirmation requires the reserved id back.
     if (!Array.isArray(files) || !files.length
         || !files.every(row => row && typeof row === 'object' && typeof row.id === 'string' && /^F[A-Z0-9]{1,100}$/.test(row.id))
-        || !files.some(row => row.id === fileId)) return failure('slack_file_completion_unconfirmed', 502, 'unknown');
+        || !files.some(row => row.id === fileId)) {
+        return { ...failure(SLACK_FILE_UNCONFIRMED, FILE_UNCONFIRMED_STATUS, 'unknown'), confirmation: 'unconfirmed' };
+    }
     const upload = { ...receipt('completed'), stage: 'completion' as const, state: 'completed' as const, fileId: reservedId };
     if (signal.aborted) return { ok: false, sent: true, retryable: false, upload, error: 'slack_send_aborted', status: 499 };
-    return { ok: true, sent: true, retryable: false, upload };
+    return { ok: true, sent: true, retryable: false, upload, confirmation: 'confirmed' };
 }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -491,7 +491,14 @@ async function telegramSendHandler(req: ChannelSendRequest): Promise<TransportSe
                 return { ok: false, error: j['ok'] === false ? String(j['error'] || 'hub outbound failed')
                     : 'telegram_hub_body_delivery_unconfirmed', status: 502 };
             }
-            return j['ok'] ? { ok: true, via: 'hub', type: req.type } : { ok: false, error: String(j['error'] || 'hub outbound failed'), status: 502 };
+            // The hub reports an unconfirmed file upload the same way a local
+            // send does. Forwarding that word is what lets sendChannelOutput
+            // still claim the caption, instead of the dispatch path posting it a
+            // second time next to a file that probably did arrive.
+            const hubConfirmation = j['confirmation'] === 'unconfirmed' || j['confirmation'] === 'confirmed'
+                ? { confirmation: j['confirmation'] } : {};
+            return j['ok'] ? { ok: true, via: 'hub', type: req.type, ...hubConfirmation }
+                : { ok: false, error: String(j['error'] || 'hub outbound failed'), status: 502, ...hubConfirmation };
         } catch (e) {
             return { ok: false, error: (e as Error).message, status: 502 };
         }

--- a/src/telegram/telegram-file.ts
+++ b/src/telegram/telegram-file.ts
@@ -5,6 +5,10 @@ import { log } from '../core/logger.js';
 import { redactOutboundText, logErrorText, userErrorText } from '../messaging/redact.js';
 import { abortableDelay } from '../messaging/outbound-lifecycle.js';
 import { deliveryFailed, deliverySent, type LiveDeliveryFields } from '../messaging/delivery-outcome.js';
+import { classifySendFailure, retryAfterMs as vendorRetryAfterMs } from '../messaging/retry.js';
+import {
+    FILE_UNCONFIRMED_STATUS, TELEGRAM_FILE_UNCONFIRMED, type FileConfirmation,
+} from '../messaging/file-receipt.js';
 
 interface TelegramApiErrorLike {
     error_code?: number;
@@ -74,7 +78,9 @@ function isTransient(err: unknown): boolean {
 }
 
 function getRetryAfterMs(err: unknown): number {
-    return (asTgErr(err).parameters?.retry_after ?? 0) * 1000;
+    // Delegates to the shared reader so the file path honours the same hints
+    // the text path does.
+    return vendorRetryAfterMs(err);
 }
 
 /** Determine upstream error category for HTTP response code. */
@@ -98,8 +104,13 @@ export async function sendTelegramFile(
     filePath: string,
     type: string,
     opts?: { caption?: string; threadId?: number; signal?: AbortSignal },
-): Promise<{ ok: boolean; attempts: number; error?: string; retryAfter?: number; statusCode?: number }
-    & Partial<LiveDeliveryFields>> {
+): Promise<{
+    ok: boolean; attempts: number; error?: string; retryAfter?: number; statusCode?: number;
+    /** Present once a send was actually attempted. Absent on a local refusal
+     *  (missing file, size limit), which delivered nothing and is not
+     *  "unconfirmed" in any useful sense. */
+    confirmation?: FileConfirmation;
+} & Partial<LiveDeliveryFields>> {
     // Validate here, not at the call sites. The Hub's outbound relay calls this
     // transport directly and skipped the check, which is how an empty document
     // still reached the API after the guard was added.
@@ -137,14 +148,42 @@ export async function sendTelegramFile(
                 default:
                     return { ok: false, attempts: attempt, error: `unsupported type: ${type}`, statusCode: 400, ...deliveryFailed(null) };
             }
+            // A Message with no usable id is not a delivered file. Telegram
+            // documents message_id 0 as an ephemeral or server-scheduled
+            // message that "will be unusable until it is actually sent", so a
+            // zero is evidence AGAINST delivery rather than weak evidence for
+            // it — and the old `String(rawId)` recorded it as a real id.
+            //
+            // A positive message_id is sufficient on its own. The media file_id
+            // is a reuse handle, not proof this chat received anything, and
+            // requiring it as well would report a truncated Message as
+            // unconfirmed for a send that did land.
             const rawId = (sentMessage as { message_id?: unknown } | undefined)?.message_id;
-            return { ok: true, attempts: attempt,
-                ...deliverySent(typeof rawId === 'number' || typeof rawId === 'string' ? String(rawId) : null) };
+            const messageId = typeof rawId === 'number' && Number.isFinite(rawId) && rawId > 0 ? String(rawId)
+                : typeof rawId === 'string' && rawId.trim() && rawId.trim() !== '0' ? rawId.trim()
+                : null;
+            if (messageId === null) {
+                return {
+                    ok: false, attempts: attempt, confirmation: 'unconfirmed',
+                    error: TELEGRAM_FILE_UNCONFIRMED, statusCode: FILE_UNCONFIRMED_STATUS,
+                    ...deliveryFailed(null, { ambiguous: true }),
+                };
+            }
+            return { ok: true, attempts: attempt, confirmation: 'confirmed', ...deliverySent(messageId) };
         } catch (err: unknown) {
             const e = asTgErr(err);
-            const transient = isTransient(err);
+            // 429 is decided by the shared classifier so the file path and the
+            // text path (messaging/retry.ts) agree on what a rate limit is; it
+            // recognises statusCode/status 429 and a bare retry_after, which the
+            // local error_code check misses. Everything else — 5xx, HttpError,
+            // ETIMEDOUT/ECONNRESET/ECONNREFUSED/EPIPE — stays with isTransient,
+            // because the shared classifier folds those into 'ambiguous' and
+            // routing the retry decision through it would stop retrying them.
+            const rateLimited = classifySendFailure(err) === 'rate-limit';
+            const transient = isTransient(err) || rateLimited;
             if (!transient || attempt === MAX_RETRIES) {
-                const sc = transient ? classifyUpstreamError(err) : (e.error_code || e.statusCode || 500);
+                const sc = rateLimited ? 429
+                    : transient ? classifyUpstreamError(err) : (e.error_code || e.statusCode || 500);
                 log.error(`[telegram:file] failed after ${attempt} attempt(s):`, logErrorText(err));
                 return stripUndefined({
                     ok: false, attempts: attempt,
@@ -152,7 +191,7 @@ export async function sendTelegramFile(
                     // credential sink in its own right — grammY puts the Bot
                     // API URL, token and all, in some error messages.
                     error: userErrorText(err) || 'unknown error',
-                    retryAfter: e.error_code === 429 ? e.parameters?.retry_after : undefined,
+                    retryAfter: rateLimited ? e.parameters?.retry_after : undefined,
                     statusCode: sc,
                 });
             }

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -196,7 +196,7 @@ cli-jaw/
 │   │   └── events.ts         ← legacy re-export stub → events/ 모듈 (15L)
 │   ├── messaging/            ← 통합 메시징 런타임 (33 files)
 │   │   ├── runtime.ts        ← 채널 lifecycle (init/shutdown/restart) + transport registry (333L)
-│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (551L)
+│   │   ├── send.ts           ← 통합 아웃바운드 메시지 라우팅 (ChannelSendRequest, 다중 채널 send 지원, 턴 주소 우선순위) (562L)
 │   │   ├── turn-conversation.ts ← 턴이 답하는 대화 주소 encode/decode + 채널 매칭 (60L) ✨
 │   │   ├── turn-delivery.ts  ← 에이전트 자가 전송 claim (턴 앵커 + digest, 소비형) → dispatch 중복 게시 억제 (252L) ✨
 │   │   ├── dedupe.ts         ← 배달 중복 제거 (TTL seen-set, 미만료 항목 보존) (118L) ✨
@@ -226,6 +226,7 @@ cli-jaw/
 │   │   ├── queue-notice.ts   ← queue-notice lifecycle (deferred close + bind race drain + bounded shutdown registry) (208L)
 │   │   ├── forwarder-origin.ts ← channel forwarder 공통 origin 필터 (own channel + producer-owned heartbeat skip) (39L)
 │   │   ├── native-body.ts    ← native runtime terminal 태그 술어 + 배달 정책 래퍼 (3봇+collector 공유) (32L) ✨
+│   │   ├── file-receipt.ts   ← 파일 전송 confirmation 어휘 (confirmed|unconfirmed) + 채널별 unconfirmed 에러코드 (49L) ✨
 │   │   ├── queue-notice-record.ts ← durable notice 기록 best-effort 래퍼 factory (channel+logPrefix) (59L) ✨
 │   │   ├── target-reply-guard.ts ← standing target-reply 공통 admission (accept identity 데이터화 + 주소 검증) (102L) ✨
 │   │   ├── channel-adapter.ts ← ChannelAdapter contract (130L)
@@ -335,21 +336,21 @@ cli-jaw/
 │   ├── telegram/             ← Telegram 인터페이스 (11 files)
 │   │   ├── reactions.ts     ← ACK reaction transport + ReactionTypeEmoji allowlist + notice transport (186L)
 │   │   ├── ipv4-fetch.ts    ← IPv4 fetch factory that honours init.signal (destroys on abort) (106L)
-│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1415L)
+│   │   ├── bot.ts            ← Telegram 봇 + forwarder lifecycle + origin 필터링 + channel-origin text/image reply + elicitation callback + voice 핸들러 등록 (1422L)
 │   │   ├── voice.ts          ← 음성 메시지 → guarded download → STT → tgOrchestrate 파이프라인 (43L)
 │   │   ├── forwarder.ts      ← text 전송 뒤 guarded local-image photo relay + escape/chunk/createForwarder (247L)
 │   │   ├── rich-message.ts   ← Bot API 10.1 rich-first send (sendTelegramMarkdown, 32k chunk, HTML/plaintext fallback) (425L)
 │   │   ├── elicitation-buttons.ts ← single_select elicitation → inline keyboard + pending store + callback codec (110L)
 │   │   ├── hub-callback.ts   ← hub-member callback URL SSRF guard (19L)
-│   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (192L)
+│   │   └── telegram-file.ts  ← Telegram 파일 전송 + 재시도 + 사이즈 검증 (231L)
 │   ├── discord/              ← Discord 인터페이스 (8 files)
-│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1030L)
+│   │   ├── bot.ts            ← Discord 봇 + transport 등록 + message/attachment 핸들러 + channel-origin image relay (1034L)
 │   │   ├── reactions.ts   ← ACK reaction transport + cancellable notice REST (122L)
 │   │   ├── commands.ts       ← Discord slash command 등록 + 핸들러 (153L)
-│   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (232L) ✨
+│   │   ├── send-only-client.ts ← Discord send-only client (webhook/DM fallback) (257L) ✨
 │   │   ├── channel-types.ts  ← Discord channel type helpers (50L) ✨
 │   │   ├── forwarder.ts      ← Discord text chunk 포워딩 + guarded local-image attachment relay (98L)
-│   │   └── discord-file.ts   ← Discord 파일 전송 (80L)
+│   │   └── discord-file.ts   ← Discord 파일 전송 (107L)
 │   ├── slack/                ← Slack 인터페이스 (41 files, Socket Mode + Web API, SDK 없음)
 │   │   ├── socket.ts         ← Socket Mode client (apps.connections.open → wss, ack-before-work, envelope dedupe TTL, hello deadline, backoff 재연결) (437L)
 │   │   ├── bot.ts            ← Slack 봇 lifecycle + attachPort 성공 후 best-effort 자기선출/영속화 + envelope routing + orchestrate 경로 + queued-result waiter + top-level/thread 1회 context prefetch (1898L)
@@ -368,7 +369,7 @@ cli-jaw/
 │   │   ├── mention-watch.ts  ← 가입 채널 backward mention scan + frontier/resume/round-robin/429 stop/60-channel overflow (369L)
 │   │   ├── attachment-recovery.ts ← app_mention 봉투에 없는 첨부를 channel+ts 재조회로 복구 (oldest+inclusive+limit=1) (53L)
 │   │   ├── commands.ts       ← slash command → 공유 parseCommand/executeCommand 파이프라인 (180L)
-│   │   ├── slack-file.ts     ← files.getUploadURLExternal → upload → completeUploadExternal 3단계 업로드 (파일명·캡션 모두 아웃바운드 마스킹) (148L)
+│   │   ├── slack-file.ts     ← files.getUploadURLExternal → upload → completeUploadExternal 3단계 업로드 (파일명·캡션 모두 아웃바운드 마스킹) (158L)
 │   │   ├── ingress.ts        ← 세션별 ingress lane + synthetic top-level followup override + admitSlackRun 동기 실행 예약(sessionLanes) + 전역 다운로드 세마포어 + shutdown abort/drain (300L) ✨
 │   │   ├── inbound-file.ts   ← 인바운드 첨부 단일 IO owner (files.info → 인증 스트리밍 다운로드 → saveUpload, 파일/메시지 바이트 예산, 고정 error code) (280L) ✨
 │   │   ├── inbound-url.ts    ← 인바운드 다운로드 URL 검증 (Slack host allowlist + https-only hop + 사설망 거부) (44L) ✨
@@ -433,7 +434,7 @@ cli-jaw/
 │   │   ├── orchestrate.ts    ← IPABCD reset/state/workers/worker-runs/snapshot/queue cancel/queue steer async accept/dispatch/virtual dispatch/batch safe summary/worker result/state PUT 라우트 + Phase60 boss-token actor distinction + --attest body gate + single-use pendingAttestation null-clear (1328L)
 │   │   ├── memory.ts         ← memory status/KV/files/settings 라우트 (193L)
 │   │   ├── settings.ts       ← settings/prompt/project pick/git summary/heartbeat-md/MCP/registry/status/quota/copilot + Pi profile register/model discovery 라우트 + CLI_KEYS 기반 quota parity/status-only metadata (738L)
-│   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (601L)
+│   │   ├── messaging.ts      ← upload/file-open/voice/telegram/channel/discord send 라우트 (612L)
 │   │   ├── avatar.ts         ← Agent/User 아바타 이미지 업로드/서빙/삭제 + settings.json 메타 저장 + safeResolveUnder 경로 보호 (147L)
 │   │   ├── quota.ts          ← Copilot/Claude/Codex/Grok/OpenCode quota helper readers + Grok weekly credits + credential-scoped Claude cache (634L)
 │   │   ├── quota-native-window.ts ← Codex duration-aware and Claude model-scoped quota parsers (122L)

--- a/tests/unit/discord-file.test.ts
+++ b/tests/unit/discord-file.test.ts
@@ -9,6 +9,76 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..', '..');
 const discordFileSrc = readFileSync(join(projectRoot, 'src/discord/discord-file.ts'), 'utf8');
 
+// ─── Confirmation (#700) ─────────────────────────────
+// Discord documents Create Message as returning the created message object;
+// 204 No Content is documented only for reactions, deletes and unpin. So an
+// answer with no message id on a file POST did not come from Discord, and
+// reporting it as a delivered upload is the same hole Slack closed by demanding
+// the reserved file id back.
+//
+// The gateway fallback is exercised here because it needs no HTTP: it runs
+// whenever the client has no token.
+
+const gatewayClient = (send: (payload: unknown) => Promise<unknown>) => ({
+    token: null,
+    channels: { fetch: async () => ({ send }) },
+}) as never;
+
+const fileTarget = {
+    channel: 'discord', targetKind: 'channel', peerKind: 'channel', targetId: 'C1',
+} as never;
+
+test('DCF-700a: a gateway send that returns a Message id is confirmed', async () => {
+    const { sendDiscordFile } = await import('../../src/discord/discord-file.js');
+    const tmp = join(projectRoot, 'package.json');
+    const r = await sendDiscordFile(gatewayClient(async () => ({ id: '123456789' })), fileTarget, tmp);
+    assert.equal(r.ok, true);
+    assert.equal(r.confirmation, 'confirmed');
+    assert.equal(r.platformMessageId, '123456789');
+    assert.equal(r.ambiguous, false);
+});
+
+test('DCF-700b: a gateway send that names nothing is unconfirmed, not success', async () => {
+    const { sendDiscordFile } = await import('../../src/discord/discord-file.js');
+    const tmp = join(projectRoot, 'package.json');
+    for (const reply of [undefined, null, {}, { id: '' }, { id: 42 }, 'ok']) {
+        const r = await sendDiscordFile(gatewayClient(async () => reply), fileTarget, tmp);
+        assert.equal(r.ok, false, JSON.stringify(reply ?? null));
+        assert.equal(r.confirmation, 'unconfirmed', JSON.stringify(reply ?? null));
+        assert.equal(r.error, 'discord_file_send_unconfirmed');
+        assert.equal(r.status, 502);
+        assert.equal(r.ambiguous, true);
+    }
+});
+
+test('DCF-700c: a throwing gateway send is a plain failure, NOT unconfirmed', async () => {
+    // sendChannelOutput lets an unconfirmed send keep its caption claim. A real
+    // rejection delivered nothing, so it must not borrow that exception.
+    const { sendDiscordFile } = await import('../../src/discord/discord-file.js');
+    const tmp = join(projectRoot, 'package.json');
+    const r = await sendDiscordFile(gatewayClient(async () => { throw new Error('nope'); }), fileTarget, tmp);
+    assert.equal(r.ok, false);
+    assert.equal(r.confirmation, undefined);
+});
+
+test('DCF-700d: the REST branch forwards confirmation instead of collapsing to { ok, error }', async () => {
+    // The connected-client path is the normal one in production. It used to
+    // return only { ok, error } on failure, which threw the flag away exactly
+    // where sendChannelOutput needed it.
+    assert.match(discordFileSrc, /confirmation: rest\.confirmation/,
+        'the REST failure branch must carry the confirmation through');
+});
+
+test('DCF-700e: 204 rejection lives in sendDiscordFileRest, not in the scheduler', async () => {
+    // 204 IS the documented success for the reaction/delete/unpin routes the
+    // scheduler also serves, so the rejection cannot live there.
+    const restSrc = readFileSync(join(projectRoot, 'src/discord/send-only-client.ts'), 'utf8');
+    const schedulerSrc = readFileSync(join(projectRoot, 'src/discord/rest-scheduler.ts'), 'utf8');
+    assert.match(restSrc, /DISCORD_FILE_UNCONFIRMED/, 'the file send must own the unconfirmed verdict');
+    assert.ok(!/DISCORD_FILE_UNCONFIRMED|unconfirmed/.test(schedulerSrc),
+        'the shared REST scheduler must stay out of this decision');
+});
+
 // ─── File size guard ─────────────────────────────────
 
 test('DISCORD_LIMITS defines 10 MiB cap', () => {

--- a/tests/unit/discord-rest-scheduler.test.ts
+++ b/tests/unit/discord-rest-scheduler.test.ts
@@ -589,7 +589,13 @@ test('send-only multipart retries build distinct FormData, Blob, and boundaries'
         forms.push(init.body);
         return forms.length === 1
             ? rateResponse({ retryAfter: '0.001' })
-            : new Response(null, { status: 204 });
+            // A real Create Message answers with the created message object.
+            // This case is about multipart retry mechanics, so it needs a
+            // SUCCESSFUL second attempt; 204 no longer is one for a file send
+            // (#700), and standing in with it would test the wrong thing.
+            : new Response(JSON.stringify({ id: '900001' }), {
+                status: 200, headers: { 'content-type': 'application/json' },
+            });
     }) as typeof fetch;
     try {
         const result = await sendDiscordFileRest('token', 'channel', filePath, 'caption');
@@ -605,6 +611,31 @@ test('send-only multipart retries build distinct FormData, Blob, and boundaries'
         assert.match(firstType ?? '', /^multipart\/form-data; boundary=/);
         assert.match(secondType ?? '', /^multipart\/form-data; boundary=/);
         assert.notEqual(firstType, secondType);
+    } finally {
+        invalidateDiscordSendClient();
+        globalThis.fetch = realFetch;
+        await rm(directory, { recursive: true, force: true });
+    }
+});
+
+test('a file POST answered with 204 is unconfirmed, not a delivered upload', async () => {
+    // 204 IS the documented success for the reaction, delete and unpin routes
+    // this same scheduler serves, so the scheduler still reports ok. Create
+    // Message is documented to return the created message object, so an empty
+    // body there did not come from Discord — and the FILE SEND is where that
+    // verdict is made (#700).
+    invalidateDiscordSendClient();
+    const directory = await mkdtemp(join(tmpdir(), 'cli-jaw-discord-rest-'));
+    const filePath = join(directory, 'sample.bin');
+    await writeFile(filePath, Buffer.from('body'));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(null, { status: 204 })) as typeof fetch;
+    try {
+        const result = await sendDiscordFileRest('token', 'channel', filePath, 'caption');
+        assert.equal(result.ok, false);
+        assert.equal(result.confirmation, 'unconfirmed');
+        assert.equal(result.error, 'discord_file_send_unconfirmed');
+        assert.equal(result.status, 502);
     } finally {
         invalidateDiscordSendClient();
         globalThis.fetch = realFetch;

--- a/tests/unit/telegram-file.test.ts
+++ b/tests/unit/telegram-file.test.ts
@@ -23,7 +23,12 @@ function tmpFile(sizeMB: number): string {
 
 function cleanup(p: string) { try { fs.unlinkSync(p); } catch { /* ignore */ } }
 
-function mockBot({ failTimes = 0, errorCode = 429, retryAfter = 0, useHttpError = false } = {}) {
+// A real Telegram send answers with the created Message. `messageId` is what
+// decides confirmation, so it is a knob here: 0 is the vendor's own "scheduled,
+// not actually sent yet" value and null stands for a reply that carried no id
+// at all — an intermediary, not Telegram.
+function mockBot({ failTimes = 0, errorCode = 429, retryAfter = 0, useHttpError = false,
+    messageId = 555 as number | null } = {}) {
     let calls = 0;
     return {
         calls: () => calls,
@@ -43,7 +48,7 @@ function mockBot({ failTimes = 0, errorCode = 429, retryAfter = 0, useHttpError 
                     if (retryAfter) err.parameters = { retry_after: retryAfter };
                     throw err;
                 }
-                return { ok: true };
+                return messageId === null ? { ok: true } : { ok: true, message_id: messageId };
             },
             async sendVoice(c: any, f: any, o?: any) { return this.sendDocument(c, f, o); },
             async sendPhoto(c: any, f: any, o?: any) { return this.sendDocument(c, f, o); },
@@ -92,7 +97,107 @@ test('sendTelegramFile: succeeds on first attempt', async () => {
         const r = await sendTelegramFile(bot, 123, f, 'document');
         assert.equal(r.ok, true);
         assert.equal(r.attempts, 1);
+        assert.equal(r.confirmation, 'confirmed');
+        assert.equal(r.platformMessageId, '555');
+        assert.equal(r.ambiguous, false);
     } finally { cleanup(f); }
+});
+
+// ─── sendTelegramFile: confirmation (#700) ────────────
+// Telegram's docs: message_id is "0 for ephemeral messages ... the relevant
+// message will be unusable until it is actually sent". The old code recorded
+// String(0) as a real id, so a message the vendor said was not sent yet was
+// reported as a delivered upload — the same hole Slack closed by requiring the
+// files[] echo back.
+
+test('TGF-700a: a reply with no message_id is unconfirmed, not success', async () => {
+    const bot = mockBot({ messageId: null });
+    const f = tmpFile(0);
+    try {
+        const r = await sendTelegramFile(bot, 123, f, 'document');
+        assert.equal(r.ok, false);
+        assert.equal(r.confirmation, 'unconfirmed');
+        assert.equal(r.error, 'telegram_file_send_unconfirmed');
+        assert.equal(r.statusCode, 502);
+        assert.equal(r.ambiguous, true);
+        assert.equal(r.platformMessageId, null);
+        assert.equal(r.attempts, 1, 'an unconfirmed reply is not a transport error to retry');
+    } finally { cleanup(f); }
+});
+
+test('TGF-700b: message_id 0 is unconfirmed, because the vendor says it is not sent yet', async () => {
+    const bot = mockBot({ messageId: 0 });
+    const f = tmpFile(0);
+    try {
+        const r = await sendTelegramFile(bot, 123, f, 'document');
+        assert.equal(r.ok, false);
+        assert.equal(r.confirmation, 'unconfirmed');
+        assert.equal(r.platformMessageId, null);
+    } finally { cleanup(f); }
+});
+
+test('TGF-700c: a positive message_id alone confirms, without a media file_id', async () => {
+    // The media file_id is a reuse handle, not proof this chat received
+    // anything. Requiring it too would false-unconfirm a truncated Message.
+    for (const type of ['document', 'photo', 'voice']) {
+        const bot = mockBot({ messageId: 7 });
+        const f = tmpFile(0);
+        try {
+            const r = await sendTelegramFile(bot, 123, f, type);
+            assert.equal(r.ok, true, type);
+            assert.equal(r.confirmation, 'confirmed', type);
+            assert.equal(r.platformMessageId, '7', type);
+        } finally { cleanup(f); }
+    }
+});
+
+test('TGF-700d: a hard refusal is NOT labelled unconfirmed', async () => {
+    // sendChannelOutput lets an unconfirmed send keep its caption claim. A 400
+    // delivered nothing, so it must not borrow that exception.
+    const bot = mockBot({ failTimes: 3, errorCode: 400 });
+    const f = tmpFile(0);
+    try {
+        const r = await sendTelegramFile(bot, 123, f, 'document');
+        assert.equal(r.ok, false);
+        assert.equal(r.confirmation, undefined);
+    } finally { cleanup(f); }
+});
+
+test('TGF-700e: 429 is classified by the shared classifier, including a bare retry_after', async () => {
+    // messaging/retry.ts recognises a retry_after with no error_code; the local
+    // check never did. Retrying it is the point: the send is still repeatable.
+    const bot = (() => {
+        let calls = 0;
+        return { calls: () => calls, api: {
+            async sendDocument(_c: any, _f: any, _o?: any) {
+                calls++;
+                if (calls === 1) { const e: any = new Error('slow down'); e.parameters = { retry_after: 1 }; throw e; }
+                return { ok: true, message_id: 9 };
+            },
+            async sendVoice(c: any, f: any, o?: any) { return this.sendDocument(c, f, o); },
+            async sendPhoto(c: any, f: any, o?: any) { return this.sendDocument(c, f, o); },
+        } };
+    })();
+    const f = tmpFile(0);
+    try {
+        const r = await sendTelegramFile(bot as never, 123, f, 'document');
+        assert.equal(r.ok, true);
+        assert.equal(r.attempts, 2, 'a bare retry_after must still be retried');
+    } finally { cleanup(f); }
+});
+
+test('TGF-700f: 5xx and socket errors still retry after the 429 move', async () => {
+    // classifySendFailure folds these into 'ambiguous'; routing the whole retry
+    // decision through it would have stopped retrying them.
+    for (const opts of [{ errorCode: 500 }, { useHttpError: true }]) {
+        const bot = mockBot({ failTimes: 1, ...opts });
+        const f = tmpFile(0);
+        try {
+            const r = await sendTelegramFile(bot, 123, f, 'document');
+            assert.equal(r.ok, true, JSON.stringify(opts));
+            assert.equal(r.attempts, 2, JSON.stringify(opts));
+        } finally { cleanup(f); }
+    }
 });
 
 // ─── sendTelegramFile: retry on 429 ───────────────────

--- a/tests/unit/telegram-thread-aware.test.ts
+++ b/tests/unit/telegram-thread-aware.test.ts
@@ -20,8 +20,14 @@ const tgt = (threadId?: string) =>
 
 function botSpy() {
     const calls: Array<{ method: string; opts: Record<string, unknown> }> = [];
+    // Telegram answers a file send with the created Message. Returning nothing
+    // made the spy a worse imitation of the vendor than it looks: since #700 a
+    // reply with no usable message_id is an UNCONFIRMED send, so these cases
+    // would fail on their fixture rather than on their subject, which is
+    // whether message_thread_id rides along.
     const mk = (method: string) => async (_chatId: unknown, _file: unknown, opts: Record<string, unknown>) => {
         calls.push({ method, opts });
+        return { message_id: 4242 };
     };
     return { calls, api: { sendVoice: mk('sendVoice'), sendPhoto: mk('sendPhoto'), sendDocument: mk('sendDocument') } };
 }


### PR DESCRIPTION
`ok` meant two different things depending on the channel. Slack refused a file upload whose completion did not echo the reserved file id back; Telegram and Discord reported the same situation as success with `ambiguous: true`, a flag no consumer read. This gives the three channels one word for it and makes the refusal consistent.

## What was actually missing

Not the reporting — the refusal. Telegram and Discord already emitted `ambiguous: true` through `deliverySent(null)`. What they did not do was decline to call it a delivery.

| | before | after |
| --- | --- | --- |
| Slack, completion with no `files[]` | `ok: false` | unchanged, plus `confirmation: 'unconfirmed'` |
| Telegram, no usable `message_id` | `ok: true`, `ambiguous: true` | `ok: false`, `confirmation: 'unconfirmed'` |
| Discord, empty/unreadable Create Message body | `ok: true`, `ambiguous: true` | `ok: false`, `confirmation: 'unconfirmed'` |

Both vendors document enough to decide this:

- **Telegram** ([Bot API](https://core.telegram.org/bots/api#sendphoto)) returns the sent Message, and `message_id` is *"0 for ephemeral messages … the relevant message will be unusable until it is actually sent"*. The old code did `String(rawId)`, so a message the vendor had just said was not sent yet was recorded as a real id. A zero is not weak evidence for delivery, it is evidence against it.
- **Discord** ([Create Message](https://discord.com/developers/docs/resources/message)) *"Returns a message object."* 204 No Content is documented only for reactions, deletes and unpin. An empty body on a message POST means something other than Discord answered — the same threat Slack's `files[]` rule exists to refuse.

## Corrections to the issue body

The issue was written against `b5ea3c0ab`. Two claims are out of date:

- **"Discord does not parse a message/attachment id"** — the REST path already parses `body.id` via `parseDiscordMessageId`. Only the gateway fallback discarded the Message entirely; that is fixed here.
- **"TG/DC only have weak proof"** — half true. Both already reported `ambiguous`. What was absent was the rejection.

Also: `telegramDeliveryError` is marked TEST-ONLY in its own comment and has no production caller, so "it is not wired to the file path" is true but not the lever. The 429 work goes through `classifySendFailure` instead.

## Where the rejection lives, and where it deliberately does not

Discord's 204 refusal is inside `sendDiscordFileRest`, **not** in `DiscordRestScheduler` and not in the shared `sendResult`. Both of those also serve Discord text sends and the reaction/delete/unpin routes, where 204 genuinely is the documented success. Putting the verdict in the scheduler would have broken those.

Only the 429 decision moves to `classifySendFailure`. That classifier folds 5xx, `HttpError` and `ETIMEDOUT`/`ECONNRESET`/`ECONNREFUSED`/`EPIPE` into `ambiguous`, so routing the whole retry predicate through it would have silently stopped retrying them. `isTransient` keeps those classes; the move only widens 429 detection to include a bare `retry_after`.

## The part that makes strict safe

Refusing an unconfirmed send is only correct if the refusal does not also drop the caption.

`sendChannelOutput` records caption self-delivery on `fromAgentSurface && ok !== false`. Flipping unconfirmed to `ok: false` would skip that claim, and the dispatch path would then post the same words **again**, beside a file that had most likely arrived. The gate is now `ok !== false || unconfirmed`, for both the self-delivery claim and the outbound stamp. A hard refusal — 400, 413, auth — is deliberately not admitted, because it delivered nothing and the turn's own answer still has to be posted.

That exception only works if the flag survives the trip, and four places were folding it away. Each gets a one-field forward and nothing else:

- `src/discord/discord-file.ts` — the REST branch collapsed a failure to `{ ok, error }`. This is the path that runs whenever a gateway client is connected, i.e. the normal one.
- `src/discord/bot.ts` `discordSendHandler` — dropped it on the success path.
- `src/manager/telegram-hub/hub-bot.ts` `sendToTopic` and `src/manager/routes/telegram-hub.ts` — the hub relay folded the result to `{ ok, error }` and its route rebuilt the body without it, so the member instance could never see it. `confirmation` now rides through exactly as `bodyDelivered` already does.
- `src/routes/messaging.ts` legacy `POST /api/telegram/send` — gated the caption claim on bare `result.ok`. This route is still advertised to agents in `a1-system.md`/`employee.md`, so leaving it would have made this change *worse* than the status quo on a live path.

The last two files are outside this worktree's normal scope; they were leased for confirmation-forwarding only, and no other behaviour in them is touched.

## NOT COVERED BY CI

- **No live channel.** CI has no Slack, Telegram or Discord credentials or network. Everything here is proven against fixtures and in-process mocks. That a real Telegram `sendPhoto` or a real Discord Create Message behaves as the docs describe is taken from the vendor documentation, not observed.
- **The hub relay is proven only in pieces.** `sendToTopic` → hub route → member `telegramSendHandler` is verified by reading, not by an end-to-end test: there is no harness that runs a hub and a member instance together.
- **The caption double-post it prevents is argued, not reproduced.** No test drives a real unconfirmed upload through `sendChannelOutput` and then a dispatch post to show the duplicate disappearing. The unit tests pin the transports' verdicts and the gate's inputs separately.
- **Discord's REST unconfirmed branch is covered by a source assertion, not a live REST mock.** The behavioural Discord tests exercise the gateway fallback, which needs no HTTP; the REST branch's forwarding is asserted structurally.
- **Frequency is unknown.** How often a real deployment sees a 204 from Discord or a zero `message_id` from Telegram is not measured here. If an intermediary in some deployment routinely answers this way, those sends now surface as failures where they previously passed silently — which is the intent, but it is a visible change.
- **No local suite was run.** Per the task's instructions `npm test`, `npm run build`, `npx tsc` and `npm install` were not executed; the push used `--no-verify`. `node scripts/check-private-boundary.mjs` passed for both the index and the outgoing range. Type checking and the unit suite are proven only by `ci-aggregate` on this PR.

Closes #700



## Tests that broke, and why

Both failures were fixtures pinning the behaviour this change removes. Neither was a regression introduced here.

- `tests/unit/discord-rest-scheduler.test.ts` — *"send-only multipart retries build distinct FormData, Blob, and boundaries"*. The case is about multipart retry mechanics and used `204` only as a convenient success for the second attempt. A file POST answered with 204 is now unconfirmed, so the stand-in no longer means what the case needs; the retry now returns a real message object. A separate case pins the 204 verdict on its own. **Old contract, not a regression.**
- `tests/unit/telegram-thread-aware.test.ts` — *"sendTelegramFile threads message_thread_id when provided"*. The spy recorded the call and returned nothing, which is a worse imitation of Telegram than it looks: the vendor always answers with the created Message. The fixture now returns one. The assertions are unchanged, and the subject of the case — whether `message_thread_id` rides along — is untouched. **Old contract, not a regression.**

Two earlier type errors were real defects in this change and were fixed: `sendToTopic`'s declared return type did not carry the field it forwards, and `isUnconfirmedSend` used a structural parameter type, which trips TypeScript's weak-type check against results whose fields are all optional.

## Files touched outside the usual channel scope

Each is a single-field forward, leased for that purpose, with no other behaviour changed: `src/manager/telegram-hub/hub-bot.ts`, `src/manager/routes/telegram-hub.ts`, `src/routes/messaging.ts`. They are here rather than in a follow-up because leaving them would make this change worse than the status quo on those paths — the caption would post twice.

