### PR TITLE
fix(adaptive-fetch): make the live-smoke manifest answerable to the resolver

### DIFF
--- a/src/browser/adaptive-fetch/endpoint-resolvers.ts
+++ b/src/browser/adaptive-fetch/endpoint-resolvers.ts
@@ -340,11 +340,40 @@ function naverFinanceCandidates(url: URL): CandidateUrl[] {
     if (url.hostname !== 'finance.naver.com') return [];
     const code = url.searchParams.get('code');
     if (!code || !/^[A-Z0-9]{4,12}$/i.test(code)) return [];
+    // #694: the window used to be frozen at a fixed pair of calendar dates, so
+    // every session past the hardcoded end would have been silently cut off.
+    // The endpoint is the Korean exchange, so the window is computed on the
+    // Seoul calendar, and the end runs a day ahead so no offset can truncate
+    // the newest session. Korea has no DST, so a fixed +9h shift is exact.
+    const now = Date.now();
+    const start = seoulTwoYearsBack(now);
+    const end = seoulYyyymmdd(now + 24 * 60 * 60 * 1000);
     return [{
         label: 'naver-finance-json',
-        url: `https://api.finance.naver.com/siseJson.naver?symbol=${encodeURIComponent(code)}&requestType=1&startTime=20240101&endTime=20261231&timeframe=day`,
+        url: `https://api.finance.naver.com/siseJson.naver?symbol=${encodeURIComponent(code)}&requestType=1&startTime=${start}&endTime=${end}&timeframe=day`,
         source: 'public_endpoint',
     }];
+}
+
+const SEOUL_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/** YYYYMMDD on the Seoul calendar. */
+function seoulYyyymmdd(epochMs: number): string {
+    const shifted = new Date(epochMs + SEOUL_OFFSET_MS);
+    const month = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(shifted.getUTCDate()).padStart(2, '0');
+    return `${shifted.getUTCFullYear()}${month}${day}`;
+}
+
+/**
+ * Two Seoul years back. Subtracting from the year field directly would emit a
+ * 29 February in a year that has none; routing through Date.UTC rolls that to
+ * 1 March instead of producing a date that never existed.
+ */
+function seoulTwoYearsBack(epochMs: number): string {
+    const shifted = new Date(epochMs + SEOUL_OFFSET_MS);
+    const rolled = Date.UTC(shifted.getUTCFullYear() - 2, shifted.getUTCMonth(), shifted.getUTCDate());
+    return seoulYyyymmdd(rolled - SEOUL_OFFSET_MS);
 }
 
 function mediumCandidates(url: URL): CandidateUrl[] {

--- a/src/browser/adaptive-fetch/live-smoke-manifest.ts
+++ b/src/browser/adaptive-fetch/live-smoke-manifest.ts
@@ -7,14 +7,16 @@ export interface LiveSmokeManifestEntry {
     reason: string;
 }
 
-export const LIVE_SMOKE_MANIFEST_VERSION = 1;
+export const LIVE_SMOKE_MANIFEST_VERSION = 2;
 
 export const LIVE_SMOKE_MANIFEST: LiveSmokeManifestEntry[] = [
     {
         id: 'npm-public-endpoint',
         url: 'https://www.npmjs.com/package/cli-jaw',
-        expectedLabels: ['npm-registry', 'direct-fetch'],
-        expectedEvidence: ['public-endpoint:npm-registry'],
+        // The resolver emits npm-registry-latest first for a versionless
+        // package URL, so that is the label the live run would actually use.
+        expectedLabels: ['npm-registry-latest', 'npm-registry', 'direct-fetch'],
+        expectedEvidence: ['public-endpoint:npm-registry-latest'],
         browserMode: 'auto',
         reason: 'package registry public endpoint drift check',
     },
@@ -53,24 +55,24 @@ export const LIVE_SMOKE_MANIFEST: LiveSmokeManifestEntry[] = [
     {
         id: 'arxiv-public-api',
         url: 'https://arxiv.org/abs/2301.00001',
-        expectedLabels: ['arxiv-oai-xml', 'direct-fetch'],
-        expectedEvidence: ['public-endpoint:arxiv-oai-xml'],
+        expectedLabels: ['arxiv-api', 'direct-fetch'],
+        expectedEvidence: ['public-endpoint:arxiv-api'],
         browserMode: 'auto',
-        reason: 'arXiv OAI API reader drift check',
+        reason: 'arXiv API reader drift check',
     },
     {
         id: 'stackoverflow-public-api',
         url: 'https://stackoverflow.com/questions/1',
-        expectedLabels: ['stackexchange-api', 'direct-fetch'],
-        expectedEvidence: ['public-endpoint:stackexchange-api'],
+        expectedLabels: ['stackexchange-question-api', 'direct-fetch'],
+        expectedEvidence: ['public-endpoint:stackexchange-question-api'],
         browserMode: 'auto',
         reason: 'StackExchange API reader drift check',
     },
     {
         id: 'wikipedia-public-api',
         url: 'https://en.wikipedia.org/wiki/Node.js',
-        expectedLabels: ['wikipedia-rest-api', 'direct-fetch'],
-        expectedEvidence: ['public-endpoint:wikipedia-rest-api'],
+        expectedLabels: ['wikipedia-summary-api', 'direct-fetch'],
+        expectedEvidence: ['public-endpoint:wikipedia-summary-api'],
         browserMode: 'auto',
         reason: 'Wikipedia REST API reader drift check',
     },

--- a/tests/unit/browser-adaptive-fetch-endpoints.test.ts
+++ b/tests/unit/browser-adaptive-fetch-endpoints.test.ts
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolvePublicEndpointCandidates } from '../../src/browser/adaptive-fetch/endpoint-resolvers.js';
 
 test('adaptive fetch resolves core public endpoint shapes', () => {
@@ -59,4 +62,73 @@ test('adaptive fetch keeps reddit json immutable and adds both Hacker News APIs'
         'hacker-news-item-api',
         'hacker-news-algolia-item-api',
     ]);
+});
+
+// #694: the Naver finance window was pinned to a fixed pair of calendar dates,
+// so it would have started truncating the newest sessions once the calendar
+// passed the hardcoded end.
+
+const resolverRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SEOUL_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function yyyymmdd(year: number, month: number, day: number): string {
+    return `${year}${String(month + 1).padStart(2, '0')}${String(day).padStart(2, '0')}`;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function seoulYyyymmddAt(epochMs: number): string {
+    const shifted = new Date(epochMs + SEOUL_OFFSET_MS);
+    return yyyymmdd(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate());
+}
+
+function seoulTwoYearsBackAt(epochMs: number): string {
+    const shifted = new Date(epochMs + SEOUL_OFFSET_MS);
+    const rolled = Date.UTC(shifted.getUTCFullYear() - 2, shifted.getUTCMonth(), shifted.getUTCDate());
+    return seoulYyyymmddAt(rolled - SEOUL_OFFSET_MS);
+}
+
+test('#694-E naver finance computes its window on the Seoul calendar', () => {
+    // The resolver reads its own clock, so bracket the call: if a Seoul
+    // midnight lands inside those microseconds, either answer is correct and
+    // the test must not flake on it.
+    const before = Date.now();
+    const candidates = resolvePublicEndpointCandidates('https://finance.naver.com/item/main.naver?code=005930');
+    const after = Date.now();
+
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0]?.label, 'naver-finance-json');
+
+    const params = new URL(candidates[0]!.url).searchParams;
+    const startTime = params.get('startTime') ?? '';
+    const endTime = params.get('endTime') ?? '';
+    assert.match(startTime, /^\d{8}$/);
+    assert.match(endTime, /^\d{8}$/);
+
+    // The end runs a Seoul day ahead so no offset can cut the newest session.
+    const ends = [seoulYyyymmddAt(before + DAY_MS), seoulYyyymmddAt(after + DAY_MS)];
+    assert.ok(ends.includes(endTime), `endTime ${endTime} is not the Seoul day after now (${ends.join(' or ')})`);
+
+    // Two Seoul years back, computed the same way the resolver computes it, so
+    // a constant that merely has the right year cannot pass.
+    const starts = [seoulTwoYearsBackAt(before), seoulTwoYearsBackAt(after)];
+    assert.ok(starts.includes(startTime), `startTime ${startTime} is not two Seoul years back (${starts.join(' or ')})`);
+
+    // And it must be a date that exists: a naive year subtraction produces a
+    // 29 February in years that have none.
+    const roundTrip = new Date(Date.UTC(
+        Number(startTime.slice(0, 4)),
+        Number(startTime.slice(4, 6)) - 1,
+        Number(startTime.slice(6)),
+    ));
+    assert.equal(roundTrip.getUTCMonth() + 1, Number(startTime.slice(4, 6)), 'startTime must be a real calendar date');
+    assert.equal(roundTrip.getUTCDate(), Number(startTime.slice(6)), 'startTime must be a real calendar date');
+});
+
+test('#694-F the resolver source carries no frozen calendar constant', () => {
+    const source = readFileSync(join(resolverRoot, 'src/browser/adaptive-fetch/endpoint-resolvers.ts'), 'utf8');
+    assert.equal(/startTime=\d/.test(source), false, 'the query must not carry a literal start date');
+    assert.equal(/endTime=\d/.test(source), false, 'the query must not carry a literal end date');
+    assert.match(source, /startTime=\$\{start\}/);
+    assert.match(source, /endTime=\$\{end\}/);
 });

--- a/tests/unit/browser-adaptive-fetch-live-smoke-manifest.test.ts
+++ b/tests/unit/browser-adaptive-fetch-live-smoke-manifest.test.ts
@@ -1,11 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getLiveSmokeManifest, LIVE_SMOKE_MANIFEST_VERSION } from '../../src/browser/adaptive-fetch/live-smoke-manifest.js';
+import { resolvePublicEndpointCandidates } from '../../src/browser/adaptive-fetch/endpoint-resolvers.js';
 import { validateFetchUrl } from '../../src/browser/adaptive-fetch/safety.js';
 
 test('live smoke manifest is default-off data with public known URLs only', () => {
     const manifest = getLiveSmokeManifest();
-    assert.equal(LIVE_SMOKE_MANIFEST_VERSION, 1);
+    assert.equal(LIVE_SMOKE_MANIFEST_VERSION, 2);
     assert.ok(manifest.length >= 4);
     for (const entry of manifest) {
         const parsed = validateFetchUrl(entry.url, { allowPrivateNetwork: false });
@@ -24,3 +28,73 @@ test('live smoke manifest returns defensive copies', () => {
     const second = getLiveSmokeManifest();
     assert.ok(!second[0]?.expectedLabels.includes('mutated'));
 });
+
+// #694: the manifest called itself a drift check but nothing compared it to the
+// resolver, so arxiv, stackexchange and wikipedia carried labels the resolver
+// has never produced. These make the manifest answerable to the code.
+//
+// Labels split in two. The resolver emits per-URL endpoint labels; the
+// scheduler and the browser ladder attach their own stage labels, which no
+// resolver call will ever return.
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const STAGE_LABELS = ['direct-fetch', 'jina-reader', 'browser-render', 'browser-metadata'];
+
+function resolverLabelsFor(url: string): Set<string> {
+    return new Set(resolvePublicEndpointCandidates(url).map(candidate => candidate.label));
+}
+
+test('#694-A every resolver-derived manifest label is actually produced for that URL', () => {
+    for (const entry of getLiveSmokeManifest()) {
+        const produced = resolverLabelsFor(entry.url);
+        for (const label of entry.expectedLabels) {
+            if (STAGE_LABELS.includes(label)) continue;
+            assert.ok(
+                produced.has(label),
+                `${entry.id}: expected label "${label}" is not produced by resolvePublicEndpointCandidates("${entry.url}"); the resolver returned [${[...produced].join(', ') || 'nothing'}]`,
+            );
+        }
+    }
+});
+
+test('#694-B a label the resolver does not produce must be a known stage label', () => {
+    for (const entry of getLiveSmokeManifest()) {
+        const produced = resolverLabelsFor(entry.url);
+        for (const label of entry.expectedLabels) {
+            assert.ok(
+                produced.has(label) || STAGE_LABELS.includes(label),
+                `${entry.id}: label "${label}" is neither resolver output nor a known stage label`,
+            );
+        }
+    }
+});
+
+test('#694-C the stage-label allowlist is grounded in a real label literal', () => {
+    // A bare substring search would pass on a comment, so match the quoted
+    // literal the producing module actually writes.
+    const sources = [
+        readFileSync(join(root, 'src/browser/adaptive-fetch/scheduler.ts'), 'utf8'),
+        readFileSync(join(root, 'src/browser/adaptive-fetch/browser-escalation.ts'), 'utf8'),
+    ].join('\n');
+    for (const label of STAGE_LABELS) {
+        assert.ok(
+            sources.includes(`'${label}'`),
+            `stage label "${label}" is not written by the scheduler or the browser ladder`,
+        );
+    }
+});
+
+test('#694-D every public-endpoint evidence names a label the entry expects', () => {
+    const prefix = 'public-endpoint:';
+    for (const entry of getLiveSmokeManifest()) {
+        for (const evidence of entry.expectedEvidence) {
+            if (!evidence.startsWith(prefix)) continue;
+            const label = evidence.slice(prefix.length);
+            assert.ok(
+                entry.expectedLabels.includes(label),
+                `${entry.id}: evidence "${evidence}" names a label the entry does not expect`,
+            );
+        }
+    }
+});
+


### PR DESCRIPTION
Follows #726, which merged into `dev` while this was in review, so the base is `dev` directly.

The manifest called itself a drift check, but nothing compared it to `resolvePublicEndpointCandidates`. Three entries carried labels the resolver has never produced, so a live run would have reported pass or fail against strings the code does not use:

| entry | manifest said | resolver produces |
| --- | --- | --- |
| arxiv | `arxiv-oai-xml` | `arxiv-api` |
| stackoverflow | `stackexchange-api` | `stackexchange-question-api` |
| wikipedia | `wikipedia-rest-api` | `wikipedia-summary-api` |

Walking every resolver label against all eleven entries confirmed those three are the only name mismatches. The resolver is the side that is right: `buildByLabel` branches on `arxiv-api` and `stackexchange-question-api`, `browser-adaptive-fetch-cli-contract.test.ts:32` requires `arxiv-api` in the normalizer source, and the public-reader tests already use all three. Renaming the resolver would break those instead.

## What changed

The manifest is corrected and `LIVE_SMOKE_MANIFEST_VERSION` goes to 2. The npm entry now expects `npm-registry-latest`, which is what the resolver emits first for a versionless package URL and what `browser-adaptive-fetch-public-readers.test.ts:219` already asserts.

Four tests make the manifest answerable to the code. `#694-A` requires every resolver-derived label to actually be produced for that entry's URL and prints the real resolver output when it is not. `#694-B` requires anything left over to be a known stage label. `#694-C` requires each of those four stage labels to appear as a quoted label literal in `scheduler.ts` or `browser-escalation.ts`, so the allowlist cannot quietly become a place to park a drifted name. `#694-D` requires every `public-endpoint:<label>` evidence string to name a label the entry expects.

The Naver finance window was pinned at `startTime=20240101&endTime=20261231` and would have started truncating recent sessions once the calendar passed that end. It is computed on the Seoul calendar now — two years back to one day ahead — and routed through `Date.UTC` so subtracting two years from a 29 February rolls to 1 March rather than emitting a date that never existed. `#694-E` brackets the resolver call with two clock reads and accepts either answer, so a Seoul midnight landing inside the call cannot make it flake. `#694-F` keeps a literal date out of the query entirely.

## Scope: this does not close #694

The issue has three completion conditions. This PR closes the first and the third. The second — normalizers for naver, medium, substack and linkedin — is a different kind of change (a bespoke parser for Naver's single-quoted `siseJson` array, plus fixtures) and ships as a follow-up PR on this same chain, which will carry the `Closes`. Hence `Refs` rather than `Closes` here.

Worth recording from that investigation: `isKnownPublicEndpointLabel` is not what blocks those four. `normalizePublicEndpointResult:34` only rejects when `source !== 'public_endpoint'`, and the resolver marks all of them `public_endpoint`, so they reach `buildByLabel` and fall out there instead.

## NOT COVERED BY CI

- **Nothing runs this manifest against the network.** There is still no live runner; the only consumers are the manifest itself and its test. What is now enforced is internal consistency between the manifest and the resolver, not that these URLs return the expected evidence in the wild.
- **The subset rule is `resolver(url) ∪ STAGE_LABELS`, not `resolver(url)` alone.** Read literally the issue's condition would fail every entry containing `direct-fetch`, because that label comes from `scheduler.ts:125` rather than any resolver. `#694-C` grounds the carve-out in real source literals, but it is a carve-out.
- **`browser-render`, `browser-metadata` and `third-party-reader:jina` in a live run.** Their producing code exists; whether a live fetch emits them is unverified.
- **The new Naver window against the real endpoint.** Whether `api.finance.naver.com` accepts a two-year span, and what it returns for it, needs the network.
- **`public-endpoint:medium-oembed` is still not produced.** `buildByLabel`'s oembed branch takes only `youtube-oembed`, `x-twitter-oembed` and `oembed-discovered`, so the medium entry's evidence is aspirational until the follow-up. `#694-D` checks that evidence names an expected label, not that the label has a normalizer.

Refs #694
