### PR TITLE
fix(db): PRAGMA user_version 스키마 마이그레이션 — 기존 홈이 import 크래시 없이 열린다

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -31,15 +31,47 @@ db.pragma('journal_mode = WAL');
 db.pragma('busy_timeout = 5000');
 db.pragma('foreign_keys = ON');
 
-db.exec(`
+// ─── Schema: one baseline + versioned migration steps ────
+//
+// `PRAGMA user_version` is the schema version. Everything a CURRENT database
+// must contain lives in the two baseline strings below; MIGRATIONS carries what
+// an EXISTING database still needs to reach that shape. The two have to agree,
+// and `assertSchemaComplete` is what makes disagreement loud: a column added
+// to the baseline without a matching migration step fails there BY NAME, instead
+// of killing the process at the first `db.prepare` further down (#691).
+//
+// Tables and indexes are separate on purpose. `CREATE TABLE IF NOT EXISTS` is a
+// no-op on a database that already has the table, so an index over a column that
+// only a migration adds would raise `no such column` on exactly the old homes
+// this exists to open — and it would do so BEFORE the step that adds the column.
+// Every index therefore runs after the migration steps, not with the tables.
+
+export const SCHEMA_VERSION = 1;
+
+/** A database this binary cannot safely open. Never a `db.prepare` crash. */
+export class SchemaMigrationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SchemaMigrationError';
+    }
+}
+
+const BASELINE_TABLES_SQL = `
     CREATE TABLE IF NOT EXISTS session (
         id          TEXT PRIMARY KEY DEFAULT 'default',
+        -- This SQL default is NOT the product default and has not been for some
+        -- time: the runtime resolves settings.cli -> session.active_cli ->
+        -- DEFAULT_CLI (src/core/main-session.ts), and DEFAULT_CLI is codex-app.
+        -- Changing the literal here would only split fresh databases from existing
+        -- ones, since ALTER cannot restate a default on a column that already
+        -- exists. Tracked with the other schema/call-site default drift in #696.
         active_cli  TEXT DEFAULT 'claude',
         session_id  TEXT,
         model       TEXT DEFAULT 'default',
         permissions TEXT DEFAULT 'auto',
         working_dir TEXT DEFAULT '~',
         effort      TEXT DEFAULT 'medium',
+        active_chat_session TEXT DEFAULT 'default',
         updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
     INSERT OR IGNORE INTO session (id) VALUES ('default');
@@ -51,11 +83,14 @@ db.exec(`
         cli         TEXT,
         model       TEXT,
         trace       TEXT DEFAULT NULL,
+        tool_log    TEXT DEFAULT NULL,
+        working_dir TEXT DEFAULT NULL,
+        trace_run_id TEXT DEFAULT NULL,
+        session_id  TEXT DEFAULT 'default',
         cost_usd    REAL,
         duration_ms INTEGER,
         created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
-    CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);
 
     CREATE TABLE IF NOT EXISTS memory (
         id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -81,6 +116,7 @@ db.exec(`
         session_id  TEXT,
         cli         TEXT,
         model       TEXT DEFAULT '',
+        output_len  INTEGER DEFAULT 0,
         created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -110,8 +146,6 @@ db.exec(`
         last_seen_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (chat_session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE
     );
-    CREATE INDEX IF NOT EXISTS idx_remote_bindings_chat_session
-        ON remote_session_bindings(chat_session_id);
 
     CREATE TABLE IF NOT EXISTS queued_messages (
         id         TEXT PRIMARY KEY,
@@ -139,6 +173,11 @@ db.exec(`
         session_id  TEXT NOT NULL,
         model       TEXT NOT NULL,
         resume_key  TEXT DEFAULT NULL,
+        output_len  INTEGER DEFAULT 0,
+        memory_snapshot TEXT DEFAULT NULL,
+        last_run_clean INTEGER DEFAULT NULL,
+        last_run_cwd TEXT DEFAULT NULL,
+        last_run_meta TEXT DEFAULT NULL,
         updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -171,8 +210,6 @@ db.exec(`
         seen_at    INTEGER NOT NULL,
         PRIMARY KEY (job_id, channel_id, message_ts)
     );
-    CREATE INDEX IF NOT EXISTS idx_mention_watch_seen_job
-        ON mention_watch_seen (job_id, seen_at);
 
     CREATE TABLE IF NOT EXISTS mention_watch_cursor (
         job_id        TEXT NOT NULL,
@@ -223,8 +260,6 @@ db.exec(`
         seen_at      INTEGER NOT NULL,
         PRIMARY KEY (job_id, workspace_id, user_id, channel_id, message_ts)
     );
-    CREATE INDEX IF NOT EXISTS idx_mention_watch_seen_v2_ns
-        ON mention_watch_seen_v2 (job_id, workspace_id, user_id, seen_at);
 
     CREATE TABLE IF NOT EXISTS mention_watch_cursor_v2 (
         job_id        TEXT NOT NULL,
@@ -278,8 +313,6 @@ db.exec(`
         payload     TEXT NOT NULL,
         archived_at INTEGER NOT NULL
     );
-    CREATE INDEX IF NOT EXISTS idx_legacy_mention_watch_archive_job
-        ON legacy_mention_watch_archive (job_id, table_name);
 
     CREATE TABLE IF NOT EXISTS heartbeat_events (
         id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -305,7 +338,6 @@ db.exec(`
         source      TEXT,
         created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
-    CREATE INDEX IF NOT EXISTS idx_jaw_ceo_transcript_at ON jaw_ceo_transcript(at);
 
     CREATE TABLE IF NOT EXISTS trace_runs (
         id TEXT PRIMARY KEY,
@@ -323,10 +355,10 @@ db.exec(`
         started_at INTEGER NOT NULL,
         finished_at INTEGER,
         last_event_at INTEGER,
-        error TEXT
+        error TEXT,
+        session_id TEXT,
+        scope_key TEXT
     );
-    CREATE INDEX IF NOT EXISTS idx_trace_runs_message ON trace_runs(message_id);
-    CREATE INDEX IF NOT EXISTS idx_trace_runs_started ON trace_runs(started_at);
 
     CREATE TABLE IF NOT EXISTS trace_events (
         run_id TEXT NOT NULL,
@@ -342,52 +374,196 @@ db.exec(`
         PRIMARY KEY (run_id, seq),
         FOREIGN KEY (run_id) REFERENCES trace_runs(id) ON DELETE CASCADE
     );
-    CREATE INDEX IF NOT EXISTS idx_trace_events_run_seq ON trace_events(run_id, seq);
-`);
+    CREATE TABLE IF NOT EXISTS background_tasks (
+        id            TEXT PRIMARY KEY,
+        kind          TEXT NOT NULL,
+        spec          TEXT NOT NULL,
+        status        TEXT NOT NULL,
+        pid           INTEGER,
+        origin_meta   TEXT,
+        result        TEXT,
+        created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+        started_at    DATETIME,
+        deadline_at   DATETIME,
+        completed_at  DATETIME,
+        notified_at   DATETIME
+    );
+`;
 
-// Additive owner metadata: legacy rows remain readable without invented scopes.
-const traceRunCols = new Set((db.prepare('PRAGMA table_info(trace_runs)').all() as { name: string }[]).map(c => c.name));
-if (!traceRunCols.has('session_id')) db.exec('ALTER TABLE trace_runs ADD COLUMN session_id TEXT');
-if (!traceRunCols.has('scope_key')) db.exec('ALTER TABLE trace_runs ADD COLUMN scope_key TEXT');
-db.exec(`
+const BASELINE_INDEXES_SQL = `
+    CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);
+    CREATE INDEX IF NOT EXISTS idx_remote_bindings_chat_session
+        ON remote_session_bindings(chat_session_id);
+    CREATE INDEX IF NOT EXISTS idx_mention_watch_seen_job
+        ON mention_watch_seen (job_id, seen_at);
+    CREATE INDEX IF NOT EXISTS idx_mention_watch_seen_v2_ns
+        ON mention_watch_seen_v2 (job_id, workspace_id, user_id, seen_at);
+    CREATE INDEX IF NOT EXISTS idx_legacy_mention_watch_archive_job
+        ON legacy_mention_watch_archive (job_id, table_name);
+    CREATE INDEX IF NOT EXISTS idx_jaw_ceo_transcript_at ON jaw_ceo_transcript(at);
+    CREATE INDEX IF NOT EXISTS idx_trace_runs_message ON trace_runs(message_id);
+    CREATE INDEX IF NOT EXISTS idx_trace_runs_started ON trace_runs(started_at);
+    CREATE INDEX IF NOT EXISTS idx_trace_events_run_seq ON trace_events(run_id, seq);
+    CREATE INDEX IF NOT EXISTS idx_background_tasks_status ON background_tasks(status);
+
+    -- Indexes over columns that only a migration step adds to an older database.
+    -- They are the reason indexes run after MIGRATIONS rather than with the tables.
+    CREATE INDEX IF NOT EXISTS idx_messages_wd ON messages(working_dir);
+    CREATE INDEX IF NOT EXISTS idx_messages_trace_run ON messages(trace_run_id);
+    CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
     CREATE INDEX IF NOT EXISTS idx_trace_runs_session ON trace_runs(session_id, id);
+
     CREATE INDEX IF NOT EXISTS idx_trace_runtime ON trace_events(run_id, seq) WHERE source = 'runtime';
     CREATE UNIQUE INDEX IF NOT EXISTS idx_trace_runtime_control ON trace_events(run_id)
         WHERE source = 'system' AND event_type = 'runtime.control.v1';
-`);
+`;
 
-// Lightweight migration for existing DBs created before `trace` column existed.
-const messageCols = db.prepare('PRAGMA table_info(messages)').all();
-if (!(messageCols as Record<string, unknown>[]).some(c => c["name"] === 'trace')) {
-    db.exec('ALTER TABLE messages ADD COLUMN trace TEXT DEFAULT NULL');
+type MigrationStep = {
+    version: number;
+    describe: string;
+    apply(database: Database.Database): void;
+};
+
+function tableColumns(database: Database.Database, table: string): Set<string> {
+    const rows = database.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    return new Set(rows.map(row => row.name));
 }
-// Migration: add tool_log column for structured ProcessBlock data
-if (!(messageCols as Record<string, unknown>[]).some(c => c["name"] === 'tool_log')) {
-    db.exec('ALTER TABLE messages ADD COLUMN tool_log TEXT DEFAULT NULL');
+
+/** Additive and idempotent, so a step interrupted halfway simply reruns. */
+function addColumnIfMissing(
+    database: Database.Database,
+    table: string,
+    column: string,
+    ddl: string,
+): void {
+    if (tableColumns(database, table).has(column)) return;
+    database.exec(`ALTER TABLE ${table} ADD COLUMN ${ddl}`);
 }
+
+const MIGRATIONS: readonly MigrationStep[] = [
+    {
+        version: 1,
+        describe: 'adopt the columns that predate user_version',
+        apply(database) {
+            // Every column here also exists in BASELINE_TABLES_SQL. A fresh database
+            // gets it from CREATE; a database made before the column existed gets it
+            // here. Both paths must end at the same shape, which is what the
+            // fresh-vs-migrated parity test asserts.
+            addColumnIfMissing(database, 'trace_runs', 'session_id', 'session_id TEXT');
+            addColumnIfMissing(database, 'trace_runs', 'scope_key', 'scope_key TEXT');
+            addColumnIfMissing(database, 'messages', 'trace', 'trace TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'messages', 'tool_log', 'tool_log TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'messages', 'working_dir', 'working_dir TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'messages', 'trace_run_id', 'trace_run_id TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'messages', 'session_id', "session_id TEXT DEFAULT 'default'");
+            addColumnIfMissing(database, 'session', 'active_chat_session', "active_chat_session TEXT DEFAULT 'default'");
+            addColumnIfMissing(database, 'chat_sessions', 'active_run_policy', 'active_run_policy TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'chat_sessions', 'generation', 'generation INTEGER NOT NULL DEFAULT 0');
+            addColumnIfMissing(database, 'employee_sessions', 'model', "model TEXT DEFAULT ''");
+            addColumnIfMissing(database, 'employee_sessions', 'output_len', 'output_len INTEGER DEFAULT 0');
+            addColumnIfMissing(database, 'session_buckets', 'resume_key', 'resume_key TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'session_buckets', 'output_len', 'output_len INTEGER DEFAULT 0');
+            // Frozen task snapshot per resume chain (#prompt-cache): regenerated only
+            // on fresh spawns, reused byte-identical across resume turns so the system
+            // prompt prefix stays cacheable. Dies with the bucket row on any clear.
+            addColumnIfMissing(database, 'session_buckets', 'memory_snapshot', 'memory_snapshot TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'session_buckets', 'last_run_clean', 'last_run_clean INTEGER DEFAULT NULL');
+            addColumnIfMissing(database, 'session_buckets', 'last_run_cwd', 'last_run_cwd TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'session_buckets', 'last_run_meta', 'last_run_meta TEXT DEFAULT NULL');
+            addColumnIfMissing(database, 'mention_watch_cursor', 'resume_before', 'resume_before TEXT DEFAULT NULL');
+            // Only the original message link can establish a historical owner. Forked
+            // copies also carry trace_run_id, so backfilling from that column would
+            // steal ownership.
+            database.exec(`UPDATE trace_runs SET session_id = (SELECT session_id FROM messages WHERE id = trace_runs.message_id)
+                WHERE session_id IS NULL AND message_id IS NOT NULL`);
+        },
+    },
+];
+
+/** The shape a current database must have, read off the baseline itself.
+ *
+ *  Derived rather than hand-listed: a second hand-written list of expected
+ *  columns is one more place to forget the column you just added, which is the
+ *  defect this whole mechanism exists to catch. */
+function baselineShape(): { columns: Map<string, Set<string>>; indexes: Set<string> } {
+    const probe = new Database(':memory:');
+    try {
+        probe.exec(BASELINE_TABLES_SQL);
+        probe.exec(BASELINE_INDEXES_SQL);
+        const columns = new Map<string, Set<string>>();
+        const tableRows = probe.prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+        ).all() as { name: string }[];
+        for (const row of tableRows) columns.set(row.name, tableColumns(probe, row.name));
+        const indexRows = probe.prepare(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+        ).all() as { name: string }[];
+        return { columns, indexes: new Set(indexRows.map(row => row.name)) };
+    } finally {
+        probe.close();
+    }
+}
+
+/** Expected is a SUBSET of actual, never an equality.
+ *
+ *  The live database legitimately carries more than the baseline: migrateSearchFts
+ *  adds the FTS5 virtual tables and their shadow tables, and db-maintenance keeps
+ *  its own bookkeeping. Only a MISSING object is a problem. */
+export function assertSchemaComplete(database: Database.Database): void {
+    const expected = baselineShape();
+    const missing: string[] = [];
+    for (const [table, wanted] of expected.columns) {
+        const actual = tableColumns(database, table);
+        if (actual.size === 0) { missing.push(`table:${table}`); continue; }
+        for (const column of wanted) if (!actual.has(column)) missing.push(`${table}.${column}`);
+    }
+    const actualIndexes = new Set((database.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+    ).all() as { name: string }[]).map(row => row.name));
+    for (const name of expected.indexes) if (!actualIndexes.has(name)) missing.push(`index:${name}`);
+    if (missing.length === 0) return;
+    throw new SchemaMigrationError(
+        `database schema is incomplete at ${DB_PATH}: missing ${missing.join(', ')}. `
+        + 'This means the baseline schema in src/core/db.ts gained something that no '
+        + 'MIGRATIONS step adds to an existing database. Add the step (and bump '
+        + 'SCHEMA_VERSION) rather than relying on CREATE TABLE, which is a no-op here.',
+    );
+}
+
+/** Bring `database` to SCHEMA_VERSION, or refuse to open it with a reason. */
+export function applySchema(database: Database.Database): void {
+    database.exec(BASELINE_TABLES_SQL);
+    const found = Number(database.pragma('user_version', { simple: true }) ?? 0);
+    if (found > SCHEMA_VERSION) {
+        throw new SchemaMigrationError(
+            `database at ${DB_PATH} was written by a newer cli-jaw (schema v${found}, `
+            + `this build understands v${SCHEMA_VERSION}). Upgrade cli-jaw instead of `
+            + 'downgrading the database; migrating backwards would drop data.',
+        );
+    }
+    // Skipped entirely once the database is current, so an ordinary boot never
+    // takes a write lock. When work IS due, BEGIN IMMEDIATE serializes it: two
+    // processes starting on the same old home would otherwise both read version 0
+    // and both run ALTER, and the loser died with 'duplicate column name'. The
+    // version is re-read inside the lock, so the loser now sees the winner's work.
+    if (found !== SCHEMA_VERSION) {
+        database.transaction(() => {
+            const from = Number(database.pragma('user_version', { simple: true }) ?? 0);
+            if (from > SCHEMA_VERSION) return;
+            for (const step of MIGRATIONS) if (step.version > from) step.apply(database);
+            database.pragma(`user_version = ${SCHEMA_VERSION}`);
+        }).immediate();
+    }
+    database.exec(BASELINE_INDEXES_SQL);
+    assertSchemaComplete(database);
+}
+
+applySchema(db);
+
 const migratedToolLogs = migrateOversizedToolLogs(db);
 if (migratedToolLogs > 0) {
     console.log(`[db:migrate] sanitized ${migratedToolLogs} oversized tool_log row(s)`);
 }
-// Migration: add working_dir column for project-scoped message isolation
-if (!(messageCols as Record<string, unknown>[]).some(c => c["name"] === 'working_dir')) {
-    db.exec('ALTER TABLE messages ADD COLUMN working_dir TEXT DEFAULT NULL');
-}
-if (!(messageCols as Record<string, unknown>[]).some(c => c["name"] === 'trace_run_id')) {
-    db.exec('ALTER TABLE messages ADD COLUMN trace_run_id TEXT DEFAULT NULL');
-}
-db.exec('CREATE INDEX IF NOT EXISTS idx_messages_wd ON messages(working_dir)');
-db.exec('CREATE INDEX IF NOT EXISTS idx_messages_trace_run ON messages(trace_run_id)');
-
-// Migration: add session_id column for multi-session message isolation
-if (!(messageCols as Record<string, unknown>[]).some(c => c["name"] === 'session_id')) {
-    db.exec("ALTER TABLE messages ADD COLUMN session_id TEXT DEFAULT 'default'");
-}
-db.exec('CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id)');
-// Only the original message link can establish a historical owner. Forked copies
-// also carry trace_run_id, so backfilling from that column would steal ownership.
-db.exec(`UPDATE trace_runs SET session_id = (SELECT session_id FROM messages WHERE id = trace_runs.message_id)
-    WHERE session_id IS NULL AND message_id IS NOT NULL`);
 
 const SEARCH_FTS_SQL = `
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
@@ -487,53 +663,6 @@ export function migrateSearchFts(database: Database.Database): boolean {
 
 const searchFtsReady = migrateSearchFts(db);
 
-// Migration: add active_chat_session to session table
-const sessionCols = db.prepare('PRAGMA table_info(session)').all();
-if (!(sessionCols as Record<string, unknown>[]).some(c => c["name"] === 'active_chat_session')) {
-    db.exec("ALTER TABLE session ADD COLUMN active_chat_session TEXT DEFAULT 'default'");
-}
-
-const chatSessionCols = db.prepare('PRAGMA table_info(chat_sessions)').all();
-if (!(chatSessionCols as Record<string, unknown>[]).some(c => c["name"] === 'active_run_policy')) {
-    db.exec('ALTER TABLE chat_sessions ADD COLUMN active_run_policy TEXT DEFAULT NULL');
-}
-if (!(chatSessionCols as Record<string, unknown>[]).some(c => c["name"] === 'generation')) {
-    db.exec('ALTER TABLE chat_sessions ADD COLUMN generation INTEGER NOT NULL DEFAULT 0');
-}
-
-const employeeSessionCols = db.prepare('PRAGMA table_info(employee_sessions)').all();
-if (!(employeeSessionCols as Record<string, unknown>[]).some(c => c["name"] === 'model')) {
-    db.exec("ALTER TABLE employee_sessions ADD COLUMN model TEXT DEFAULT ''");
-}
-if (!(employeeSessionCols as Record<string, unknown>[]).some(c => c["name"] === 'output_len')) {
-    db.exec('ALTER TABLE employee_sessions ADD COLUMN output_len INTEGER DEFAULT 0');
-}
-
-const sessionBucketCols = db.prepare('PRAGMA table_info(session_buckets)').all();
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'resume_key')) {
-    db.exec('ALTER TABLE session_buckets ADD COLUMN resume_key TEXT DEFAULT NULL');
-}
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'output_len')) {
-    db.exec('ALTER TABLE session_buckets ADD COLUMN output_len INTEGER DEFAULT 0');
-}
-// Frozen task snapshot per resume chain (#prompt-cache): regenerated only on
-// fresh spawns, reused byte-identical across resume turns so the system
-// prompt prefix stays cacheable. Dies with the bucket row on any clear.
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'memory_snapshot')) {
-    db.exec('ALTER TABLE session_buckets ADD COLUMN memory_snapshot TEXT DEFAULT NULL');
-}
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'last_run_clean')) db.exec('ALTER TABLE session_buckets ADD COLUMN last_run_clean INTEGER DEFAULT NULL');
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'last_run_cwd')) db.exec('ALTER TABLE session_buckets ADD COLUMN last_run_cwd TEXT DEFAULT NULL');
-if (!(sessionBucketCols as Record<string, unknown>[]).some(c => c["name"] === 'last_run_meta')) db.exec('ALTER TABLE session_buckets ADD COLUMN last_run_meta TEXT DEFAULT NULL');
-
-// `CREATE TABLE IF NOT EXISTS` above is a no-op on a database that already has
-// the table, so a column added later needs its own migration or the prepared
-// statement below fails at import time — which takes the whole process down.
-const mentionWatchCursorCols = db.prepare('PRAGMA table_info(mention_watch_cursor)').all();
-if (!(mentionWatchCursorCols as Record<string, unknown>[]).some(c => c["name"] === 'resume_before')) {
-    db.exec('ALTER TABLE mention_watch_cursor ADD COLUMN resume_before TEXT DEFAULT NULL');
-}
-
 // ─── Prepared Statements ─────────────────────────────
 
 export const getSession = () => db.prepare('SELECT * FROM session WHERE id = ?').get('default');
@@ -543,24 +672,8 @@ export const updateSession = db.prepare(`
 `);
 // Background runtime hook tasks (src/bgtask/) — registration is durable so
 // server restarts can recover watchers and re-deliver unsent notifications.
-// Prepared statements live in src/bgtask/registry.ts (module-local).
-db.exec(`
-    CREATE TABLE IF NOT EXISTS background_tasks (
-        id            TEXT PRIMARY KEY,
-        kind          TEXT NOT NULL,
-        spec          TEXT NOT NULL,
-        status        TEXT NOT NULL,
-        pid           INTEGER,
-        origin_meta   TEXT,
-        result        TEXT,
-        created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
-        started_at    DATETIME,
-        deadline_at   DATETIME,
-        completed_at  DATETIME,
-        notified_at   DATETIME
-    );
-    CREATE INDEX IF NOT EXISTS idx_background_tasks_status ON background_tasks(status);
-`);
+// Prepared statements live in src/bgtask/registry.ts (module-local); the table
+// itself is part of BASELINE_TABLES_SQL above.
 
 export const insertMessage = db.prepare('INSERT INTO messages (role, content, cli, model, trace, working_dir, session_id) VALUES (?, ?, ?, ?, NULL, ?, ?)');
 export const insertMessageWithTrace = db.prepare('INSERT INTO messages (role, content, cli, model, trace, tool_log, working_dir, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
@@ -898,45 +1011,29 @@ export const insertSlackEventDedup = db.prepare('INSERT OR REPLACE INTO slack_ev
 export const sweepSlackEventDedup = db.prepare('DELETE FROM slack_event_dedup WHERE expires_at <= ?');
 export const clearSlackEventDedup = db.prepare('DELETE FROM slack_event_dedup');
 
-// ─── Mention watch (heartbeat) ───────────────────
-export const findMentionWatchSeen = db.prepare(
-    'SELECT 1 FROM mention_watch_seen WHERE job_id = ? AND channel_id = ? AND message_ts = ?');
-export const insertMentionWatchSeen = db.prepare(
-    'INSERT OR IGNORE INTO mention_watch_seen (job_id, channel_id, message_ts, seen_at) VALUES (?, ?, ?, ?)');
-/** Drop receipts the cursor has already passed.
- *
- *  Bounded by the CURSOR, not by row count. A count-based prune deletes the
- *  oldest rows regardless of position, and the cursor legitimately sits behind
- *  them: it stops at the first mention still awaiting an answer, while later
- *  mentions in the same window may already be answered and recorded. Pruning
- *  those would make the next scan — which re-reads from the stalled cursor —
- *  answer them a second time.
- *
- *  A row at or below the cursor is unreachable instead: the next scan asks Slack
- *  for messages strictly after it, so its receipt can never be consulted again.
- *  Compared numerically because a Slack ts is a decimal string and its string
- *  order breaks across digit counts. */
-export const pruneMentionWatchSeen = db.prepare(
-    'DELETE FROM mention_watch_seen WHERE job_id = ? AND channel_id = ? '
-    + 'AND CAST(message_ts AS REAL) <= CAST(? AS REAL)');
-export const getMentionWatchCursor = db.prepare(
-    'SELECT last_ts, resume_before FROM mention_watch_cursor WHERE job_id = ? AND channel_id = ?');
-/** Move the frontier. `resume_before` is left alone: the two advance on
-    different conditions, and folding them into one write would clear a pending
-    descent every time a cursor moved. */
-export const upsertMentionWatchCursor = db.prepare(
-    'INSERT INTO mention_watch_cursor (job_id, channel_id, last_ts, updated_at) VALUES (?, ?, ?, ?) '
-    + 'ON CONFLICT(job_id, channel_id) DO UPDATE SET last_ts = excluded.last_ts, updated_at = excluded.updated_at');
-/** Store where an unfinished backward walk stopped, so the next tick descends
-    from there instead of re-reading the newest windows. */
-export const setMentionWatchResumeBefore = db.prepare(
-    'INSERT INTO mention_watch_cursor (job_id, channel_id, last_ts, resume_before, updated_at) '
-    + "VALUES (?, ?, COALESCE((SELECT last_ts FROM mention_watch_cursor WHERE job_id = ? AND channel_id = ?), ''), ?, ?) "
-    + 'ON CONFLICT(job_id, channel_id) DO UPDATE SET resume_before = excluded.resume_before, updated_at = excluded.updated_at');
-export const getMentionWatchRotation = db.prepare(
-    'SELECT last_channel_id FROM mention_watch_rotation WHERE job_id = ?');
-export const upsertMentionWatchRotation = db.prepare(
-    'INSERT OR REPLACE INTO mention_watch_rotation (job_id, last_channel_id, updated_at) VALUES (?, ?, ?)');
+// ─── Mention watch v1: quarantine surface only ────
+//
+// Nothing in src/ writes a v1 row. The scanner writes the namespaced v2 ledger
+// through src/memory/mention-watch-ledger.ts, and the only v1 reader left is
+// src/memory/legacy-mention-watch-quarantine.ts, which holds such a job until an
+// operator restarts it with a fresh floor.
+//
+// What remains here exists so a TEST can build a home that predates the v2 key —
+// there is no other way to produce one now. Production code must not import it:
+// a v1 write is the workspace-less row shape that fb07276b0 removed, and writing
+// one re-creates the misattribution the v2 key exists to prevent. The v1
+// read/prune/rotation statements that had no caller at all are gone.
+export const legacyMentionWatchV1Fixture = {
+    insertSeen: db.prepare(
+        'INSERT OR IGNORE INTO mention_watch_seen (job_id, channel_id, message_ts, seen_at) VALUES (?, ?, ?, ?)'),
+    upsertCursor: db.prepare(
+        'INSERT INTO mention_watch_cursor (job_id, channel_id, last_ts, updated_at) VALUES (?, ?, ?, ?) '
+        + 'ON CONFLICT(job_id, channel_id) DO UPDATE SET last_ts = excluded.last_ts, updated_at = excluded.updated_at'),
+    insertRotation: db.prepare(
+        'INSERT OR REPLACE INTO mention_watch_rotation (job_id, last_channel_id, updated_at) VALUES (?, ?, ?)'),
+    hasSeen: db.prepare(
+        'SELECT 1 FROM mention_watch_seen WHERE job_id = ? AND channel_id = ? AND message_ts = ?'),
+} as const;
 // ─── Mention watch v2: namespace-scoped ───────────
 // Reached only through src/memory/mention-watch-ledger.ts, which requires a
 // WatchNamespace. Every predicate below names all three parts of it.
@@ -1059,15 +1156,11 @@ export const commitLegacyFreshStart = db.transaction((
     return true;
 });
 
-const deleteMentionWatchSeenForJob = db.prepare('DELETE FROM mention_watch_seen WHERE job_id = ?');
-const deleteMentionWatchCursorForJob = db.prepare('DELETE FROM mention_watch_cursor WHERE job_id = ?');
-const deleteMentionWatchRotationForJob = db.prepare('DELETE FROM mention_watch_rotation WHERE job_id = ?');
-/** Disabling or renaming a job should not leave its bookkeeping behind. */
-export const clearMentionWatchState = db.transaction((jobId: string): void => {
-    deleteMentionWatchSeenForJob.run(jobId);
-    deleteMentionWatchCursorForJob.run(jobId);
-    deleteMentionWatchRotationForJob.run(jobId);
-});
+// `clearMentionWatchState` used to live here: a v1-only delete with no archive and
+// no caller anywhere in the repository. Releasing a held job goes through
+// `commitLegacyFreshStart` above, which archives before it deletes and claims the
+// quarantine row first. A second, quieter path to the same tables was a way to
+// lose the record of what a job had already answered.
 
 type QueuedMessageMigrationPayload = Record<string, unknown> & {
     schemaVersion?: number;

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -43,7 +43,7 @@ cli-jaw/
 │   │   ├── compact.ts        ← compact 헬퍼 (COMPACT_MARKER_CONTENT, managed summary builder, cutoff logic, harvestGitGrep + harvestChatGrep 1KB/1KB budget split) (782L)
 │   │   ├── instance.ts       ← 인스턴스 ID, node/jaw 경로, 유닛명 sanitize (61L)
 │   │   ├── session-generation.ts ← persistent chat_sessions.generation (not process-local spawn tokens) (94L)
-│   │   ├── db.ts             ← SQLite 스키마 + prepared statements + trace + tool_log + working_dir migration + closeDb() WAL checkpoint + checkOrphanedWal + busy_timeout + clearMessagesScoped + queued_messages table + model-aware clearEmployeeSession + getRecentMessagesLite + searchMessages(days+recent scope) + getMessageContext(±N range) (1181L)
+│   │   ├── db.ts             ← SQLite 스키마 + prepared statements + trace + tool_log + working_dir migration + user_version schema migration + closeDb() WAL checkpoint + checkOrphanedWal + busy_timeout + clearMessagesScoped + queued_messages table + model-aware clearEmployeeSession + getRecentMessagesLite + searchMessages(days+recent scope) + getMessageContext(±N range) (1274L)
 │   │   ├── db-maintenance.ts ← legacy tool_log 재살균 1회 마이그레이션(schema_migrations 마커) + page/freelist 통계 + checkpoint+VACUUM (`jaw db maintain`) (49L)
 │   │   ├── chat-sessions.ts  ← 채팅 세션 CRUD + 활성 세션 전환 (234L)
 │   │   ├── rate-limit.ts     ← 클라이언트 클래스별(cli/manager/browser/lan/remote) 슬라이딩 윈도 리미터 + atomic peek/commit + Retry-After 미들웨어 팩토리 (217L)

--- a/tests/unit/db-legacy-mention-watch-surface.test.ts
+++ b/tests/unit/db-legacy-mention-watch-surface.test.ts
@@ -1,0 +1,85 @@
+// The v1 mention-watch ledger has no runtime writer, and that has to stay true.
+//
+// A v1 row is keyed by job id alone, with no workspace and no user. A job id is
+// reusable, so a later watch inheriting that cursor silently skips everything
+// below it — missing a mention is the one outcome the feature exists to prevent,
+// which is why fb07276b0 moved the ledger to a namespaced v2 key. The v1 tables
+// survive only so legacy-mention-watch-quarantine can hold and archive what is
+// already in them.
+//
+// A grep is the right shape of test here: the defect is an IMPORT, and it does
+// its damage the moment production code can reach these statements again (#691).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Reachable only from src/core/db.ts and from tests that build an old home. */
+const V1_ONLY_SYMBOLS = [
+    'legacyMentionWatchV1Fixture',
+    // Removed outright: no caller anywhere when #691 landed. Listed so that
+    // re-adding one has to be a deliberate edit to this file too.
+    'findMentionWatchSeen',
+    'insertMentionWatchSeen',
+    'pruneMentionWatchSeen',
+    'getMentionWatchCursor',
+    'upsertMentionWatchCursor',
+    'setMentionWatchResumeBefore',
+    'getMentionWatchRotation',
+    'upsertMentionWatchRotation',
+    'clearMentionWatchState',
+];
+
+const OWNER = 'src/core/db.ts';
+
+function* sourceFiles(dir: string): Generator<string> {
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+            yield* sourceFiles(full);
+        } else if (/\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(entry.name)) {
+            yield full;
+        }
+    }
+}
+
+function runtimeFiles(): string[] {
+    const files = [...sourceFiles(join(projectRoot, 'src')), ...sourceFiles(join(projectRoot, 'bin'))];
+    const serverEntry = join(projectRoot, 'server.ts');
+    try { if (statSync(serverEntry).isFile()) files.push(serverEntry); } catch { /* absent */ }
+    return files.filter(file => relative(projectRoot, file).split('\\').join('/') !== OWNER);
+}
+
+test('LEGACY-V1-001: no runtime file reaches the v1 mention-watch statements', () => {
+    const offenders: string[] = [];
+    for (const file of runtimeFiles()) {
+        const source = readFileSync(file, 'utf8');
+        for (const symbol of V1_ONLY_SYMBOLS) {
+            // Word boundaries keep the v2 names (insertMentionWatchSeenV2 and
+            // friends) out of this, which are the statements production SHOULD use.
+            if (new RegExp(`\\b${symbol}\\b`).test(source)) {
+                offenders.push(`${relative(projectRoot, file)}: ${symbol}`);
+            }
+        }
+    }
+    assert.deepEqual(offenders, [], [
+        'v1 mention-watch statements must stay inside ' + OWNER + '.',
+        'Writing a v1 row re-creates the workspace-less ledger that fb07276b0 removed;',
+        'use src/memory/mention-watch-ledger.ts, which requires a WatchNamespace.',
+    ].join(' '));
+});
+
+test('LEGACY-V1-002: the owner still exposes the quarantine fixture surface', () => {
+    // Guards the test above from passing because the symbol was renamed away and
+    // the scan now matches nothing at all.
+    const owner = readFileSync(join(projectRoot, OWNER), 'utf8');
+    assert.match(owner, /export const legacyMentionWatchV1Fixture/);
+    assert.match(owner, /export const commitLegacyFreshStart/);
+});
+

--- a/tests/unit/db-schema-migration.test.ts
+++ b/tests/unit/db-schema-migration.test.ts
@@ -1,0 +1,252 @@
+// A database that predates PRAGMA user_version has to keep opening. CI never
+// exercises that: every run gets a fresh CLI_JAW_HOME, so the migration path is
+// dead code there unless a test builds an old home on purpose. This file builds
+// one, and asserts the two halves of the schema cannot drift apart (#691).
+//
+// isolated-home MUST be the first import: it rewrites CLI_JAW_HOME, and
+// src/core/config.ts freezes DB_PATH the moment it is evaluated. For the same
+// reason src/core/db.ts is imported DYNAMICALLY, after the fixture file exists —
+// a static import opens (and thereby creates) an empty database first.
+import '../setup/isolated-home.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+
+/** The schema as it stood before any of the step-1 columns existed.
+ *
+ *  Exactly the columns MIGRATIONS[0] adds are missing here, and nothing else:
+ *  a gap the steps do not cover is a different test (MIG-004). Tables added
+ *  later are absent entirely, which is what CREATE TABLE IF NOT EXISTS is for. */
+const LEGACY_V0_SQL = `
+    CREATE TABLE session (
+        id          TEXT PRIMARY KEY DEFAULT 'default',
+        active_cli  TEXT DEFAULT 'claude',
+        session_id  TEXT,
+        model       TEXT DEFAULT 'default',
+        permissions TEXT DEFAULT 'auto',
+        working_dir TEXT DEFAULT '~',
+        effort      TEXT DEFAULT 'medium',
+        updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    INSERT OR IGNORE INTO session (id) VALUES ('default');
+
+    CREATE TABLE messages (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        role        TEXT NOT NULL,
+        content     TEXT NOT NULL,
+        cli         TEXT,
+        model       TEXT,
+        cost_usd    REAL,
+        duration_ms INTEGER,
+        created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE chat_sessions (
+        id          TEXT PRIMARY KEY,
+        seq         INTEGER NOT NULL UNIQUE,
+        label       TEXT DEFAULT NULL,
+        created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    INSERT OR IGNORE INTO chat_sessions (id, seq) VALUES ('default', 0);
+
+    CREATE TABLE employee_sessions (
+        employee_id TEXT PRIMARY KEY,
+        session_id  TEXT,
+        cli         TEXT,
+        created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE session_buckets (
+        bucket      TEXT PRIMARY KEY,
+        session_id  TEXT NOT NULL,
+        model       TEXT NOT NULL,
+        updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE trace_runs (
+        id TEXT PRIMARY KEY,
+        message_id INTEGER,
+        parent_run_id TEXT,
+        cli TEXT NOT NULL,
+        model TEXT,
+        working_dir TEXT,
+        agent_label TEXT,
+        audience TEXT NOT NULL DEFAULT 'public',
+        status TEXT NOT NULL DEFAULT 'running',
+        raw_retention_status TEXT NOT NULL DEFAULT 'available',
+        event_count INTEGER NOT NULL DEFAULT 0,
+        byte_count INTEGER NOT NULL DEFAULT 0,
+        started_at INTEGER NOT NULL,
+        finished_at INTEGER,
+        last_event_at INTEGER,
+        error TEXT
+    );
+
+    CREATE TABLE mention_watch_cursor (
+        job_id        TEXT NOT NULL,
+        channel_id    TEXT NOT NULL,
+        last_ts       TEXT NOT NULL,
+        updated_at    INTEGER NOT NULL,
+        PRIMARY KEY (job_id, channel_id)
+    );
+`;
+
+function writeLegacyDatabase(path: string, sql = LEGACY_V0_SQL): void {
+    const fixture = new Database(path);
+    try {
+        fixture.exec(sql);
+        fixture.prepare("INSERT INTO messages(role, content) VALUES('user', ?)").run('older than user_version');
+    } finally {
+        fixture.close();
+    }
+}
+
+// Written BEFORE src/core/db.ts is ever evaluated, so the singleton opens this
+// file rather than creating an empty one.
+const HOME = process.env['CLI_JAW_HOME'];
+assert.ok(HOME, 'isolated-home must set CLI_JAW_HOME');
+writeLegacyDatabase(join(HOME, 'jaw.db'));
+
+type Shape = { columns: Map<string, Set<string>>; indexes: Set<string> };
+
+function shapeOf(database: Database.Database): Shape {
+    const columns = new Map<string, Set<string>>();
+    const tables = database.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    ).all() as { name: string }[];
+    for (const entry of tables) {
+        const rows = database.prepare(`PRAGMA table_info(${entry.name})`).all() as { name: string }[];
+        columns.set(entry.name, new Set(rows.map(row => row.name)));
+    }
+    const indexes = database.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+    ).all() as { name: string }[];
+    return { columns, indexes: new Set(indexes.map(row => row.name)) };
+}
+
+function sortedEntries(shape: Shape): [string, string[]][] {
+    return [...shape.columns.entries()]
+        .map(([table, cols]) => [table, [...cols].sort()] as [string, string[]])
+        .sort((a, b) => a[0].localeCompare(b[0]));
+}
+
+function freshDir(label: string): string {
+    return mkdtempSync(join(tmpdir(), `jaw-schema-${label}-`));
+}
+
+test('db schema: user_version migration of an existing home', async t => {
+    const dbModule = await import('../../src/core/db.ts');
+    const { db, applySchema, assertSchemaComplete, SCHEMA_VERSION, SchemaMigrationError } = dbModule;
+
+    await t.test('MIG-001: a pre-user_version home opens and is stamped', () => {
+        // Importing at all is most of the assertion: the prepared statements are
+        // created at module scope, and before #691 a missing column killed the
+        // whole process right there.
+        assert.equal(Number(db.pragma('user_version', { simple: true })), SCHEMA_VERSION);
+        assert.ok(dbModule.getSession());
+
+        const before = dbModule.getMessages.all('default') as unknown[];
+        dbModule.insertMessage.run('user', 'after migration', 'codex', 'default', '/tmp', 'default');
+        const after = dbModule.getMessages.all('default') as unknown[];
+        assert.equal(after.length, before.length + 1);
+
+        // The row written before the migration survived it and landed in the
+        // default session rather than being dropped.
+        const legacyRow = db.prepare(
+            "SELECT session_id FROM messages WHERE content = 'older than user_version'",
+        ).get() as { session_id: string } | undefined;
+        assert.ok(legacyRow, 'the pre-migration row must still be there');
+        assert.equal(legacyRow.session_id, 'default');
+    });
+
+    await t.test('MIG-002: the indexes over migrated columns exist', () => {
+        // The ordering trap: these index columns are added by a migration step, so
+        // creating the indexes alongside the tables raises "no such column" on
+        // exactly the old home this feature exists to open.
+        const names = new Set((db.prepare(
+            "SELECT name FROM sqlite_master WHERE type='index'",
+        ).all() as { name: string }[]).map(row => row.name));
+        for (const index of [
+            'idx_messages_wd', 'idx_messages_trace_run', 'idx_messages_session',
+            'idx_trace_runs_session', 'idx_trace_runtime_control',
+        ]) {
+            assert.ok(names.has(index), `missing index ${index} after migrating a legacy home`);
+        }
+    });
+
+    await t.test('MIG-003: a migrated database and a fresh one end at the same schema', () => {
+        // This is the coupling that keeps CREATE and MIGRATIONS honest. Add a
+        // column to the baseline without a migration step and the migrated side
+        // lacks it; add one only to a step and the fresh side lacks it.
+        const fresh = new Database(join(freshDir('fresh'), 'jaw.db'));
+        const migrated = new Database(join(freshDir('migrated'), 'jaw.db'));
+        try {
+            applySchema(fresh);
+            migrated.exec(LEGACY_V0_SQL);
+            applySchema(migrated);
+            assert.deepEqual(sortedEntries(shapeOf(migrated)), sortedEntries(shapeOf(fresh)));
+            assert.deepEqual(
+                [...shapeOf(migrated).indexes].sort(),
+                [...shapeOf(fresh).indexes].sort(),
+            );
+            // Guard against the comparison passing vacuously.
+            assert.ok(shapeOf(fresh).columns.get('messages')?.has('session_id'));
+            assert.ok(shapeOf(fresh).indexes.has('idx_messages_session'));
+        } finally {
+            fresh.close();
+            migrated.close();
+        }
+    });
+
+    await t.test('MIG-004: a gap no step covers fails by name, not at db.prepare', () => {
+        const path = join(freshDir('gap'), 'jaw.db');
+        // "effort" is in the baseline and in no migration step, so a database
+        // missing it is exactly the "added to CREATE only" mistake.
+        writeLegacyDatabase(path, LEGACY_V0_SQL.replace("        effort      TEXT DEFAULT 'medium',\n", ''));
+        const database = new Database(path);
+        try {
+            assert.throws(() => applySchema(database), (error: unknown) => {
+                assert.ok(error instanceof SchemaMigrationError);
+                assert.match(error.message, /session\.effort/);
+                return true;
+            });
+        } finally {
+            database.close();
+        }
+    });
+
+    await t.test('MIG-005: a newer schema is refused instead of downgraded', () => {
+        const database = new Database(join(freshDir('newer'), 'jaw.db'));
+        try {
+            applySchema(database);
+            database.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
+            assert.throws(() => applySchema(database), (error: unknown) => {
+                assert.ok(error instanceof SchemaMigrationError);
+                assert.match(error.message, /newer cli-jaw/);
+                return true;
+            });
+        } finally {
+            database.close();
+        }
+    });
+
+    await t.test('MIG-006: applying the schema twice changes nothing', () => {
+        const path = join(freshDir('twice'), 'jaw.db');
+        writeLegacyDatabase(path);
+        const database = new Database(path);
+        try {
+            applySchema(database);
+            const once = sortedEntries(shapeOf(database));
+            applySchema(database);
+            assert.deepEqual(sortedEntries(shapeOf(database)), once);
+            assert.equal(Number(database.pragma('user_version', { simple: true })), SCHEMA_VERSION);
+            assert.doesNotThrow(() => assertSchemaComplete(database));
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/tests/unit/heartbeat-mention-watch-fresh-start.test.ts
+++ b/tests/unit/heartbeat-mention-watch-fresh-start.test.ts
@@ -10,14 +10,14 @@ import express, { type NextFunction, type Request, type Response } from 'express
 
 import { registerHeartbeatRoutes } from '../../src/routes/heartbeat.ts';
 import { loadHeartbeatFile, saveHeartbeatFile, settings } from '../../src/core/config.ts';
-import { insertMentionWatchSeen, upsertMentionWatchCursor, findMentionWatchSeen, commitLegacyFreshStart } from '../../src/core/db.ts';
+import { legacyMentionWatchV1Fixture, commitLegacyFreshStart } from '../../src/core/db.ts';
 import { detectLegacyMentionWatch, isQuarantined, quarantineState } from '../../src/memory/legacy-mention-watch-quarantine.ts';
 import { startHeartbeat, stopHeartbeat, getHeartbeatRuntimeState } from '../../src/memory/heartbeat.ts';
 import { resetVerifiedSlackWorkspace } from '../../src/slack/verified-workspace.ts';
 
 /** Present in the v1 table, which is what a losing claim must not have erased. */
 const legacySeenExists = (jobId: string, channelId: string, ts: string): boolean =>
-    findMentionWatchSeen.get(jobId, channelId, ts) !== undefined;
+    legacyMentionWatchV1Fixture.hasSeen.get(jobId, channelId, ts) !== undefined;
 
 const WORKSPACE = 'T_TESTWS';
 
@@ -62,8 +62,8 @@ async function withHeartbeatServer(run: (baseUrl: string) => Promise<void>): Pro
 
 /** A job holding a v1 ledger, which is what an unmigrated install looks like. */
 function seedHeldJob(jobId: string, since = '900.000100') {
-    insertMentionWatchSeen.run(jobId, 'C_LEGACY', since, Date.now());
-    upsertMentionWatchCursor.run(jobId, 'C_LEGACY', since, Date.now());
+    legacyMentionWatchV1Fixture.insertSeen.run(jobId, 'C_LEGACY', since, Date.now());
+    legacyMentionWatchV1Fixture.upsertCursor.run(jobId, 'C_LEGACY', since, Date.now());
     saveHeartbeatFile({ jobs: [{
         id: jobId, name: jobId, enabled: true, schedule: { kind: 'every', minutes: 10 }, prompt: 'answer',
         mentionWatch: { channel: 'slack', userId: 'U_SUJI', channelIds: ['C_LEGACY'], since },
@@ -264,12 +264,12 @@ test('a losing claim leaves the v1 rows alone', () => {
     // return does not roll better-sqlite3 back, so doing the destructive half
     // first would commit it for an approval that reported failure.
     const jobId = 'hold_cas_loser';
-    insertMentionWatchSeen.run(jobId, 'C_LEGACY', '900.000100', Date.now());
+    legacyMentionWatchV1Fixture.insertSeen.run(jobId, 'C_LEGACY', '900.000100', Date.now());
     detectLegacyMentionWatch(Date.now());
     assert.equal(commitLegacyFreshStart(jobId, 'first', 1), true);
 
     // Re-seed, then lose the claim: the row must survive.
-    insertMentionWatchSeen.run(jobId, 'C_SECOND', '950.000100', Date.now());
+    legacyMentionWatchV1Fixture.insertSeen.run(jobId, 'C_SECOND', '950.000100', Date.now());
     assert.equal(commitLegacyFreshStart(jobId, 'second', 2), false);
     assert.equal(legacySeenExists(jobId, 'C_SECOND', '950.000100'), true);
 });

--- a/tests/unit/legacy-mention-watch-quarantine.test.ts
+++ b/tests/unit/legacy-mention-watch-quarantine.test.ts
@@ -10,12 +10,12 @@ import {
     quarantineState,
     approveLegacyFreshStart,
 } from '../../src/memory/legacy-mention-watch-quarantine.ts';
-import { insertMentionWatchSeen, upsertMentionWatchCursor, getLegacyQuarantine } from '../../src/core/db.ts';
+import { legacyMentionWatchV1Fixture, getLegacyQuarantine } from '../../src/core/db.ts';
 
 /** Write a v1 row, which is what an unmigrated ledger looks like. */
 function seedLegacy(jobId: string, channelId = 'C_LEGACY', ts = '900.000100') {
-    insertMentionWatchSeen.run(jobId, channelId, ts, Date.now());
-    upsertMentionWatchCursor.run(jobId, channelId, ts, Date.now());
+    legacyMentionWatchV1Fixture.insertSeen.run(jobId, channelId, ts, Date.now());
+    legacyMentionWatchV1Fixture.upsertCursor.run(jobId, channelId, ts, Date.now());
 }
 
 test('a job with v1 rows is held', () => {


### PR DESCRIPTION
## 문제

`src/core/db.ts` 는 스키마 버전 없이 `CREATE TABLE IF NOT EXISTS` + `PRAGMA table_info` + `ALTER TABLE` 조합으로 스키마를 진화시킨다. 모듈을 import 하는 것이 곧 DB 를 여는 일이고, 거의 모든 prepared statement 가 같은 import 안에서 준비된다. 기존 홈에 컬럼이 하나 없으면 `db.prepare` 가 그 자리에서 throw 하고 **프로세스 전체가 죽는다.** `db.ts:529` 주석이 이 위험을 이미 적어 두고 있었다.

재현되는 실수는 한 가지다. 컬럼을 CREATE 에만 넣고 ALTER 를 빼면 새 설치는 멀쩡하고 **기존 사용자만** 서버가 안 뜬다. 그리고 CI 는 매 실행마다 새 `CLI_JAW_HOME` 을 쓰기 때문에 그 경로를 한 번도 밟지 않는다.

## 무엇이 바뀌었나

**`PRAGMA user_version` 이 단일 스키마 버전이 된다.** ALTER 19개가 `MIGRATIONS[0]` 스텝으로 들어갔고, 스텝은 컬럼 가드로 멱등하다.

**CREATE 블록이 진짜 "현재 최종 스키마"가 된다.** 지금까지 ALTER 로만 생기던 컬럼 12개(`messages.tool_log/working_dir/trace_run_id/session_id`, `session.active_chat_session`, `employee_sessions.output_len`, `session_buckets.output_len/memory_snapshot/last_run_*`, `trace_runs.session_id/scope_key`)를 CREATE 에 접어 넣었다. `CREATE TABLE IF NOT EXISTS` 는 기존 DB 에서 no-op 이라 동작이 바뀌지 않고, 새 DB 와 마이그레이션된 DB 가 같은 모양으로 끝난다.

**`assertSchemaComplete` 가 그 베이스라인을 `:memory:` 프로브로 읽어 실제 DB 와 대조한다.** 빠진 것이 있으면 prepare 크래시 대신 `session.effort` 처럼 **이름을 담은** `SchemaMigrationError` 로 실패한다. 기대 집합을 사람이 두 번 적지 않는 것이 요점이다 — 손으로 관리하는 두 번째 목록은 방금 추가한 컬럼을 잊어버릴 장소가 하나 더 느는 것뿐이다. 비교는 **기대 ⊆ 실제** 라 `migrateSearchFts` 가 만드는 FTS 가상/shadow 테이블 같은 정상적인 초과분을 오탐하지 않는다.

**테이블과 인덱스를 분리했다.** `idx_messages_wd` / `idx_messages_trace_run` / `idx_messages_session` / `idx_trace_runs_session` 은 마이그레이션이 추가하는 컬럼을 참조한다. 테이블과 같이 만들면 레거시 홈에서 `CREATE TABLE` 이 no-op 인 채로 인덱스가 `no such column` 으로 죽고, **ALTER 에 도달하지도 못한다** — 이 변경이 열려고 하는 바로 그 홈에서. 인덱스는 전부 마이그레이션 뒤에 돈다. (이건 감사 라운드2에서 잡힌 것이고, 그대로 갔으면 회귀가 아니라 신규 사고였다.)

**마이그레이션이 필요할 때만 `BEGIN IMMEDIATE` 로 직렬화하고 락 안에서 버전을 다시 읽는다.** 같은 옛 홈에서 두 프로세스가 동시에 뜨면 둘 다 버전 0 을 읽고 둘 다 ALTER 를 돌려 진 쪽이 `duplicate column name` 으로 죽던 경합이 닫힌다. 이미 최신인 홈은 쓰기 락을 아예 잡지 않는다. 상위 버전 DB 는 조용히 열지 않고 업그레이드하라고 거절한다.

**v1 mention-watch 표면 정리.** 호출부가 아예 없던 `pruneMentionWatchSeen` `getMentionWatchCursor` `setMentionWatchResumeBefore` `getMentionWatchRotation` `upsertMentionWatchRotation` 을 삭제했다. `clearMentionWatchState` 도 삭제했다 — archive 없이 v1 세 테이블을 지우는데 저장소 어디에도 호출부가 없었고, 보류된 job 해제는 `commitLegacyFreshStart` 가 보관 후 삭제로 처리한다. 테스트만 쓰던 나머지 셋은 `legacyMentionWatchV1Fixture` 하나로 내려, 이름과 주석이 "v2 이전 홈을 만드는 테스트용, 프로덕션 import 금지"를 못 박는다.

## 증거

`tests/unit/db-schema-migration.test.ts` 가 user_version 이전 스키마로 `jaw.db` 를 만든 뒤 **db.ts 싱글톤을 동적 import** 해서 실제 부팅 경로를 탄다. `isolated-home` 을 첫 정적 import 로 두고 `db.ts`/`config.ts` 를 정적 import 하지 않는 것이 이 순서가 성립하는 유일한 방법이다 — `config.ts` 는 평가되는 순간 `DB_PATH` 를 고정한다.

| 케이스 | 무엇을 막나 |
| --- | --- |
| MIG-001 | 옛 홈이 열리고 버전이 찍힌다. 마이그레이션 전에 쓴 행이 살아남아 default 세션으로 백필된다 |
| MIG-002 | 마이그레이션 컬럼 위의 인덱스가 실제로 존재한다 (위의 순서 함정) |
| MIG-003 | 마이그레이션된 DB 와 새 DB 의 컬럼/인덱스 집합이 같다 — **CREATE 와 MIGRATIONS 를 묶어두는 실제 장치** |
| MIG-004 | 어떤 스텝도 채우지 않는 구멍이 prepare 크래시가 아니라 이름 있는 에러로 실패한다 |
| MIG-005 / 006 | 상위 버전 거절, 두 번 적용해도 동일 |

`tests/unit/db-legacy-mention-watch-surface.test.ts` 는 `src/` `bin/` `server.ts` 가 v1 statement 에 닿지 않음을 단언한다. 결함의 형태가 import 그 자체라 스캔이 맞는 모양이고, 심볼이 조용히 사라져 스캔이 공집합이 되는 경우를 막는 대조 단언을 함께 둔다.

기계적 대조도 했다: HEAD 와 이 브랜치의 `db.ts` 에서 스키마 객체를 추출해 비교했을 때 **사라진 테이블·컬럼·인덱스 0건**, 추가된 컬럼은 의도한 12개뿐, ALTER 19개가 `addColumnIfMissing` 19개와 1:1, `trace_runs` 백필 보존.

## 이슈 본문 대비 달라진 점

이슈 제안 2는 "v1 prepared statement 를 quarantine/archive 경로가 쓰는 것만 남기고 내부화하거나 삭제"라고 했다. 실제로 확인해 보니 quarantine 경로는 v1 DML 을 **직접 쓰지 않는다** — `countLegacyMentionWatchRows` 로 존재만 확인하고 `commitLegacyFreshStart` 로 보관·삭제한다. v1 seen/cursor/rotation statement 중 프로덕션 호출부는 **0건**이었고, 테스트 2개만 쓰고 있었다. 그래서 "내부화"가 아니라 "테스트 fixture 표면으로 격리 + 나머지 삭제"로 갔다.

`session.active_cli` 의 SQL 기본값 `'claude'` 는 **바꾸지 않았다.** 읽기 경로가 이미 `settings.cli → session.active_cli → DEFAULT_CLI` 로 해석하고, 컬럼 기본값을 바꾸면 ALTER 가 기존 컬럼의 기본값을 고칠 수 없으므로 새 DB 와 기존 DB 가 갈라진다. 드리프트를 주석으로 기록하고 #696 으로 넘긴다.

## NOT COVERED BY CI

이 변경에서 CI 가 증명하지 못하는 표면:

- **실제 사용자 홈의 임의 중간 스키마.** 테스트가 재현하는 것은 합성 v0 fixture 한 종류다. 그 사이 어딘가에서 만들어진 홈은 커버되지 않는다.
- **동시 다중 프로세스 첫 부팅.** `BEGIN IMMEDIATE` 로 직렬화되도록 설계했지만 멀티프로세스 경합은 유닛 범위 밖이라 증명하지 않았다. 설계 근거만 있다.
- **인덱스 빌드가 `busy_timeout`(5s)을 넘기는 대형 DB.** 인덱스는 트랜잭션 밖이라(현행도 그렇다) 이 경우 `SQLITE_BUSY` 가 가능하다. 회귀는 아니지만 개선도 아니다.
- **WAL 손상/복구 경로.**
- **Windows 레인.** 새 유닛 2개는 `scripts/ci/windows-unit-manifest.txt` 에 없다 — 그 파일은 이 작업의 파일 울타리 밖이고 다른 워크트리가 소유한다. Linux `test 1..4/4` 에서만 돈다.
- **실제 v1 잔재를 가진 홈의 quarantine 흐름.** 합성 row 까지만.
- **로컬 스위트는 NOT RUN.** 지시에 따라 `npm test` / `npm run build` / `npx tsc` / `npm install` 을 돌리지 않았다(이 워크트리엔 `node_modules` 자체가 없다). 유일한 증거는 이 PR 의 exact head SHA 에서 본 `ci-aggregate` 다.

Closes #691
