### PR TITLE
feat(adaptive-fetch): pin the vendored Defuddle bundle's identity

### DIFF
--- a/src/browser/adaptive-fetch/defuddle-provenance.ts
+++ b/src/browser/adaptive-fetch/defuddle-provenance.ts
@@ -1,0 +1,49 @@
+/**
+ * #695: the vendored Defuddle bundle carries no version string of its own, so
+ * this module is the only handle on what those 699KB actually are. The bundle
+ * does contain a `version:"0.13.01"` — that belongs to Temml, which is bundled
+ * inside it, and using it as a Defuddle version would be wrong.
+ *
+ * Replacing the bundle means changing these values in the same commit, because
+ * browser-adaptive-fetch-defuddle-integrity.test.ts refuses to pass otherwise.
+ * That is what turns an upgrade into a hash PR rather than an edit to a number
+ * in vendor/README.md.
+ *
+ * Checked against the npm registry and the GitHub release on 2026-09-11.
+ */
+export const DEFUDDLE_VENDOR = {
+    /** Upstream release the bundle was built from. */
+    version: '0.18.1',
+    /** Upstream tags this release without a "v" prefix. */
+    releaseTag: '0.18.1',
+    /** Publish date of that release, for anyone reading an advisory later. */
+    releasedAt: '2026-04-22',
+    /**
+     * npm tarball integrity for defuddle@0.18.1. Recorded provenance, not
+     * something the test re-fetches; CI does not run npm pack.
+     */
+    tarballIntegrity: 'sha512-AvFPFOsoDjt5xUOA1QxzafSSzJ5dqEIC63yO72tHYtSjj1DYY/XM0XTPUCsHkm5A2f1X9ulBvoSVFJrd4s2ckA==',
+    /**
+     * The entry the bundle must be built from. exports["."] is the lite build,
+     * which silently ignores `markdown: true` and returns cleaned HTML.
+     */
+    entry: 'dist/index.full.js',
+    /** Byte length of vendor/defuddle.iife.min.js. */
+    bytes: 699043,
+    /** sha256 of vendor/defuddle.iife.min.js. */
+    sha256: '581bdb074e62570834c284031499e3d80ccca966915ab493b3e662e088770dab',
+} as const;
+
+/**
+ * Names the full entry contributes and the lite entry does not. These are
+ * module export names and library property names, which esbuild preserves; a
+ * minified local identifier would change on every rebuild and is useless as a
+ * marker.
+ */
+export const FULL_ENTRY_MARKERS = [
+    'toMarkdown',
+    'createMarkdownContent',
+    'turndown',
+    'fencedCodeBlock',
+    'blankReplacement',
+] as const;

--- a/src/browser/adaptive-fetch/vendor/README.md
+++ b/src/browser/adaptive-fetch/vendor/README.md
@@ -23,4 +23,36 @@ Uses the **full** entry (`dist/index.full.js`, ~700KB minified): the
 markdown serializer lives only in the full build — the lite `dist/index.js`
 silently ignores `markdown: true` and returns cleaned HTML (verified
 2026-06-10 against v0.18.1). After rebuilding, update the version in this
-file and rerun `npm run test:unit`.
+file and rerun `npm test` (there is no `test:unit` script).
+
+### Pinned provenance
+
+| | |
+| --- | --- |
+| Upstream | kepano/defuddle v0.18.1, released 2026-04-22, MIT |
+| Entry | `dist/index.full.js` (the package's `exports["./full"]`) |
+| Bundle bytes | 699043 |
+| Bundle sha256 | `581bdb074e62570834c284031499e3d80ccca966915ab493b3e662e088770dab` |
+| npm tarball integrity | `sha512-AvFPFOsoDjt5xUOA1QxzafSSzJ5dqEIC63yO72tHYtSjj1DYY/XM0XTPUCsHkm5A2f1X9ulBvoSVFJrd4s2ckA==` |
+
+These values also live in `../defuddle-provenance.ts` and are enforced by
+`tests/unit/browser-adaptive-fetch-defuddle-integrity.test.ts`. Editing the
+numbers in this file alone changes nothing: the test compares the real bytes
+against the module, and the module against this table.
+
+The bundle itself contains no Defuddle version string. It does contain
+`version:"0.13.01"`, which belongs to Temml — bundled inside it — and is not a
+Defuddle version.
+
+### Upgrading is a hash PR, not a README edit
+
+1. Rebuild from the **full** entry with the command above.
+2. Recompute the byte length and sha256, and put both in
+   `../defuddle-provenance.ts` along with the new version, release date and
+   npm tarball integrity.
+3. Update the table above to the same values.
+4. Read the upstream advisories for the version you are leaving and the one you
+   are taking. GHSA-5mq8-78gm-pjmq (CVE-2026-30830, XSS in the schema-text
+   fallback) affects `<= 0.7.0` only, so the pin above is outside its range.
+5. The integrity test fails until steps 1-3 agree with each other. That failure
+   is the point of the gate.

--- a/tests/unit/browser-adaptive-fetch-defuddle-integrity.test.ts
+++ b/tests/unit/browser-adaptive-fetch-defuddle-integrity.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runInContext, createContext } from 'node:vm';
+import { DEFUDDLE_VENDOR, FULL_ENTRY_MARKERS } from '../../src/browser/adaptive-fetch/defuddle-provenance.js';
+
+// #695: the bundle is 699KB of minified vendor code with no version string in
+// it, one unrelated commit behind it, and nothing in the build that looks at
+// its contents. These pin what it is, so replacing it has to be a deliberate
+// change to defuddle-provenance.ts rather than an edit to a number in README.
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const vendorDir = join(root, 'src/browser/adaptive-fetch/vendor');
+const bundlePath = join(vendorDir, 'defuddle.iife.min.js');
+
+function bundleBytes(): Buffer {
+    return readFileSync(bundlePath);
+}
+
+function sha256(bytes: Buffer): string {
+    return createHash('sha256').update(bytes).digest('hex');
+}
+
+test('#695-A the vendored bundle matches its recorded size and sha256', () => {
+    const bytes = bundleBytes();
+    assert.equal(
+        bytes.byteLength,
+        DEFUDDLE_VENDOR.bytes,
+        `vendor bundle is ${bytes.byteLength} bytes, provenance records ${DEFUDDLE_VENDOR.bytes}`,
+    );
+    const actual = sha256(bytes);
+    assert.equal(
+        actual,
+        DEFUDDLE_VENDOR.sha256,
+        `vendor bundle sha256 is ${actual}; update defuddle-provenance.ts and vendor/README.md together`,
+    );
+});
+
+test('#695-B README records the same upstream version and entry as the provenance module', () => {
+    const readme = readFileSync(join(vendorDir, 'README.md'), 'utf8');
+    const expected = `v${DEFUDDLE_VENDOR.version}`;
+    const mentions = readme.match(/v\d+\.\d+\.\d+/g) ?? [];
+    assert.ok(mentions.length > 0, 'vendor/README.md must state the upstream version');
+    // Every mention, not just the first: a stale line left above a new one
+    // would otherwise pass.
+    for (const mention of mentions) {
+        assert.equal(mention, expected, `vendor/README.md mentions ${mention} but the pinned version is ${expected}`);
+    }
+    assert.ok(
+        readme.includes(DEFUDDLE_VENDOR.entry),
+        `vendor/README.md must name the required entry ${DEFUDDLE_VENDOR.entry}`,
+    );
+    assert.ok(readme.includes(DEFUDDLE_VENDOR.sha256), 'vendor/README.md must carry the pinned sha256');
+});
+
+test('#695-C a lite-entry rebuild fails the gate', () => {
+    // The lite entry drops the markdown serializer, so a rebuild against
+    // exports["."] loses every one of these names.
+    const source = bundleBytes().toString('utf8');
+    for (const marker of FULL_ENTRY_MARKERS) {
+        assert.ok(
+            source.includes(marker),
+            `"${marker}" is missing — this looks like a lite-entry build, which ignores markdown: true`,
+        );
+    }
+});
+
+test('#695-D the bundle is the esbuild IIFE the extractor expects', () => {
+    const source = bundleBytes().toString('utf8');
+    assert.ok(
+        source.startsWith('var Defuddle='),
+        'the extractor injects this and reads globalThis.Defuddle, so it must be the named IIFE build',
+    );
+});
+
+test('#695-E the pinned bundle evaluates and exposes a Defuddle class', () => {
+    // Hash first, in this test rather than relying on #695-A: the runner uses
+    // concurrency, so a separate test passing is no guarantee this one is
+    // evaluating reviewed bytes.
+    const bytes = bundleBytes();
+    assert.equal(sha256(bytes), DEFUDDLE_VENDOR.sha256, 'refusing to evaluate a bundle that is not the pinned one');
+
+    // An empty context, so nothing leaks into the test realm. The bundle guards
+    // its document access, so it loads without a DOM; parse() would need one
+    // and is deliberately not called.
+    const context = createContext({});
+    const exported = runInContext(`${bytes.toString('utf8')}\n;Defuddle;`, context, { timeout: 20_000 }) as unknown;
+    assert.equal(typeof exported, 'function', 'the bundle must expose Defuddle as a constructor');
+    const proto = Object.getOwnPropertyNames((exported as { prototype: object }).prototype);
+    assert.ok(proto.includes('parse'), 'Defuddle.prototype.parse is what the extractor calls');
+    assert.ok(proto.includes('parseAsync'), 'Defuddle.prototype.parseAsync is part of the same surface');
+});
+
+test('#695-F the recorded tarball integrity has the shape npm publishes', () => {
+    // Format only. Verifying it would mean fetching the tarball, which the
+    // unit lane does not do.
+    assert.match(DEFUDDLE_VENDOR.tarballIntegrity, /^sha512-[A-Za-z0-9+/]+={0,2}$/);
+    assert.equal(DEFUDDLE_VENDOR.releaseTag.startsWith('v'), false, 'upstream tags without a v prefix');
+    assert.match(DEFUDDLE_VENDOR.releasedAt, /^\d{4}-\d{2}-\d{2}$/);
+});
+


### PR DESCRIPTION
The bundle is 699KB of minified vendor code with no version string of its own, one unrelated commit behind it (`3e42781b7`, a Slack docs message), and nothing in the build that looks at its contents. `vendor/README.md` described the upstream release and the full-entry rebuild procedure honestly — but nothing enforced either, so an upgrade was an edit to a number in a markdown file and a lite-entry rebuild would have silently turned markdown output back into HTML.

## What changed

`defuddle-provenance.ts` records what those bytes are: upstream version, release date, the entry they must be built from, byte length, sha256, and the npm tarball integrity. Six tests hold the tree to it.

| | |
| --- | --- |
| `#695-A` | the bundle matches the recorded size and sha256, printing the real hash on failure so an upgrade PR can copy it |
| `#695-B` | every `v`-prefixed version in the README equals the pinned one, and the README carries the entry path and the hash |
| `#695-C` | all five markdown-serializer names the full entry contributes are present, so a lite-entry rebuild fails |
| `#695-D` | the file is still the named IIFE the extractor injects and reads back off `globalThis` |
| `#695-E` | the pinned bytes actually evaluate to a `Defuddle` class with `parse` and `parseAsync` |
| `#695-F` | the recorded tarball integrity has the shape npm publishes |

`#695-E` recomputes the hash itself before evaluating, rather than leaning on `#695-A`: the runner is concurrent, so a sibling test passing is no guarantee this one is looking at reviewed bytes. It evaluates in an empty `vm` context, which works without a DOM because the bundle guards its `document` access; `parse()` would need one and is deliberately not called.

The markers are export and property names that esbuild preserves (`toMarkdown`, `createMarkdownContent`, `turndown`, `fencedCodeBlock`, `blankReplacement`). Minified local identifiers were rejected as markers because they change on every rebuild.

The README gains the pinned table and an upgrade checklist that is explicit that editing its numbers alone does nothing.

## Upstream facts, checked rather than assumed

Verified against the npm registry and the GitHub API on 2026-09-11: release `0.18.1` exists, tagged without a `v`, published 2026-04-22; `exports["./full"]` is `dist/index.full.js` while `exports["."]` is the lite build, which confirms the README's entry claim; latest is `0.19.3` (2026-08-22). The one published advisory, GHSA-5mq8-78gm-pjmq / CVE-2026-30830, affects `<= 0.7.0` and is patched in `0.9.0`, so the pinned version is outside its range. Upgrading to `0.19.3` is deliberately not part of this PR — the point of the pin is that such an upgrade now has to be a hash PR.

Worth knowing for anyone tempted by it: the bundle does contain `version:"0.13.01"`. That is Temml, bundled inside it, not a Defuddle version.

## NOT COVERED BY CI

- **That these bytes really are an esbuild rebuild of `defuddle@0.18.1`'s full entry.** CI does not run `npm pack`. The recorded tarball integrity is provenance a human checked, not a value any test reproduces. What the gate guarantees is that the reviewed bytes are still the bytes in the tree.
- **Reproducibility of the minified output.** Two different esbuild versions building the same Defuddle release give different hashes, so the pin is on *this file*, not on the upstream version.
- **Extraction quality, and that `markdown: true` returns markdown.** `#695-E` proves the class loads. Exercising `parse()` needs a DOM.
- **The lite-entry failure mode is a heuristic.** There is no lite fixture in the tree to prove the negative; `#695-C` asserts the full-entry names are present and infers the rest from upstream's entry split.
- **That `new Function(src)()` creates the global on a CSP-strict page.** The existing extractor test still stubs that with a fake `true`, and this PR does not change it.
- **The copy `atomic-build.sh` puts in `dist/`.** It still `cp -R`s `vendor/` without verification; that script is outside this lane's file scope.

Closes #695
