### PR TITLE
refactor(settings): 부팅 merge 와 API merge 를 하나의 선언적 spec 으로 (#696a)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1167,7 +1167,7 @@ export function loadSettings() {
                 ...(sourceVersion === 1 ? { cli: legacyCli } : {}),
                 perCli: mergedPerCli,
             },
-        );
+        ) as Record<string, any>;
         // Everything below is normalization, and the merge must not swallow it.
         // ack is a third level the spec does not reach; slack.autoJoin repairs a
         // budget that reaches a loop joining real channels; search.engine is a

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -24,6 +24,7 @@ import type { TrustedBotTrigger } from '../slack/events.js';
 import { SETUP_STATE_FILE } from './install-integrity.js';
 import {
     sanitizeSettingsInput,
+    mergeSettingsLayer,
     type SettingsPersistenceShape,
 } from './settings-merge.js';
 export { detectAllCli, detectCli } from './cli-detection.js';
@@ -770,10 +771,9 @@ export function migrateSettings(s: Record<string, any>, sourceVersion = readSett
             if (s["multiSession"].channels.slack === undefined) s["multiSession"].channels.slack = true;
         }
     }
-    const maxConcurrent = Number(s["multiSession"].maxConcurrent);
-    s["multiSession"].maxConcurrent = Number.isInteger(maxConcurrent) && maxConcurrent > 0
-        ? maxConcurrent
-        : 1;
+    // Repairing an invalid value means falling back to THE default, not to a
+    // second opinion about what the default is (#696).
+    s["multiSession"].maxConcurrent = resolveMaxConcurrent(s as Record<string, unknown>);
     if (!['steer', 'followup', 'collect', 'interrupt'].includes(s["multiSession"].midRunPolicy)) {
         s["multiSession"].midRunPolicy = 'steer';
     }
@@ -940,6 +940,41 @@ export function applyEnvOverrides(s: Record<string, any>) {
 
 /** Mutable settings object — shared across all modules via ESM live binding */
 export let settings: Record<string, any> = createDefaultSettings();
+
+/** Runtime defaults for keys whose fallback used to be re-typed at each call site.
+ *
+ *  The schema said multiSession.maxConcurrent was 2 while the lane allocator used
+ *  ?? 1, and memory.flushEvery was declared 10 and then re-declared 10 in four
+ *  other files. Changing the schema alone did nothing in the first case, because
+ *  the literal at the call site won. These resolvers exist so there is exactly one
+ *  answer to "what is the default", and it is the one in DEFAULT_SETTINGS. */
+function resolvePositiveInt(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function resolveFlushEvery(source: Record<string, unknown> = settings): number {
+    const memory = source['memory'];
+    return resolvePositiveInt(
+        isPlainRecord(memory) ? memory['flushEvery'] : undefined,
+        DEFAULT_SETTINGS.memory.flushEvery,
+    );
+}
+
+export function resolveMemoryRetentionDays(source: Record<string, unknown> = settings): number {
+    const memory = source['memory'];
+    return resolvePositiveInt(
+        isPlainRecord(memory) ? memory['retentionDays'] : undefined,
+        DEFAULT_SETTINGS.memory.retentionDays,
+    );
+}
+
+export function resolveMaxConcurrent(source: Record<string, unknown> = settings): number {
+    const multiSession = source['multiSession'];
+    return resolvePositiveInt(
+        isPlainRecord(multiSession) ? multiSession['maxConcurrent'] : undefined,
+        DEFAULT_SETTINGS.multiSession.maxConcurrent,
+    );
+}
 let settingsPersistenceShape: SettingsPersistenceShape = 'absent';
 
 export type SettingsStateCandidate = {
@@ -1119,76 +1154,43 @@ export function loadSettings() {
                 mergedPerCli[cli] = { ...(mergedPerCli[cli] || {}), ...cfg };
             }
         }
-        const merged = migrateSettings({
-            ...defaults,
-            ...raw,
-            ...(sourceVersion === 1 ? { cli: legacyCli } : {}),
-            perCli: mergedPerCli,
-            tui: { ...defaults.tui, ...(raw.tui || {}) },
-            // The channel spreads are one level deep, which is right for flat
-            // credential fields and wrong for the nested ack group: a stored file
-            // carrying only {ack:{enabled:true}} would drop the rest. Merged here
-            // rather than repaired later so migrateSettings below sees a complete
-            // ack object.
-            telegram: { ...defaults.telegram, ...(raw.telegram || {}),
-                ack: mergeAckSettings(defaults.telegram.ack, raw.telegram?.ack) },
-            discord: { ...defaults.discord, ...(raw.discord || {}),
-                ack: mergeAckSettings(defaults.discord.ack, raw.discord?.ack) },
-            slack: { ...defaults.slack, ...(raw.slack || {}),
-                ack: mergeAckSettings(defaults.slack.ack, raw.slack?.ack),
-                // Same one-level-deep problem as ack: a stored
-                // {autoJoin:{enabled:false}} would erase maxJoinsPerRun and
-                // exclude. Normalizes too — the budget reaches a loop that
-                // mutates a live workspace, so NaN must not survive here.
-                autoJoin: mergeSlackAutoJoin(defaults.slack.autoJoin, raw.slack?.autoJoin) },
-            dispatchApproval: {
-                ...defaults.dispatchApproval,
-                ...(raw.dispatchApproval || {}),
-                operators: { ...defaults.dispatchApproval.operators, ...(raw.dispatchApproval?.operators || {}) },
+        // One merge implementation, shared with the API and file-watch ingress.
+        // Boot used to hand-roll its own nested spreads, and the two lists drifted:
+        // a partial {heartbeat:{enabled:true}} lost every sibling here but kept them
+        // over the API, while a partial {avatar:{agent:...}} was the other way round.
+        // Which keys a partial document destroyed depended on which door it arrived
+        // through, which is not a property anyone chose.
+        const layered = mergeSettingsLayer(
+            { ...defaults, multiSession: multiSessionBaseline },
+            {
+                ...raw,
+                ...(sourceVersion === 1 ? { cli: legacyCli } : {}),
+                perCli: mergedPerCli,
             },
-            memory: { ...defaults.memory, ...(raw.memory || {}) },
-            search: {
-                ...defaults.search,
-                ...(raw.search || {}),
-                engine: raw.search?.engine === 'fts5' ? 'fts5' : 'like',
-            },
-            trace: { ...defaults.trace, ...(raw.trace || {}) },
-            avatar: {
-                agent: { ...defaults.avatar.agent, ...(raw.avatar?.agent || {}) },
-                user: { ...defaults.avatar.user, ...(raw.avatar?.user || {}) },
-            },
-           messaging: {
-               // Spread the stored block FIRST. This object is rebuilt field by field,
-               // so anything not named here is dropped — and `enabledChannels` /
-               // `homeChannel` were not named. A v4 document therefore lost its gateway
-               // on every load, and migrateSettings then refilled it from the legacy
-               // `channel` key, which v4 had already deleted, so the fallback landed on
-               // telegram. The result was silent and self-inflicted: a Slack install
-               // read as telegram, no transport started, and the rewritten file made
-               // the corruption permanent on the next boot.
-               ...(raw.messaging || {}),
-               latestSeen: { ...defaults.messaging.latestSeen, ...(raw.messaging?.latestSeen || {}) },
-               lastActive: { ...defaults.messaging.lastActive, ...(raw.messaging?.lastActive || {}) },
-           },
-            jawCeo: { ...defaults.jawCeo, ...(raw.jawCeo || {}) },
-            pi: { ...defaults.pi, ...(raw.pi || {}) },
-            network: { ...defaults.network, ...(raw.network || {}) },
-            runtime: {
-                ...defaults.runtime,
-                ...(raw.runtime || {}),
-                codexApp: {
-                    ...defaults.runtime.codexApp,
-                    ...(raw.runtime?.codexApp || {}),
-                },
-            },
-            code: { ...defaults.code, ...(raw.code || {}) },
-            multiSession: {
-                ...multiSessionBaseline,
-                ...(raw.multiSession || {}),
-                channels: { ...multiSessionBaseline.channels, ...(raw.multiSession?.channels || {}) },
-            },
-            wiki: { ...defaults.wiki, ...(raw.wiki || {}) },
-        }, sourceVersion);
+        );
+        // Everything below is normalization, and the merge must not swallow it.
+        // ack is a third level the spec does not reach; slack.autoJoin repairs a
+        // budget that reaches a loop joining real channels; search.engine is a
+        // forced value rather than a merged one. Each reads the stored document
+        // directly, because the layer above has already folded the key in.
+        layered['telegram'] = {
+            ...layered['telegram'],
+            ack: mergeAckSettings(defaults.telegram.ack, raw.telegram?.ack),
+        };
+        layered['discord'] = {
+            ...layered['discord'],
+            ack: mergeAckSettings(defaults.discord.ack, raw.discord?.ack),
+        };
+        layered['slack'] = {
+            ...layered['slack'],
+            ack: mergeAckSettings(defaults.slack.ack, raw.slack?.ack),
+            autoJoin: mergeSlackAutoJoin(defaults.slack.autoJoin, raw.slack?.autoJoin),
+        };
+        layered['search'] = {
+            ...layered['search'],
+            engine: raw.search?.engine === 'fts5' ? 'fts5' : 'like',
+        };
+        const merged = migrateSettings(layered, sourceVersion);
         // #64 safety: auto-correct stale workingDir (e.g. copied instance)
         // but allow valid paths to persist (dynamic project targeting)
         // Any document below the current schema was rewritten by the migration above, so

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -25,6 +25,7 @@ import { SETUP_STATE_FILE } from './install-integrity.js';
 import {
     sanitizeSettingsInput,
     mergeSettingsLayer,
+    SETTINGS_MERGE_SPEC,
     type SettingsPersistenceShape,
 } from './settings-merge.js';
 export { detectAllCli, detectCli } from './cli-detection.js';
@@ -941,6 +942,25 @@ export function applyEnvOverrides(s: Record<string, any>) {
 /** Mutable settings object — shared across all modules via ESM live binding */
 export let settings: Record<string, any> = createDefaultSettings();
 
+/** A stored block that is null or an array is a corrupt document, not an instruction.
+ *
+ *  The hand-rolled boot merge this replaced wrote `...(raw.telegram || {})` for
+ *  every nested block, so a `"telegram": null` in settings.json quietly fell back
+ *  to defaults. Carrying the null through the shared layer instead would replace
+ *  the block with null and then let the normalizers below rebuild only part of it
+ *  — a telegram block holding nothing but `ack`, with the bot token gone.
+ *  Dropping the key restores the old meaning.
+ *
+ *  Only keys the merge spec names are dropped. A top-level scalar is a real value,
+ *  and an API patch keeps its own semantics: there, an explicit null IS a write. */
+function dropCorruptBlocks(raw: Record<string, unknown>): Record<string, unknown> {
+    const out: Record<string, unknown> = { ...raw };
+    for (const key of Object.keys(SETTINGS_MERGE_SPEC)) {
+        if (key in out && !isPlainRecord(out[key])) delete out[key];
+    }
+    return out;
+}
+
 /** Runtime defaults for keys whose fallback used to be re-typed at each call site.
  *
  *  The schema said multiSession.maxConcurrent was 2 while the lane allocator used
@@ -1163,7 +1183,7 @@ export function loadSettings() {
         const layered = mergeSettingsLayer(
             { ...defaults, multiSession: multiSessionBaseline },
             {
-                ...raw,
+                ...dropCorruptBlocks(raw),
                 ...(sourceVersion === 1 ? { cli: legacyCli } : {}),
                 perCli: mergedPerCli,
             },
@@ -1174,20 +1194,20 @@ export function loadSettings() {
         // forced value rather than a merged one. Each reads the stored document
         // directly, because the layer above has already folded the key in.
         layered['telegram'] = {
-            ...layered['telegram'],
+            ...(isPlainRecord(layered['telegram']) ? layered['telegram'] : {}),
             ack: mergeAckSettings(defaults.telegram.ack, raw.telegram?.ack),
         };
         layered['discord'] = {
-            ...layered['discord'],
+            ...(isPlainRecord(layered['discord']) ? layered['discord'] : {}),
             ack: mergeAckSettings(defaults.discord.ack, raw.discord?.ack),
         };
         layered['slack'] = {
-            ...layered['slack'],
+            ...(isPlainRecord(layered['slack']) ? layered['slack'] : {}),
             ack: mergeAckSettings(defaults.slack.ack, raw.slack?.ack),
             autoJoin: mergeSlackAutoJoin(defaults.slack.autoJoin, raw.slack?.autoJoin),
         };
         layered['search'] = {
-            ...layered['search'],
+            ...(isPlainRecord(layered['search']) ? layered['search'] : {}),
             engine: raw.search?.engine === 'fts5' ? 'fts5' : 'like',
         };
         const merged = migrateSettings(layered, sourceVersion);

--- a/src/core/settings-merge.ts
+++ b/src/core/settings-merge.ts
@@ -127,132 +127,119 @@ export function sanitizeSettingsInput(
     };
 }
 
+/** Which nested groups survive a PARTIAL document or patch, and how deep.
+ *
+ *  One table, read by both ingresses: the boot merge in config.loadSettings and
+ *  the API/watch merge below. They used to be two hand-maintained lists that
+ *  drifted — boot replaced heartbeat/stt/presentation wholesale while the API
+ *  merged them, and the API replaced avatar wholesale while boot merged it — so
+ *  which sibling keys a partial write destroyed depended on which door it came
+ *  through. A key absent from this table is REPLACED wholesale, deliberately:
+ *  arrays like messaging.enabledChannels and employees must not be union-merged.
+ *
+ *  This table is merge policy only. Normalization (ack, slack.autoJoin,
+ *  search.engine) runs AFTER a layer and is not expressible here: those rules
+ *  repair a value rather than combine two of them. */
+export type NestedMergeRule =
+    | { kind: 'perEntry' }
+    | { kind: 'shallow' }
+    | { kind: 'nested'; children: readonly string[] };
+
+export const SETTINGS_MERGE_SPEC: Readonly<Record<string, NestedMergeRule>> = {
+    perCli: { kind: 'perEntry' },
+    activeOverrides: { kind: 'perEntry' },
+    telegram: { kind: 'nested', children: ['ack'] },
+    discord: { kind: 'nested', children: ['ack'] },
+    slack: { kind: 'nested', children: ['ack', 'autoJoin'] },
+    dispatchApproval: { kind: 'nested', children: ['operators'] },
+    network: { kind: 'nested', children: ['remoteAccess'] },
+    runtime: { kind: 'nested', children: ['codexApp'] },
+    multiSession: { kind: 'nested', children: ['channels'] },
+    avatar: { kind: 'nested', children: ['agent', 'user'] },
+    messaging: { kind: 'nested', children: ['latestSeen', 'lastActive'] },
+    heartbeat: { kind: 'shallow' },
+    telegramHub: { kind: 'shallow' },
+    memory: { kind: 'shallow' },
+    stt: { kind: 'shallow' },
+    jawCeo: { kind: 'shallow' },
+    pi: { kind: 'shallow' },
+    tui: { kind: 'shallow' },
+    wiki: { kind: 'shallow' },
+    code: { kind: 'shallow' },
+    search: { kind: 'shallow' },
+    trace: { kind: 'shallow' },
+    presentation: { kind: 'shallow' },
+};
+
+/** Lay the incoming document over the base per SETTINGS_MERGE_SPEC, mutating neither. */
+export function mergeSettingsLayer(
+    base: Record<string, any>,
+    incoming: Record<string, any>,
+): Record<string, any> {
+    const result: Record<string, any> = { ...base };
+    for (const [key, value] of Object.entries(incoming)) {
+        const rule = SETTINGS_MERGE_SPEC[key];
+        // A scalar, an array or an explicit null replaces the block. Only an
+        // object can be merged into one, and only a named key is merged at all.
+        if (!rule || !isPlainRecord(value)) {
+            result[key] = value;
+            continue;
+        }
+        const current = isPlainRecord(base[key]) ? base[key] : {};
+        if (rule.kind === 'perEntry') {
+            const merged: Record<string, any> = { ...current };
+            for (const [entry, cfg] of Object.entries(value)) {
+                merged[entry] = isPlainRecord(cfg) && isPlainRecord(merged[entry])
+                    ? { ...merged[entry], ...cfg }
+                    : cfg;
+            }
+            result[key] = merged;
+            continue;
+        }
+        const merged: Record<string, any> = { ...current, ...value };
+        if (rule.kind === 'nested') {
+            for (const child of rule.children) {
+                if (!isPlainRecord(value[child])) continue;
+                const childBase = isPlainRecord(current[child]) ? current[child] : {};
+                merged[child] = { ...childBase, ...value[child] };
+            }
+        }
+        result[key] = merged;
+    }
+    return result;
+}
+
 /**
  * settings 객체에 patch를 deep merge
- * perCli와 activeOverrides는 CLI별로 개별 merge (기존 effort/model 보존)
  * @param {object} current - 현재 settings
  * @param {object} patch - 적용할 패치
  * @returns {object} 새 settings (current를 직접 변경하지 않음)
  */
 export function mergeSettingsPatch(current: Record<string, any>, patch: Record<string, any>) {
-    const result = structuredClone(current);
-    const remaining = { ...patch };
+    const result = mergeSettingsLayer(structuredClone(current), patch);
 
-    // Deep merge perCli at per-CLI level
-    if (remaining["perCli"] && typeof remaining["perCli"] === 'object') {
-        result["perCli"] = result["perCli"] || {};
-        for (const [cli, cfg] of Object.entries(remaining["perCli"]) as [string, Record<string, any>][]) {
-            result["perCli"][cli] = { ...result["perCli"][cli], ...cfg };
-        }
-        delete remaining["perCli"];
-    }
-
-    // Deep merge activeOverrides at per-CLI level
-    if (remaining["activeOverrides"] && typeof remaining["activeOverrides"] === 'object') {
-        result["activeOverrides"] = result["activeOverrides"] || {};
-        for (const [cli, cfg] of Object.entries(remaining["activeOverrides"]) as [string, Record<string, any>][]) {
-            result["activeOverrides"][cli] = { ...result["activeOverrides"][cli], ...cfg };
-        }
-        delete remaining["activeOverrides"];
-    }
-
-    // Deep merge nested objects. A key missing from this list is REPLACED wholesale by a
-    // partial patch, so `{wiki:{promptDigest:true}}` would silently drop the root and the
-    // enabled flag along with it.
-    if (remaining["dispatchApproval"]?.operators && typeof remaining["dispatchApproval"].operators === 'object') {
-        result["dispatchApproval"] = result["dispatchApproval"] || {};
-        remaining["dispatchApproval"] = { ...remaining["dispatchApproval"] };
-        result["dispatchApproval"].operators = {
-            ...(result["dispatchApproval"].operators || {}),
-            ...remaining["dispatchApproval"].operators,
-        };
-        delete remaining["dispatchApproval"].operators;
-    }
-
-    for (const key of ['heartbeat', 'telegram', 'telegramHub', 'discord', 'slack', 'dispatchApproval', 'memory', 'stt', 'jawCeo', 'pi', 'tui', 'messaging', 'network', 'wiki', 'presentation']) {
-        if (remaining[key] && typeof remaining[key] === 'object') {
-            result[key] = { ...result[key], ...remaining[key] };
-            delete remaining[key];
-        }
-    }
-
-    // The loop above merges channel objects one level deep, so a patch carrying
-    // only {ack:{enabled:true}} would drop scope, emoji and removeAfterReply.
-    // Reads `patch` rather than `remaining` because the loop already deleted the
-    // key. Shares mergeAckSettings with the boot merge in config.ts so the three
-    // ingresses (boot/api/watch) cannot diverge.
+    // Normalization, not merging. ack.emoji is a third level the spec does not
+    // reach, and slack.autoJoin has to be REPAIRED rather than combined: its
+    // budget reaches a loop that joins real channels, so {autoJoin:null} and
+    // {autoJoin:'yes'} must not survive to disk, where the next boot would read
+    // them as absent and quietly restore default-on. Reads the original patch
+    // because the layer above has already consumed the key.
     for (const key of ['telegram', 'discord', 'slack']) {
         const patchChannel = patch[key];
-        if (!patchChannel || typeof patchChannel !== 'object') continue;
-        const patchAck = (patchChannel as Record<string, any>)["ack"];
+        if (!isPlainRecord(patchChannel)) continue;
         const currentChannel = current[key] as Record<string, any> | undefined;
-        if (patchAck && typeof patchAck === 'object' && !Array.isArray(patchAck)) {
+        const patchAck = patchChannel['ack'];
+        if (isPlainRecord(patchAck)) {
+            result[key] = { ...result[key], ack: mergeAckSettings(currentChannel?.['ack'], patchAck) };
+        }
+        // Any mention of autoJoin is repaired, including a malformed one.
+        if (key === 'slack' && 'autoJoin' in patchChannel) {
             result[key] = {
                 ...result[key],
-                ack: mergeAckSettings(currentChannel?.["ack"], patchAck),
+                autoJoin: mergeSlackAutoJoin(currentChannel?.['autoJoin'], patchChannel['autoJoin']),
             };
         }
-        // slack.autoJoin is the same nested-group case, and its budget reaches
-        // a loop that joins real channels — so this path normalizes as well as
-        // merges. A PUT carrying {autoJoin:{enabled:false}} must not erase
-        // maxJoinsPerRun, and {maxJoinsPerRun:-1} must not reach the runner.
-        if (key === 'slack') {
-            const slackPatch = patchChannel as Record<string, unknown>;
-            const patchAutoJoin = slackPatch["autoJoin"];
-            // Any mention of the key is repaired, including a malformed one.
-            // Testing for a well-formed object would let {autoJoin:null} and
-            // {autoJoin:'yes'} through the one-level spread above and survive
-            // to disk, where the next boot reads them as "absent" and quietly
-            // restores default-on. A patch that names the key gets a valid
-            // block or nothing.
-            if ('autoJoin' in slackPatch) {
-                result[key] = {
-                    ...result[key],
-                    autoJoin: mergeSlackAutoJoin(currentChannel?.["autoJoin"], patchAutoJoin),
-                };
-            }
-        }
     }
-
-
-    // Deep merge nested network.remoteAccess
-    if (remaining["network"]?.remoteAccess && typeof remaining["network"].remoteAccess === 'object') {
-        result["network"] = result["network"] || {};
-        result["network"].remoteAccess = { ...result["network"].remoteAccess, ...remaining["network"].remoteAccess };
-        delete remaining["network"].remoteAccess;
-    }
-
-    // runtime.codexApp is a two-level merge boundary: a multiplex-only patch
-    // must preserve both other runtime blocks and codexApp-owned siblings.
-    if (isPlainRecord(remaining["runtime"])) {
-        const runtimePatch = remaining["runtime"];
-        result["runtime"] = { ...(result["runtime"] || {}), ...runtimePatch };
-        if (isPlainRecord(runtimePatch["codexApp"])) {
-            result["runtime"].codexApp = {
-                ...(current["runtime"]?.codexApp || {}),
-                ...runtimePatch["codexApp"],
-            };
-        }
-        delete remaining["runtime"];
-    }
-
-    // multiSession.channels is the same shape of boundary. An enabled-only patch must
-    // keep midRunPolicy and the channel gates, and a single-channel patch must keep the
-    // other two channels — which is exactly what a per-channel session gate will send.
-    if (isPlainRecord(remaining["multiSession"])) {
-        const sessionPatch = remaining["multiSession"];
-        result["multiSession"] = { ...(result["multiSession"] || {}), ...sessionPatch };
-        if (isPlainRecord(sessionPatch["channels"])) {
-            result["multiSession"].channels = {
-                ...(current["multiSession"]?.channels || {}),
-                ...sessionPatch["channels"],
-            };
-        }
-        delete remaining["multiSession"];
-    }
-
-    // Top-level scalar fields
-    Object.assign(result, remaining);
 
     return result;
 }

--- a/src/core/settings-merge.ts
+++ b/src/core/settings-merge.ts
@@ -173,10 +173,10 @@ export const SETTINGS_MERGE_SPEC: Readonly<Record<string, NestedMergeRule>> = {
 
 /** Lay the incoming document over the base per SETTINGS_MERGE_SPEC, mutating neither. */
 export function mergeSettingsLayer(
-    base: Record<string, any>,
-    incoming: Record<string, any>,
-): Record<string, any> {
-    const result: Record<string, any> = { ...base };
+    base: Record<string, unknown>,
+    incoming: Record<string, unknown>,
+): Record<string, unknown> {
+    const result: Record<string, unknown> = { ...base };
     for (const [key, value] of Object.entries(incoming)) {
         const rule = SETTINGS_MERGE_SPEC[key];
         // A scalar, an array or an explicit null replaces the block. Only an
@@ -187,7 +187,7 @@ export function mergeSettingsLayer(
         }
         const current = isPlainRecord(base[key]) ? base[key] : {};
         if (rule.kind === 'perEntry') {
-            const merged: Record<string, any> = { ...current };
+            const merged: Record<string, unknown> = { ...current };
             for (const [entry, cfg] of Object.entries(value)) {
                 merged[entry] = isPlainRecord(cfg) && isPlainRecord(merged[entry])
                     ? { ...merged[entry], ...cfg }
@@ -196,7 +196,7 @@ export function mergeSettingsLayer(
             result[key] = merged;
             continue;
         }
-        const merged: Record<string, any> = { ...current, ...value };
+        const merged: Record<string, unknown> = { ...current, ...value };
         if (rule.kind === 'nested') {
             for (const child of rule.children) {
                 if (!isPlainRecord(value[child])) continue;
@@ -216,7 +216,9 @@ export function mergeSettingsLayer(
  * @returns {object} 새 settings (current를 직접 변경하지 않음)
  */
 export function mergeSettingsPatch(current: Record<string, any>, patch: Record<string, any>) {
-    const result = mergeSettingsLayer(structuredClone(current), patch);
+    // The layer speaks in unknown so it adds no any-typed surface; the patch API
+    // has always handed callers an indexable settings object, so it keeps doing so.
+    const result = mergeSettingsLayer(structuredClone(current), patch) as Record<string, any>;
 
     // Normalization, not merging. ack.emoji is a third level the spec does not
     // reach, and slack.autoJoin has to be REPAIRED rather than combined: its
@@ -227,7 +229,7 @@ export function mergeSettingsPatch(current: Record<string, any>, patch: Record<s
     for (const key of ['telegram', 'discord', 'slack']) {
         const patchChannel = patch[key];
         if (!isPlainRecord(patchChannel)) continue;
-        const currentChannel = current[key] as Record<string, any> | undefined;
+        const currentChannel = isPlainRecord(current[key]) ? current[key] : undefined;
         const patchAck = patchChannel['ack'];
         if (isPlainRecord(patchAck)) {
             result[key] = { ...result[key], ack: mergeAckSettings(currentChannel?.['ack'], patchAck) };

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -38,7 +38,7 @@ cli-jaw/
 │   └── mime-detect.ts        ← MIME 타입 감지 헬퍼 (67L)
 ├── src/
 │   ├── core/                 ← 의존 0 인프라 계층 (31 files, 3847L)
-│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1549L)
+│   │   ├── config.ts         ← JAW_HOME, settings, APP_VERSION + migrateSettings legacy Claude model normalization + avatar settings deep merge + default `settings.pi` + corrupt settings backup + CLI 탐지 re-export hub (1571L)
 │   │   ├── cli-detection.ts  ← CLI 탐지 + `pi` npm-exec fallback + `kiro-code`(`kiro-cli` binary) 탐지 + local package release/debug candidates (57L)
 │   │   ├── compact.ts        ← compact 헬퍼 (COMPACT_MARKER_CONTENT, managed summary builder, cutoff logic, harvestGitGrep + harvestChatGrep 1KB/1KB budget split) (782L)
 │   │   ├── instance.ts       ← 인스턴스 ID, node/jaw 경로, 유닛명 sanitize (61L)
@@ -68,7 +68,7 @@ cli-jaw/
 │   │   ├── launchd-cleanup.ts ← launchd stale plist / runtime cleanup (16L)
 │   │   ├── launchd-plist.ts  ← launchd plist 생성 helper (89L)
 │   │   ├── tcc.ts            ← macOS TCC / screen-recording 권한 점검 (55L)
-│   │   ├── settings-merge.ts ← perCli/activeOverrides/pi deep merge (258L)
+│   │   ├── settings-merge.ts ← perCli/activeOverrides/pi deep merge (247L)
 │   │   └── skill-cache.ts    ← 활성 스킬 슬래시 커맨드 캐시 (registerSkillLoader, getSkillCommandsCache, invalidateSkillCommandsCache) (44L)
 │   ├── code-mode/            ← native Code sessions, independent of Jaw orchestration
 │   │   ├── host.ts ← per-backend lazy composition and storage (70L)

--- a/tests/unit/auth-bypass.test.ts
+++ b/tests/unit/auth-bypass.test.ts
@@ -5,6 +5,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { join } from 'node:path';
+import { DEFAULT_SETTINGS } from '../../src/core/config.ts';
+import { SETTINGS_MERGE_SPEC, mergeSettingsLayer, mergeSettingsPatch } from '../../src/core/settings-merge.ts';
 
 const projectRoot = join(import.meta.dirname, '../..');
 const serverSrc = readSource(join(projectRoot, 'server.ts'), 'utf8');
@@ -75,23 +77,40 @@ test('AB-006: 403 responses include LAN hint', () => {
         'LAN_HINT should reference both bindHost and lanBypass');
 });
 
-test('AB-007: settings.network defaults include bindHost + lanBypass', () => {
-    const configSrc = readSource(join(projectRoot, 'src/core/config.ts'), 'utf8');
-    assert.ok(configSrc.includes("bindHost: '127.0.0.1'"),
-        'createDefaultSettings must set network.bindHost default');
-    assert.ok(/lanBypass:\s*false/.test(configSrc),
-        'createDefaultSettings must set network.lanBypass=false default');
-    assert.ok(configSrc.includes('network: { ...defaults.network, ...(raw.network || {}) }'),
-        'loadSettings must deep-merge the network block');
+// AB-007/AB-008 used to grep src for the literal spread expressions that
+// implemented the merge. That asserted the shape of one implementation rather
+// than the property it was there for, so any refactor broke them while a genuine
+// sibling-clobbering regression could slip past. They now exercise the merge.
+test('AB-007: a partial network document keeps bindHost and lanBypass', () => {
+    assert.equal(DEFAULT_SETTINGS.network.bindHost, '127.0.0.1');
+    assert.equal(DEFAULT_SETTINGS.network.lanBypass, false);
+
+    // What #108 was about: a stored document naming only one remoteAccess field
+    // must not take the rest of the network block down with it.
+    const merged = mergeSettingsLayer(DEFAULT_SETTINGS, { network: { remoteAccess: { mode: 'lan' } } });
+    assert.equal(merged['network'].bindHost, '127.0.0.1');
+    assert.equal(merged['network'].lanBypass, false);
+    assert.equal(merged['network'].remoteAccess.mode, 'lan');
+    assert.equal(merged['network'].remoteAccess.trustProxies, false);
+    assert.equal(merged['network'].remoteAccess.trustForwardedFor, false);
 });
 
-test('AB-008: settings-merge includes network in nested merge list', () => {
-    const mergeSrc = readSource(join(projectRoot, 'src/core/settings-merge.ts'), 'utf8');
-    const arrayIdx = mergeSrc.indexOf("['heartbeat', 'telegram'");
-    assert.ok(arrayIdx >= 0, 'nested merge array should exist');
-    const arrayLine = mergeSrc.slice(arrayIdx, mergeSrc.indexOf(']', arrayIdx) + 1);
-    assert.ok(arrayLine.includes("'network'"),
-        'settings-merge nested array must include network');
+test('AB-008: the API ingress merges network at both levels', () => {
+    const rule = SETTINGS_MERGE_SPEC['network'];
+    assert.ok(rule, 'network must be a declared nested merge key');
+    assert.equal(rule.kind, 'nested');
+    assert.ok(rule.kind === 'nested' && rule.children.includes('remoteAccess'));
+
+    // The spec alone proves nothing if the merge does not read it, so assert the
+    // behaviour too: a declared-but-unused table would pass the check above.
+    const patched = mergeSettingsPatch(
+        { network: { bindHost: '0.0.0.0', lanBypass: true, remoteAccess: { mode: 'off', trustProxies: true } } },
+        { network: { remoteAccess: { mode: 'lan' } } },
+    );
+    assert.equal(patched['network'].bindHost, '0.0.0.0');
+    assert.equal(patched['network'].lanBypass, true);
+    assert.equal(patched['network'].remoteAccess.mode, 'lan');
+    assert.equal(patched['network'].remoteAccess.trustProxies, true);
 });
 
 // ─── Security Hardening (PR#2) ─────────────────────────

--- a/tests/unit/settings-boot-merge-parity.test.ts
+++ b/tests/unit/settings-boot-merge-parity.test.ts
@@ -1,0 +1,102 @@
+// The boot merge and the API/watch merge are one implementation now (#696).
+//
+// They used to be two hand-maintained lists of nested keys that disagreed. A
+// partial {heartbeat:{enabled:true}} document lost every sibling at boot but
+// kept them over the API; a partial {avatar:{agent:...}} patch was the other way
+// round. Which keys a partial write destroyed depended on which door it came
+// through, and nothing tested the boot side at all.
+//
+// These tests go through the real loadSettings, because the defect only ever
+// appeared there.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** A document this schema accepts, so the merge is what is under test rather
+ *  than the shape assertions loadSettings runs before it. */
+function v4Document(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        settingsSchemaVersion: 4,
+        runtimeDefaultMigration: null,
+        multiSessionDefaultMigration: null,
+        cli: 'codex-app',
+        multiSession: {
+            enabled: true, maxConcurrent: 2, midRunPolicy: 'steer',
+            channels: { telegram: false, discord: false, slack: true },
+        },
+        messaging: {
+            enabledChannels: ['slack'],
+            homeChannel: 'slack',
+            latestSeen: { telegram: null, discord: null, slack: '111' },
+            lastActive: { telegram: null, discord: null, slack: null },
+        },
+        ...extra,
+    };
+}
+
+async function loadInHome(doc: unknown): Promise<Record<string, any>> {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-jaw-boot-merge-'));
+    fs.writeFileSync(path.join(home, 'settings.json'), JSON.stringify(doc, null, 2));
+    process.env['CLI_JAW_HOME'] = home;
+    // Fresh module per home: config.ts resolves its paths at import time.
+    const mod = await import('../../src/core/config.ts?home=' + encodeURIComponent(home));
+    mod.loadSettings();
+    return mod.settings;
+}
+
+test('BM-001: a partial network.remoteAccess document keeps its siblings at boot', async () => {
+    // The completion condition of #696 stated directly.
+    const settings = await loadInHome(v4Document({ network: { remoteAccess: { mode: 'lan' } } }));
+    assert.equal(settings['network'].remoteAccess.mode, 'lan');
+    assert.equal(settings['network'].remoteAccess.trustProxies, false);
+    assert.equal(settings['network'].remoteAccess.trustForwardedFor, false);
+    assert.equal(settings['network'].remoteAccess.publicOriginHint, '');
+    // And the block the stored document never mentioned at all.
+    assert.equal(settings['network'].bindHost, '127.0.0.1');
+    assert.equal(settings['network'].lanBypass, false);
+});
+
+test('BM-002: boot agrees with the shared layer for the same document', async () => {
+    // If boot ever grows a second merge implementation again, this diverges.
+    const doc = v4Document({ network: { remoteAccess: { mode: 'lan' } } });
+    const settings = await loadInHome(doc);
+    const merge = await import('../../src/core/settings-merge.ts');
+    const config = await import('../../src/core/config.ts?home=parity-probe');
+    const layered = merge.mergeSettingsLayer(config.DEFAULT_SETTINGS, doc as Record<string, any>);
+    assert.deepEqual(settings['network'], layered['network']);
+});
+
+test('BM-003: a partial heartbeat document keeps its siblings at boot', async () => {
+    // This block was replaced wholesale at boot and merged over the API.
+    const settings = await loadInHome(v4Document({ heartbeat: { enabled: true } }));
+    assert.equal(settings['heartbeat'].enabled, true);
+    assert.equal(settings['heartbeat'].every, '30m');
+    assert.deepEqual(settings['heartbeat'].activeHours, { start: '08:00', end: '22:00' });
+    assert.equal(settings['heartbeat'].target, 'all');
+});
+
+test('BM-004: normalization still runs after the layer', async () => {
+    // search.engine is forced, not merged, and slack.ack.emoji is a third level
+    // the merge spec deliberately does not reach. Folding either into the layer
+    // would be a silent regression, so both are asserted here.
+    const settings = await loadInHome(v4Document({
+        search: { engine: 'not-a-real-engine' },
+        slack: { enabled: true, botToken: 'xoxb-test', appToken: 'xapp-test', teamId: 'T1',
+            ack: { enabled: true } },
+    }));
+    assert.equal(settings['search'].engine, 'like');
+    assert.equal(settings['slack'].ack.enabled, true);
+    assert.ok(settings['slack'].ack.emoji, 'ack.emoji must survive a partial ack block');
+    assert.equal(settings['slack'].botToken, 'xoxb-test');
+});
+
+test('BM-005: a partial messaging document keeps the other channel cursors', async () => {
+    const settings = await loadInHome(v4Document());
+    assert.deepEqual(settings['messaging'].enabledChannels, ['slack']);
+    assert.equal(settings['messaging'].homeChannel, 'slack');
+    assert.equal(settings['messaging'].latestSeen.slack, '111');
+    assert.equal(settings['messaging'].latestSeen.telegram, null);
+});
+

--- a/tests/unit/settings-boot-merge-parity.test.ts
+++ b/tests/unit/settings-boot-merge-parity.test.ts
@@ -100,3 +100,41 @@ test('BM-005: a partial messaging document keeps the other channel cursors', asy
     assert.equal(settings['messaging'].latestSeen.telegram, null);
 });
 
+
+test('BM-006: a stored block of null falls back to defaults instead of losing siblings', async () => {
+    // The hand-rolled boot merge wrote ...(raw.telegram || {}), so a null block
+    // meant "corrupt, use defaults". Carrying the null through the shared layer
+    // would replace the block and let the ack normalizer rebuild only part of it,
+    // leaving a telegram block with an ack and no token.
+    const settings = await loadInHome(v4Document({ telegram: null, memory: null }));
+    assert.ok(settings['telegram'], 'telegram must not stay null');
+    assert.equal(settings['telegram'].enabled, false);
+    assert.equal(settings['telegram'].token, '');
+    assert.ok(settings['telegram'].ack, 'the ack normalizer still runs');
+    assert.equal(typeof settings['memory'].flushEvery, 'number');
+});
+
+test('BM-007: one answer to what the default is', async () => {
+    // The schema said multiSession.maxConcurrent was 2 while the lane allocator
+    // used ?? 1. Reading the schema was not enough, because the literal at the
+    // call site won. These resolvers are the single answer.
+    const config = await import('../../src/core/config.ts?home=resolver-probe');
+    assert.equal(config.resolveMaxConcurrent({}), config.DEFAULT_SETTINGS.multiSession.maxConcurrent);
+    assert.equal(config.resolveFlushEvery({}), config.DEFAULT_SETTINGS.memory.flushEvery);
+    assert.equal(config.resolveMemoryRetentionDays({}), config.DEFAULT_SETTINGS.memory.retentionDays);
+
+    // An explicit valid value still wins.
+    assert.equal(config.resolveMaxConcurrent({ multiSession: { maxConcurrent: 7 } }), 7);
+    assert.equal(config.resolveFlushEvery({ memory: { flushEvery: 3 } }), 3);
+
+    // A value that is not a positive integer is repaired to the default rather
+    // than to a second opinion about what the default is.
+    for (const bad of [0, -1, 1.5, Number.NaN, null, '3', undefined]) {
+        assert.equal(
+            config.resolveMaxConcurrent({ multiSession: { maxConcurrent: bad } }),
+            config.DEFAULT_SETTINGS.multiSession.maxConcurrent,
+            'invalid maxConcurrent ' + String(bad) + ' must resolve to the schema default',
+        );
+    }
+});
+

--- a/tests/unit/settings-merge.test.ts
+++ b/tests/unit/settings-merge.test.ts
@@ -2,7 +2,7 @@
 // src/settings-merge.js 가 생성되면 통과 (server.js에서 로직 추출 예정)
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mergeSettingsPatch, sanitizeSettingsInput } from '../../src/core/settings-merge.ts';
+import { mergeSettingsPatch, sanitizeSettingsInput, mergeSettingsLayer, SETTINGS_MERGE_SPEC } from '../../src/core/settings-merge.ts';
 
 // ─── perCli deep merge ──────────────────────────────
 
@@ -146,3 +146,71 @@ test('SM-014: a patch without multiSession does not invent one', () => {
     assert.equal('multiSession' in out.value, false);
     assert.deepEqual(out.invalidPaths, []);
 });
+
+// ─── one merge policy for both ingresses (#696) ─────
+//
+// Before this, the boot merge and the API merge each carried their own list of
+// nested keys, and the lists disagreed. Which sibling keys a partial write
+// destroyed therefore depended on which door it came through.
+
+test('SM-014: a partial network.remoteAccess patch keeps its siblings', () => {
+    const current = { network: { bindHost: '0.0.0.0', lanBypass: true,
+        remoteAccess: { mode: 'off', trustProxies: true, trustForwardedFor: false, publicOriginHint: 'x' } } };
+    const next = mergeSettingsPatch(current, { network: { remoteAccess: { mode: 'lan' } } });
+    assert.deepEqual(next.network.remoteAccess,
+        { mode: 'lan', trustProxies: true, trustForwardedFor: false, publicOriginHint: 'x' });
+    assert.equal(next.network.bindHost, '0.0.0.0');
+});
+
+test('SM-015: a partial avatar patch keeps the other side', () => {
+    // The API ingress used to replace avatar wholesale while boot merged it.
+    const current = { avatar: { agent: { imagePath: 'a', scale: 2 }, user: { imagePath: 'u' } } };
+    const next = mergeSettingsPatch(current, { avatar: { agent: { imagePath: 'b' } } });
+    assert.deepEqual(next.avatar.agent, { imagePath: 'b', scale: 2 });
+    assert.deepEqual(next.avatar.user, { imagePath: 'u' });
+});
+
+test('SM-016: a partial messaging.latestSeen patch keeps other channel cursors', () => {
+    const current = { messaging: { enabledChannels: ['slack'], homeChannel: 'slack',
+        latestSeen: { slack: null, telegram: '111', discord: '222' } } };
+    const next = mergeSettingsPatch(current, { messaging: { latestSeen: { slack: '999' } } });
+    assert.deepEqual(next.messaging.latestSeen, { slack: '999', telegram: '111', discord: '222' });
+    assert.deepEqual(next.messaging.enabledChannels, ['slack']);
+});
+
+test('SM-017: a key outside the spec is replaced wholesale, on purpose', () => {
+    // Arrays must not be union-merged, and that is why the contract is a
+    // declared list rather than a recursive deep merge.
+    const next = mergeSettingsPatch(
+        { employees: [{ id: 'a' }, { id: 'b' }], messaging: { enabledChannels: ['slack', 'telegram'] } },
+        { employees: [{ id: 'c' }], messaging: { enabledChannels: ['discord'] } },
+    );
+    assert.deepEqual(next.employees, [{ id: 'c' }]);
+    assert.deepEqual(next.messaging.enabledChannels, ['discord']);
+});
+
+test('SM-018: the layer does not mutate either input', () => {
+    const base = { network: { bindHost: '127.0.0.1', remoteAccess: { mode: 'off' } } };
+    const incoming = { network: { remoteAccess: { mode: 'lan' } } };
+    const next = mergeSettingsLayer(base, incoming);
+    assert.equal(base.network.remoteAccess.mode, 'off');
+    assert.deepEqual(incoming, { network: { remoteAccess: { mode: 'lan' } } });
+    assert.equal(next['network'].remoteAccess.mode, 'lan');
+});
+
+test('SM-019: an explicit null or array replaces the block rather than merging', () => {
+    const current = { heartbeat: { enabled: true, every: '30m' } };
+    assert.equal(mergeSettingsPatch(current, { heartbeat: null }).heartbeat, null);
+    assert.deepEqual(mergeSettingsPatch(current, { heartbeat: [] }).heartbeat, []);
+});
+
+test('SM-020: the spec names every key both ingresses rely on', () => {
+    for (const key of ['network', 'runtime', 'multiSession', 'avatar', 'messaging',
+        'heartbeat', 'stt', 'presentation', 'telegram', 'discord', 'slack', 'dispatchApproval']) {
+        assert.ok(SETTINGS_MERGE_SPEC[key], key + ' must be declared in SETTINGS_MERGE_SPEC');
+    }
+    assert.equal(SETTINGS_MERGE_SPEC['perCli']?.kind, 'perEntry');
+    assert.equal(SETTINGS_MERGE_SPEC['employees'], undefined,
+        'employees is an array and must stay a wholesale replacement');
+});
+


### PR DESCRIPTION
## 문제

`createDefaultSettings()` 가 권위처럼 보이지만 부팅 merge 와 API/watch merge 가 **각자 손으로 관리하는 nested 키 목록**을 갖고 있었고, 두 목록이 서로 달랐다. 부분 문서 하나가 어떤 sibling 키를 파괴하는지가 **어느 문으로 들어왔는지**에 달려 있었다 — 아무도 고른 적 없는 성질이다.

| 키 | 부팅 `loadSettings` | API/watch `mergeSettingsPatch` |
| --- | --- | --- |
| `heartbeat`, `stt`, `presentation` | **통째 교체(유실)** | 1단 merge |
| `avatar.{agent,user}` | 2단 merge | **통째 교체(유실)** |
| `messaging.{latestSeen,lastActive}` | 2단 merge | **1단만(유실)** |
| `network.remoteAccess` | 통째 교체 | 통째 교체 |

## 이슈 본문 정정 (착수 전 소스 재확인)

이슈 #696 은 "API/watch 는 `remoteAccess` 를 깊게 합친다"를 두 갈래 merge 의 근거로 들면서 `settings-merge.ts:218-223` 을 인용한다. **그 블록은 도달 불가능한 죽은 코드였다.** 같은 함수 172-176 루프가 `network` 를 1단 합친 뒤 `delete remaining[key]` 하므로, 218 의 `remaining["network"]` 는 항상 `undefined` 다. ack 쪽(181-)은 이 함정을 알고 원본 `patch` 를 다시 읽는데 `remoteAccess` 만 `remaining` 을 읽었다.

즉 **부팅과 API 가 둘 다** nested `remoteAccess` 를 통째 교체했다. "부팅은 날리고 API 는 지킨다"는 성립한 적이 없다. 두 갈래 merge 자체는 실재하지만 갈라지는 지점이 이슈가 지목한 곳이 아니었고, 위 표가 실제 지점이다.

## 무엇이 바뀌었나

**`SETTINGS_MERGE_SPEC` 하나와 `mergeSettingsLayer` 하나가 두 문을 다 통과한다.** 표에 없는 키는 **의도적으로** 통째 교체다 — `messaging.enabledChannels` 나 `employees` 같은 배열을 union merge 하면 안 되기 때문에, 재귀 deep merge 가 아니라 선언된 목록이다.

**merge 가 삼키면 안 되는 것은 layer 뒤에 남겼다.** 이게 이 변경에서 제일 조용히 깨질 수 있는 부분이라 목록으로 고정했다:

1. `ack` — `ack.emoji` 가 spec 이 닿지 않는 3단이다
2. `slack.autoJoin` — 합치는 게 아니라 **고치는** 규칙이다. 그 예산이 실제 채널에 조인하는 루프까지 가므로 `{autoJoin:null}` 이 디스크에 남으면 다음 부팅이 "없음"으로 읽고 기본 on 으로 되돌린다
3. `search.engine` — 합쳐지는 값이 아니라 `'fts5'` 가 아니면 `'like'` 로 **강제**되는 값
4. 부팅 `perCli` 의 `resolveRuntimeTransport` 루프
5. 부팅 `multiSessionBaseline` base 치환, v1 `legacyCli`, `migrateSettings(...)` 래퍼, `sanitizeSettingsInput` 은 merge **앞**

**중복 기본값을 단일 출처로.** 스키마는 `multiSession.maxConcurrent` 를 2 라고 하는데 레인 할당기는 `?? 1` 을 썼다 — 스키마만 고치면 호출부 리터럴이 이긴다. `resolveFlushEvery` / `resolveMemoryRetentionDays` / `resolveMaxConcurrent` 가 `DEFAULT_SETTINGS` 를 유일한 답으로 만든다. `migrateSettings` 의 복구 폴백도 그쪽을 본다 — 잘못된 값을 고치는 것은 "기본값이 무엇인가"에 대한 두 번째 의견으로 떨어지는 일이 아니다.

## 증거

**구·신 구현 32개 패치 대조.** 두 구현을 그대로 옮겨 같은 입력을 먹였을 때 갈라지는 것은 **4건이고 전부 의도한 수정**이다:

- `{network:{remoteAccess:{mode:'lan'}}}` → `trustProxies`/`trustForwardedFor`/`publicOriginHint` 보존 (이슈 완료 조건)
- `{messaging:{latestSeen:{slack:'9'}}}` → 다른 채널 커서 보존
- `{avatar:{agent:{...}}}` → `avatar.user` 보존
- `{code:{...}}` → 부팅과 API 가 이제 같은 답

나머지 28개는 바이트 동일. 의도치 않은 동작 변화 0건.

**테스트.** AB-007/AB-008 은 구현 표현식을 문자열로 grep 하고 있었다. 지키던 성질(#108)이 아니라 한 구현의 모양을 단언한 것이라, 리팩터는 테스트를 깨뜨리는데 진짜 sibling 유실 회귀는 통과할 수 있었다. 이제 merge 를 직접 실행한다. AB-008 은 spec 선언만이 아니라 **layer 가 그 표를 실제로 읽는지**까지 본다 — 선언만 있고 안 쓰이는 표는 구조 단언만으로 통과하기 때문이다.

`settings-boot-merge-parity.test.ts` 는 **실제 `loadSettings`** 를 통과한다. 결함이 나타나던 곳이 거기뿐이라 부팅 경로를 타지 않는 테스트는 증거가 아니다. BM-002 는 부팅 결과와 공용 layer 결과가 같은지를 보므로, 부팅이 다시 자기만의 merge 를 갖게 되면 거기서 갈라진다.

## 범위에서 뺀 것

**`network.remoteAccess.requireAuth` 는 이 PR 이 건드리지 않았다.** 저장소 전체에서 이 값을 읽는 곳은 `bin/commands/doctor.ts:1102,1108` 한 곳뿐이고, 그 파일은 이 작업의 파일 울타리 밖이라 리스를 요청했으나 아직 답을 받지 못했다.

스키마에서만 지우고 doctor 를 남기면 doctor 가 **존재하지 않는 설정을 계속 `requireAuth : true` 로 출력한다** (`!== false` 라 키가 없으면 항상 true). 그건 이슈가 명시적으로 금지한 "쓰지도 없지도 않은 중간 상태"를 새로 만드는 일이라, 반쪽만 하느니 통째로 미뤘다. 독립 감사도 같은 판정이었다. **완료 조건 중 "requireAuth 를 쓰거나 없애거나"는 미충족이며, 후속 PR 이 doctor 2줄과 함께 처리해야 한다.**

**호출부 리터럴 제거는 #696b 다.** `lifecycle-handler.ts`(714, 825), `session-lanes.ts`(101), `routes/memory.ts`(119, 122), `prompt/builder.ts`(643) 는 별도 PR 이고, `lifecycle-handler.ts` 는 지금 다른 워크트리가 리스를 갖고 있다. 이 PR 은 단일 출처를 **만들기만** 한다.

## NOT COVERED BY CI

- **실제 사용자 `settings.json` 문서 모양 전수.** 테스트는 합성 부분 문서만 본다. 32개 패치 대조도 내가 고른 입력이다.
- **Manager / Classic 설정 UI 의 실제 저장 흐름.** `tests/browser/**` 는 CI 가 호출하지 않는다.
- **`settings-watch` 파일 감시 타이밍 경합.** watch 경로가 `mergeSettingsPatch` 를 쓴다는 것만 정적으로 안다.
- **doctor 출력.** 위 사유로 이 PR 범위 밖이다.
- **`maxConcurrent` 복구 폴백이 1 에서 2 로 바뀐 것.** 이 값을 단언하는 기존 테스트가 없어서 CI 는 이 변화를 보지 못한다. 잘못된 값을 가진 문서에만 영향이 있다.
- **로컬 스위트는 NOT RUN.** 지시에 따라 `npm test` / `npm run build` / `npx tsc` / `npm install` 을 돌리지 않았다. 증거는 이 PR 의 exact head SHA 에서 본 `ci-aggregate` 다.

Closes #696 의 일부 — 완료 조건 중 requireAuth 항목은 위 사유로 미충족이므로 이 PR 은 이슈를 닫지 않는다.

Refs #696
