### PR TITLE
fix(adaptive-fetch): give every resolved platform a normalizer or a reason

### DIFF
--- a/src/browser/adaptive-fetch/endpoint-resolvers.ts
+++ b/src/browser/adaptive-fetch/endpoint-resolvers.ts
@@ -27,11 +27,25 @@ export function resolvePublicEndpointCandidates(rawUrl: string | URL): Candidate
         ...naverBlogCandidates(url),
         ...naverNewsCandidates(url),
         ...naverFinanceCandidates(url),
-        ...mediumCandidates(url),
-        ...substackCandidates(url),
-        ...linkedinCandidates(url),
     ];
 }
+
+/**
+ * #694: labels whose candidate already is the content rather than a structured
+ * API response — raw file bytes, or a cleaner rendition of the same page. They
+ * are meant to flow through the ordinary text and extraction path, so having no
+ * normalizer is the design for them rather than a gap in coverage.
+ */
+export const DIRECT_CONTENT_LABELS = [
+    // The raw file itself; there is nothing to structure.
+    'github-raw',
+    // Naver's mobile hosts render the same article with far less chrome.
+    'naver-blog-mobile',
+    'naver-news-mobile',
+] as const;
+
+/** #694: the one label handed to the yt-dlp reader rather than to a fetch. */
+export const YTDLP_LABELS = ['youtube-ytdlp'] as const;
 
 function githubCandidates(url: URL): CandidateUrl[] {
     if (url.hostname !== 'github.com') return [];
@@ -376,30 +390,11 @@ function seoulTwoYearsBack(epochMs: number): string {
     return seoulYyyymmdd(rolled - SEOUL_OFFSET_MS);
 }
 
-function mediumCandidates(url: URL): CandidateUrl[] {
-    if (!/(^|\.)medium\.com$/i.test(url.hostname)) return [];
-    return [{
-        label: 'medium-oembed',
-        url: `https://medium.com/oembed?url=${encodeURIComponent(url.href)}`,
-        source: 'public_endpoint',
-    }];
-}
-
-function substackCandidates(url: URL): CandidateUrl[] {
-    if (!/(^|\.)substack\.com$/i.test(url.hostname)) return [];
-    return [{
-        label: 'substack-oembed',
-        url: `https://substack.com/oembed?url=${encodeURIComponent(url.href)}`,
-        source: 'public_endpoint',
-    }];
-}
-
-function linkedinCandidates(url: URL): CandidateUrl[] {
-    if (!/(^|\.)linkedin\.com$/i.test(url.hostname)) return [];
-    if (!url.pathname.startsWith('/posts/') && !url.pathname.startsWith('/pulse/')) return [];
-    return [{
-        label: 'linkedin-oembed',
-        url: `https://www.linkedin.com/oembed?url=${encodeURIComponent(url.href)}&format=json`,
-        source: 'public_endpoint',
-    }];
-}
+// #694: medium / substack / linkedin oEmbed candidates were removed. None of
+// the three endpoints answers: checked live on 2026-09-11, medium.com/oembed
+// returns 403 from Cloudflare even with browser headers, and both
+// substack.com/oembed and the publication-host variant, and
+// linkedin.com/oembed, return 404. They also had no normalizer, so a candidate
+// that did answer would have fallen through to raw text anyway. Synthesising a
+// URL that is always refused only costs a request and a misleading "supported"
+// entry in the manifest.

--- a/src/browser/adaptive-fetch/live-smoke-manifest.ts
+++ b/src/browser/adaptive-fetch/live-smoke-manifest.ts
@@ -7,7 +7,7 @@ export interface LiveSmokeManifestEntry {
     reason: string;
 }
 
-export const LIVE_SMOKE_MANIFEST_VERSION = 2;
+export const LIVE_SMOKE_MANIFEST_VERSION = 3;
 
 export const LIVE_SMOKE_MANIFEST: LiveSmokeManifestEntry[] = [
     {
@@ -75,14 +75,6 @@ export const LIVE_SMOKE_MANIFEST: LiveSmokeManifestEntry[] = [
         expectedEvidence: ['public-endpoint:wikipedia-summary-api'],
         browserMode: 'auto',
         reason: 'Wikipedia REST API reader drift check',
-    },
-    {
-        id: 'medium-oembed',
-        url: 'https://medium.com/@user/test-post-abc123',
-        expectedLabels: ['medium-oembed', 'direct-fetch'],
-        expectedEvidence: ['public-endpoint:medium-oembed'],
-        browserMode: 'auto',
-        reason: 'Medium oembed public endpoint drift check',
     },
     {
         id: 'youtube-oembed',

--- a/src/browser/adaptive-fetch/public-endpoint-normalizers.ts
+++ b/src/browser/adaptive-fetch/public-endpoint-normalizers.ts
@@ -66,6 +66,10 @@ export function normalizePublicEndpointResult(
 }
 
 function buildByLabel(label: string, rawText: string, json: Json | null) {
+    // #694: the predicate is authoritative. A branch added below without a
+    // matching entry there returns null here, so the fixture test covering that
+    // label fails rather than the branch quietly never running.
+    if (!hasPublicEndpointNormalizer(label)) return null;
     if (label === 'github-repo-api') return githubRepo(json);
     if (label.startsWith('npm-registry')) return npmRegistry(json);
     if (label === 'pypi-json') return pypi(json);
@@ -85,7 +89,88 @@ function buildByLabel(label: string, rawText: string, json: Json | null) {
     if (label === 'lobsters-story-json') return lobsters(json);
     if (label === 'reddit-json') return reddit(json);
     if (label === 'rss-atom-discovered') return rssAtom(rawText, json);
+    if (label === 'naver-finance-json') return naverFinance(rawText);
     return null;
+}
+
+const NORMALIZER_LABELS = new Set([
+    'github-repo-api',
+    'pypi-json',
+    'hacker-news-item-api',
+    'hacker-news-algolia-item-api',
+    'wikipedia-summary-api',
+    'arxiv-api',
+    'crossref-work-api',
+    'wayback-cdx-api',
+    'stackexchange-question-api',
+    'devto-article-api',
+    'youtube-oembed',
+    'x-twitter-oembed',
+    'oembed-discovered',
+    'v2ex-topic-api',
+    'lobsters-story-json',
+    'reddit-json',
+    'rss-atom-discovered',
+    'naver-finance-json',
+]);
+
+const NORMALIZER_PREFIXES = ['npm-registry', 'openlibrary-', 'bluesky-', 'mastodon-'];
+
+/**
+ * #694: whether a resolver label has a structured normalizer at all. The
+ * manifest claimed platform support for four labels that fell straight through
+ * to raw text; this makes that question answerable by a test instead of by
+ * reading the dispatch.
+ */
+export function hasPublicEndpointNormalizer(label: string): boolean {
+    if (NORMALIZER_LABELS.has(label)) return true;
+    return NORMALIZER_PREFIXES.some(prefix => label.startsWith(prefix));
+}
+
+/**
+ * Naver's siseJson endpoint answers with a JavaScript array literal, not JSON:
+ * the header row is single-quoted while the data rows are double-quoted, so
+ * JSON.parse refuses it outright. Verified against a live response on
+ * 2026-09-11.
+ */
+function naverFinance(rawText: string) {
+    const rows = parseNaverSiseRows(rawText);
+    const header = rows[0];
+    const candles = rows.slice(1).filter(row => row.length >= 5 && /^\d{8}$/.test(String(row[0])));
+    if (!header || candles.length === 0) return null;
+
+    const latest = candles[candles.length - 1]!;
+    const first = candles[0]!;
+    const close = Number(latest[4]);
+    const open = Number(latest[1]);
+    const change = Number.isFinite(close) && Number.isFinite(open) ? close - open : null;
+
+    return built('naver-finance', `Naver Finance ${String(latest[0])}`, [
+        `Sessions: ${candles.length} (${String(first[0])} to ${String(latest[0])})`,
+        line('Latest date', latest[0]),
+        line('Open', latest[1]),
+        line('High', latest[2]),
+        line('Low', latest[3]),
+        line('Close', latest[4]),
+        line('Volume', latest[5]),
+        change == null ? null : `Change from open: ${change}`,
+    ], {
+        sessions: candles.length,
+        firstDate: String(first[0]),
+        latestDate: String(latest[0]),
+        latestClose: Number.isFinite(close) ? close : null,
+        columns: header.map(cell => String(cell)),
+    });
+}
+
+function parseNaverSiseRows(rawText: string): unknown[][] {
+    const trimmed = rawText.trim();
+    if (!trimmed.startsWith('[')) return [];
+    // Only the quoting differs from JSON. The payload is numbers and ASCII
+    // dates plus a Korean header row, none of which contains an apostrophe.
+    const parsed = parseJson(trimmed.replace(/'/g, '"'));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((row): row is unknown[] => Array.isArray(row));
 }
 
 function githubRepo(json: Json | null) {
@@ -378,7 +463,7 @@ function parseJson(raw: string): Json | null {
 }
 
 function isKnownPublicEndpointLabel(label: string): boolean {
-    return /^(github-|reddit-|hacker-news-|wikipedia-|npm-|pypi-|arxiv-|bluesky-|mastodon-|stackexchange-|devto-|crossref-|openlibrary-|wayback-|youtube-|x-twitter-|v2ex-|lobsters-|rss-|oembed-)/.test(label);
+    return /^(github-|reddit-|hacker-news-|wikipedia-|npm-|pypi-|arxiv-|bluesky-|mastodon-|stackexchange-|devto-|crossref-|openlibrary-|wayback-|youtube-|x-twitter-|v2ex-|lobsters-|rss-|oembed-|naver-)/.test(label);
 }
 
 function asObject(value: unknown): Record<string, unknown> {

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -411,7 +411,7 @@ cli-jaw/
 │   │   ├── adaptive-fetch/   ← Adaptive web fetch 서브모듈 (34 files; scheduler/stage-types P0 + browser pool/proxy/BM25/Camoufox/yt-dlp) ✨
 │   │   │   ├── index.ts      ← adaptive fetch orchestrator (152L)
 │   │   │   ├── safety.ts     ← URL/content safety checks (287L)
-│   │   │   ├── endpoint-resolvers.ts ← reader API endpoint resolution (405L)
+│   │   │   ├── endpoint-resolvers.ts ← reader API endpoint resolution (400L)
 │   │   │   ├── browser-escalation.ts ← fallback to browser fetch (330L)
 │   │   │   └── ... (14 more: fetcher, content-scorer, validators, metadata, transforms, trace, waf-profiles, browser-session, human-loop, output, browser-runtime, third-party-readers, reader-adapters, challenge-detector)
 │   │   └── web-ai/           ← Web AI 브라우저 자동화 (96 TS files; ChatGPT/Gemini/Grok + session-artifacts/capability-probe/tier-timeout/watcher-lock)

--- a/tests/unit/browser-adaptive-fetch-endpoints.test.ts
+++ b/tests/unit/browser-adaptive-fetch-endpoints.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolvePublicEndpointCandidates } from '../../src/browser/adaptive-fetch/endpoint-resolvers.js';
+import { resolvePublicEndpointCandidates, DIRECT_CONTENT_LABELS, YTDLP_LABELS } from '../../src/browser/adaptive-fetch/endpoint-resolvers.js';
+import { normalizePublicEndpointResult, hasPublicEndpointNormalizer } from '../../src/browser/adaptive-fetch/public-endpoint-normalizers.js';
 
 test('adaptive fetch resolves core public endpoint shapes', () => {
     assert.deepEqual(resolvePublicEndpointCandidates('https://example.com/article'), []);
@@ -131,4 +132,111 @@ test('#694-F the resolver source carries no frozen calendar constant', () => {
     assert.equal(/endTime=\d/.test(source), false, 'the query must not carry a literal end date');
     assert.match(source, /startTime=\$\{start\}/);
     assert.match(source, /endTime=\$\{end\}/);
+});
+
+// #694: "23 platforms supported" was only ever a claim. Four labels reached no
+// normalizer at all, and three of those pointed at endpoints that do not
+// answer. These make the claim answerable by a test.
+
+const PLATFORM_URLS = [
+    'https://github.com/org/repo',
+    'https://github.com/org/repo/blob/main/README.md',
+    'https://www.reddit.com/r/test/comments/abc/title/',
+    'https://news.ycombinator.com/item?id=123',
+    'https://en.wikipedia.org/wiki/Node.js',
+    'https://www.npmjs.com/package/cli-jaw',
+    'https://pypi.org/project/requests/',
+    'https://arxiv.org/abs/2301.00001',
+    'https://bsky.app/profile/alice.bsky.social',
+    'https://bsky.app/profile/alice.bsky.social/post/abc123',
+    'https://mastodon.social/@user/123456',
+    'https://mastodon.social/@user',
+    'https://stackoverflow.com/questions/1',
+    'https://dev.to/author/some-article',
+    'https://doi.org/10.1000/xyz123',
+    'https://openlibrary.org/works/OL1W',
+    'https://openlibrary.org/books/OL1M',
+    'https://web.archive.org/web/20200101000000/https://example.com/',
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://x.com/user/status/123',
+    'https://www.v2ex.com/t/123',
+    'https://lobste.rs/s/abc/title',
+    'https://blog.naver.com/someone/12345',
+    'https://n.news.naver.com/mnews/article/001/0014567890',
+    'https://finance.naver.com/item/main.naver?code=005930',
+];
+
+test('#694b-A every label the resolver can emit is accounted for', () => {
+    const seen = new Set<string>();
+    for (const url of PLATFORM_URLS) {
+        const candidates = resolvePublicEndpointCandidates(url);
+        assert.ok(candidates.length > 0, `${url} resolved to no candidate at all`);
+        for (const candidate of candidates) seen.add(candidate.label);
+    }
+    assert.ok(seen.size >= 20, `expected the resolver to cover at least 20 labels, saw ${seen.size}`);
+
+    for (const label of seen) {
+        const accounted = hasPublicEndpointNormalizer(label)
+            || (DIRECT_CONTENT_LABELS as readonly string[]).includes(label)
+            || (YTDLP_LABELS as readonly string[]).includes(label);
+        assert.ok(
+            accounted,
+            `"${label}" is produced by the resolver but has no normalizer, is not declared direct content, and is not the yt-dlp label — it would fall through to raw text while looking supported`,
+        );
+    }
+});
+
+test('#694b-B the three unanswerable oEmbed endpoints are gone', () => {
+    // Checked live on 2026-09-11: medium 403 (Cloudflare), substack 404 on both
+    // substack.com and the publication host, linkedin 404.
+    for (const url of [
+        'https://medium.com/@user/test-post-abc123',
+        'https://bot-eat-brain.substack.com/p/some-post',
+        'https://www.linkedin.com/posts/someone-activity-123',
+        'https://www.linkedin.com/pulse/some-article',
+    ]) {
+        const labels = resolvePublicEndpointCandidates(url).map(candidate => candidate.label);
+        for (const dead of ['medium-oembed', 'substack-oembed', 'linkedin-oembed']) {
+            assert.equal(labels.includes(dead), false, `${url} still synthesises ${dead}`);
+        }
+    }
+});
+
+test('#694b-C naver finance is normalized from its non-JSON array response', () => {
+    // The live shape: a single-quoted header row and double-quoted data rows,
+    // which JSON.parse refuses outright.
+    const raw = [
+        "[['날짜', '시가', '고가', '저가', '종가', '거래량', '외국인소진율'],",
+        '["20240911", 65100, 65500, 64200, 64900, 35809707, 55.2],',
+        '["20240912", 66000, 66600, 65200, 66300, 35884106, 55.11],',
+        '["20240913", 65000, 65500, 64300, 64400, 25045135, 54.9]]',
+    ].join('\n');
+    assert.throws(() => JSON.parse(raw), 'the fixture must be the real non-JSON shape');
+
+    const normalized = normalizePublicEndpointResult({
+        ok: true,
+        status: 200,
+        finalUrl: 'https://api.finance.naver.com/siseJson.naver?symbol=005930',
+        contentType: 'text/plain',
+        text: raw,
+        evidence: [],
+        warnings: [],
+    }, { label: 'naver-finance-json', source: 'public_endpoint' });
+
+    assert.ok(normalized, 'naver-finance-json must normalize');
+    assert.ok(normalized!.evidence.includes('public-endpoint:naver-finance-json'));
+    assert.equal(normalized!.metadata['sessions'], 3);
+    assert.equal(normalized!.metadata['latestDate'], '20240913');
+    assert.equal(normalized!.metadata['latestClose'], 64400);
+    assert.match(normalized!.text, /Close: 64400/);
+});
+
+test('#694b-D a garbled naver payload is refused rather than half-parsed', () => {
+    for (const raw of ['', 'not an array', "[['날짜']]", '[]']) {
+        const normalized = normalizePublicEndpointResult({
+            ok: true, status: 200, finalUrl: 'https://api.finance.naver.com/siseJson.naver?symbol=005930',
+            contentType: 'text/plain', text: raw, evidence: [], warnings: [],
+        }, { label: 'naver-finance-json', source: 'public_endpoint' });
+        assert.equal(normalized, null, `"${raw.slice(0, 20)}" must not normalize`);
+    }
 });

--- a/tests/unit/browser-adaptive-fetch-endpoints.test.ts
+++ b/tests/unit/browser-adaptive-fetch-endpoints.test.ts
@@ -240,3 +240,42 @@ test('#694b-D a garbled naver payload is refused rather than half-parsed', () =>
         assert.equal(normalized, null, `"${raw.slice(0, 20)}" must not normalize`);
     }
 });
+
+test('#694b-E the normalizer predicate and the dispatch it guards agree exactly', () => {
+    // buildByLabel runs behind hasPublicEndpointNormalizer, so the two can fail
+    // in both directions and both are the bug #694 is about. A branch with no
+    // set entry is unreachable — the failure that left the scheduler's yt-dlp
+    // branch dead. A set entry with no branch says "supported" and then returns
+    // raw text — the failure that made four platforms look supported. Read the
+    // dispatch and the declarations and require set equality.
+    const source = readFileSync(join(resolverRoot, 'src/browser/adaptive-fetch/public-endpoint-normalizers.ts'), 'utf8');
+    const dispatchAt = source.indexOf('function buildByLabel');
+    const labelsAt = source.indexOf('const NORMALIZER_LABELS');
+    const prefixesAt = source.indexOf('const NORMALIZER_PREFIXES');
+    const predicateAt = source.indexOf('export function hasPublicEndpointNormalizer');
+    assert.ok(
+        dispatchAt > -1 && labelsAt > dispatchAt && prefixesAt > labelsAt && predicateAt > prefixesAt,
+        'buildByLabel, its label set, its prefix list and the predicate must all be present in that order',
+    );
+
+    const quoted = (text: string) => [...text.matchAll(/'([^']+)'/g)].map(match => match[1]!);
+    const dispatch = source.slice(dispatchAt, labelsAt);
+    const branchLabels = new Set([...dispatch.matchAll(/label === '([^']+)'/g)].map(match => match[1]!));
+    const branchPrefixes = new Set([...dispatch.matchAll(/label\.startsWith\('([^']+)'\)/g)].map(match => match[1]!));
+    const declaredLabels = new Set(quoted(source.slice(labelsAt, prefixesAt)));
+    const declaredPrefixes = new Set(quoted(source.slice(prefixesAt, predicateAt)));
+
+    assert.ok(branchLabels.size >= 15, `expected many exact-label branches, found ${branchLabels.size}`);
+    assert.ok(branchPrefixes.size >= 3, `expected several prefix branches, found ${branchPrefixes.size}`);
+
+    const missing = [...branchLabels].filter(label => !declaredLabels.has(label));
+    assert.deepEqual(missing, [], `buildByLabel handles ${missing.join(', ')} but the guard rejects them, so those branches can never run`);
+    const orphaned = [...declaredLabels].filter(label => !branchLabels.has(label));
+    assert.deepEqual(orphaned, [], `the guard calls ${orphaned.join(', ')} normalizable but buildByLabel has no branch, so they fall through to raw text while looking supported`);
+    assert.deepEqual([...branchPrefixes].filter(p => !declaredPrefixes.has(p)), [], 'a prefix branch is missing from the guard');
+    assert.deepEqual([...declaredPrefixes].filter(p => !branchPrefixes.has(p)), [], 'the guard declares a prefix buildByLabel does not handle');
+
+    // The predicate must actually answer for what it declares.
+    for (const label of declaredLabels) assert.ok(hasPublicEndpointNormalizer(label));
+    for (const prefix of declaredPrefixes) assert.ok(hasPublicEndpointNormalizer(`${prefix}probe`));
+});

--- a/tests/unit/browser-adaptive-fetch-live-smoke-manifest.test.ts
+++ b/tests/unit/browser-adaptive-fetch-live-smoke-manifest.test.ts
@@ -9,7 +9,7 @@ import { validateFetchUrl } from '../../src/browser/adaptive-fetch/safety.js';
 
 test('live smoke manifest is default-off data with public known URLs only', () => {
     const manifest = getLiveSmokeManifest();
-    assert.equal(LIVE_SMOKE_MANIFEST_VERSION, 2);
+    assert.equal(LIVE_SMOKE_MANIFEST_VERSION, 3);
     assert.ok(manifest.length >= 4);
     for (const entry of manifest) {
         const parsed = validateFetchUrl(entry.url, { allowPrivateNetwork: false });
@@ -97,4 +97,3 @@ test('#694-D every public-endpoint evidence names a label the entry expects', ()
         }
     }
 });
-


### PR DESCRIPTION
Completes #694. #730 closed the label-drift and calendar-constant halves; this closes the platform-coverage half, which is what the issue title's "6개 플랫폼은 노멀라이저가 없다" refers to.

## Per-platform decision

Each of the six was checked against the live endpoint on 2026-09-11 before deciding.

| platform | live result | decision |
| --- | --- | --- |
| medium | `medium.com/oembed` → **403** from Cloudflare, with browser UA and `Accept: application/json` alike | removed from the resolver |
| substack | `substack.com/oembed` → **404**; publication-host `<pub>.substack.com/oembed` also **404** after redirect | removed from the resolver |
| linkedin | `linkedin.com/oembed` → **404** for both the `/posts/` and `/pulse/` shapes | removed from the resolver |
| naver finance | `api.finance.naver.com/siseJson.naver` → **200**, a JS array literal `JSON.parse` refuses | normalizer added |
| naver blog | `m.blog.naver.com` serves the same post as HTML | kept, declared direct content |
| naver news | `n.news.naver.com` → **200** HTML | kept, declared direct content |

The three removals are what the issue asks for when an endpoint is dead. They also had no normalizer, so even a 200 would have produced raw text under a label that looked supported. Synthesising a URL that is always refused costs a request and buys a misleading manifest entry. The medium entry in the live-smoke manifest goes with them, and `LIVE_SMOKE_MANIFEST_VERSION` becomes 3.

The two Naver mobile labels are the case the issue's wording does not have a slot for. They are not dead endpoints and they are not structured APIs — they rewrite a desktop URL to a cleaner rendition of the same article, which is exactly what the ordinary text and extraction path is for. Rather than argue that in a comment, the resolver now declares `DIRECT_CONTENT_LABELS` and a test enforces it. `github-raw` belongs to the same category and was previously in the same unaccounted state: it returns the file itself, and there is nothing to structure.

## Making "supported" checkable

`buildByLabel` now runs behind `hasPublicEndpointNormalizer`, which is the authoritative set rather than a second copy of the dispatch: a branch added without a matching entry returns null, so that label's fixture test fails instead of the branch quietly never running.

`#694b-A` resolves one URL per platform, collects every label the resolver emits, and fails on any label that is neither normalized, declared direct content, nor the yt-dlp label. That is the claim the issue said was untrue, now expressed as a test. `#694b-B` pins the three removals. `#694b-C` and `#694b-D` cover the Naver parser against the real response shape and against garbled input.

## NOT COVERED BY CI

- **The live endpoint results above.** They came from `curl` at a point in time from one network. CI does not re-check them, so a platform that starts answering again will not announce itself — the removals will simply stay removed until someone looks.
- **The Naver parser against a changed response shape.** `#694b-C` uses a fixture captured from a live 200. If Naver adds a string column containing an apostrophe, the quote substitution stops being safe; the parser then fails to parse and returns null, which is fail-closed rather than wrong, but no test observes that future shape.
- **Whether the two-year window the resolver now requests is inside Naver's accepted range.** The live probe used exactly that window and returned 200, but that is one observation, not a contract.
- **That `DIRECT_CONTENT_LABELS` candidates actually extract better than the original URL.** The test enforces that they are declared, not that the mobile rendition is an improvement.
- **`#694b-A` covers one URL shape per platform.** Labels reachable only through other shapes (an npm version URL, for instance) are covered by prefix rather than by a walked example.
- **Out of this lane's file scope:** `tests/waf/waf-manifest.ts:11` still notes Medium as "oembed available". That file is outside the browser/adaptive-fetch fence this task was given, so it is left for whoever owns it.

Closes #694
