### PR TITLE
docs(runtime): record why Pi has two stop ports

### DIFF
--- a/structure/runtime-integration.md
+++ b/structure/runtime-integration.md
@@ -380,6 +380,35 @@ These controls are not an arbitrary-process sandbox or aggregate pool/server
 shutdown certificate. Opaque wrappers and escaped descendants remain explicit
 limits; version output never enters Activity, MESSAGE or channel delivery.
 
+### Two stop ports, by definition rather than by drift
+
+Pi has two stop ports and that is deliberate. A pooled boss turn stops through
+`cancelTurn` → `requestCancel` → `lease.cancel()` → `cancelLease`
+(`runtime-pool.ts`), which writes an in-band RPC `abort` when the probed
+`abortEffective` capability allows it and otherwise kills the session. Ending the
+turn there must not end the child, because the pool reuses that session. A
+one-shot employee stops through `cancelOwnedPiProcess` → `cancelPiExecution` →
+the execution's own cancellation port, which signals the child through the
+cleanup owner. For a one-shot the turn IS the process, so ending the child is
+the stop. `spawnPersistentPiRpc` therefore installs no process-cancellation
+symbol and `spawnPiRpc` writes no `abort` frame.
+
+The abort-versus-kill decision itself is not duplicated: `cancelLease` is generic
+over `ManagedRuntime` and shared by every pooled runtime, with the Pi wrapper
+supplying only `interrupt` and `kill`. Every employee-reaching stop path tries the
+Pi cancellation port before any generic terminate, and no in-flight pooled turn
+reaches a generic terminate at all, because `cancelTurn` is installed before the
+run's process handle.
+
+An audit has read this pair as duplication (#701). It is not. Collapsing it would
+mean either routing employees through the pool, which costs them their isolated
+cwd and session, or giving a one-shot an in-band abort that must still be
+followed by the same teardown. Routing pooled Pi through `runNativeRuntime` would
+make it worse rather than better: that runner cancels through `session.cancel()`
+rather than `lease.cancel()`, so it would remove Pi from the shared `cancelLease`
+policy described above. Bringing Pi into the native runtime family is tracked
+separately as #738, and is a different goal from unifying cancellation.
+
 ## Native Code sessions
 
 `src/code-mode/` owns the `/api/code` API. The host composes an


### PR DESCRIPTION
#701 was filed because the pooled and one-shot Pi cancellation paths looked like duplication. The investigation that closed it concluded they are not: the difference is definitional, not drift. This records that in the runtime doc so the next audit does not re-file it as debt.

## What it says

A pooled boss turn stops through `cancelTurn` → `requestCancel` → `lease.cancel()` → `cancelLease`, which writes an in-band RPC `abort` when the probed `abortEffective` capability allows it and otherwise kills the session. Ending the turn there must not end the child, because the pool reuses that session. A one-shot employee stops through `cancelOwnedPiProcess` → `cancelPiExecution` → the execution's own cancellation port. For a one-shot the turn *is* the process, so ending the child is the stop.

The note also records the part that is easy to miss: the abort-versus-kill decision is **not** duplicated. `cancelLease` is generic over `ManagedRuntime` and shared by every pooled runtime, with the Pi wrapper supplying only `interrupt` and `kill`. And it records why the obvious "fix" is backwards — `runNativeRuntime` cancels through `session.cancel()` rather than `lease.cancel()`, so routing pooled Pi through it would remove Pi from that shared policy. The genuine follow-up is #738.

## NOT COVERED BY CI

- **Documentation only; no behaviour is asserted.** Nothing in `src/` changed, so no test proves the doc still matches the code. If the cancellation paths are later restructured, this section can go stale silently.
- **The claims are source-derived, not test-derived.** They were verified by reading the current paths at `spawn.ts` (`killAgentById`, `requestCancel`, `cancelTurn` install order), `runtime-pool.ts` `cancelLease`, and the two `pi-runtime.ts` spawners, and re-checked against `dev` before this PR. No CI job re-checks them.
- **`structure/verify-counts.sh` is not in `ci-aggregate`.** It runs under `install-risk-gate.mjs`. It was run locally and reports ALL PASS; `runtime-integration.md` is prose and is not line-counted in `str_func.md`, so no count needed updating.
- **No local suite was run.** Per this branch's constraint, `npm test`, `npm run build`, and `tsc` were NOT RUN locally.

Refs #701, #738
