### PR TITLE
refactor(settings): 호출부 설정 기본값 사본 제거 (#696b)

### DIFF
--- a/src/agent/lifecycle-handler.ts
+++ b/src/agent/lifecycle-handler.ts
@@ -4,7 +4,7 @@ import { revokeSlackToolGrant } from '../slack/tool-context.js';
 
 import type { ChildProcess } from 'child_process';
 import { broadcast } from '../core/bus.js';
-import { settings, detectCli } from '../core/config.js';
+import { settings, detectCli, resolveFlushEvery } from '../core/config.js';
 import { clearEmployeeSession, insertMessage, insertMessageWithTrace, insertMessageWithTraceRun, updateSession, clearSessionBucket, markAnchorConsumed, updateSessionBucketLastRun } from '../core/db.js';
 import { getActiveChatSession } from '../core/chat-sessions.js';
 import { persistMainSession, type SessionOwnerToken } from './session-persistence.js';
@@ -722,7 +722,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
                     catch { console.warn('[runtime] heartbeat anchor update failed'); }
                 }
                 incrementMemoryFlush();
-                const threshold = settings['memory']?.flushEvery ?? 10;
+                const threshold = resolveFlushEvery();
                 if (settings['memory']?.enabled !== false && countTurnForFlush(threshold)) {
                     void triggerMemoryFlush();
                 }
@@ -833,7 +833,7 @@ export async function handleAgentExit(params: ExitHandlerParams): Promise<void> 
             // the TARGET is global now, not because the trigger is per session — when
             // everyone is summarised together, who spent the counter stops mattering.
             incrementMemoryFlush();
-            const threshold = settings["memory"]?.flushEvery ?? 10;
+            const threshold = resolveFlushEvery();
             if (settings["memory"]?.enabled !== false && countTurnForFlush(threshold)) {
                 // The outcome needs no handling: an insufficient cycle is spent by policy,
                 // and a locked one has already queued its own retry.

--- a/src/orchestrator/session-lanes.ts
+++ b/src/orchestrator/session-lanes.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { settings } from '../core/config.js';
+import { resolveMaxConcurrent } from '../core/config.js';
 
 type MainJob = { start(): void };
 
@@ -98,5 +98,5 @@ export class SessionLanes {
 }
 
 export const sessionLanes = new SessionLanes(
-    () => settings["multiSession"]?.maxConcurrent ?? 1,
+    () => resolveMaxConcurrent(),
 );

--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import { createHash } from 'crypto';
 import { join } from 'path';
-import { settings, JAW_HOME, PROMPTS_DIR, SKILLS_DIR, SKILLS_REF_DIR, loadHeartbeatFile, deriveCdpPort, DEFAULT_PORT } from '../core/config.js';
+import { settings, JAW_HOME, PROMPTS_DIR, SKILLS_DIR, SKILLS_REF_DIR, loadHeartbeatFile, deriveCdpPort, DEFAULT_PORT, resolveFlushEvery } from '../core/config.js';
 import { expandHomePath } from '../core/path-expand.js';
 import { stripUndefined } from '../core/strip-undefined.js';
 import { resolveSkillId } from '../../lib/mcp/skills-aliases.js';
@@ -640,7 +640,7 @@ export function loadRecentMemories() {
 function appendLegacyMemoryContext(prompt: string) {
     let next = prompt;
     try {
-        const threshold = settings["memory"]?.flushEvery ?? 10;
+        const threshold = resolveFlushEvery();
         const injectInterval = Math.ceil(threshold / 2);
         // Phase 53-A: Always inject memory in the first 3 turns of a session
         // so short conversations never miss context.

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import { join } from 'path';
 import { ok, fail } from '../http/response.js';
 import { getMemory, upsertMemory, deleteMemory } from '../core/db.js';
-import { settings, saveSettings, JAW_HOME } from '../core/config.js';
+import { settings, saveSettings, JAW_HOME, resolveFlushEvery, resolveMemoryRetentionDays } from '../core/config.js';
 import * as memoryModule from '../memory/memory.js';
 import { bootstrapMemory, getMemoryStatus, getLastReflectedAt, hasSoulFile, loadSoulSummary, listMemoryFiles, reindexMemory, syncKvShadowImport } from '../memory/runtime.js';
 import { getFlushStatus } from '../agent/memory-flush-controller.js';
@@ -116,10 +116,10 @@ export function registerMemoryRoutes(app: Express, requireAuth: AuthMiddleware):
             });
         res.json({
             enabled: settings["memory"]?.enabled !== false,
-            flushEvery: settings["memory"]?.flushEvery ?? 10,
+            flushEvery: resolveFlushEvery(),
             cli: settings["memory"]?.cli || '',
             model: settings["memory"]?.model || '',
-            retentionDays: settings["memory"]?.retentionDays ?? 30,
+            retentionDays: resolveMemoryRetentionDays(),
             flushLanguage: settings["memory"]?.flushLanguage || 'en',
             path: memDir, files,
             counter: memoryFlushCounter,

--- a/tests/unit/settings-default-single-source.test.ts
+++ b/tests/unit/settings-default-single-source.test.ts
@@ -1,0 +1,64 @@
+// The schema default and the call-site default have to be the same number, and
+// the only way to keep them the same is to have one of them (#696).
+//
+// multiSession.maxConcurrent was declared 2 in the schema while the lane
+// allocator used ?? 1, so changing the schema did nothing: the literal at the
+// call site won. memory.flushEvery was declared 10 and then re-declared 10 in
+// four other files, which agreed only by luck.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_SETTINGS, resolveFlushEvery, resolveMaxConcurrent, resolveMemoryRetentionDays } from '../../src/core/config.ts';
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Settings keys whose default must come from DEFAULT_SETTINGS, nowhere else. */
+const SINGLE_SOURCE_KEYS = ['flushEvery', 'maxConcurrent'] as const;
+
+/** config.ts declares the defaults, so it is the one file allowed to name them. */
+const OWNER = 'src/core/config.ts';
+
+function* sourceFiles(dir: string): Generator<string> {
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+            yield* sourceFiles(full);
+        } else if (/\.tsx?$/.test(entry.name)) {
+            yield full;
+        }
+    }
+}
+
+test('SDS-001: no source file re-declares a settings default the schema already owns', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(join(projectRoot, 'src'))) {
+        const rel = relative(projectRoot, file).split('\\').join('/');
+        if (rel === OWNER) continue;
+        const source = readFileSync(file, 'utf8');
+        for (const key of SINGLE_SOURCE_KEYS) {
+            // settings["memory"]?.flushEvery ?? 10  — the shape that wins over the schema.
+            const pattern = new RegExp(key + '\\s*\\?\\?\\s*-?\\d');
+            if (pattern.test(source)) offenders.push(rel + ': ' + key);
+        }
+    }
+    assert.deepEqual(offenders, [], [
+        'These call sites carry their own copy of a settings default.',
+        'Use resolveFlushEvery / resolveMaxConcurrent from src/core/config.ts instead,',
+        'so changing DEFAULT_SETTINGS actually changes the runtime value.',
+    ].join(' '));
+});
+
+test('SDS-002: the resolvers answer with the schema value', () => {
+    assert.equal(resolveFlushEvery({}), DEFAULT_SETTINGS.memory.flushEvery);
+    assert.equal(resolveMaxConcurrent({}), DEFAULT_SETTINGS.multiSession.maxConcurrent);
+    assert.equal(resolveMemoryRetentionDays({}), DEFAULT_SETTINGS.memory.retentionDays);
+    // And the schema value is not accidentally the old call-site literal for the
+    // key where the two disagreed.
+    assert.equal(DEFAULT_SETTINGS.multiSession.maxConcurrent, 2);
+});
+


### PR DESCRIPTION
## 문제

스키마가 권위처럼 보이지만 호출부가 같은 기본값을 다시 적어 두고 있었고, 둘이 갈라진 곳에서는 **호출부가 이긴다.**

| 키 | 스키마 | 호출부 |
| --- | --- | --- |
| `multiSession.maxConcurrent` | `2` | `?? 1` (`session-lanes.ts:101`) |
| `memory.flushEvery` | `10` | `?? 10` 네 곳 |
| `memory.retentionDays` | `30` | `?? 30` (`routes/memory.ts:122`) |

`maxConcurrent` 는 스키마를 고쳐도 아무 일이 일어나지 않는다. `flushEvery` 는 숫자가 우연히 같아서 지금은 증상이 없을 뿐, 한쪽만 바꾸는 순간 갈라진다.

## 무엇이 바뀌었나

#696a 가 `DEFAULT_SETTINGS` 위에 만든 해석기로 네 호출부를 전부 돌렸다.

- `src/agent/lifecycle-handler.ts` (725, 836) → `resolveFlushEvery()`
- `src/orchestrator/session-lanes.ts` (101) → `resolveMaxConcurrent()`
- `src/routes/memory.ts` (119, 122) → `resolveFlushEvery()` / `resolveMemoryRetentionDays()`
- `src/prompt/builder.ts` (643) → `resolveFlushEvery()`

`session-lanes.ts` 는 이제 `settings` 를 import 하지 않는다 — 이 파일이 설정에 대해 알아야 할 것은 "몇 개까지인가"뿐이다.

## 증거

`SDS-001` 이 `src/` 전체를 훑어 `<key> ?? <숫자>` 모양이 되돌아오는 것을 막는다. `config.ts` 만 그 숫자를 적을 수 있다. **이슈 #696 의 완료 조건("`?? 10` / `?? 1` 같은 설정 폴백이 core/routes 에서 사라진다")을 실행 가능한 형태로 고정한 것이다.**

`SDS-002` 는 해석기가 실제로 스키마 값을 돌려주는지, 그리고 둘이 갈라져 있던 `maxConcurrent` 가 이제 `2` 인지를 단언한다.

## 범위에서 뺀 것

`src/agent/memory-flush-controller.ts` 의 `flushRowLimit` 도 `10` 을 들고 있다. 그건 트리거 주기가 아니라 **한 쿼리가 읽는 행 수 상한**이고, 주석이 "Clamp, not min" 이라고 명시한다. 같은 숫자를 쓰고 있을 뿐 같은 설정이 아니라서 이번 범위에 넣지 않았다.

## 동작 변화

`multiSession.maxConcurrent` 가 문서에 없을 때 레인 수가 **1 에서 2 로** 바뀐다. 부팅이 이 키를 항상 채우므로 정상 경로에서는 폴백이 거의 타지 않고, v3 미만 문서는 `LEGACY_MULTI_SESSION_BASELINE`(1)이 먼저 채운다. 소비처 `SessionLanes` 는 `positiveInt()` 를 거치므로 2 를 그대로 받는다.

## NOT COVERED BY CI

- **실제 설정 문서에서 이 폴백이 타는 경로.** 부팅이 키를 채우므로 폴백은 비정상 문서에서만 관측된다. 테스트는 해석기를 직접 부른다.
- **레인 수가 1 에서 2 로 바뀌었을 때의 실제 동시성 거동.** 유닛은 숫자만 본다.
- **로컬 스위트는 NOT RUN.** 지시에 따라 `npm test` / `npm run build` / `npx tsc` / `npm install` 을 돌리지 않았다. 증거는 이 PR 의 exact head SHA 에서 본 `ci-aggregate` 다.
- 현재 `dev` 자체가 red 다 — `4b4e64a4c` 가 `ko.json` 에만 `slack.workflow.unavailable` / `slack.workflow.unconfirmed` 를 넣어 `zh.json has every key ko.json has` 가 실패한다. 이 PR 과 무관하며 조율 세션에 보고했다.

## 의존

base 는 `codex/696a-settings-schema`(#733) 다. 해석기가 거기서 온다. #733 이 머지되면 base 를 `dev` 로 리타깃한다.

Closes #696
