### PR TITLE
fix(i18n): give zh.json the two Slack workflow keys

### DIFF
--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -973,5 +973,7 @@
   "slack.progress.status.unconfirmed": "完成未确认",
   "slack.progress.deliveryComplete": "答复已发送",
   "slack.progress.deliveryFailed": "无法确认答复已发送",
-  "slack.progress.deliveryUnconfirmed": "答复发送情况未确认"
+  "slack.progress.deliveryUnconfirmed": "答复发送情况未确认",
+  "slack.workflow.unavailable": "由于无法验证该自动化的发送方与请求信息，或指定的已启用技能，因此未予执行。请检查配置。",
+  "slack.workflow.unconfirmed": "已注册的工作流未返回实质性结果。相关工作可能已经开始，请在重试前查看其记录。"
 }


### PR DESCRIPTION
`dev` is red on `locale-parity`, and so is every open PR branched from it.

`4b4e64a4c` added `slack.workflow.unavailable` and `slack.workflow.unconfirmed` to `ko.json`, `en.json` and `ja.json` but not `zh.json`. `tests/unit/locale-parity.test.ts` requires every locale to carry every `ko` key, so `test 2/4` fails with `zh.json is missing 2 keys` on run [34571102181](https://github.com/lidge-jun/cli-jaw/actions/runs/34571102181) — the dev push run for that exact head.

This adds only those two keys. No other locale, key, or value changes.

Verified locally with a key/placeholder comparison across all four locales rather than the suite:

```
en parity OK (977 keys)
ja parity OK (977 keys)
zh parity OK (977 keys)
LOCALE PARITY PASS
```

## NOT COVERED BY CI

- **Translation quality is not machine-checkable.** The test asserts key parity and placeholder survival, not that the Simplified Chinese reads well. The two strings were written to match the `ko`/`en`/`ja` meaning; a native reviewer may want to reword them.
- **No placeholders are involved**, so the placeholder half of the gate is vacuous for these two keys.
- **No local suite was run.** Per this branch's constraint, `npm test`, `npm run build`, and `tsc` were NOT RUN locally.
