### PR TITLE
Harden the heartbeat scheduler and make an interrupted promotion resumable

### DIFF
--- a/.github/workflows/postinstall-platform.yml
+++ b/.github/workflows/postinstall-platform.yml
@@ -266,7 +266,23 @@ jobs:
   windows-wsl:
     name: Windows WSL postinstall policy
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: windows-2022
+    # windows-2025, not windows-2022, and the reason is inside the action rather
+    # than the image. setup-wsl v7.0.0 calls `wsl.exe --update` from
+    # installDistribution only when ALL of these hold (SetupWsl.kt:420-427):
+    #   wslVersion() != 1 && ImageOS == "win22" && RUNNER_ARCH == X64
+    #   && RUNNER_ENVIRONMENT == "github-hosted"
+    # That call is a win22-specific WSL2 kernel workaround, and it reaches a
+    # Microsoft endpoint we do not control. It answered `Forbidden (403)` on
+    # 729f0dca (run 34624568593) and hung for 30 minutes on f8a6aac7 until the
+    # job was cancelled (run 34668399466 attempt 1); the same tree passed on
+    # attempt 2. Retry.kt at that tag re-invokes with no delay, so ten attempts
+    # burned two seconds against a deterministic 403.
+    # Leaving win22 makes the guard false while KEEPING WSL2. The alternative,
+    # `wsl-version: '1'`, also makes it false but certifies the installer against
+    # WSL1's translation layer instead of the WSL2 VM that real users run, and
+    # src/core/platform-kind.ts does not distinguish them — the suite would stay
+    # green on weaker evidence. That stays the recorded fallback, not the default.
+    runs-on: windows-2025
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -274,6 +290,10 @@ jobs:
 
       - name: Setup WSL
         uses: Vampire/setup-wsl@v7
+        # Bounds a hang, rather than buying a pass: the job may still take 25
+        # minutes, but provisioning that stops answering fails in 5 instead of
+        # consuming the whole budget and reporting as a cancellation.
+        timeout-minutes: 5
         with:
           distribution: Ubuntu-24.04
           use-cache: 'false'

--- a/scripts/promote-to-main.sh
+++ b/scripts/promote-to-main.sh
@@ -19,11 +19,62 @@ fi
 
 PREVIEW_VERSION="$(git show "$PREVIEW_SHA:package.json" \
   | node -e 'const fs=require("node:fs"); process.stdout.write(JSON.parse(fs.readFileSync(0,"utf8")).version)')"
-if [[ ! "$PREVIEW_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-preview\.[0-9]+$ ]]; then
-  echo "ERROR: preview version must match X.Y.Z-preview.TIMESTAMP; got $PREVIEW_VERSION" >&2
-  exit 1
+
+# The version alone cannot decide what to do here. This script writes to the
+# remote in the middle of its own run: it lease-pushes preview to the stable bump
+# and only then waits for CI before touching main. When that wait gave up,
+# preview already carried X.Y.Z while main sat at its parent, and a re-run was
+# refused by the prerelease check that used to live on this line, so the release
+# was finished by hand. Loosening that check alone would be worse: the run would
+# fall into npm version --allow-same-version below and lease-push a SECOND commit
+# for a version CI had already certified. Classify the situation instead; the
+# rules and their fixtures live in scripts/promotion-state.mjs.
+MAIN_IS_ANCESTOR=false
+if git merge-base --is-ancestor refs/remotes/origin/main "$PREVIEW_SHA" 2>/dev/null; then
+  MAIN_IS_ANCESTOR=true
 fi
-STABLE_VERSION="${BASH_REMATCH[1]}"
+PREVIEW_PARENT_VERSION="$(git show "$PREVIEW_SHA^:package.json" 2>/dev/null \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).version)}catch{process.stdout.write("")}})' || true)"
+PREVIEW_SUBJECT="$(git log -1 --format=%s "$PREVIEW_SHA")"
+PREVIEW_DIFF="$(git diff --name-only "$PREVIEW_SHA^" "$PREVIEW_SHA" 2>/dev/null || true)"
+MAIN_HEAD_SHA="$(git rev-parse refs/remotes/origin/main^{commit})"
+PROMOTION_STATE_LINE="$(
+  node -e '
+    // node -e puts the FIRST user argument at argv[1]; there is no script path
+    // to skip, so slicing at 2 silently drops previewVersion and hands the SHA
+    // to the classifier as a version.
+    const v = process.argv.slice(1);
+    process.stdout.write(JSON.stringify({
+      previewVersion: v[0], previewSha: v[1], mainSha: v[2],
+      mainIsAncestor: v[3] === "true", parentVersion: v[4], previewSubject: v[5],
+      changedFiles: v[6] ? v[6].split(String.fromCharCode(10)).filter(Boolean) : [],
+    }));
+  ' \
+    "$PREVIEW_VERSION" "$PREVIEW_SHA" "$MAIN_HEAD_SHA" \
+    "$MAIN_IS_ANCESTOR" "$PREVIEW_PARENT_VERSION" "$PREVIEW_SUBJECT" "$PREVIEW_DIFF" \
+  | node scripts/promotion-state.mjs
+)"
+PROMOTION_STATE="${PROMOTION_STATE_LINE%% *}"
+STABLE_VERSION="$(echo "$PROMOTION_STATE_LINE" | awk '{print $2}')"
+RESUME=false
+case "$PROMOTION_STATE" in
+  prerelease)
+    ;;
+  resume)
+    # preview already holds the bump this script writes and main has not taken
+    # it. Skip the mint and the lease push; run the certification tail only.
+    RESUME=true
+    echo "NOTE: resuming an unfinished promotion of v$STABLE_VERSION at $PREVIEW_SHA" >&2
+    ;;
+  already_on_main)
+    echo "Nothing to do: main and preview are both v$STABLE_VERSION at $PREVIEW_SHA." >&2
+    exit 0
+    ;;
+  *)
+    echo "ERROR: ${PROMOTION_STATE_LINE#* }" >&2
+    exit 1
+    ;;
+esac
 
 TESTS_URL="$(gh run list \
   --workflow test.yml \
@@ -66,63 +117,96 @@ cleanup() {
   exit "$status"
 }
 trap cleanup EXIT
-prepare_promotion_checkout "$REMOTE_URL" "$PREVIEW_SHA" preview "$WORKTREE"
+if [ "$RESUME" = true ]; then
+  # Resume takes the commit preview already holds. Minting again would produce a
+  # second commit for the same version, and lease-pushing it would replace a tree
+  # CI had already certified, so neither the bump nor the preview push happens on
+  # this path. The clone exists only so the main push below has the object: a push
+  # from this repository would fail with "fatal: bad object".
+  PROMOTION_COMMIT="$PREVIEW_SHA"
+  git clone --quiet --no-checkout "$REMOTE_URL" "$WORKTREE"
+  git -C "$WORKTREE" fetch --quiet origin "$PROMOTION_COMMIT"
+  echo "resuming at the commit preview already carries: $PROMOTION_COMMIT"
+else
+  prepare_promotion_checkout "$REMOTE_URL" "$PREVIEW_SHA" preview "$WORKTREE"
 
-(
-  cd "$WORKTREE"
-  npm ci --ignore-scripts
-  npm version "$STABLE_VERSION" --no-git-tag-version --allow-same-version
-  node scripts/sync-electron-version.cjs
-  npm run gate:all
-  node scripts/require-release-evidence.mjs --accept-ci-evidence
-  git add package.json package-lock.json electron/package.json electron/package-lock.json
-  git commit -m "chore: promote v$STABLE_VERSION"
-  assert_promotion_checkout_ready_to_push "$WORKTREE" "$PREVIEW_SHA" preview
-)
-PROMOTION_COMMIT="$(git -C "$WORKTREE" rev-parse HEAD)"
+  (
+    cd "$WORKTREE"
+    npm ci --ignore-scripts
+    npm version "$STABLE_VERSION" --no-git-tag-version --allow-same-version
+    node scripts/sync-electron-version.cjs
+    npm run gate:all
+    node scripts/require-release-evidence.mjs --accept-ci-evidence
+    git add package.json package-lock.json electron/package.json electron/package-lock.json
+    git commit -m "chore: promote v$STABLE_VERSION"
+    assert_promotion_checkout_ready_to_push "$WORKTREE" "$PREVIEW_SHA" preview
+  )
+  PROMOTION_COMMIT="$(git -C "$WORKTREE" rev-parse HEAD)"
 
-# Fast-forward preview first. preview is where the release CI that publish.yml
-# gates on actually runs, so the bump has to be certified there before main can
-# take it. --force-with-lease pins the push to the SHA this run certified: if
-# preview moved while the gates ran, the push is refused instead of silently
-# discarding whatever landed.
-#
-# Every push here runs from the promotion checkout. The promotion commit exists
-# only in that clone, so pushing from the main repository fails with
-# "fatal: bad object" -- the object it is asked to send was never written here.
-git -C "$WORKTREE" push --force-with-lease="refs/heads/preview:$PREVIEW_SHA" \
-  origin "$PROMOTION_COMMIT:refs/heads/preview"
-echo "preview fast-forwarded to the promotion commit: $PROMOTION_COMMIT"
+  # Fast-forward preview first. preview is where the release CI that publish.yml
+  # gates on actually runs, so the bump has to be certified there before main can
+  # take it. --force-with-lease pins the push to the SHA this run certified: if
+  # preview moved while the gates ran, the push is refused instead of silently
+  # discarding whatever landed.
+  #
+  # Every push here runs from the promotion checkout. The promotion commit exists
+  # only in that clone, so pushing from the main repository fails with
+  # "fatal: bad object" -- the object it is asked to send was never written here.
+  git -C "$WORKTREE" push --force-with-lease="refs/heads/preview:$PREVIEW_SHA" \
+    origin "$PROMOTION_COMMIT:refs/heads/preview"
+  echo "preview fast-forwarded to the promotion commit: $PROMOTION_COMMIT"
+fi
 
 wait_for_run() {
-  local workflow="$1" label="$2" branch="$3" sha="$4" url="" failed=""
-  local deadline=$((SECONDS + 1200))
-  while [ "$SECONDS" -lt "$deadline" ]; do
+  # $5 is the event filter. Tests must stay push-only: publish.yml accepts a
+  # certifying Tests run only from a preview/main push, so waiting on any other
+  # event here would wait for evidence the gate then rejects. The platform
+  # workflow is the opposite: publish.yml and require-release-evidence.mjs both
+  # look it up by commit with no event filter, so insisting on push here made a
+  # legal re-dispatch unable to finish a promotion it had already satisfied.
+  local workflow="$1" label="$2" branch="$3" sha="$4" event="${5:-push}"
+  local url="" states="" live="" failed=""
+  local -a event_filter=()
+  [ -n "$event" ] && event_filter=(--event "$event")
+
+  # The budget bounds DISCOVERY, not execution. It used to bound both at 1200s,
+  # which is shorter than the 1500s the windows-wsl job alone is allowed, so a
+  # slow-but-legal platform run could exhaust it while still running. Once a run
+  # for this SHA exists, it carries its own timeout-minutes and that is the bound
+  # we respect; a run that never appears is what this deadline is for.
+  local discovery_deadline=$((SECONDS + 1200))
+  while :; do
     url="$(gh run list \
       --workflow "$workflow" \
       --branch "$branch" \
       --commit "$sha" \
-      --event push \
+      "${event_filter[@]}" \
       --status success \
       --limit 1 --json url --jq '.[0].url // ""')"
     [ -n "$url" ] && { echo "$label certified by: $url" >&2; return 0; }
-    failed="$(gh run list \
+
+    # One listing, newest first, so liveness and failure are judged against the
+    # same snapshot. Both workflows set cancel-in-progress, so a superseded run
+    # leaves a cancelled conclusion next to a live replacement; reading only the
+    # newest completed row called the SHA dead while it was still being tested.
+    states="$(gh run list \
       --workflow "$workflow" \
       --branch "$branch" \
       --commit "$sha" \
-      --event push \
-      --status completed \
-      --limit 1 --json conclusion --jq '.[0].conclusion // ""')"
-    case "$failed" in
-      failure|cancelled|timed_out|startup_failure|action_required)
-        echo "ERROR: $branch $label completed with $failed" >&2
-        return 1
-        ;;
-    esac
+      "${event_filter[@]}" \
+      --limit 20 --json status,conclusion --jq '.[] | "\(.status) \(.conclusion // "")"')"
+    live="$(printf '%s\n' "$states" | grep -c -E '^(queued|in_progress|waiting|requested|pending)' || true)"
+    failed="$(printf '%s\n' "$states" | grep -m1 -E '^completed (failure|cancelled|timed_out|startup_failure|action_required)$' || true)"
+    if [ -n "$failed" ] && [ "${live:-0}" -eq 0 ]; then
+      echo "ERROR: $branch $label completed with ${failed#completed }" >&2
+      return 1
+    fi
+    if [ "${live:-0}" -eq 0 ] && [ "$SECONDS" -ge "$discovery_deadline" ]; then
+      echo "ERROR: no $branch $label run appeared for $sha within 1200s" >&2
+      return 1
+    fi
     sleep 10
   done
-  echo "ERROR: timed out waiting for successful $branch $label" >&2
-  return 1
 }
 
 # postinstall-platform.yml carries paths: filters, so it never runs for a SHA
@@ -139,9 +223,23 @@ if [ -n "$PREVIOUS_TAG" ]; then
   [ "$DETECTOR_STATUS" -eq 1 ] && PLATFORM_REQUIRED=true
 fi
 
-wait_for_run test.yml "Tests" preview "$PROMOTION_COMMIT"
+# Printed on every path that gives up after preview already moved, so the
+# operator resumes instead of reconstructing the tail by hand. The script is
+# resumable now: re-running it classifies this exact state and skips the bump.
+promote_resume_hint() {
+  echo "" >&2
+  echo "preview already carries v$STABLE_VERSION at $PROMOTION_COMMIT; main was not moved." >&2
+  echo "Resume once the required runs are green (the bump is not repeated):" >&2
+  echo "  bash scripts/promote-to-main.sh" >&2
+}
+
+wait_for_run test.yml "Tests" preview "$PROMOTION_COMMIT" push || { promote_resume_hint; exit 1; }
 if [ "$PLATFORM_REQUIRED" = true ]; then
-  wait_for_run postinstall-platform.yml "Postinstall Platform Checks" preview "$PROMOTION_COMMIT"
+  # No event filter: publish.yml and require-release-evidence.mjs both accept any
+  # successful platform run for the commit, so promote must not be stricter than
+  # the gate it is feeding.
+  wait_for_run postinstall-platform.yml "Postinstall Platform Checks" preview "$PROMOTION_COMMIT" "" \
+    || { promote_resume_hint; exit 1; }
 fi
 
 # ─── Fast-forward main onto the certified commit ────────────────────────────

--- a/scripts/promotion-state.mjs
+++ b/scripts/promotion-state.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * promotion-state.mjs — decide what promote-to-main.sh is looking at.
+ *
+ * WHY THIS EXISTS. `promote-to-main.sh` does three things in order: mint the
+ * stable bump, force-with-lease `preview` to it, then fast-forward `main`. The
+ * middle step is a remote write, and everything after it can still fail — the
+ * script waits for CI before touching `main`. When that wait gave up, `preview`
+ * was already carrying `X.Y.Z` while `main` sat at its parent, and re-running
+ * the script was refused at its own prerelease check, because `X.Y.Z` is not
+ * `X.Y.Z-preview.TIMESTAMP`. The only remaining path was hand recovery.
+ *
+ * Loosening that regex alone would be worse than the bug: the script would walk
+ * into `npm version --allow-same-version`, mint a SECOND commit for the same
+ * version, and lease-push it over a commit CI had already certified. So the
+ * decision is not "is this a prerelease" but "which of four situations is this",
+ * and it is a pure function so the contract test can assert behaviour on
+ * fixtures instead of grepping the shell script for phrases.
+ *
+ * States:
+ *   prerelease      preview is X.Y.Z-preview.N  -> mint and push, the normal path
+ *   already_on_main preview is X.Y.Z and main is the same commit -> nothing to do
+ *   resume          preview is X.Y.Z and carries a promotion commit main has not
+ *                   taken yet -> skip the bump, run the certification tail only
+ *   refuse          anything else -> stop, because we cannot name what happened
+ *
+ * `resume` is deliberately narrow. It is not "preview looks stable"; it is a
+ * fingerprint of a promotion this script itself left behind: main is an ancestor,
+ * the parent commit is the matching prerelease, the subject is the one we write,
+ * and the diff against that parent touches nothing but the four version
+ * manifests. A stable `preview` that fails any clause is `refuse`, not resume,
+ * because a tree we cannot identify must never be fast-forwarded onto main.
+ */
+
+/** The only files a promotion commit is allowed to change. */
+export const VERSION_MANIFESTS = Object.freeze([
+    'package.json',
+    'package-lock.json',
+    'electron/package.json',
+    'electron/package-lock.json',
+]);
+
+const PRERELEASE_RE = /^(\d+\.\d+\.\d+)-preview\.\d+$/;
+const STABLE_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * @param {{
+ *   previewVersion?: string,
+ *   previewSha?: string,
+ *   mainSha?: string,
+ *   mainIsAncestor?: boolean,
+ *   parentVersion?: string,
+ *   previewSubject?: string,
+ *   changedFiles?: string[],
+ * }} input
+ */
+export function classifyPromotionState(input = {}) {
+    const previewVersion = String(input.previewVersion ?? '').trim();
+    const previewSha = String(input.previewSha ?? '').trim();
+    const mainSha = String(input.mainSha ?? '').trim();
+
+    const prerelease = PRERELEASE_RE.exec(previewVersion);
+    if (prerelease) {
+        return { state: 'prerelease', stableVersion: prerelease[1] };
+    }
+
+    if (!STABLE_RE.test(previewVersion)) {
+        return {
+            state: 'refuse',
+            reason: `preview version must match X.Y.Z-preview.TIMESTAMP or a promotable X.Y.Z; got ${previewVersion || '(empty)'}`,
+        };
+    }
+
+    // Equality first: an already-finished promotion is a normal outcome and must
+    // not be reported as a broken state just because the operator ran again.
+    if (previewSha.length > 0 && previewSha === mainSha) {
+        return { state: 'already_on_main', stableVersion: previewVersion };
+    }
+
+    if (input.mainIsAncestor !== true) {
+        return {
+            state: 'refuse',
+            reason: 'origin/main is not an ancestor of origin/preview, so preview was rewritten rather than promoted',
+        };
+    }
+
+    const expectedSubject = `chore: promote v${previewVersion}`;
+    if (String(input.previewSubject ?? '').trim() !== expectedSubject) {
+        return {
+            state: 'refuse',
+            reason: `preview head is not a promotion commit: expected subject "${expectedSubject}"`,
+        };
+    }
+
+    const parentVersion = String(input.parentVersion ?? '').trim();
+    const parentPre = PRERELEASE_RE.exec(parentVersion);
+    if (!parentPre || parentPre[1] !== previewVersion) {
+        return {
+            state: 'refuse',
+            reason: `preview parent must be the matching prerelease ${previewVersion}-preview.TIMESTAMP; got ${parentVersion || '(empty)'}`,
+        };
+    }
+
+    const changed = (input.changedFiles ?? []).map((f) => String(f).replace(/\\/g, '/').trim()).filter(Boolean);
+    if (changed.length === 0) {
+        return { state: 'refuse', reason: 'promotion commit changed nothing, so it is not the bump this script writes' };
+    }
+    const stray = changed.filter((f) => !VERSION_MANIFESTS.includes(f));
+    if (stray.length > 0) {
+        return {
+            state: 'refuse',
+            reason: `promotion commit touches more than the version manifests: ${stray.join(', ')}`,
+        };
+    }
+
+    return { state: 'resume', stableVersion: previewVersion };
+}
+
+// CLI: JSON on stdin, one line out as "<state> <stableVersion> <reason...>".
+// The shell reads field one and ignores the rest unless it needs to print why.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href) {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    let parsed;
+    try {
+        parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+    } catch (err) {
+        process.stdout.write(`refuse - could not parse promotion state input: ${err.message}\n`);
+        process.exit(0);
+    }
+    const result = classifyPromotionState(parsed);
+    process.stdout.write(`${result.state} ${result.stableVersion ?? '-'} ${result.reason ?? ''}\n`.replace(/\s+$/, '') + '\n');
+}

--- a/src/memory/heartbeat.ts
+++ b/src/memory/heartbeat.ts
@@ -78,6 +78,20 @@ const heartbeatTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const heartbeatCronSlots = new Map<string, string>();
 let heartbeatWatcher: fs.FSWatcher | null = null;
 let heartbeatBusy = false;
+// One job, one run. `heartbeatBusy` already stops two try-bodies from
+// interleaving, because it is set synchronously before the first await, so this
+// is not about concurrency. It is about the SAME job being executed twice in a
+// row: a tick deferred during an active PABCD cycle stays queued, a later tick
+// for that job runs directly once the cycle ends, and the finishing run then
+// drains the copy it left behind. Two identical reports, seconds apart. The
+// queue dedupe below cannot see this because the second arrival never queues.
+const inFlightJobs = new Set<string>();
+// Bumped whenever the schedule is torn down, which includes every settings
+// reload and every PUT through the API. A run that was admitted under an older
+// generation has been superseded: its job object, destination and prompt may all
+// have been replaced on disk, so it must not send, write an anchor, or drain.
+let heartbeatGeneration = 0;
+let heartbeatAbort: AbortController | null = null;
 type HeartbeatPendingReason = 'busy' | 'pabcd_active' | 'agent_busy';
 type HeartbeatPendingPolicy = 'defer';
 interface PendingHeartbeatJob {
@@ -181,6 +195,18 @@ function queueHeartbeatJob(
     return true;
 }
 
+/** Drop any queued copy of a job that is about to run, or has just run. */
+function forgetPendingJob(jobId: string): void {
+    for (let i = pendingJobs.length - 1; i >= 0; i -= 1) {
+        if (String(pendingJobs[i]?.job["id"] ?? "") === jobId) pendingJobs.splice(i, 1);
+    }
+}
+
+/** The signal a live tick should observe; null until the first run arms one. */
+export function heartbeatRunSignal(): AbortSignal | undefined {
+    return heartbeatAbort?.signal;
+}
+
 export function getHeartbeatRuntimeState() {
     return pendingSnapshot();
 }
@@ -226,9 +252,23 @@ export function startHeartbeat() {
 }
 
 export function stopHeartbeat() {
+    // Tearing down timers was never enough. A tick already inside its try-body
+    // kept the job object it was admitted with and went on to send, anchor and
+    // write the mention-watch ledger, and the queue it left behind was still
+    // drained by whatever finished next, including from the external callers in
+    // orchestrator/pipeline, routes/orchestrate, cli/handlers-runtime and
+    // agent/spawn/queue. Bump the generation and abort first so an in-flight run
+    // stops at its next checkpoint, then drop the queue it would have replayed.
+    heartbeatGeneration += 1;
+    heartbeatAbort?.abort();
+    heartbeatAbort = null;
+    pendingJobs.length = 0;
     for (const timer of heartbeatTimers.values()) clearTimeout(timer);
     heartbeatTimers.clear();
-    heartbeatCronSlots.clear();
+    // Cron slots deliberately survive. startHeartbeatCronLoop runs the current
+    // minute immediately on arm, so clearing the map here let a save plus the
+    // file watcher rebuild the schedule and fire the same minute again. Keeping
+    // the slot means the immediate tick recognises work it already did.
 }
 
 export interface HeartbeatReportDecision { send: boolean; anchor: boolean; delivered: boolean }
@@ -354,6 +394,11 @@ async function runMentionWatchJob(job: Record<string, any>, watch: HeartbeatMent
         selfUserId: getSlackSelfUserId(),
         allowlist: readSlackAllowlist(sc["channelIds"]),
         log: (message) => log.info(`[heartbeat:${job["name"]}] ${message}`),
+        // The tick already knows how to stop: it checks deps.signal before each
+        // answer and reports stoppedBecause 'aborted'. Nothing ever handed it one,
+        // so a scan that started before a settings reload kept answering and kept
+        // writing receipts under the old configuration.
+        ...(heartbeatRunSignal() ? { signal: heartbeatRunSignal()! } : {}),
         // Yield to anything a person is waiting on. Re-read per item because the
         // previous answer may have taken minutes.
         yieldNow: (hit) => {
@@ -573,6 +618,14 @@ async function reserveHeartbeatDestinationGrant(
 
 export async function runHeartbeatJob(job: Record<string, any>, deps: HeartbeatJobDeps = {}) {
     const runner = job["runner"] || 'main';
+    const jobId = String(job["id"] ?? job["name"] ?? '');
+    // Checked before every other guard. A job already executing must be skipped
+    // outright, not queued: queueing it is what produced the back-to-back double
+    // report, because the finishing run drains what the queue still holds.
+    if (jobId && inFlightJobs.has(jobId)) {
+        log.info(`[heartbeat:${job["name"]}] already running, skip`);
+        return;
+    }
     if (runner === 'main' && getState('default') !== 'IDLE') {
         const queued = queueHeartbeatJob(job, 'pabcd_active', 'defer');
         log.info(`[heartbeat:${job["name"]}] ${queued ? 'deferred' : 'already deferred'} during active PABCD (${pendingJobs.length} pending)`);
@@ -592,6 +645,16 @@ export async function runHeartbeatJob(job: Record<string, any>, deps: HeartbeatJ
         return;
     }
     heartbeatBusy = true;
+    // Admission point. From here the run owns this id, and the queue must not
+    // keep a copy of it: a deferred entry for this job was satisfied by this very
+    // tick. The generation is captured so the finally block can tell whether the
+    // schedule was torn down underneath it.
+    const generation = heartbeatGeneration;
+    if (jobId) {
+        inFlightJobs.add(jobId);
+        forgetPendingJob(jobId);
+    }
+    if (!heartbeatAbort) heartbeatAbort = new AbortController();
     try {
         // A mention watch replaces the prompt path entirely: its prompt describes
         // how to answer a message that has not been found yet, so running it bare
@@ -749,12 +812,20 @@ export async function runHeartbeatJob(job: Record<string, any>, deps: HeartbeatJ
         log.error(`[heartbeat:${job["name"]}] error:`, (err as Error).message);
     } finally {
         heartbeatBusy = false;
-        await drainPending();
+        if (jobId) inFlightJobs.delete(jobId);
+        // A superseded run must not hand work to the next one. Draining here after
+        // stopHeartbeat would replay jobs from a configuration the operator has
+        // already replaced, which is exactly what made stop look advisory.
+        if (generation === heartbeatGeneration) await drainPending();
     }
 }
 
 export async function drainPending() {
     if (pendingJobs.length === 0) return;
+    // Reachable from orchestrator/pipeline, routes/orchestrate, cli/handlers-runtime
+    // and agent/spawn/queue, none of which know whether the schedule is still
+    // armed. Without this a stopped heartbeat kept starting jobs.
+    if (heartbeatTimers.size === 0) return;
     if (isAgentBusy(HEARTBEAT_SCOPE) || messageQueue.length > 0 || hasPendingWorkerReplays(HEARTBEAT_SCOPE)) return;
     const next = pendingJobs.shift()?.job;
     if (!next) return;

--- a/structure/infra.md
+++ b/structure/infra.md
@@ -442,6 +442,26 @@ preview**. It then fast-forwards `preview` to that commit, waits for `test.yml`
 green **on that exact SHA**, re-checks that live `preview` still equals it, and
 fast-forwards `main` to the same commit with a plain non-force push.
 
+The wait is not a wall clock over execution. `wait_for_run` spends its 1200s
+budget only while no run for the SHA has appeared; once one is queued or running
+it is followed for its own lifetime, because the `windows-wsl` job alone may take
+25 minutes and the old fixed budget was shorter than that. A failed or cancelled
+conclusion is terminal only when no live run remains for the SHA: both workflows
+set `cancel-in-progress`, so a superseded run leaves a cancelled row beside its
+replacement. The platform lookup carries no `--event` filter, matching
+`publish.yml` and `require-release-evidence.mjs`, which resolve it by commit; the
+Tests lookup stays push-only because `publish.yml` accepts nothing else.
+
+Because the script writes to the remote before it is finished, it can be
+interrupted with `preview` already carrying the stable bump and `main` behind.
+`scripts/promotion-state.mjs` classifies that state (`prerelease`, `resume`,
+`already_on_main`, `refuse`) and a re-run resumes: it takes the commit `preview`
+already holds and skips both the version bump and the preview push, so a tree CI
+has certified is never replaced by a same-version copy. `resume` requires the
+full fingerprint — `main` an ancestor, the parent the matching prerelease, the
+subject `chore: promote vX.Y.Z`, and a diff touching only the four version
+manifests — and anything else is refused rather than guessed at.
+
 There is no PR and no squash (#480). `main` and `preview` end up on the SAME
 commit, which is why the ancestry guard keeps holding on the next cycle.
 

--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -318,7 +318,7 @@ cli-jaw/
 │   ├── memory/               ← 데이터 영속화 + advanced memory runtime (17 files)
 │   │   ├── advanced.ts       ← Advanced Memory re-export stub (1L)
 │   │   ├── bootstrap.ts      ← legacy memory/bootstrap import + structured root 초기화 (588L)
-│   │   ├── heartbeat.ts      ← Heartbeat 잡 스케줄 + cron/every timer orchestration + minute-slot dedupe + fs.watch (820L)
+│   │   ├── heartbeat.ts      ← Heartbeat 잡 스케줄 + cron/every timer orchestration + minute-slot dedupe + in-flight skip + generation/abort teardown + fs.watch (891L)
 │   │   ├── heartbeat-schedule.ts ← Heartbeat schedule normalize + cron validate/match + timezone validate + immediate cron loop helper (410L)
 │   │   ├── heartbeat-mention-watch.ts ← Slack mention 항목 loop + busy yield + server-owned thread send + WatchNamespace 경유 ledger 접근 (249L)
 │   │   ├── mention-watch-ledger.ts ← v2 ledger 단일 접근 경로 (WatchNamespace = job+workspace+user, 모든 SQL이 3파트 predicate 유지, A/B 대칭 테스트가 최종 보증) (104L) ✨

--- a/structure/telegram.md
+++ b/structure/telegram.md
@@ -561,13 +561,14 @@ Mounted at `/api/dashboard/telegram-hub` (`loopbackOnly` middleware).
 
 ---
 
-## memory/heartbeat.ts — Scheduled Jobs (205L)
+## memory/heartbeat.ts — Scheduled Jobs (891L)
 
 | Function | 역할 |
 | --- | --- |
 | `startHeartbeat()` | cron-like 주기 작업 시작 |
-| `stopHeartbeat()` | 작업 중지 |
-| `runHeartbeatJob(job)` | 단일 작업 실행 (busy guard) |
+| `stopHeartbeat()` | 세대 증가 + abort + 대기 큐 비우기 + 타이머 해제 (cron 슬롯은 유지) |
+| `runHeartbeatJob(job)` | 단일 작업 실행 (in-flight skip + busy guard + 세대 포착) |
+| `drainPending()` | 대기 큐 1건 실행 — 스케줄이 해제된 상태에서는 아무것도 하지 않는다 |
 | `watchHeartbeatFile()` | fs.watch debounce — 파일 변경시 재로드 |
 
 ### 의존 모듈
@@ -579,9 +580,23 @@ Mounted at `/api/dashboard/telegram-hub` (`loopbackOnly` middleware).
 - 설정: `~/.cli-jaw/heartbeat.json`
 - 각 작업: `id`, `name`, `enabled`, `schedule`, `prompt`
 - `schedule`은 `{ kind: 'every', minutes }` 또는 `{ kind: 'cron', cron, timeZone? }`
-- busy guard: 이전 작업 실행 중이면 버리지 않고 `pendingJobs` 큐에 넣는다
+- busy guard: 다른 작업이 실행 중이면 버리지 않고 `pendingJobs` 큐에 넣는다. 단 **같은**
+  작업이 이미 실행 중이면 큐에 넣지 않고 건너뛴다 — 큐에 넣으면 끝나는 실행의 `finally`가
+  그 사본을 다시 실행해 같은 보고가 두 번 전달됐다.
+- 실행이 받아들여지는 시점에 그 작업의 대기 사본은 제거된다. PABCD 중 연기된 틱은 이후의
+  정상 틱이 수행한 것으로 충족된 것이므로 다시 재생하지 않는다.
+- `stopHeartbeat()`는 세대를 올리고 진행 중인 실행을 abort 하며 대기 큐를 비운다. 세대가
+  바뀐 실행은 전송·앵커·ledger 기록과 drain을 수행하지 않는다. `drainPending()`은 외부
+  (`orchestrator/pipeline`, `routes/orchestrate`, `cli/handlers-runtime`, `agent/spawn/queue`)
+  에서도 호출되므로, 타이머가 없으면 스스로 아무 일도 하지 않는다.
+- cron 슬롯 맵은 재로드를 넘어 살아남는다. `startHeartbeatCronLoop`가 arm 즉시 현재 분을
+  실행하므로, 슬롯을 비우면 저장 + 파일 감시 재빌드로 같은 분이 두 번 발사된다.
+- mention watch 틱은 스케줄러의 `AbortSignal`을 받는다. 이미 `deps.signal`을 읽고
+  `stoppedBecause: 'aborted'`를 보고하던 경로가 이제 실제로 연결돼 있다.
 - 실행 프롬프트 앞에는 memory search 지시가 자동으로 붙는다
-- 결과 전송은 Telegram 고정이 아니라 `sendChannelOutput({ channel: 'active', ... })`를 통해 현재 활성 채널로 간다
+- 결과 전송은 작업에 바인딩된 목적지로만 간다. 활성 채널로 보내는 경로는 없다 —
+  목적지는 완결돼 있거나 보류되며, 자세한 규칙은 이 문서 위쪽
+  `heartbeat-destination.ts` 절에 있다.
 
 ---
 

--- a/tests/unit/heartbeat-overlap.test.ts
+++ b/tests/unit/heartbeat-overlap.test.ts
@@ -1,0 +1,142 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Overlap and cancellation, against the real scheduler.
+ *
+ * tests/unit/heartbeat-queue.test.ts cannot answer these questions: it
+ * reimplements the queue locally and never imports the owner, so it stays green
+ * however heartbeat.ts behaves.
+ *
+ * Two defects are pinned here. Neither is a concurrency bug — heartbeatBusy is
+ * set synchronously before the first await, so two try-bodies cannot interleave.
+ * They are about the same job being executed twice in sequence, and about a
+ * teardown that did not actually stop anything.
+ */
+
+const collectUrl = new URL('../../src/orchestrator/collect.ts', import.meta.url).href;
+const sendUrl = new URL('../../src/messaging/send.ts', import.meta.url).href;
+const dbUrl = new URL('../../src/core/db.ts', import.meta.url).href;
+const stateUrl = new URL('../../src/orchestrator/state-machine.ts', import.meta.url).href;
+const spawnUrl = new URL('../../src/agent/spawn.ts', import.meta.url).href;
+const registryUrl = new URL('../../src/orchestrator/worker-registry.ts', import.meta.url).href;
+
+const [realSend, realDb, realState, realSpawn, realRegistry] = await Promise.all([
+    import('../../src/messaging/send.js'),
+    import('../../src/core/db.js'),
+    import('../../src/orchestrator/state-machine.js'),
+    import('../../src/agent/spawn.js'),
+    import('../../src/orchestrator/worker-registry.js'),
+]);
+
+/** Flips to 'P' to simulate an active PABCD cycle deferring a main-runner tick. */
+let pabcdState = 'IDLE';
+/** Resolved by the test to release a run that is parked inside its try-body. */
+let releaseRun: (() => void) | null = null;
+let collectCalls = 0;
+const sent: string[] = [];
+
+mock.module(collectUrl, { namedExports: {
+    orchestrateAndCollectData: async () => {
+        collectCalls += 1;
+        if (releaseRun) {
+            await new Promise<void>(resolve => { releaseRun = resolve; });
+        }
+        return { text: 'status: ok\nsummary: tick complete', data: {} };
+    },
+    orchestrateAndCollect: async () => 'unused',
+} });
+mock.module(sendUrl, { namedExports: {
+    ...realSend,
+    sendChannelOutput: async (input: Record<string, any>) => { sent.push(String(input['text'])); return { ok: true }; },
+} });
+mock.module(dbUrl, { namedExports: {
+    ...realDb,
+    getEmployees: { all: () => [] },
+    insertHeartbeatAnchor: { run: () => {} },
+} });
+mock.module(stateUrl, { namedExports: { ...realState, getState: () => pabcdState } });
+mock.module(spawnUrl, { namedExports: { ...realSpawn, isAgentBusy: () => false, messageQueue: [] } });
+mock.module(registryUrl, { namedExports: { ...realRegistry, hasPendingWorkerReplays: () => false } });
+
+const { runHeartbeatJob, drainPending, stopHeartbeat, getHeartbeatRuntimeState } =
+    await import('../../src/memory/heartbeat.js');
+const { resolveHeartbeatBinding } = await import('../../src/memory/heartbeat-destination.js');
+
+const destination = { channel: 'slack' as const, targetId: 'C_REPORTS', scope: 'channel_root' as const };
+const JOB = { id: 'hb-1', name: 'status', runner: 'main', reportPolicy: 'always', destination };
+
+function runJob(overrides: Record<string, unknown> = {}) {
+    return runHeartbeatJob({ ...JOB, ...overrides }, {
+        verifyDestination: async target => resolveHeartbeatBinding(target),
+        reserveDestinationGrant: async () => () => {},
+    });
+}
+
+function reset() {
+    pabcdState = 'IDLE';
+    releaseRun = null;
+    collectCalls = 0;
+    sent.length = 0;
+    stopHeartbeat();
+}
+
+test('HB-OVL-001: a deferred tick is not replayed after a later tick already ran the job', async () => {
+    // The sequence that produced two identical reports seconds apart: a tick is
+    // deferred while PABCD is busy, a later tick runs the job directly once the
+    // cycle ends, and the finishing run drains the copy the first tick left.
+    reset();
+    pabcdState = 'P';
+    await runJob();
+    assert.equal(collectCalls, 0, 'the deferred tick must not have executed');
+    assert.equal(getHeartbeatRuntimeState().pending, 1, 'the deferred tick must be queued');
+
+    pabcdState = 'IDLE';
+    await runJob();
+
+    assert.equal(collectCalls, 1, 'the job must run exactly once, not once per queued copy');
+    assert.equal(sent.length, 1, 'exactly one report may be delivered');
+    assert.equal(getHeartbeatRuntimeState().pending, 0, 'the satisfied queue entry must be gone');
+});
+
+test('HB-OVL-002: a job already running is skipped rather than queued', async () => {
+    reset();
+    releaseRun = () => {};
+    const first = runJob();
+    // The run is parked inside its try-body; a second arrival must not enqueue a
+    // copy that the finishing run would then execute.
+    await runJob();
+    assert.equal(getHeartbeatRuntimeState().pending, 0, 'a running job must not be queued again');
+    const release = releaseRun;
+    releaseRun = null;
+    release?.();
+    await first;
+    assert.equal(collectCalls, 1, 'the second arrival must not produce a second execution');
+});
+
+test('HB-OVL-003: stopHeartbeat drops queued work and the finishing run does not drain it', async () => {
+    reset();
+    pabcdState = 'P';
+    await runJob();
+    await runJob({ id: 'hb-2', name: 'other' });
+    assert.equal(getHeartbeatRuntimeState().pending, 2, 'both ticks must be queued');
+
+    stopHeartbeat();
+    assert.equal(getHeartbeatRuntimeState().pending, 0, 'stop must drop the queue it would otherwise replay');
+
+    pabcdState = 'IDLE';
+    await drainPending();
+    assert.equal(collectCalls, 0, 'a stopped schedule must not start work from any caller');
+});
+
+test('HB-OVL-004: drainPending is inert while the schedule is not armed', async () => {
+    // drainPending is reachable from orchestrator/pipeline, routes/orchestrate,
+    // cli/handlers-runtime and agent/spawn/queue, none of which know whether the
+    // heartbeat is running.
+    reset();
+    pabcdState = 'P';
+    await runJob();
+    pabcdState = 'IDLE';
+    await drainPending();
+    assert.equal(collectCalls, 0, 'no timers are armed, so nothing may be dequeued');
+});

--- a/tests/unit/heartbeat-pabcd-guard.test.ts
+++ b/tests/unit/heartbeat-pabcd-guard.test.ts
@@ -44,7 +44,14 @@ test('heartbeat defers while the main agent is busy', () => {
 
 test('heartbeat drain respects main-agent and user-queue priority', () => {
     const drainIdx = heartbeatSrc.indexOf('export async function drainPending');
-    const drainBlock = heartbeatSrc.slice(drainIdx, drainIdx + 500);
+    // The window used to be a fixed 500 characters, which measured byte distance
+    // rather than the function: adding a comment inside drainPending pushed the
+    // shift() call out of range and failed a test whose subject had not changed.
+    // Slice to the next top-level declaration instead.
+    const afterDrain = heartbeatSrc.indexOf('\nfunction ', drainIdx);
+    const afterDrainExport = heartbeatSrc.indexOf('\nexport ', drainIdx + 1);
+    const ends = [afterDrain, afterDrainExport].filter(i => i > drainIdx);
+    const drainBlock = heartbeatSrc.slice(drainIdx, ends.length ? Math.min(...ends) : heartbeatSrc.length);
 
     assert.ok(heartbeatSrc.includes("import { hasPendingWorkerReplays } from '../orchestrator/worker-registry.js'"));
     assert.ok(drainIdx > -1, 'drainPending must exist');

--- a/tests/unit/promotion-state.test.ts
+++ b/tests/unit/promotion-state.test.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { classifyPromotionState, VERSION_MANIFESTS } from '../../scripts/promotion-state.mjs';
+
+/**
+ * The shape these fixtures describe is not hypothetical. Promoting v2.17.50 left
+ * `preview` at the stable bump while `main` stayed at its parent, because the
+ * certification wait gave up before the main push. Re-running the script was
+ * then refused by its own prerelease check, so the release was finished by hand.
+ *
+ * These cases assert the classifier can tell that situation apart from the three
+ * it must NOT treat as resumable.
+ */
+
+const RESUMABLE = {
+    previewVersion: '2.17.50',
+    previewSha: 'f8a6aac7e649fef1eb3d8eba1ced5c207ec12597',
+    mainSha: '112b9e21aa8f2ee61f7d7ee9dfe3de953f5206bc',
+    mainIsAncestor: true,
+    parentVersion: '2.17.50-preview.20260912112701',
+    previewSubject: 'chore: promote v2.17.50',
+    changedFiles: [...VERSION_MANIFESTS],
+};
+
+test('PROMO-001: a prerelease preview takes the ordinary mint-and-push path', () => {
+    const result = classifyPromotionState({ previewVersion: '2.17.51-preview.20260913010203' });
+    assert.equal(result.state, 'prerelease');
+    assert.equal(result.stableVersion, '2.17.51');
+});
+
+test('PROMO-002: a finished promotion reports itself instead of failing', () => {
+    const sha = 'f8a6aac7e649fef1eb3d8eba1ced5c207ec12597';
+    const result = classifyPromotionState({ previewVersion: '2.17.50', previewSha: sha, mainSha: sha });
+    assert.equal(result.state, 'already_on_main');
+});
+
+test('PROMO-003: the exact state a timed-out promotion leaves behind is resumable', () => {
+    const result = classifyPromotionState(RESUMABLE);
+    assert.equal(result.state, 'resume');
+    assert.equal(result.stableVersion, '2.17.50');
+});
+
+test('PROMO-004: resume needs every clause, not a stable-looking version', () => {
+    // Each row removes exactly one clause from a resumable fingerprint. Dropping
+    // any of them must refuse, because the thing being fast-forwarded onto main
+    // would no longer be a commit this script is known to have written.
+    const cases: Array<[string, Record<string, unknown>]> = [
+        ['main is not an ancestor, so preview was rewritten', { mainIsAncestor: false }],
+        ['the head is not a promotion commit', { previewSubject: 'fix(heartbeat): something else' }],
+        ['the parent is not the matching prerelease', { parentVersion: '2.17.49-preview.20260911' }],
+        ['the parent is already stable', { parentVersion: '2.17.49' }],
+        ['the commit carries source changes', { changedFiles: ['package.json', 'src/memory/heartbeat.ts'] }],
+        ['the commit carries a workflow change', { changedFiles: ['.github/workflows/publish.yml'] }],
+        ['the commit changed nothing', { changedFiles: [] }],
+    ];
+    for (const [why, override] of cases) {
+        const result = classifyPromotionState({ ...RESUMABLE, ...override });
+        assert.equal(result.state, 'refuse', `must refuse when ${why}`);
+        assert.ok((result.reason ?? '').length > 0, `refusal must say why when ${why}`);
+    }
+});
+
+test('PROMO-005: a version that is neither prerelease nor stable is refused', () => {
+    for (const previewVersion of ['', '2.17', 'v2.17.50', '2.17.50-rc.1', '2.17.50-preview']) {
+        const result = classifyPromotionState({ ...RESUMABLE, previewVersion });
+        assert.equal(result.state, 'refuse', `must refuse "${previewVersion}"`);
+    }
+});
+
+test('PROMO-006: the manifest allowlist is exactly the four release ledger files', () => {
+    // Widening this list is how a source change would become resumable, so the
+    // list itself is the assertion rather than an implementation detail.
+    assert.deepEqual([...VERSION_MANIFESTS].sort(), [
+        'electron/package-lock.json',
+        'electron/package.json',
+        'package-lock.json',
+        'package.json',
+    ]);
+});

--- a/tests/unit/release-scripts-contract.test.ts
+++ b/tests/unit/release-scripts-contract.test.ts
@@ -182,6 +182,59 @@ test('stable promotion delegates checkout isolation and never auto-rewrites docs
     assert.ok(!script.includes('verify-counts.sh --fix'));
 });
 
+test('stable promotion resumes after preview already carries the stable bump', () => {
+    // Promoting v2.17.50 left preview at the stable bump and main at its parent:
+    // the certification wait gave up before the main push, and re-running was
+    // refused by the script's own prerelease check, so the release was finished by
+    // hand. The decision is a classifier with fixtures (promotion-state.test.ts);
+    // what this test owns is that the script actually routes through it and that
+    // resume cannot become a second bump.
+    const script = read('scripts/promote-to-main.sh');
+
+    assert.ok(
+        script.includes('node scripts/promotion-state.mjs'),
+        'promotion must classify the preview state instead of pattern-matching the version inline',
+    );
+    for (const state of ['prerelease', 'resume', 'already_on_main']) {
+        assert.ok(script.includes(state), `promotion must handle the ${state} state`);
+    }
+
+    // The bump and the preview push belong to the prerelease path only. On resume
+    // the commit already exists and CI has seen it; minting again would replace a
+    // certified tree with a same-version copy.
+    const resumeBranch = script.slice(script.indexOf('if [ "$RESUME" = true ]; then'), script.indexOf('else', script.indexOf('if [ "$RESUME" = true ]; then')));
+    assert.ok(resumeBranch.length > 0, 'promotion must carry an explicit resume branch');
+    assert.ok(!resumeBranch.includes('npm version'), 'resume must not re-mint the version bump');
+    assert.ok(!resumeBranch.includes('--force-with-lease'), 'resume must not re-push preview');
+
+    // Ordering is the safety property: certification still precedes the main ref
+    // update on every path, and main is still never forced.
+    assert.ok(
+        script.indexOf('wait_for_run test.yml') < script.indexOf('refs/heads/main'),
+        'the Tests wait must still precede the main push',
+    );
+    assert.ok(!/push[^\n]*--force[^-]/.test(script), 'the main push must never use --force');
+
+    // The wait budget used to be a 1200s wall clock covering execution, which is
+    // shorter than the 1500s the windows-wsl job alone may take. A run that exists
+    // must be waited on for its own lifetime.
+    const waiter = script.slice(script.indexOf('wait_for_run() {'), script.indexOf('promote_resume_hint'));
+    assert.ok(waiter.includes('discovery_deadline'), 'the deadline must bound discovery, not a running job');
+    assert.ok(
+        waiter.includes('queued|in_progress'),
+        'the waiter must keep polling while a run for this SHA is still live',
+    );
+    assert.ok(
+        /live.*-eq 0/s.test(waiter),
+        'a failed conclusion may only be terminal when no live run remains, because cancel-in-progress leaves cancelled rows beside replacements',
+    );
+
+    assert.ok(
+        script.includes('promote_resume_hint'),
+        'giving up after preview moved must tell the operator how to resume',
+    );
+});
+
 test('stable promotion cleans up its checkout without leaking a remote branch', () => {
     // The old promotion minted codex/promote-<version>-<sha12> on origin, so the
     // trap had to delete it on every abort between push and merge; five such

--- a/tests/unit/windows-ci-coverage.test.ts
+++ b/tests/unit/windows-ci-coverage.test.ts
@@ -155,3 +155,56 @@ test('WCI-005: push and pull_request cover the SAME Windows-critical set', () =>
     // Manual dispatch is the escape hatch when a release needs the lane on demand.
     assert.ok(on.workflow_dispatch !== undefined, 'workflow_dispatch must remain available');
 });
+
+// WCI-006: the WSL lane must not sit on the one runner image that makes
+// setup-wsl call `wsl.exe --update`.
+//
+// setup-wsl v7.0.0 reaches that Microsoft endpoint only when every clause holds
+// (SetupWsl.kt:420-427): `wslVersion() != 1`, `ImageOS == "win22"`,
+// `RUNNER_ARCH == X64`, `RUNNER_ENVIRONMENT == "github-hosted"`. It answered 403
+// on one release SHA and hung for thirty minutes on another. Two clauses are
+// ours to choose. Dropping to `wsl-version: 1` is the cheaper one and the wrong
+// one: it certifies the installer against WSL1 rather than the WSL2 VM users
+// run, and src/core/platform-kind.ts cannot tell the two apart, so the evidence
+// would weaken while every test stayed green. Leaving win22 is the choice this
+// test pins; the wsl-version fallback stays legal but must be explicit.
+test('WCI-006: the WSL lane avoids the win22 --update path without weakening to WSL1', () => {
+    const job = (workflow.jobs ?? {})['windows-wsl'];
+    assert.ok(job, 'windows-wsl job must exist');
+    assert.ok(!job['continue-on-error'], 'windows-wsl must stay a blocking gate');
+
+    assert.notEqual(
+        job['runs-on'],
+        'windows-2022',
+        'windows-2022 is the one ImageOS that makes setup-wsl call wsl.exe --update (SetupWsl.kt:420-427)',
+    );
+
+    const setup = (job.steps ?? []).find((step: Record<string, unknown>) =>
+        String(step?.['uses'] ?? '').startsWith('Vampire/setup-wsl@'));
+    assert.ok(setup, 'the WSL lane must still provision through Vampire/setup-wsl');
+
+    // A hang has to die on its own budget. Asserted downward only: raising this
+    // is the move this test exists to notice.
+    const stepTimeout = setup['timeout-minutes'];
+    assert.equal(typeof stepTimeout, 'number', 'Setup WSL needs its own timeout-minutes');
+    assert.ok(stepTimeout <= 5, `Setup WSL timeout-minutes must stay <= 5 (got ${stepTimeout})`);
+
+    const jobTimeout = job['timeout-minutes'];
+    if (jobTimeout !== undefined) {
+        assert.ok(jobTimeout <= 25, `windows-wsl timeout-minutes must stay <= 25 (got ${jobTimeout})`);
+    }
+
+    const inputs = (setup['with'] ?? {}) as Record<string, unknown>;
+    // `update` upgrades the distribution's apt packages (SetupWsl.kt:253-255);
+    // it never governed the kernel call, so it must not be mistaken for the fix.
+    assert.notEqual(inputs['update'], true, 'distribution apt upgrade is not the kernel-update switch');
+
+    // The fallback is allowed, but only as a deliberate value. A WSL1 lane that
+    // appeared by accident would silently narrow what this gate proves.
+    if (inputs['wsl-version'] !== undefined) {
+        assert.ok(
+            [1, '1'].includes(inputs['wsl-version'] as string | number),
+            'wsl-version, if set, is the recorded WSL1 fallback and must be exactly 1',
+        );
+    }
+});


### PR DESCRIPTION
## Problem

Promoting v2.17.50 stalled with `preview` already carrying the stable bump and `main` still behind, and the release was finished by hand. That was not bad luck:

- `promote-to-main.sh` gave `wait_for_run` a fixed 1200s budget covering execution, while the `windows-wsl` job alone is allowed 1500s.
- Once the wait gave up, re-running was refused by the script's own prerelease check, because `preview` no longer looked like `X.Y.Z-preview.TIMESTAMP`.
- The job it was waiting for depends on a Microsoft endpoint: `wsl.exe --update` answered `Forbidden (403)` on 729f0dca and hung for 30 minutes on f8a6aac7 before the job was cancelled.

Separately, the heartbeat scheduler could deliver the same report twice and could not be stopped.

## Changes

**Heartbeat.** `heartbeatBusy` already prevents two try-bodies from interleaving, so nothing raced. What overlapped was one job running twice in sequence: a tick deferred during an active PABCD cycle stayed queued, a later tick ran that job directly, and the finishing run drained the copy left behind. `stopHeartbeat` cleared timers while leaving the queue populated, with no abort and no generation, so an in-flight tick kept sending under a configuration the operator had already replaced, and `drainPending` — reachable from four other modules — kept starting jobs afterwards. Cron slots now survive the rebuild, because `startHeartbeatCronLoop` runs the current minute immediately on arm. The `AbortSignal` the mention-watch tick already reads is finally passed to it.

**Promotion.** `scripts/promotion-state.mjs` classifies what the script is looking at (`prerelease`, `resume`, `already_on_main`, `refuse`) as a pure function, so the contract test asserts behaviour instead of grepping the shell for phrases. Resume takes the commit `preview` already holds and skips both the bump and the preview push, so a certified tree is never replaced by a same-version copy. The waiter now bounds discovery only and follows a live run for its own lifetime; a failed conclusion is terminal only when no live run remains, because `cancel-in-progress` leaves cancelled rows beside replacements. The platform lookup drops its push-event filter to match `publish.yml`.

**WSL gate.** setup-wsl v7.0.0 calls `wsl.exe --update` only when `wslVersion() != 1 && ImageOS == "win22" && RUNNER_ARCH == X64 && RUNNER_ENVIRONMENT == "github-hosted"` (SetupWsl.kt:420-427). Leaving win22 makes that guard false while keeping WSL2. Dropping to `wsl-version: 1` also works but would certify the installer against WSL1's translation layer instead of the WSL2 VM users run, and `platform-kind.ts` cannot tell them apart — the suite would stay green on weaker evidence, so that stays the recorded fallback. A step-level `timeout-minutes: 5` bounds a future hang instead of letting it consume the job budget.

## Validation

`npm run gate:all` → 23/23 passed. 129 heartbeat tests green. Each new guard was mutation-checked: removing it turns exactly the matching test red.

- `HB-OVL-001..004` exercise the real `runHeartbeatJob`/`drainPending`/`stopHeartbeat`, not the local reimplementation in `heartbeat-queue.test.ts`.
- `PROMO-001..006` cover all four promotion states, including the exact shape today's interruption left behind.
- `WCI-006` pins the runner image, the step bound and the fallback structurally.
- `promote-to-main.sh` was run live against the current remotes: it classified `already_on_main` and exited 0 without writing.

**This PR exists for the one piece a unit test cannot give:** a real `Windows WSL postinstall policy` run on `windows-2025`. `postinstall-platform.yml` does not run on `dev` pushes, so that evidence has to come from here before this reaches `preview`.
