### PR TITLE
fix(messaging): resolve scheduled Slack pair to configured dest only

### DIFF
--- a/src/messaging/send.ts
+++ b/src/messaging/send.ts
@@ -117,18 +117,18 @@ export type ChannelSendRequest = {
      *  fidelity. Absent means the caller would rather be told it is unsupported
      *  than have the message quietly arrive as something else. */
     interactiveFallback?: 'text';
-    /** Non-interactive senders (heartbeats, scheduled jobs) set this to false so a
-     *  missing target FAILS instead of silently resolving to whoever spoke last.
-     *  The last-active chain exists for CONVERSATIONAL replies where "this
-     *  conversation" is the obvious destination (#397); a scheduled report has no
-     *  such context, so inheriting one delivers it to an unrelated thread (#437).
-     *  Absent keeps the historical behaviour — every existing caller is unchanged. */
+    /** Interactive senders (live operator/agent reply) leave this unset so omit-target
+     *  still walks last-active / turnTarget / latest-seen (#397, #474).
+     *  Scheduled senders (reminders, web-ai drain, alerts) and producer-owned
+     *  senders (heartbeat job, mention-watch server post, channel forwarders) set
+     *  this to false so a missing target FAILS instead of inheriting a stranger's
+     *  thread (#437). Absent keeps the Interactive default. */
     allowActiveFallback?: boolean;
     /** Skip the two volatile slots and resolve straight to the configured
-     *  allowlist. For reminders, watcher notifications and alerts, which have a
-     *  destination in the operator sense (the channel that was set up to receive
-     *  them) but not a conversational one — so last-active is wrong while failing
-     *  outright would be worse than delivering somewhere stable (#438). */
+     *  allowlist. Scheduled callers must also set allowActiveFallback: false.
+     *  The pair plus a missing allowlist/home is silence, not last-active.
+     *  preferConfiguredTarget alone still last-resorts (historical #438); that
+     *  leftover is closed by the callers, not by inverting this default. */
     preferConfiguredTarget?: boolean;
     /** The conversation the CALLING TURN is answering for, echoed back by the
      *  agent from its per-turn prompt. Trusted only as far as the same allowlist
@@ -451,11 +451,14 @@ export async function sendChannelOutput(req: ChannelSendRequest): Promise<{ ok: 
 
     // Resolve target: explicit > validated lastActive > validated latestSeen > configured fallback > error
     //
-    // Gated on allowActiveFallback: a scheduled sender opts OUT of this chain
-    // entirely (#437). Without that opt-out a heartbeat with no target inherits
-    // whichever conversation last spoke to the bot, which is how two reports
-    // landed in an unrelated design thread on 2026-08-25.
-    if (!req.target && req.allowActiveFallback !== false) {
+    // Scheduled pair (preferConfiguredTarget + allowActiveFallback:false): configured
+    // dest only. That helper used to live inside the last-active gate, so opting out
+    // of last-active also skipped the allowlist (SEND-RESOLVE-01).
+    // Interactive omit-target still walks the chain below (#397, #474).
+    if (!req.target && req.preferConfiguredTarget === true && req.allowActiveFallback === false) {
+        const configured = getConfiguredFallbackTarget(channel);
+        if (configured) req.target = configured;
+    } else if (!req.target && req.allowActiveFallback !== false) {
         const configuredFirst = req.preferConfiguredTarget ? getConfiguredFallbackTarget(channel) : null;
         if (configuredFirst) req.target = configuredFirst;
         // The turn's OWN conversation outranks both volatile slots. Those slots

--- a/tests/unit/send-validation.test.ts
+++ b/tests/unit/send-validation.test.ts
@@ -674,10 +674,7 @@ test('a configured-target send ignores an unrelated last-active conversation', a
     }, ['C_CONFIGURED']);
 });
 
-test('with nothing configured it still falls back rather than going silent', async () => {
-    // Failing outright would be worse than the old behaviour for an alert: an
-    // operator who never set an allowlist would simply stop hearing about
-    // problems. Delivery is best-effort, the PREFERENCE is what changed.
+test('preferConfiguredTarget alone still last-resorts when allowlist is empty', async () => {
     await withIsolatedSlack(async capture => {
         const { sendChannelOutput } = await import('../../src/messaging/send.js');
         const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
@@ -690,7 +687,45 @@ test('with nothing configured it still falls back rather than going silent', asy
 
         assert.equal(result.ok, true);
         assert.equal(capture.requests[0]?.target?.targetId, 'C_CURRENT');
+        assert.equal(capture.requests[0]?.target?.threadId, '1710000000.000100');
     });
+});
+
+test('scheduled pair plus empty allowlist sends zero transports', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_CURRENT'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'alert',
+            preferConfiguredTarget: true,
+            allowActiveFallback: false,
+        });
+
+        assert.equal(result.ok, false);
+        assert.equal(capture.requests.length, 0);
+        assert.match(String(result.error || ''), /No target available for slack/);
+    });
+});
+
+test('scheduled pair uses configured dest and ignores last-active', async () => {
+    await withIsolatedSlack(async capture => {
+        const { sendChannelOutput } = await import('../../src/messaging/send.js');
+        const { setLastActiveTarget } = await import('../../src/messaging/runtime.js');
+        setLastActiveTarget('slack', slackTarget('C_CURRENT'));
+
+        const result = await sendChannelOutput({
+            channel: 'slack', type: 'text', text: 'alert',
+            preferConfiguredTarget: true,
+            allowActiveFallback: false,
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(capture.requests.length, 1);
+        assert.equal(capture.requests[0]?.target?.targetId, 'C_CONFIGURED');
+        assert.notEqual(capture.requests[0]?.target?.targetId, 'C_CURRENT');
+    }, ['C_CONFIGURED']);
 });
 
 test('conversational sends are untouched by the new preference', async () => {


### PR DESCRIPTION
## Summary
- Scheduled senders that set both `preferConfiguredTarget` and `allowActiveFallback: false` now resolve through the configured allowlist instead of inheriting last-active.
- `preferConfiguredTarget` used to live inside the last-active gate, so opting out of last-active also skipped the allowlist (SEND-RESOLVE-01).
- Interactive omit-target still walks last-active / turnTarget / latest-seen. Pair + empty allowlist stays silent.

## Test plan
- [x] `npx tsx --experimental-test-module-mocks tests/run.mts tests/unit/send-validation.test.ts` — 51/51
- [ ] CI `ci-aggregate` green
- [ ] Confirm existing `#437` opt-out (no `preferConfiguredTarget`) still fail-closes
- [ ] Confirm `#438` preferConfigured-only + empty allowlist still last-resorts


Made with [Cursor](https://cursor.com)